### PR TITLE
Passing the title raw (after escaping for html) so that if there is a…

### DIFF
--- a/templates/html-header.twig
+++ b/templates/html-header.twig
@@ -2,7 +2,7 @@
 <html>
 <head>
 	<meta charset="{{ site.charset }}">
-	<title>{% if wp_title %}{{ wp_title }} - {{ site.name }}{% else %}{{ site.name }}{% endif %}</title>
+	<title>{% if wp_title %}{{ wp_title|e('esc_html')|raw }} - {{ site.name }}{% else %}{{ site.name }}{% endif %}</title>
 	<meta name="description" content="{{ site.description }}">
 
 	{% if google_tag_value %}


### PR DESCRIPTION
… quote in a title, it does not get converted to html entities