### PR TITLE
Show tag name instead of slug

### DIFF
--- a/templates/single.twig
+++ b/templates/single.twig
@@ -17,7 +17,7 @@
 						<a class="tag-item tag-item--main" href="{{ filter_url }}">{{ page_type }}</a>
 					{% endif %}
 					{% for tag in post.tags %}
-						<a class="tag-item " href="{{ tag.link }}">#{{ tag.title }}</a>
+						<a class="tag-item " href="{{ tag.link }}">#{{ tag_name|e('wp_kses_post')|raw }}</a>
 					{% endfor %}
 				</div>
 				<h1 class="page-header-title">{{ post.title|raw }}</h1>


### PR DESCRIPTION
Per [this comment](https://jira.greenpeace.org/browse/PLANET-1581?focusedCommentId=60973&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-60973) the Take Action card on Posts shows the slug instead of the name. This commit fixes that.