### PR TITLE
Feature/1503 search

### DIFF
--- a/search.php
+++ b/search.php
@@ -118,7 +118,7 @@ $context['campaigns'] = [
 		'results' => 0,
 	],
 ];
-$context['categories'] = [
+$context['page_types'] = [
 	[
 		'name'    => 'Organisation',
 		'results' => 0,

--- a/search.php
+++ b/search.php
@@ -120,10 +120,6 @@ $context['campaigns'] = [
 ];
 $context['page_types'] = [
 	[
-		'name'    => 'Organisation',
-		'results' => 0,
-	],
-	[
 		'name'    => 'Press Release',
 		'results' => 0,
 	],

--- a/search.php
+++ b/search.php
@@ -43,6 +43,43 @@ $context['search_query'] = $search_query;
 $context['found_posts']  = $wp_query->found_posts;
 $context['domain']       = 'planet4-master-theme';
 
+foreach ( $context['posts'] as $post ) {
+	switch ( $post->post_type ) {
+		case 'page':
+			if ( 'act' === basename( get_permalink( $post->post_parent ) ) ) {
+				$content_type_text = __( 'ACTION', 'planet4-master-theme' );
+				$content_type = 'action';
+			} else {
+				$content_type_text = __( 'PAGE', 'planet4-master-theme' );
+				$content_type = 'page';
+			}
+			break;
+		case 'attachment':
+			$content_type_text = __( 'DOCUMENT', 'planet4-master-theme' );
+			$content_type = 'document';
+			break;
+		default:
+			$content_type_text = __( 'POST', 'planet4-master-theme' );
+			$content_type = 'post';
+	}
+
+	$page_types = get_the_terms( $post->ID, 'p4-page-type' );
+
+	$tags = get_the_terms( $post->ID, 'post_tag' );
+
+	$context['posts_data'][ $post->ID ] = [
+		'content_type_text' => $content_type_text,
+		'content_type'      => $content_type,
+		'page_types'        => $page_types,
+	];
+	foreach ( $tags as $tag ) {
+		$context['posts_data'][ $post->ID ]['tags'][] = [
+			'name' => $tag->name,
+			'link' => get_tag_link( $tag ),
+		];
+	}
+}
+
 $context['filters'] = [
 //	[
 //		'name' => 'filter_name',
@@ -76,32 +113,44 @@ $context['campaigns'] = [
 		'name'    => '#CampaignName3',
 		'results' => 0,
 	],
+	[
+		'name'    => '#CampaignName4',
+		'results' => 0,
+	],
 ];
 $context['categories'] = [
 	[
-		'name'    => '#1',
+		'name'    => 'Organisation',
 		'results' => 0,
 	],
 	[
-		'name'    => '#2',
+		'name'    => 'Press Release',
 		'results' => 0,
 	],
 	[
-		'name'    => '#3',
+		'name'    => 'Publication',
+		'results' => 0,
+	],
+	[
+		'name'    => 'Story',
 		'results' => 0,
 	],
 ];
 $context['content_types'] = [
 	[
-		'name'    => '#1',
+		'name'    => 'Action',
 		'results' => 0,
 	],
 	[
-		'name'    => '#2',
+		'name'    => 'Document',
 		'results' => 0,
 	],
 	[
-		'name'    => '#3',
+		'name'    => 'Page',
+		'results' => 0,
+	],
+	[
+		'name'    => 'Post',
 		'results' => 0,
 	],
 ];
@@ -112,15 +161,15 @@ $context['pagination'] = [
 ];
 
 $context['suggestions'] = [
-	'agriculture',
-	'agriculture',
-	'agriculture',
-	'food',
-	'food',
-	'food',
-	'organic',
-	'organic',
-	'organic',
+//	'agriculture',
+//	'agriculture',
+//	'agriculture',
+//	'food',
+//	'food',
+//	'food',
+//	'organic',
+//	'organic',
+//	'organic',
 ];
 
 Timber::render( $templates, $context );

--- a/templates/search.twig
+++ b/templates/search.twig
@@ -261,18 +261,20 @@
 								<button class="btn btn-medium btn-small btn-transparent more-btn" style="display: none;">{{ __( 'Show X more results', domain ) }}</button>
 							</div>
 						{% endif %}
-						<div class="suggested-search-terms">
-							<h3>{{ __( 'Suggested search terms', domain ) }}</h3>
-							<div class="suggested-list row">
-								{% for suggestion in suggestions %}
-									<div class="col-md-4">
-										<ul class="list-unstyled">
-											<li><a href="#"> {{ suggestion }}</a></li>
-										</ul>
-									</div>
-								{% endfor %}
+						{% if ( suggestions ) %}
+							<div class="suggested-search-terms">
+								<h3>{{ __( 'Suggested search terms', domain ) }}</h3>
+								<div class="suggested-list row">
+									{% for suggestion in suggestions %}
+										<div class="col-md-4">
+											<ul class="list-unstyled">
+												<li><a href="#"> {{ suggestion }}</a></li>
+											</ul>
+										</div>
+									{% endfor %}
+								</div>
 							</div>
-						</div>
+						{% endif %}
 					</div>
 				</div>
 			</div>

--- a/templates/search.twig
+++ b/templates/search.twig
@@ -81,12 +81,12 @@
 														</a>
 														<div id="item-modal-category" class="collapse" role="tabpanel">
 															<ul class="list-unstyled">
-																{% for category in categories %}
+																{% for page_type in page_types %}
 																	<li>
 																		<label class="custom-control custom-checkbox">
 																			<input type="checkbox" class="custom-control-input" {{ disabled }} />
 																			<span class="custom-control-indicator"></span>
-																			<span class="custom-control-description">{{ category.name }} ({{ category.results }})</span>
+																			<span class="custom-control-description">{{ page_type.name }} ({{ page_type.results }})</span>
 																		</label>
 																	</li>
 																{% endfor %}
@@ -199,12 +199,12 @@
 								</a>
 								<div id="item-category" class="collapse" role="tabpanel">
 									<ul class="list-unstyled">
-										{% for category in categories %}
+										{% for page_type in page_types %}
 											<li>
 												<label class="custom-control custom-checkbox">
 													<input type="checkbox" class="custom-control-input" {{ disabled }} />
 													<span class="custom-control-indicator"></span>
-													<span class="custom-control-description">{{ category.name }} ({{ category.results }})</span>
+													<span class="custom-control-description">{{ page_type.name }} ({{ page_type.results }})</span>
 												</label>
 											</li>
 										{% endfor %}

--- a/templates/tease-search.twig
+++ b/templates/tease-search.twig
@@ -1,18 +1,24 @@
 
 {% if ( 'action' == posts_data[post.ID].content_type ) %}
+	{% set is_action = true %}
+{% elseif ( 'document' == posts_data[post.ID].content_type ) %}
+	{% set is_document = true %}
+{% endif %}
+
+{% if ( is_action ) %}
 <li id="result-row-{{ post.ID }}" class="media search-result-list-item search-result-list-item-bg" style="background-image: url('{{ post.thumbnail.src }}');">
 	<div class="blank-block"></div>
 {% else %}
 <li id="result-row-{{ post.ID }}" class="media search-result-list-item">
 {% endif %}
-	{% if ( 'document' == posts_data[post.ID].content_type ) %}
+	{% if ( is_document ) %}
 		<div class="search-result-item-actionbox hidden-sm-down">
 			<a href="{{ post.guid }}" download class="btn btn-medium btn-small btn-transparent action-btn">
 				<i class="icon-doc-ic"></i>{{ __( 'Download', domain ) }}
 			</a>
 		</div>
 	{% endif %}
-	{% if ( 'action' != posts_data[post.ID].content_type ) %}
+	{% if ( not is_action ) %}
 		<img class="d-flex search-result-item-image" src="{{ post.thumbnail.src }}" alt="{{ post.thumbnail.alt|default( post.title ) }}" />
 	{% endif %}
 	<div id="tease-{{ post.ID }}" class="media-body search-result-item-body tease tease-{{ post.post_type }}">
@@ -25,7 +31,7 @@
 				<a href="{{ tag.link }}" class="search-result-item-tag">#{{ tag.name }}</a>{% if ( not loop.last ) %},{% endif %}
 			{% endfor %}
 		</div>
-		{% if ( 'document' == posts_data[post.ID].content_type ) %}
+		{% if ( is_document ) %}
 			<a href="{{ post.guid }}" class="search-result-item-headline">{{ post.title|raw }}</a>
 		{% else %}
 			<a href="{{ post.link() }}" class="search-result-item-headline">{{ post.title|raw }}</a>
@@ -34,9 +40,9 @@
 			<span class="search-result-item-date">{{ post.post_date|date('d/m/Y') }}</span>
 		</div>
 		<p class="search-result-item-content">{{ post.preview()|truncate( 25, true )|raw }}</p>
-		{% if ( 'action' == posts_data[post.ID].content_type ) %}
+		{% if ( is_action ) %}
 			<a href="{{ post.link }}" class="btn btn-primary btn-medium btn-small">{{ __( 'Take Action', domain ) }}</a>
-		{% elseif ( 'document' == posts_data[post.ID].content_type ) %}
+		{% elseif ( is_document ) %}
 			<a href="{{ post.guid }}" download="" class="btn btn-medium btn-small btn-transparent action-btn hidden-md-up btn-block">
 				<i class="icon-doc-ic"></i>{{ __('Download', domain ) }}
 			</a>

--- a/templates/tease-search.twig
+++ b/templates/tease-search.twig
@@ -1,31 +1,45 @@
-<li id="result-row-{{ post.ID }}" class="media search-result-list-item {{ is_action ? 'search-result-list-item-bg' : '' }}">
-	{% if ( is_document ) %}
+
+{% if ( 'action' == posts_data[post.ID].content_type ) %}
+<li id="result-row-{{ post.ID }}" class="media search-result-list-item search-result-list-item-bg" style="background-image: url('{{ post.thumbnail.src }}');">
+	<div class="blank-block"></div>
+{% else %}
+<li id="result-row-{{ post.ID }}" class="media search-result-list-item">
+{% endif %}
+	{% if ( 'document' == posts_data[post.ID].content_type ) %}
 		<div class="search-result-item-actionbox hidden-sm-down">
-			<button class="btn btn-medium btn-small btn-transparent action-btn">
+			<a href="{{ post.guid }}" download class="btn btn-medium btn-small btn-transparent action-btn">
 				<i class="icon-doc-ic"></i>{{ __( 'Download', domain ) }}
-			</button>
+			</a>
 		</div>
 	{% endif %}
-	{% if ( is_action ) %}
-		<div class="blank-block"></div>
+	{% if ( 'action' != posts_data[post.ID].content_type ) %}
+		<img class="d-flex search-result-item-image" src="{{ post.thumbnail.src }}" alt="{{ post.thumbnail.alt|default( post.title ) }}" />
 	{% endif %}
-	<img class="d-flex search-result-item-image" src="{{ post.thumbnail.src }}" alt="{{ post.thumbnail.alt|default( post.title ) }}" />
 	<div id="tease-{{ post.ID }}" class="media-body search-result-item-body tease tease-{{ post.post_type }}">
 		<div class="search-result-tags">
-			<a href="#" class="search-result-item-title">{{ post.post_type }}</a>
-			<a href="#" class="search-result-item-head">{{ taxonomy }}</a>
-			<a href="#" class="search-result-item-tag">#{{ campaign }}</a>
+			<a href="#" class="search-result-item-title">{{ posts_data[post.ID].content_type_text }}</a>
+			{% for page_type in posts_data[post.ID].page_types %}
+				<a href="#" class="search-result-item-head">{{ page_type.name }}</a>
+			{% endfor %}
+			{% for tag in posts_data[post.ID].tags %}
+				<a href="{{ tag.link }}" class="search-result-item-tag">#{{ tag.name }}</a>{% if ( not loop.last ) %},{% endif %}
+			{% endfor %}
 		</div>
-		<a href="{{ post.link }}" class="search-result-item-headline">{{ post.title|raw }}</a>
+		{% if ( 'document' == posts_data[post.ID].content_type ) %}
+			<a href="{{ post.guid }}" class="search-result-item-headline">{{ post.title|raw }}</a>
+		{% else %}
+			<a href="{{ post.link() }}" class="search-result-item-headline">{{ post.title|raw }}</a>
+		{% endif %}
 		<div class="search-result-item-info">
 			<span class="search-result-item-date">{{ post.post_date|date('d/m/Y') }}</span>
 		</div>
 		<p class="search-result-item-content">{{ post.preview()|truncate( 25, true )|raw }}</p>
-		{% if ( is_document ) %}
-			<button class="btn btn-medium btn-small btn-transparent action-btn hidden-md-up btn-block"><i class="icon-doc-ic"></i>{{ __('Download', domain ) }}</button>
-		{% endif %}
-		{% if ( is_action ) %}
-			<button class="btn btn-primary btn-medium btn-small">TAKE ACTION</button>
+		{% if ( 'action' == posts_data[post.ID].content_type ) %}
+			<a href="{{ post.link }}" class="btn btn-primary btn-medium btn-small">{{ __( 'Take Action', domain ) }}</a>
+		{% elseif ( 'document' == posts_data[post.ID].content_type ) %}
+			<a href="{{ post.guid }}" download="" class="btn btn-medium btn-small btn-transparent action-btn hidden-md-up btn-block">
+				<i class="icon-doc-ic"></i>{{ __('Download', domain ) }}
+			</a>
 		{% endif %}
 	</div>
 </li>


### PR DESCRIPTION
Update Search page markup. Provide all required data to the search and tease-search templates. Result items now display the correct content type, page type, campaign tags. Document items now link directly to the attachment instead of the post that contains it, so that the document can be opened with one click. Download button now works. Action items now have the set featured image as background. Added Take Action button links. Hide Suggested terms block if there are no suggestions.