### PR TITLE
1575 search fixes - Spreadsheet issue 129

### DIFF
--- a/classes/class-p4-search.php
+++ b/classes/class-p4-search.php
@@ -52,7 +52,7 @@ if ( ! class_exists( 'P4_Search' ) ) {
 			} else {
 				$this->context = Timber::get_context();
 
-				if ( $this->validate( $this->context, $selected_sort, $filters ) ) {
+				if ( $this->validate( $selected_sort, $filters, $this->context ) ) {
 					$this->selected_sort = $selected_sort;
 					$this->filters       = $filters;
 				}
@@ -389,13 +389,13 @@ if ( ! class_exists( 'P4_Search' ) ) {
 		/**
 		 * Validates the input.
 		 *
-		 * @param array  $context Associative array with the data to be passed to the view.
 		 * @param string $selected_sort The selected orderby to be validated.
 		 * @param array  $filters The selected filters to be validated.
+		 * @param array  $context Associative array with the data to be passed to the view.
 		 *
 		 * @return bool True if validation is ok, false if validation fails.
 		 */
-		public function validate( $context, &$selected_sort, &$filters ) : bool {
+		public function validate( &$selected_sort, &$filters, $context ) : bool {
 			$selected_sort = filter_var( $selected_sort, FILTER_SANITIZE_STRING );
 			if ( ! in_array( $selected_sort, array_keys( $context['sort_options'] ), true ) ) {
 				$selected_sort = P4_Search::DEFAULT_SORT;

--- a/templates/navigation-bar.twig
+++ b/templates/navigation-bar.twig
@@ -54,7 +54,7 @@
 		</button>
 		<form id="search_form" action="{{ data_nav_bar.home_url }}" class="form nav-item nav-search-wrap">
 			<input type="text" class="form-control" placeholder="{{ __( 'Search', domain ) }}"
-				   value="{{ data_nav_bar.search_query }}" name="s" aria-label="Search">
+				   value="{{ data_nav_bar.search_query|e('wp_kses_post')|raw }}" name="s" aria-label="Search">
 			<input id="orderby" type="hidden" name="orderby" value="{{ selected_sort ?? default_sort }}"/>
 			<button class="top-nav-search-btn" type="submit">
 				<i class="fa fa-search"></i>

--- a/templates/search.twig
+++ b/templates/search.twig
@@ -10,7 +10,7 @@
 		<div class="container">
 			<div class="without-search-result row clearfix">
 				<div class="col-md-12">
-					<h2 class="result-statement">{{ page_title }}</h2>
+					<h2 class="result-statement">{{ page_title|e('wp_kses_post')|raw }}</h2>
 					{% if ( not posts ) %}
 						<p class="search-info">{{ __( 'We\'re sorry we couldn\'t find any matches for your search term.', domain ) }}</p>
 						<ul class="search-help-info">
@@ -28,7 +28,7 @@
 						<form id="search_form_inner" role="search" class="form" action="{{ data_nav_bar.home_url }}">
 							<div class="row">
 								<div class="col-md-5">
-									<input type="search" class="form-control mb-2 mb-sm-0" placeholder="{{ __( 'Search', domain ) }}" value="{{ search_query }}" name="s" aria-label="Search">
+									<input type="search" class="form-control mb-2 mb-sm-0" placeholder="{{ __( 'Search', domain ) }}" value="{{ search_query|e('wp_kses_post')|raw }}" name="s" aria-label="Search">
 									<input type="hidden" name="orderby" value="{{ selected_sort ?? default_sort }}" />
 								</div>
 								<div class="col-md-4">


### PR DESCRIPTION
Display correctly the search input inside both search fields and in the page title as well, when it contains special characters.
The get_search_query() escapes the search input value by default but I still escape the variable that contains it on output (just to be sure in case someone else changes what this variable contains)