### PR TITLE
Changed avatar size used in author_profile template.

### DIFF
--- a/templates/blocks/author_profile.twig
+++ b/templates/blocks/author_profile.twig
@@ -9,7 +9,9 @@
 		</div>
 		<figure class="author-block-image">
 			{% if ( post.author.avatar ) %}
-				<img itemprop="image" class="author-pic" src="{{ post.author.avatar }}" alt="{{ post.author.name }}">
+				<img itemprop="image" class="author-pic"
+				     src="{{ fn('get_avatar_url', post.author.id, {'size' : 294}) }}"
+				     alt="{{ post.author.name }}">
 			{% endif %}
 		</figure>
 	</footer>


### PR DESCRIPTION
Timber uses default wordpress value (96px) for avatar url creation.
Changed to 294px to look closer to the design.
[Issue 1651](https://jira.greenpeace.org/browse/PLANET-1651)