### PR TITLE
Feature/937: Search sort

### DIFF
--- a/search.php
+++ b/search.php
@@ -22,10 +22,9 @@ $context['sort_options'] = [
 	'recent'   => __( 'Most recent', 'planet4-master-theme' ),
 ];
 
-$search        = get_search_query();
 $default_sort  = 'relevant';
-$field         = 'search_results_sort';
-$selected_sort = filter_input( INPUT_POST, $field, FILTER_SANITIZE_STRING );
+$selected_sort = filter_input( INPUT_GET, 'order', FILTER_SANITIZE_STRING );
+$search        = get_search_query();
 
 if ( ! in_array( $selected_sort, array_keys( $context['sort_options'] ), true ) ) {
 	$context['selected_sort'] = $default_sort;
@@ -35,27 +34,26 @@ if ( ! in_array( $selected_sort, array_keys( $context['sort_options'] ), true ) 
 
 switch ( $context['selected_sort'] ) {
 	case 'recent':
-		$context['posts']  = Timber::get_posts( [
+		$context['posts'] = Timber::get_posts( [
+			// TODO - Find solution for Timber bug (see https://github.com/timber/timber/issues/935).
+			// which does not include attachments to get_posts() results if we supply an array as an argument.
 			's'       => $search,
 			'orderby' => 'post_date',
 			'order'   => 'DESC',
 		] );
 		break;
 	default:
-		$context['posts'] = Timber::get_posts( [
-			's' => $search,
-		] );
+		$context['posts'] = Timber::get_posts();
 }
-
 $found_posts = count( $context['posts'] );
-$context['title']  = $found_posts . ' results for \'' . get_search_query() . '\'';
 
+$context['title']  = "$found_posts results for '$search'";
+$context['domain'] = 'planet4-master-theme';
 $context['issues'] = get_categories( [
 	'child_of' => get_category_by_slug( 'issues' )->term_id,
 	'orderby'  => 'name',
 	'order'    => 'ASC',
 ] );
-
 $context['campaigns'] = [
 	[
 		'name'    => '#CampaignName1',
@@ -70,7 +68,6 @@ $context['campaigns'] = [
 		'results' => 0,
 	],
 ];
-
 $context['categories'] = [
 	[
 		'name'    => '#1',
@@ -85,7 +82,6 @@ $context['categories'] = [
 		'results' => 0,
 	],
 ];
-
 $context['content_types'] = [
 	[
 		'name'    => '#1',
@@ -100,7 +96,5 @@ $context['content_types'] = [
 		'results' => 0,
 	],
 ];
-
-$context['domain'] = 'planet4-master-theme';
 
 Timber::render( $templates, $context );

--- a/search.php
+++ b/search.php
@@ -16,16 +16,14 @@
 global $wp_query;
 
 $templates = array( 'search.twig', 'archive.twig', 'index.twig' );
-$context = Timber::get_context();
-
-$default_sort = 'relevant';
-$found_posts = $wp_query->found_posts;
-$context['title']  = $found_posts . ' results for \'' . get_search_query() . '\'';
+$context   = Timber::get_context();
 $context['sort_options'] = [
 	'relevant' => __( 'Most relevant', 'planet4-master-theme' ),
 	'recent'   => __( 'Most recent', 'planet4-master-theme' ),
 ];
 
+$search        = get_search_query();
+$default_sort  = 'relevant';
 $field         = 'search_results_sort';
 $selected_sort = filter_input( INPUT_POST, $field, FILTER_SANITIZE_STRING );
 
@@ -37,11 +35,20 @@ if ( ! in_array( $selected_sort, array_keys( $context['sort_options'] ), true ) 
 
 switch ( $context['selected_sort'] ) {
 	case 'recent':
-		$context['posts']  = Timber::get_posts(); // TODO - Sort by date.
+		$context['posts']  = Timber::get_posts( [
+			's'       => $search,
+			'orderby' => 'post_date',
+			'order'   => 'DESC',
+		] );
 		break;
 	default:
-		$context['posts']  = Timber::get_posts();
+		$context['posts'] = Timber::get_posts( [
+			's' => $search,
+		] );
 }
+
+$found_posts = count( $context['posts'] );
+$context['title']  = $found_posts . ' results for \'' . get_search_query() . '\'';
 
 $context['issues'] = get_categories( [
 	'child_of' => get_category_by_slug( 'issues' )->term_id,

--- a/search.php
+++ b/search.php
@@ -13,8 +13,6 @@
  * Planet4 - Search functionality.
  */
 
-global $wp_query;
-
 $templates = array( 'search.twig', 'archive.twig', 'index.twig' );
 $context   = Timber::get_context();
 $context['sort_options'] = [
@@ -37,15 +35,29 @@ switch ( $context['selected_sort'] ) {
 		$context['posts'] = Timber::get_posts( [
 			// TODO - Find solution for Timber bug (see https://github.com/timber/timber/issues/935).
 			// which does not include attachments to get_posts() results if we supply an array as an argument.
-			's'       => $search,
+			// This might be related to Timber not collaborating well with SearchWP. Needs further investigation.
+			's' => $search,
+			'post_type' => [
+				'post',
+				'page',
+				'attachment',
+			],
+			'post_status' => 'any',
 			'orderby' => 'post_date',
-			'order'   => 'DESC',
+			'order' => 'DESC',
+			'numberposts' => -1,
 		] );
 		break;
 	default:
+		// TODO - Add 'numberposts' option.
+		// The issue seems like it is related with Timber and SearchWP not collaborating very well here.
+		// If we add a parameter to Timber::get_posts() then it looks like it skips SearcWP and does
+		// not include attachments. So, for now I leave the default sort without parameter to
+		// be able to review the attachment searching functionality.
 		$context['posts'] = Timber::get_posts();
 }
-$found_posts = count( $context['posts'] );
+// Cast to array for forward compatibility with php 7.2 which requires count parameter to be array or object that implements Countable.
+$found_posts = count( (array) $context['posts'] );
 
 $context['title']  = "$found_posts results for '$search'";
 $context['domain'] = 'planet4-master-theme';

--- a/search.php
+++ b/search.php
@@ -9,10 +9,91 @@
  * @since   Timber 0.1
  */
 
+/**
+ * Planet4 - Search functionality.
+ */
+
+global $wp_query;
+
 $templates = array( 'search.twig', 'archive.twig', 'index.twig' );
 $context = Timber::get_context();
 
-$context['title'] = 'Search results for ' . get_search_query();
-$context['posts'] = Timber::get_posts();
+$default_sort = 'relevant';
+$found_posts = $wp_query->found_posts;
+$context['title']  = $found_posts . ' results for \'' . get_search_query() . '\'';
+$context['sort_options'] = [
+	'relevant' => __( 'Most relevant', 'planet4-master-theme' ),
+	'recent'   => __( 'Most recent', 'planet4-master-theme' ),
+];
+
+$field         = 'search_results_sort';
+$selected_sort = filter_input( INPUT_POST, $field, FILTER_SANITIZE_STRING );
+
+if ( ! in_array( $selected_sort, array_keys( $context['sort_options'] ), true ) ) {
+	$context['selected_sort'] = $default_sort;
+} else {
+	$context['selected_sort'] = $selected_sort;
+}
+
+switch ( $context['selected_sort'] ) {
+	case 'recent':
+		$context['posts']  = Timber::get_posts(); // TODO - Sort by date.
+		break;
+	default:
+		$context['posts']  = Timber::get_posts();
+}
+
+$context['issues'] = get_categories( [
+	'child_of' => get_category_by_slug( 'issues' )->term_id,
+	'orderby'  => 'name',
+	'order'    => 'ASC',
+] );
+
+$context['campaigns'] = [
+	[
+		'name'    => '#CampaignName1',
+		'results' => 0,
+	],
+	[
+		'name'    => '#CampaignName2',
+		'results' => 0,
+	],
+	[
+		'name'    => '#CampaignName3',
+		'results' => 0,
+	],
+];
+
+$context['categories'] = [
+	[
+		'name'    => '#1',
+		'results' => 0,
+	],
+	[
+		'name'    => '#2',
+		'results' => 0,
+	],
+	[
+		'name'    => '#3',
+		'results' => 0,
+	],
+];
+
+$context['content_types'] = [
+	[
+		'name'    => '#1',
+		'results' => 0,
+	],
+	[
+		'name'    => '#2',
+		'results' => 0,
+	],
+	[
+		'name'    => '#3',
+		'results' => 0,
+	],
+];
+
+$context['domain'] = 'planet4-master-theme';
 
 Timber::render( $templates, $context );

--- a/templates/navigation-bar.twig
+++ b/templates/navigation-bar.twig
@@ -92,8 +92,9 @@
                                     <a href="#search" id="search-trigger"><i class="fa fa-search fa-lg"></i></a>
                                 </div>
                                 <div class="search-box">
-                                    <form action="{{ data_nav_bar.home_url }}" id="search_form">
+                                    <form id="search_form_mobile" action="{{ data_nav_bar.home_url }}">
                                         <input class="form-control" type="search" placeholder="{{ __( 'Search', domain ) }}" value="{{ data_nav_bar.search_query }}" name="s" aria-label="Search">
+                                        <input id="order" type="hidden" name="order" value="{{ selected_sort ?? 'relevant' }}" />
                                         <input id="search-submit" type="submit" class="btn btn-green" value="{{ __( 'Search', domain ) }}" />
                                     </form>
                                 </div>
@@ -184,9 +185,10 @@
                                         <a href="#">{{ __( 'Sign up', domain ) }}</a>
                                     </li>
                                     <li class="nav-item nav-search-wrap">
-                                        <form role="search" class="form" action="{{ data_nav_bar.home_url }}">
+                                        <form id="search_form" role="search" class="form" action="{{ data_nav_bar.home_url }}">
                                             <input class="form-control" type="search" placeholder="{{ __( 'Search', domain ) }}" value="{{ data_nav_bar.search_query }}" name="s" aria-label="Search">
-                                            <button class="top-nav-search-btn" type="submit">
+                                            <input id="order" type="hidden" name="order" value="{{ selected_sort ?? 'relevant' }}" />
+                                            <button class="top-nav-search-btn">
                                                 <i class="fa fa-search"></i>
                                             </button>
                                         </form>

--- a/templates/search.twig
+++ b/templates/search.twig
@@ -38,12 +38,12 @@
 		.results td {
 			vertical-align: top;
 		}
+		#results_settings {
+			float: right;
+		}
 		.result-post-date {
 			font-style: italic;
 			color: grey;
-		}
-		#search_sort_form {
-			float: right;
 		}
 	</style>
 	<div id="search-results-container" class="search-results-container">
@@ -107,12 +107,9 @@
 					<br />
 				</div>
 				<div class="results">
-					<form id="search_sort_form" name="search_sort_form" method="post">
-						{# Add Nonce verification here for protection against CSRF attacks. #}
-						<input type="hidden" name="form_submit" value="{{ form_submit }}">
-
+					<div id="results_settings" name="results_settings">
 						<h4>{{ __( 'Sort by', domain ) }}</h4>
-						<select id="search_results_sort" name="search_results_sort" class="custom-select">
+						<select id="select_order" name="select_order" class="custom-select">
 							{% for key, sort_option in sort_options %}
 								{% if key == selected_sort %}
 									<option value="{{ key }}" selected>{{ sort_option }}</option>
@@ -121,7 +118,7 @@
 								{% endif %}
 							{% endfor %}
 						</select>
-					</form>
+					</div>
 					<table>
 						{% for post in posts %}
 							{% include ['tease-search.twig', 'tease-'~post.post_type~'.twig', 'tease.twig'] %}
@@ -137,8 +134,9 @@
 		$ = jQuery;
 
 		$(document).ready(function() {
-			$("#search_results_sort").off("change").on("change", function () {
-				this.closest("form").submit();
+			$("#select_order").on("change", function () {
+				$("#order", $("#search_form")).val( $(this).val() ).parent().submit();
+				return false;
 			});
 		} );
 	</script>

--- a/templates/search.twig
+++ b/templates/search.twig
@@ -137,10 +137,6 @@
 		$ = jQuery;
 
 		$(document).ready(function() {
-
-			/**
-			 * Taxonomy_Image
-			 */
 			$("#search_results_sort").off("change").on("change", function () {
 				this.closest("form").submit();
 			});

--- a/templates/search.twig
+++ b/templates/search.twig
@@ -1,0 +1,149 @@
+{% extends "base.twig" %}
+
+{% block content %}
+	<style>
+		#search-results-container {
+			width: 80%;
+			padding-top: 130px;
+			top:0;
+			bottom: 0;
+			left: 0;
+			right: 0;
+			margin: auto;
+		}
+		#search-results-container > h2 {
+			text-align: center;
+		}
+		#search-results-filter {
+			display: flex;
+			justify-content: center;
+		}
+		.filters-box {
+			padding-left: 20px;
+			border: 1px solid rgba(0,0,0,0.75);
+			-webkit-box-shadow: -4px 9px 5px 0 rgba(0,0,0,0.75);
+			-moz-box-shadow: -4px 9px 5px 0 rgba(0,0,0,0.75);
+			box-shadow: -4px 9px 5px 0 rgba(0,0,0,0.75);
+		}
+		.filters {
+			display: inline-block;
+			width: 30%;
+			float:left;
+		}
+		.results {
+			display: inline-block;
+			width: 70%;
+			float:left;
+		}
+		.results td {
+			vertical-align: top;
+		}
+		.result-post-date {
+			font-style: italic;
+			color: grey;
+		}
+		#search_sort_form {
+			float: right;
+		}
+	</style>
+	<div id="search-results-container" class="search-results-container">
+		{% if ( posts ) %}
+			<h2>{{ title }}</h2>
+			<div id="search-results-filter" class="search-results-filter">
+				<div class="filters">
+					<h4>{{ __( 'Refine your search', domain ) }}</h4>
+					<br />
+
+					<div class="filters-box">
+						<h5>{{ __( 'Issue', domain ) }}</h5>
+					</div>
+					<br />
+					{% for issue in issues %}
+						<label class="custom-control custom-checkbox">
+							<input type="checkbox" class="custom-control-input" /> {{ issue.name }} ({{ issue.results }})
+							<span class="custom-control-indicator"></span>
+						</label>
+						<br />
+					{% endfor %}
+					<br />
+
+					<div class="filters-box">
+						<h5>{{ __( 'Campaign', domain ) }}</h5>
+					</div>
+					<br />
+					{% for campaign in campaigns %}
+						<label class="custom-control custom-checkbox">
+							<input type="checkbox" class="custom-control-input" /> {{ campaign.name }} ({{ campaign.results }})
+							<span class="custom-control-indicator"></span>
+						</label>
+						<br />
+					{% endfor %}
+					<br />
+
+					<div class="filters-box">
+						<h5>{{ __( 'Category', domain ) }}</h5>
+					</div>
+					<br />
+					{% for category in categories %}
+						<label class="custom-control custom-checkbox">
+							<input type="checkbox" class="custom-control-input" /> {{ category.name }} ({{ category.results }})
+							<span class="custom-control-indicator"></span>
+						</label>
+						<br />
+					{% endfor %}
+					<br />
+
+					<div class="filters-box">
+						<h5>{{ __( 'Content Type', domain ) }}</h5>
+					</div>
+					<br />
+					{% for content_type in content_types %}
+						<label class="custom-control custom-checkbox">
+							<input type="checkbox" class="custom-control-input" /> {{ content_type.name }} ({{ content_type.results }})
+							<span class="custom-control-indicator"></span>
+						</label>
+						<br />
+					{% endfor %}
+					<br />
+				</div>
+				<div class="results">
+					<form id="search_sort_form" name="search_sort_form" method="post">
+						{# Add Nonce verification here for protection against CSRF attacks. #}
+						<input type="hidden" name="form_submit" value="{{ form_submit }}">
+
+						<h4>{{ __( 'Sort by', domain ) }}</h4>
+						<select id="search_results_sort" name="search_results_sort" class="custom-select">
+							{% for key, sort_option in sort_options %}
+								{% if key == selected_sort %}
+									<option value="{{ key }}" selected>{{ sort_option }}</option>
+								{% else %}
+									<option value="{{ key }}">{{ sort_option }}</option>
+								{% endif %}
+							{% endfor %}
+						</select>
+					</form>
+					<table>
+						{% for post in posts %}
+							{% include ['tease-search.twig', 'tease-'~post.post_type~'.twig', 'tease.twig'] %}
+						{% endfor %}
+					</table>
+				</div>
+			{% else %}
+				<h2>No results found.</h2>
+			{% endif %}
+		</div>
+	</div>
+	<script type="text/javascript">
+		$ = jQuery;
+
+		$(document).ready(function() {
+
+			/**
+			 * Taxonomy_Image
+			 */
+			$("#search_results_sort").off("change").on("change", function () {
+				this.closest("form").submit();
+			});
+		} );
+	</script>
+{% endblock %}

--- a/templates/tease-post.twig
+++ b/templates/tease-post.twig
@@ -2,7 +2,7 @@
 
 {% block content %}
 	<h2 class="h2"><a href="{{ post.link }}">{{ post.title|raw }}</a></h2>
-		<p>{{ post.get_preview(25)|raw }}</p>
+		<p>{{ post.preview()|truncate( 25, true )|raw }}</p>
 		{% if ( post.thumbnail.src ) %}
 			<img src="{{ post.thumbnail.src }}" />
 		{% endif %}

--- a/templates/tease-search.twig
+++ b/templates/tease-search.twig
@@ -1,0 +1,16 @@
+<tr id="result-row-{{ post.ID }}">
+	<th>
+		{% if ( post.get_thumbnail ) %}
+			<img src="{{ post.thumbnail.src }}" height="150" width="150" alt="image" />
+		{% endif %}
+	</th>
+	<td>
+		<article class="tease tease-{{ post.post_type }}" id="tease-{{ post.ID }}">
+			{% block content %}
+				<h2 class="h2"><a href="{{ post.link }}">{{ post.title|raw }}</a></h2>
+				<span class="result-post-date">{{ post.post_date|date('M d, Y') }}</span>
+				<p>{{ post.preview()|truncate( 25, true )|raw }}</p>
+			{% endblock %}
+		</article>
+	</td>
+</tr>

--- a/templates/tease-search.twig
+++ b/templates/tease-search.twig
@@ -1,7 +1,7 @@
 <tr id="result-row-{{ post.ID }}">
 	<th>
 		{% if ( post.get_thumbnail ) %}
-			<img src="{{ post.thumbnail.src }}" height="150" width="150" alt="image" />
+			<img src="{{ post.thumbnail.src }}" height="150" width="150" alt="{{ post.thumbnail.alt|default( post.title ) }}" />
 		{% endif %}
 	</th>
 	<td>

--- a/templates/tease.twig
+++ b/templates/tease.twig
@@ -1,7 +1,7 @@
 <article class="tease tease-{{ post.post_type }}" id="tease-{{ post.ID }}">
 	{% block content %}
 		<h2 class="h2"><a href="{{ post.link }}">{{ post.title|raw }}</a></h2>
-		<p>{{ post.get_preview|raw }}</p>
+		<p>{{ post.preview()|truncate( 25, true )|raw }}</p>
 		{% if ( post.get_thumbnail ) %}
 			<img src="{{ post.thumbnail.src }}" />
 		{% endif %}


### PR DESCRIPTION
Initial version of the P4 Search Results page. It is using SearchWP plugin's search under the hood. (Sorting by most recent is not completed). Added simple markup to resemble the final design. Replaced Timber's get_preview() deprecated function calls with preview(). Truncated preview down to 25 words.