### PR TITLE
Remove obsolete tags_support_query function.

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -115,7 +115,6 @@ class P4_Master_Site extends TimberSite {
 		add_filter( 'searchwp_query_orderby',   array( $this, 'edit_searchwp_query_orderby' ), 11, 2 );
 		add_filter( 'posts_where',              array( $this, 'edit_search_mime_types' ) );
 		add_action( 'cmb2_admin_init',          array( $this, 'register_header_metabox' ) );
-//		add_action( 'pre_get_posts',            array( $this, 'tags_support_query' ) );
 		add_action( 'admin_enqueue_scripts',    array( $this, 'enqueue_admin_assets' ) );
 		add_action( 'wp_enqueue_scripts',       array( $this, 'enqueue_public_assets' ) );
 		add_filter( 'wp_kses_allowed_html',     array( $this, 'set_custom_allowed_attributes_filter' ) );
@@ -532,21 +531,6 @@ class P4_Master_Site extends TimberSite {
 	 */
 	public function register_oembed_provider() {
 		wp_oembed_add_provider( '#https?://(?:www\.)?[^/^\.]+\.carto(db)?\.com/\S+#i', 'https://services.carto.com/oembed', true );
-	}
-
-	/**
-	 * Include tags and categories when querying.
-	 *
-	 * @param WP_Query $wp_query The WP_Query object.
-	 */
-	public function tags_support_query( $wp_query ) {
-		if ( $wp_query->get( 'tag' ) ) {
-			$wp_query->set( 'post_type', 'any' );
-		}
-
-		if ( $wp_query->get( 'category_name' ) ) {
-			$wp_query->set( 'post_type', 'any' );
-		}
 	}
 
 	/**


### PR DESCRIPTION
Remove obsolete tags_support_query function, since it does not affect functionality.
Related to PR #212 