### PR TITLE
Presentation templates disparities

### DIFF
--- a/templates/blocks/header.twig
+++ b/templates/blocks/header.twig
@@ -2,14 +2,15 @@
 	<div class="clearfix page-content-wrap">
 		<div class="fixed-element clearfix">
 			<div class="container">
-				<div class="page-header">
+				<div class="page-header col-md-8 col-lg-8 col-sm-12 pl-0 pr-0">
 					{% if ( issue or campaigns ) %}
 						<div class="top-tags-wrap">
 							{% if ( issue ) %}
 								<a class="category_link category-topic-title" href="{{ issue.link|default('#') }}">{{ issue.name|e('wp_kses_post')|raw }}</a>
-								<span class="category-topic-title-seprater"></span>
 							{% endif %}
+
 							{% if ( campaigns ) %}
+								<span class="category-topic-title-seprater"></span>
 								{% for campaign in campaigns %}
 									<a href="{{ campaign.link }}">#{{ campaign.name|e('wp_kses_post')|raw }}</a>
 								{% endfor %}

--- a/templates/tag.twig
+++ b/templates/tag.twig
@@ -8,26 +8,25 @@
 				background-size: cover;
 			}
 			.tag_template {
-				padding-top: 100px;
+				padding-top: 200px;
 			}
-			.tag_template .tag_header_container {
+			.tag_template > .container {
 				color: white;
 			}
-			.category_link {
+			.page-header > a {
 				font-size: 120%;
 				color: #ffd920;
 				text-transform: uppercase;
 			}
-			.tag_description {
-				width: 40%;
-			}
 		</style>
 	{% endif %}
 	<div class="tag_template">
-		<div class="container tag_header_container">
-			<a class="category_link" href="{{ category_link|default('#') }}">{{ category_name|e('wp_kses_post')|raw }}</a>
-			<h1 class="tag_name">#{{ tag_name|e('wp_kses_post')|raw }}</h1>
-			<p class="tag_description">{{ tag_description }}</p>
+		<div class="container">
+			<div class="page-header col-md-8 col-lg-8 col-sm-12 pl-0 pr-0">
+				<a href="{{ category_link|default('#') }}">{{ category_name|e('wp_kses_post')|raw }}</a>
+				<h1>#{{ tag_name|e('wp_kses_post')|raw }}</h1>
+				<p>{{ tag_description }}</p>
+			</div>
 		</div>
 		{% for name, block in blocks %}
 			{{ block|shortcodes|raw }}


### PR DESCRIPTION
Fix Header Block disparity so that description text does not spread across page width. Also, fixed small issue where the Separator bullet between Issue and Campaign links appeared even if there were no Campaign links. Adjusted Campaign page markup to be similar to presentation layer markup and remove unecessary classes and aligned its header to start at the same height as the other pages headers.