### PR TITLE
Feature/Image-Tag association

### DIFF
--- a/assets/js/post_tag.js
+++ b/assets/js/post_tag.js
@@ -19,7 +19,10 @@ $(document).ready(function() {
 				.on("select", function () {
 					var $selected_image = media_modal.state().get("selection").first().toJSON();
 					$("#tag_attachment_id").val($selected_image.id);
-					$(".tag_attachment .attachment-thumbnail").attr("src", $selected_image.sizes.thumbnail.url);
+					$("#tag_attachment").val($selected_image.url);
+					$(".add-wrap .attachment-thumbnail").attr("src", $selected_image.sizes.thumbnail.url);
+					$(".edit-wrap .attachment-thumbnail").attr("src", $selected_image.url);
+					$(".dashicons-dismiss:hidden").show();
 				})
 				.open();
 		}
@@ -27,15 +30,22 @@ $(document).ready(function() {
 		return false;
 	});
 
-	$(".tag_attachment .attachment-thumbnail").off("click").on("click", function () {
+	$(".form-field .attachment-thumbnail").off("click").on("click", function () {
 		$("#insert_image_tag_button").click();
 	});
 
 	// Clean up the custom fields, since the taxonomy save is made via ajax and the taxonomy page does not reload.
 	$("#submit", $("#addtag")).off("click").on("click", function () {
 		setTimeout(function () {
-			jQuery("#tag_attachment_id").val("");
-			jQuery(".tag_attachment .attachment-thumbnail").attr("src", "");
+			$("#tag_attachment_id, #tag_attachment").val("");
+			$(".form-field .attachment-thumbnail").attr("src", "");
 		}, 300);
 	});
+
+	$(".dashicons-dismiss").off("click").on("click", function () {
+		$("#tag_attachment_id").val(0);
+		$("#tag_attachment").val("");
+		$(".form-field .attachment-thumbnail").attr("src", "");
+		$(this).hide();
+	} );
 } );

--- a/classes/class-p4-taxonomy-image.php
+++ b/classes/class-p4-taxonomy-image.php
@@ -43,8 +43,9 @@ if ( ! class_exists( 'P4_Taxonomy_Image' ) ) {
 		 */
 		public function add_taxonomy_form_fields( $wp_tag ) {
 			if ( isset( $wp_tag ) && $wp_tag instanceof WP_Term ) {
-				$attachment_id  = get_term_meta( $wp_tag->term_id, 'tag_attachment_id', true );
-				$attachment_url = get_term_meta( $wp_tag->term_id, 'tag_attachment', true ); ?>
+				$attachment_id    = get_term_meta( $wp_tag->term_id, 'tag_attachment_id', true );
+				$image_attributes = wp_get_attachment_image_src( $attachment_id, 'full' );
+				$attachment_url   = $image_attributes ? $image_attributes[0] : ''; ?>
 
 				<tr class="form-field edit-wrap term-image-wrap">
 					<th>
@@ -58,7 +59,7 @@ if ( ! class_exists( 'P4_Taxonomy_Image' ) ) {
 						</button>
 						<p class="description"><?php esc_html_e( 'Associate this tag with an image.', 'planet4-master-theme' ); ?></p>
 						<img class="attachment-thumbnail size-thumbnail" src="<?php echo esc_url( $attachment_url ); ?>"/>
-						<i class="dashicons dashicons-dismiss <?php echo $attachment_url ? '' : 'hidden'; ?>" style="cursor: pointer;"></i>
+						<i class="dashicons dashicons-dismiss <?php echo $image_attributes ? '' : 'hidden'; ?>" style="cursor: pointer;"></i>
 					</td>
 				</tr>
 			<?php } else { ?>

--- a/classes/class-p4-taxonomy-image.php
+++ b/classes/class-p4-taxonomy-image.php
@@ -42,33 +42,36 @@ if ( ! class_exists( 'P4_Taxonomy_Image' ) ) {
 		 * @param WP_Term $wp_tag The object passed to the callback when on Edit Tag page.
 		 */
 		public function add_taxonomy_form_fields( $wp_tag ) {
-			if ( isset( $wp_tag ) && $wp_tag instanceof WP_Term ) { ?>
-				<tr class="form-field term-image-wrap">
+			if ( isset( $wp_tag ) && $wp_tag instanceof WP_Term ) {
+				$attachment_id  = get_term_meta( $wp_tag->term_id, 'tag_attachment_id', true );
+				$attachment_url = get_term_meta( $wp_tag->term_id, 'tag_attachment', true ); ?>
+
+				<tr class="form-field edit-wrap term-image-wrap">
 					<th>
-						<label for="tag_attachment_id"><?php esc_html_e( 'Image', 'planet4-master-theme' ); ?></label>
+						<label><?php esc_html_e( 'Image', 'planet4-master-theme' ); ?></label>
 					</th>
 					<td>
-						<input type="hidden" name="tag_attachment_id" id="tag_attachment_id" class="tag_attachment_id" value="" />
+						<input type="hidden" name="tag_attachment_id" id="tag_attachment_id" class="tag-attachment-id" value="<?php echo esc_attr( $attachment_id ); ?>" />
+						<input type="hidden" name="tag_attachment" id="tag_attachment" class="tag-attachment-url" value="<?php echo esc_url( $attachment_url ); ?>" />
 						<button class="button insert-media add_media" name="insert_image_tag_button" id="insert_image_tag_button" type="button">
 							<?php esc_html_e( 'Select/Upload Image', 'planet4-master-theme' ); ?>
 						</button>
 						<p class="description"><?php esc_html_e( 'Associate this tag with an image.', 'planet4-master-theme' ); ?></p>
-						<p class="tag_attachment">
-							<?php echo wp_get_attachment_image( get_term_meta( $wp_tag->term_id, 'tag_attachment_id', true ) ); ?>
-						</p>
+						<img class="attachment-thumbnail size-thumbnail" src="<?php echo esc_url( $attachment_url ); ?>"/>
+						<i class="dashicons dashicons-dismiss <?php echo $attachment_url ? '' : 'hidden'; ?>" style="cursor: pointer;"></i>
 					</td>
 				</tr>
 			<?php } else { ?>
-				<div class="form-field term-image-wrap">
-					<label for="tag_attachment_id"><?php esc_html_e( 'Image', 'planet4-master-theme' ); ?></label>
+				<div class="form-field add-wrap term-image-wrap">
+					<label><?php esc_html_e( 'Image', 'planet4-master-theme' ); ?></label>
 					<input type="hidden" name="tag_attachment_id" id="tag_attachment_id" class="tag_attachment_id" value="" />
+					<input type="hidden" name="tag_attachment" id="tag_attachment" class="tag-attachment-url" value="" />
 					<button class="button insert-media add_media" name="insert_image_tag_button" id="insert_image_tag_button" type="button">
 						<?php esc_html_e( 'Select/Upload Image', 'planet4-master-theme' ); ?>
 					</button>
 					<p class="description"><?php esc_html_e( 'Associate this tag with an image.', 'planet4-master-theme' ); ?></p>
-					<p class="tag_attachment">
-						<img class="attachment-thumbnail size-thumbnail" src=""/>
-					</p>
+					<img class="attachment-thumbnail size-thumbnail" src="" />
+					<i class="dashicons dashicons-dismiss hidden" style="cursor: pointer;"></i>
 				</div>
 				<?php
 			}
@@ -80,11 +83,14 @@ if ( ! class_exists( 'P4_Taxonomy_Image' ) ) {
 		 * @param int $term_id The ID of the WP_Term object that is added or edited.
 		 */
 		public function save_taxonomy_meta( $term_id ) {
-			$field         = 'tag_attachment_id';
-			$attachment_id = filter_input( INPUT_POST, $field, FILTER_VALIDATE_INT );
+			$field_id       = 'tag_attachment_id';
+			$field_url      = 'tag_attachment';
+			$attachment_id  = filter_input( INPUT_POST, $field_id, FILTER_VALIDATE_INT );
+			$attachment_url = filter_input( INPUT_POST, $field_url, FILTER_VALIDATE_URL );
 
 			if ( $this->validate( $attachment_id ) ) {
-				update_term_meta( $term_id, $field, $attachment_id );
+				update_term_meta( $term_id, $field_id, $attachment_id );
+				update_term_meta( $term_id, $field_url, $attachment_url );
 			}
 		}
 
@@ -132,12 +138,12 @@ if ( ! class_exists( 'P4_Taxonomy_Image' ) ) {
 		/**
 		 * Validates the input.
 		 *
-		 * @param int $input The user input to be validated.
+		 * @param int    $id The attachment id to be validated.
 		 *
 		 * @return bool True if validation is ok, false if validation fails.
 		 */
-		public function validate( $input ) : bool {
-			if ( $input <= 0 ) {
+		public function validate( $id ) : bool {
+			if ( $id < 0 ) {
 				return false;
 			}
 			return true;


### PR DESCRIPTION
Fixed bug that caused the selected image to not show up when in Edit Tag page. Fixed bug that caused selected image to disappear when Updating a Tag. Added functionality (X icon) to de-associate an image from a Tag completely. Display the full image inside Edit Tag page and keep the thumbnails only for the Add Tag page. Now we are saving also the attachment's url for less read operations when trying to display the associated image.