### PR TITLE
Disallow creation of tags to all roles besides administrator

### DIFF
--- a/partials/tags_box.php
+++ b/partials/tags_box.php
@@ -1,0 +1,13 @@
+<ul id="p4_tags_list" style="height: 150px; overflow: auto; border: 1px solid #dfdfdf; margin: 1em 0; padding: .5em;">
+	<?php foreach ( $tags as $tag ) { ?>
+		<li>
+			<input type="checkbox" data-wp-taxonomy="post_tag" value="<?php echo $tag->name; ?>"
+			       name="tax_input[post_tag][]" id="tagged_<?php echo $tag->term_id; ?>"
+				<?php if ( in_array( $tag->term_id, $assigned_tags, true ) ) {
+					echo ' checked="true"';
+				} ?>/>
+			<label for="tagged_<?php echo $tag->term_id; ?>"><?php echo $tag->name; ?></label>
+		</li>
+	<?php } ?>
+</ul>
+<p>New tags can only be added by an administrator.</p>


### PR DESCRIPTION
Add functions to disallow creation of tags to all roles besides administrator.

- Remove default wordpress selection box for all roles besides administrator.
- Add checkboxes list for selecting post's / page's tags for all roles besides administrator.
- Add hook to prevent creation of tags for all roles besides administrator.

[Issue 1690](https://jira.greenpeace.org/browse/PLANET-1690)