### PR TITLE
Search page bug fixes.

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -155,13 +155,14 @@ class P4_Master_Site extends TimberSite {
 		$context['data_nav_bar'] = [
 			'images'       => $this->theme_images_dir,
 			'home_url'     => home_url( '/' ),
-			'search_query' => get_search_query(),
+			'search_query' => trim( get_search_query() ),
 		];
 		$context['domain']       = 'planet4-master-theme';
 		$context['foo']          = 'bar';   // For unit test purposes.
 		$context['navbar_menu']  = new TimberMenu( 'navigation-bar-menu' );
 		$context['site']         = $this;
 		$context['sort_options'] = $this->sort_options;
+		$context['default_sort']  = P4_Search::DEFAULT_SORT;
 
 		$options                          = get_option( 'planet4_options' );
 		$context['donatelink']            = $options['donate_button'] ?? '#';
@@ -283,6 +284,9 @@ class P4_Master_Site extends TimberSite {
 		wp_enqueue_script( 'main', $this->theme_dir . '/assets/js/main.js', array( 'jquery' ), '0.2.0', true );
 		wp_enqueue_script( 'custom', $this->theme_dir . '/assets/js/custom.js', array( 'jquery' ), '0.1.2', true );
 		wp_enqueue_script( 'slick', 'https://cdn.jsdelivr.net/npm/slick-carousel@1.8.1/slick/slick.min.js', array(), '0.1.0', true );
+		if ( is_search() ) {
+			wp_enqueue_script( 'search', $this->theme_dir . '/assets/js/search.js', array( 'jquery' ), '0.1.0', true );
+		}
 	}
 
 	/**

--- a/search.php
+++ b/search.php
@@ -13,12 +13,14 @@
  * Planet4 - Search functionality.
  */
 if ( is_main_query() && is_search() ) {
-	if ( 'GET' === $_SERVER['REQUEST_METHOD'] ) {
-		$selected_sort = $_GET['orderby'];
+	if ( 'GET' === filter_input( INPUT_SERVER, 'REQUEST_METHOD' ) ) {
+		$selected_sort    = filter_input( INPUT_GET, 'orderby',  FILTER_SANITIZE_STRING );
+		$selected_filters = $_GET['f'];
+		$filters          = [];
 
 		// Handle submitted filter options.
-		if ( is_array( $_GET['f'] ) ) {
-			foreach ( $_GET['f'] as $type => $filter_type ) {
+		if ( $selected_filters && is_array( $selected_filters ) ) {
+			foreach ( $selected_filters as $type => $filter_type ) {
 				foreach ( $filter_type as $name => $id ) {
 					$filters[ $type ][] = [
 						'id'   => $id,
@@ -27,8 +29,7 @@ if ( is_main_query() && is_search() ) {
 				}
 			}
 		}
-		wp_enqueue_script( 'search', get_template_directory_uri() . '/assets/js/search.js', [], '0.1.0', true );
-		$search = new P4_Search( get_search_query(), $selected_sort, $filters );
+		$search = new P4_Search( trim( get_search_query() ), $selected_sort, $filters );
 		$search->add_load_more();
 		$search->view();
 	}

--- a/templates/navigation-bar.twig
+++ b/templates/navigation-bar.twig
@@ -55,7 +55,7 @@
 		<form id="search_form" action="{{ data_nav_bar.home_url }}" class="form nav-item nav-search-wrap">
 			<input type="text" class="form-control" placeholder="{{ __( 'Search', domain ) }}"
 				   value="{{ data_nav_bar.search_query }}" name="s" aria-label="Search">
-			<input id="orderby" type="hidden" name="orderby" value="{{ data_nav_bar.search_query ? ( selected_sort ?? default_sort ) : 'post_date' }}"/>
+			<input id="orderby" type="hidden" name="orderby" value="{{ selected_sort ?? default_sort }}"/>
 			<button class="top-nav-search-btn" type="submit">
 				<i class="fa fa-search"></i>
 				<span class="screen-reader-text">{{ __( 'Search', domain ) }}</span>

--- a/templates/navigation-bar.twig
+++ b/templates/navigation-bar.twig
@@ -55,7 +55,7 @@
 		<form id="search_form" action="{{ data_nav_bar.home_url }}" class="form nav-item nav-search-wrap">
 			<input type="text" class="form-control" placeholder="{{ __( 'Search', domain ) }}"
 				   value="{{ data_nav_bar.search_query }}" name="s" aria-label="Search">
-			<input id="orderby" type="hidden" name="orderby" value="{{ selected_sort ?? 'relevant' }}"/>
+			<input id="orderby" type="hidden" name="orderby" value="{{ data_nav_bar.search_query ? ( selected_sort ?? default_sort ) : 'post_date' }}"/>
 			<button class="top-nav-search-btn" type="submit">
 				<i class="fa fa-search"></i>
 				<span class="screen-reader-text">{{ __( 'Search', domain ) }}</span>

--- a/templates/search.twig
+++ b/templates/search.twig
@@ -7,7 +7,7 @@
 		<div class="container">
 			<div class="without-search-result row clearfix">
 				<div class="col-md-12">
-					<h2 class="result-statement">{{ found_posts }} results for <span>'{{ search_query }}'</span></h2>
+					<h2 class="result-statement">{{ page_title }}</h2>
 					{% if ( not all_posts ) %}
 						<p class="search-info">{{ __( 'We\'re sorry we couldn\'t find any matches for your search term.', domain ) }}</p>
 						<ul class="search-help-info">
@@ -26,7 +26,7 @@
 							<div class="row">
 								<div class="col-md-5">
 									<input type="search" class="form-control mb-2 mb-sm-0" placeholder="{{ __( 'Search', domain ) }}" value="{{ search_query }}" name="s" aria-label="Search">
-									<input type="hidden" name="orderby" value="{{ selected_sort ?? 'relevant' }}" />
+									<input type="hidden" name="orderby" value="{{ search_query ? ( selected_sort ?? default_sort ) : 'post_date' }}" />
 								</div>
 								<div class="col-md-4">
 									<div class="btn-group btn-block" role="group" aria-label="" id="search-type">
@@ -276,7 +276,9 @@
 									<label class="mr-sm-2" for="select_order">{{ __('Sort by', domain ) }}</label>
 									<select id="select_order" name="select_order" class="">
 										{% for key, sort_option in sort_options %}
-											{% if key == selected_sort %}
+											{% if ( not search_query and key == 'relevant' ) %}
+												<option value="{{ key }}" disabled>{{ sort_option.name }}</option>
+											{% elseif key == selected_sort %}
 												<option value="{{ key }}" selected>{{ sort_option.name }}</option>
 											{% else %}
 												<option value="{{ key }}">{{ sort_option.name }}</option>


### PR DESCRIPTION
Fix multiple bugs on search filtering. Bug that was not returning attachments (Documents) when searching for everything. Bug that was not allowing correct filtering by Content Type when we searched for everything. Bug that did not allow multiple Page type filters. Bug that did not allow multiple Content Type filters. Changed implementation so that we can search for everything (with or without filters applied) by not entering anything at all( /?s= ),instead of entering the space character. Made it so that when we search for everything then the 'Most relevant' sort option gets disabled. Page title changes depending on searching for everything or not.