### PR TITLE
Feature/1428 Search attachments

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -33,6 +33,8 @@ class P4_Master_Site extends TimberSite {
 		'en_US' => 'International (English)',
 		'el_GR' => 'Greece (Ελληνικά)',
 	];
+	/** @var string $default_sort */
+	protected $default_sort;
 	/** @var int $posts_per_page */
 	protected $posts_per_page;
 	/** @var array $services */
@@ -81,6 +83,7 @@ class P4_Master_Site extends TimberSite {
 		Timber::$dirname        = [ 'templates', 'views' ];
 		$this->theme_dir        = get_template_directory_uri();
 		$this->theme_images_dir = $this->theme_dir . '/images/';
+		$this->default_sort     = 'relevant';
 		$this->posts_per_page   = 10;
 	}
 
@@ -293,10 +296,11 @@ class P4_Master_Site extends TimberSite {
 	function edit_searchwp_query_orderby( $sql ) {
 		global $wp_query;
 
-		$selected_sort = filter_input( INPUT_GET, 'order', FILTER_SANITIZE_STRING );
+		$selected_sort  = filter_input( INPUT_GET, 'orderby', FILTER_SANITIZE_STRING );
+		$selected_order = $wp_query->get( 'order' );
 
-		if ( 'recent' === $selected_sort ) {
-			return sprintf( 'ORDER BY post_date %s', $wp_query->get( 'order' ) );
+		if ( $selected_sort !== $this->default_sort ) {
+			return sprintf( 'ORDER BY %s %s', $selected_sort, $selected_order );
 		}
 		return $sql;
 	}

--- a/functions.php
+++ b/functions.php
@@ -294,7 +294,7 @@ class P4_Master_Site extends TimberSite {
 	 * @return string The customized part of the query related to the ORDER BY.
 	 */
 	function edit_searchwp_query_orderby( $sql ) {
-		global $wp_query, $wpdb;
+		global $wp_query;
 
 		$selected_sort  = filter_input( INPUT_GET, 'orderby', FILTER_SANITIZE_STRING );
 		$selected_order = $wp_query->get( 'order' );

--- a/functions.php
+++ b/functions.php
@@ -33,6 +33,8 @@ class P4_Master_Site extends TimberSite {
 		'en_US' => 'International (English)',
 		'el_GR' => 'Greece (Ελληνικά)',
 	];
+	/** @var int $posts_per_page */
+	protected $posts_per_page;
 	/** @var array $services */
 	protected $services;
 	/** @var array $child_css */
@@ -79,6 +81,7 @@ class P4_Master_Site extends TimberSite {
 		Timber::$dirname        = [ 'templates', 'views' ];
 		$this->theme_dir        = get_template_directory_uri();
 		$this->theme_images_dir = $this->theme_dir . '/images/';
+		$this->posts_per_page   = 10;
 	}
 
 	/**
@@ -90,16 +93,18 @@ class P4_Master_Site extends TimberSite {
 		add_theme_support( 'menus' );
 		add_post_type_support( 'page', 'excerpt' );  // Added excerpt option to pages.
 
-		add_filter( 'timber_context',        array( $this, 'add_to_context' ) );
-		add_filter( 'get_twig',              array( $this, 'add_to_twig' ) );
-		add_action( 'init',                  array( $this, 'register_post_types' ) );
-		add_action( 'init',                  array( $this, 'register_taxonomies' ) );
-		add_action( 'cmb2_admin_init',       array( $this, 'register_header_metabox' ) );
-		add_action( 'pre_get_posts',         array( $this, 'tags_support_query' ) );
-		add_action( 'admin_init',            array( $this, 'add_copyright_text' ) );
-		add_action( 'admin_init',            array( $this, 'add_google_tag_manager_identifier_setting' ) );
-		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_assets' ) );
-		add_action( 'wp_enqueue_scripts',    array( $this, 'enqueue_public_assets' ) );
+		add_filter( 'timber_context',         array( $this, 'add_to_context' ) );
+		add_filter( 'get_twig',               array( $this, 'add_to_twig' ) );
+		add_action( 'init',                   array( $this, 'register_post_types' ) );
+		add_action( 'init',                   array( $this, 'register_taxonomies' ) );
+		add_action( 'pre_get_posts',          array( $this, 'add_search_options' ) );
+		add_filter( 'searchwp_query_orderby', array( $this, 'edit_searchwp_query_orderby' ), 10, 2 );
+		add_action( 'cmb2_admin_init',        array( $this, 'register_header_metabox' ) );
+		add_action( 'pre_get_posts',          array( $this, 'tags_support_query' ) );
+		add_action( 'admin_init',             array( $this, 'add_copyright_text' ) );
+		add_action( 'admin_init',             array( $this, 'add_google_tag_manager_identifier_setting' ) );
+		add_action( 'admin_enqueue_scripts',  array( $this, 'enqueue_admin_assets' ) );
+		add_action( 'wp_enqueue_scripts',     array( $this, 'enqueue_public_assets' ) );
 
 		remove_action( 'wp_head', 'print_emoji_detection_script', 7 );
 		remove_action( 'wp_head', 'wp_generator' );
@@ -264,6 +269,36 @@ class P4_Master_Site extends TimberSite {
 		if ( $wp_query->get( 'category_name' ) ) {
 			$wp_query->set( 'post_type', 'any' );
 		}
+	}
+
+	/**
+	 * Add custom options to the main WP_Query.
+	 *
+	 * @param WP_Query $wp The WP Query to customize.
+	 */
+	public function add_search_options( WP_Query $wp ) {
+		if ( ! $wp->is_main_query() || ! $wp->is_search() ) {
+			return;
+		}
+		$wp->set( 'posts_per_page', $this->posts_per_page );
+	}
+
+	/**
+	 * Customize the order of search results.
+	 *
+	 * @param string $sql The part of the query related to the ORDER BY.
+	 *
+	 * @return string The customized part of the query related to the ORDER BY.
+	 */
+	function edit_searchwp_query_orderby( $sql ) {
+		global $wp_query;
+
+		$selected_sort = filter_input( INPUT_GET, 'order', FILTER_SANITIZE_STRING );
+
+		if ( 'recent' === $selected_sort ) {
+			return sprintf( 'ORDER BY post_date %s', $wp_query->get( 'order' ) );
+		}
+		return $sql;
 	}
 
 	/**

--- a/functions.php
+++ b/functions.php
@@ -294,15 +294,15 @@ class P4_Master_Site extends TimberSite {
 	 * @return string The customized part of the query related to the ORDER BY.
 	 */
 	function edit_searchwp_query_orderby( $sql ) {
-		global $wp_query;
+		global $wp_query, $wpdb;
 
 		$selected_sort  = filter_input( INPUT_GET, 'orderby', FILTER_SANITIZE_STRING );
 		$selected_order = $wp_query->get( 'order' );
 
 		if ( $selected_sort !== $this->default_sort ) {
-			return sprintf( 'ORDER BY %s %s', $selected_sort, $selected_order );
+			return esc_sql( sprintf( 'ORDER BY %s %s', $selected_sort, $selected_order ) );
 		}
-		return $sql;
+		return esc_sql( $sql );
 	}
 
 	/**

--- a/search.php
+++ b/search.php
@@ -19,12 +19,12 @@ global $wp_query;
 $templates = array( 'search.twig', 'archive.twig', 'index.twig' );
 $context   = Timber::get_context();
 $context['sort_options'] = [
-	'relevant' => __( 'Most relevant', 'planet4-master-theme' ),
-	'recent'   => __( 'Most recent', 'planet4-master-theme' ),
+	'relevant'  => __( 'Most relevant', 'planet4-master-theme' ),
+	'post_date' => __( 'Most recent', 'planet4-master-theme' ),
 ];
 
 $default_sort  = 'relevant';
-$selected_sort = filter_input( INPUT_GET, 'order', FILTER_SANITIZE_STRING );
+$selected_sort = filter_input( INPUT_GET, 'orderby', FILTER_SANITIZE_STRING );
 $search        = get_search_query();
 
 if ( ! in_array( $selected_sort, array_keys( $context['sort_options'] ), true ) ) {
@@ -34,12 +34,10 @@ if ( ! in_array( $selected_sort, array_keys( $context['sort_options'] ), true ) 
 }
 
 /*
-  The issue seems like it is related with Timber and SearchWP not collaborating very well here. After investigating this we found that
-  If we do not pass an argument to Timber::get_posts() then it falls back to the main WP_Query which works with SearchWP.
-  If we pass an argument to Timber::get_posts() then it creates a subquery and SearchWP is not aware of that and therefore we do not get attachemnts included in search results.
-  A solution is to proceed without passing query options to get_posts at all
-  and instead use the `edit_searchwp_query_orderby` of searchwp to edit the order by part of the main WP_Query directly.
-*/
+ * With no args passed to this call, Timber uses the main query which we filter for customisations via P4_Master_Site class.
+ *
+ * When customising this query, use filters on the main query to avoid bypassing SearchWP's handling of the query.
+ */
 $context['posts'] = Timber::get_posts();
 
 $found_posts = $wp_query->found_posts;

--- a/search.php
+++ b/search.php
@@ -38,7 +38,7 @@ if ( ! in_array( $selected_sort, array_keys( $context['sort_options'] ), true ) 
   If we do not pass an argument to Timber::get_posts() then it falls back to the main WP_Query which works with SearchWP.
   If we pass an argument to Timber::get_posts() then it creates a subquery and SearchWP is not aware of that and therefore we do not get attachemnts included in search results.
   A solution is to proceed without passing query options to get_posts at all
-  and instead use the `pre_get_posts` hook to set the options to the main WP_Query directly.
+  and instead use the `edit_searchwp_query_orderby` of searchwp to edit the order by part of the main WP_Query directly.
 */
 $context['posts'] = Timber::get_posts();
 

--- a/search.php
+++ b/search.php
@@ -9,9 +9,12 @@
  * @since   Timber 0.1
  */
 
+use Timber\Timber;
 /**
  * Planet4 - Search functionality.
  */
+
+global $wp_query;
 
 $templates = array( 'search.twig', 'archive.twig', 'index.twig' );
 $context   = Timber::get_context();
@@ -30,37 +33,24 @@ if ( ! in_array( $selected_sort, array_keys( $context['sort_options'] ), true ) 
 	$context['selected_sort'] = $selected_sort;
 }
 
-switch ( $context['selected_sort'] ) {
-	case 'recent':
-		$context['posts'] = Timber::get_posts( [
-			// TODO - Find solution for Timber bug (see https://github.com/timber/timber/issues/935).
-			// which does not include attachments to get_posts() results if we supply an array as an argument.
-			// This might be related to Timber not collaborating well with SearchWP. Needs further investigation.
-			's' => $search,
-			'post_type' => [
-				'post',
-				'page',
-				'attachment',
-			],
-			'post_status' => 'any',
-			'orderby' => 'post_date',
-			'order' => 'DESC',
-			'numberposts' => -1,
-		] );
-		break;
-	default:
-		// TODO - Add 'numberposts' option.
-		// The issue seems like it is related with Timber and SearchWP not collaborating very well here.
-		// If we add a parameter to Timber::get_posts() then it looks like it skips SearcWP and does
-		// not include attachments. So, for now I leave the default sort without parameter to
-		// be able to review the attachment searching functionality.
-		$context['posts'] = Timber::get_posts();
-}
-// Cast to array for forward compatibility with php 7.2 which requires count parameter to be array or object that implements Countable.
-$found_posts = count( (array) $context['posts'] );
+/*
+  The issue seems like it is related with Timber and SearchWP not collaborating very well here. After investigating this we found that
+  If we do not pass an argument to Timber::get_posts() then it falls back to the main WP_Query which works with SearchWP.
+  If we pass an argument to Timber::get_posts() then it creates a subquery and SearchWP is not aware of that and therefore we do not get attachemnts included in search results.
+  A solution is to proceed without passing query options to get_posts at all
+  and instead use the `pre_get_posts` hook to set the options to the main WP_Query directly.
+*/
+$context['posts'] = Timber::get_posts();
 
+$found_posts = $wp_query->found_posts;
 $context['title']  = "$found_posts results for '$search'";
 $context['domain'] = 'planet4-master-theme';
+
+// Add pagination temporarily until we have a lazy loading solution. Use Timber::get_pagination() if we want a more customized one.
+$context['pagination'] = [
+	'screen_reader_text' => ' ',
+];
+
 $context['issues'] = get_categories( [
 	'child_of' => get_category_by_slug( 'issues' )->term_id,
 	'orderby'  => 'name',

--- a/templates/navigation-bar.twig
+++ b/templates/navigation-bar.twig
@@ -94,7 +94,7 @@
                                 <div class="search-box">
                                     <form id="search_form_mobile" action="{{ data_nav_bar.home_url }}">
                                         <input class="form-control" type="search" placeholder="{{ __( 'Search', domain ) }}" value="{{ data_nav_bar.search_query }}" name="s" aria-label="Search">
-                                        <input id="order" type="hidden" name="order" value="{{ selected_sort ?? 'relevant' }}" />
+                                        <input id="orderby" type="hidden" name="orderby" value="{{ selected_sort ?? 'relevant' }}" />
                                         <input id="search-submit" type="submit" class="btn btn-green" value="{{ __( 'Search', domain ) }}" />
                                     </form>
                                 </div>
@@ -187,7 +187,7 @@
                                     <li class="nav-item nav-search-wrap">
                                         <form id="search_form" role="search" class="form" action="{{ data_nav_bar.home_url }}">
                                             <input class="form-control" type="search" placeholder="{{ __( 'Search', domain ) }}" value="{{ data_nav_bar.search_query }}" name="s" aria-label="Search">
-                                            <input id="order" type="hidden" name="order" value="{{ selected_sort ?? 'relevant' }}" />
+                                            <input id="orderby" type="hidden" name="orderby" value="{{ selected_sort ?? 'relevant' }}" />
                                             <button class="top-nav-search-btn">
                                                 <i class="fa fa-search"></i>
                                             </button>

--- a/templates/search.twig
+++ b/templates/search.twig
@@ -136,7 +136,7 @@
 
 		$(document).ready(function() {
 			$("#select_order").on("change", function () {
-				$("#order", $("#search_form")).val( $(this).val() ).parent().submit();
+				$("#orderby", $("#search_form")).val( $(this).val() ).parent().submit();
 				return false;
 			});
 		} );

--- a/templates/search.twig
+++ b/templates/search.twig
@@ -124,6 +124,7 @@
 							{% include ['tease-search.twig', 'tease-'~post.post_type~'.twig', 'tease.twig'] %}
 						{% endfor %}
 					</table>
+					{{ fn( 'the_posts_pagination', pagination ) }}
 				</div>
 			{% else %}
 				<h2>No results found.</h2>


### PR DESCRIPTION
Fix issue with Timber and SearchWP not collaborating well when we provided parameter to Timber's get_posts() function. Now Most Recent sorting includes attachments as well. Also, fixed issue with displaying max 10 results. Also, added pagination as a temp solution until we add lazy loading.