### PR TITLE
1575 search fixes - Spreadsheet issue 156

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -468,7 +468,7 @@ class P4_Master_Site extends TimberSite {
 		$selected_sort = filter_input( INPUT_GET, 'orderby', FILTER_SANITIZE_STRING );
 		$selected_sort = sanitize_sql_orderby( $selected_sort );
 
-		if ( P4_Search::DEFAULT_SORT !== $selected_sort ) {
+		if ( $selected_sort && P4_Search::DEFAULT_SORT !== $selected_sort ) {
 			$selected_order = $this->sort_options[ $selected_sort ]['order'];
 			$orderby        = esc_sql( sprintf( 'ORDER BY %s %s', $selected_sort, $selected_order ) );
 		} else {


### PR DESCRIPTION
Check that orderby URL param is actually set before applying the ORDER BY clause, so that it will not cause a wrong SQL clause and so that search links can work without orderby param included in the link (e.g. 404 search form).