### PR TITLE
Campaign page update - Spreadsheet issue 165

### DIFF
--- a/tag.php
+++ b/tag.php
@@ -86,10 +86,6 @@ if ( is_tag() ) {
 
 	$campaign->add_block( HappyPoint::BLOCK_NAME, [
 		'background'          => $background,
-		'boxout_title'        => __( 'Get action alerts in your inbox', 'planet4-master-theme' ),
-		'boxout_descr'        => __( 'Some text here about the transparency of the communications. Opt out or contact us at any time.', 'planet4-master-theme' ),
-		'boxout_link_text'    => __( 'Subscribe', 'planet4-master-theme' ),
-		'boxout_link_url'     => '#',
 		'background_html'     => wp_get_attachment_image( $background ),
 		'background_src'      => wp_get_attachment_image_src( $background, 'full' ),
 		'engaging_network_id' => $options['engaging_network_form_id'] ?? '',

--- a/tag.php
+++ b/tag.php
@@ -80,12 +80,21 @@ if ( is_tag() ) {
 		'category_id' => $category->term_id ?? __( 'This Campaign is not assigned to an Issue', 'planet4-master-theme' ),
 	] );
 
+	// Get the image selected as background for the Subscribe section (HappyPoint block) inside the current Tag.
+	$background = get_term_meta( $context['tag']->term_id, 'happypoint_attachment_id', true );
+	$options    = get_option( 'planet4_options' );
+
 	$campaign->add_block( HappyPoint::BLOCK_NAME, [
-		'background'       => get_term_meta( $context['tag']->term_id, 'happypoint_attachment_id', true ),
-		'boxout_title'     => __( 'Get action alerts in your inbox', 'planet4-master-theme' ),
-		'boxout_descr'     => __( 'Some text here about the transparency of the communications. Opt out or contact us at any time.', 'planet4-master-theme' ),
-		'boxout_link_text' => __( 'Subscribe', 'planet4-master-theme' ),
-		'boxout_link_url'  => '#',
+		'background'          => $background,
+		'boxout_title'        => __( 'Get action alerts in your inbox', 'planet4-master-theme' ),
+		'boxout_descr'        => __( 'Some text here about the transparency of the communications. Opt out or contact us at any time.', 'planet4-master-theme' ),
+		'boxout_link_text'    => __( 'Subscribe', 'planet4-master-theme' ),
+		'boxout_link_url'     => '#',
+		'background_html'     => wp_get_attachment_image( $background ),
+		'background_src'      => wp_get_attachment_image_src( $background, 'full' ),
+		'engaging_network_id' => $options['engaging_network_form_id'] ?? '',
+		'opacity'             => number_format( ( 30 / 100 ), 1 ),
+		'mailing_list_iframe' => 'true',
 	] );
 
 	$campaign->view();


### PR DESCRIPTION
Update Campaign page code so that it can correctly auto-generate the Happy Point block now that it is updated with EN mailing list.

The web editors need to set the background image for the Happy Point block, located within the Tag page itself inside the WP admin panel.