### PR TITLE
Feature/1642 check categories on post save

### DIFF
--- a/assets/admin/js/edit_post.js
+++ b/assets/admin/js/edit_post.js
@@ -1,19 +1,36 @@
 $(document).ready(function () {
 
+	// Populate array with planet4 page types if it is not defined from the backend.
+	if (p4_page_types === undefined) {
+		var p4_page_types = ["press release", "publication", "story"];
+	}
+
+	// Populate array with categories that are also planet4 page types
+	var categories_array = $('#categorychecklist input[type=checkbox]').map(
+		function () {
+			var category = $.trim($(this).parent().text()).toLowerCase();
+			var category_id = $.trim($(this).attr('id'));
+			if (p4_page_types.includes(category)) {
+				return {id: category_id, category: category}
+			}
+		}).get();
+
 	// Click event listener for categories select box.
 	// If a category is chosen that is also a p4-page-type, then change also the p4-page-type attribute of the page.
 	$('#categorychecklist input[type=checkbox]').on("change", function () {
 		var category_name = $.trim($(this).parent().text()).toLowerCase();
-		var p4_page_types = $('select[name="p4-page-type"] option').map(
-			function () {
-				return $.trim($(this).text()).toLowerCase();
-			}).get().filter(e => 'none' !== e);
 
 		if ($(this).prop("checked") === true) {
-			if ($.inArray(category_name.toLowerCase(), p4_page_types) > -1) {
-				var select_value = category_name.split(" ").join("-");
-				$("select[name='p4-page-type']").val(select_value);
+			if (p4_page_types.includes(category_name)) {
+				remove_categories(categories_array, category_name);
 			}
 		}
 	});
+
+	function remove_categories(categories_array, category_name) {
+		var categories_to_be_removed = categories_array.filter(e = > e.category !== category_name);
+		categories_to_be_removed.forEach(function (category) {
+			$("#categorychecklist input[id=" + category.id + "]").prop('checked', false);
+		});
+	}
 });

--- a/assets/admin/js/edit_post.js
+++ b/assets/admin/js/edit_post.js
@@ -28,7 +28,7 @@ $(document).ready(function () {
 	});
 
 	function remove_categories(categories_array, category_name) {
-		var categories_to_be_removed = categories_array.filter(e = > e.category !== category_name);
+		var categories_to_be_removed = categories_array.filter(e => e.category !== category_name);
 		categories_to_be_removed.forEach(function (category) {
 			$("#categorychecklist input[id=" + category.id + "]").prop('checked', false);
 		});

--- a/functions.php
+++ b/functions.php
@@ -303,6 +303,18 @@ class P4_Master_Site extends TimberSite {
 
 		if ( 'post.php' === $hook || 'post-new.php' === $hook ) {
 			wp_enqueue_script( 'edit_post', $this->theme_dir . '/assets/admin/js/edit_post.js', array( 'jquery' ), '0.0.1', true );
+
+			// get planet4 page types
+			$terms = get_terms( [
+				'taxonomy' => 'p4-page-type',
+				'hide_empty' => false,
+			] );
+
+			// get planet4 page types slugs.
+			$p4_page_types = array_map(function($k) {
+				return $k->slug;
+			}, $terms);
+			wp_localize_script( 'edit_post', 'p4_page_types', $p4_page_types );
 		}
 	}
 
@@ -414,15 +426,18 @@ class P4_Master_Site extends TimberSite {
 			'new_item_name'     => __( 'New Page Type' ),
 			'menu_name'         => __( 'Page Types' ),
 		];
-		$args         = [
-			'hierarchical' => false,
-			'labels'       => $p4_page_type,
-			'show_ui'      => true,
-			'query_var'    => true,
-			'rewrite'      => [
+		$args = [
+			'hierarchical'       => false,
+			'labels'             => $p4_page_type,
+			'show_ui'            => true,
+			'show_admin_column'  => false,
+			'show_in_nav_menus'  => true,
+			'query_var'          => true,
+			'show_in_quick_edit' => false,
+			'rewrite'            => [
 				'slug' => 'p4-page-types',
 			],
-			'meta_box_cb'  => [ $this, 'p4_metabox_markup' ]
+			'meta_box_cb'        => false
 		];
 		register_taxonomy( 'p4-page-type', [ 'p4_page_type', 'post' ], $args );
 
@@ -458,7 +473,7 @@ class P4_Master_Site extends TimberSite {
 	}
 
 	/**
-	 * Save custom taxonomy for planet4 post types
+	 * Save custom taxonomy for planet4 post types according to the categories that were assigned to the post.
 	 *
 	 * @param int $post_id Id of the saved post.
 	 */
@@ -467,53 +482,62 @@ class P4_Master_Site extends TimberSite {
 		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
 			return;
 		}
-		// Check nonce.
-		if ( ! isset( $_POST['p4-page-type-nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['p4-page-type-nonce'] ) ), 'p4-save-page-type' ) ) {
-			return;
-		}
+
 		// Check user's capabilities.
 		if ( ! current_user_can( 'edit_post', $post_id ) ) {
 			return;
 		}
+
 		// Make sure there's input.
-		if ( ! isset( $_POST['p4-page-type'] ) ) { // Input var okay.
+		if ( ! isset( $_POST['post_category'] ) ) { // Input var okay.
 			return;
 		}
-		// If "none" was selected, remove the term.
-		if ( $_POST['p4-page-type'] === '-1' ) {
+
+		// get assigned to post categories.
+		$assigned_categories = $_POST['post_category'];
+
+		// get available categories.
+		$p4_wp_categories = get_categories();
+
+		// get planet4 page types
+		$terms = get_terms( array(
+			'taxonomy'   => 'p4-page-type',
+			'hide_empty' => false,
+		) );
+
+		// get planet4 page types slugs.
+		$p4_page_types_slugs = array_map( function ( $k ) {
+			return $k->slug;
+		}, $terms );
+
+		if ( empty( $assigned_categories ) ) {
+			return;
+		}
+
+		// Determine which of the categories assigned are also a planet4 page type.
+		$matches_found = 0;
+		$matched_slugs = [];
+		foreach ( $assigned_categories as $assigned_category ) {
+			foreach ( $p4_wp_categories as $category ) {
+				if ( intval( $assigned_category ) == $category->term_id && in_array( $category->slug, $p4_page_types_slugs ) ) {
+					$matched_slugs[] = $category->slug;
+					$matches_found ++;
+				}
+			}
+		}
+
+		// If more than one of those categories are assigned, then remove all of those from the post.
+		// If only one of these categories are assigned, assign also p4-page-type to post.
+		// Else remove the p4-page-type attribute from the post.
+		if ( $matches_found > 1 ) {
+			foreach ( $matched_slugs as $slug ) {
+				wp_remove_object_terms( $post_id, $slug, 'category' );
+			}
+		} else if ( $matches_found == 1 && ! empty( $matched_slugs ) ) {
+			wp_set_post_terms( $post_id, $matched_slugs[0], 'p4-page-type' );
+		} else if ( $matches_found == 0 ) {
 			wp_set_post_terms( $post_id, [], 'p4-page-type' );
-
-			return;
 		}
-		// Make sure the term exists and it's not an error.
-		$selected = get_term_by( 'slug', sanitize_text_field( wp_unslash( $_POST['p4-page-type'] ) ), 'p4-page-type' ); // Input var okay.
-		if ( false === $selected || is_wp_error( $selected ) ) {
-			return;
-		}
-		// Save post type.
-		wp_set_post_terms( $post_id, sanitize_text_field( $selected->slug ), 'p4-page-type' );
-	}
-
-	/**
-	 * Add a dropdown to choose planet4 post type.
-	 *
-	 * @param WP_Post $post
-	 */
-	public function p4_metabox_markup( WP_Post $post ) {
-		$attached_type = get_the_terms( $post, 'p4-page-type' );
-		$current_type  = ( is_array( $attached_type ) ) ? $attached_type[0]->slug : -1;
-		$all_types     = get_terms( 'p4-page-type', [ 'hide_empty' => false ] );
-		wp_nonce_field( 'p4-save-page-type', 'p4-page-type-nonce' );
-		?>
-		<select name="p4-page-type">
-			<?php foreach ( $all_types as $term ) : ?>
-				<option <?php selected( $current_type, $term->slug ); ?> value="<?php echo esc_attr( $term->slug ); ?>">
-					<?php echo esc_html( $term->name ); ?>
-				</option>
-			<?php endforeach; ?>
-			<option value="-1" <?php selected( -1, $current_type ); ?> >none</option>
-		</select>
-		<?php
 	}
 
 	/**


### PR DESCRIPTION
Assign p4-page-type to post after post save, if one of the relevant categories ("Press Release", "Publication", "Story") is selected.

Allow only one of the planet4 page type categories to be selected in edit post page.

Remove p4-page-type select box from edit post page.

[Issue 1642](https://jira.greenpeace.org/browse/PLANET-1642?focusedCommentId=61130&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-61130)