### PR TITLE
[PLANET-1780] Expand page backgrounds to full width and height

### DIFF
--- a/assets/scss/common/_page-header.scss
+++ b/assets/scss/common/_page-header.scss
@@ -82,6 +82,11 @@
       @include linear-gradient( 360deg, $white 0%, transparent 100% );
     }
   }
+
+  img {
+    width: 100%;
+    height: auto;
+  }
 }
 
 .page-header-image {

--- a/assets/scss/common/_skewed-overlay.scss
+++ b/assets/scss/common/_skewed-overlay.scss
@@ -2,15 +2,6 @@
   pointer-events: none;
   height: 100%;
 
-  /* To accomodate very long content. */
-  @include mobile-only {
-    max-height: 4500px;
-  }
-
-  @include medium-and-up {
-    max-height: 9000px;
-  }
-
   width: 100%;
   position: absolute;
   z-index: 1;


### PR DESCRIPTION
Not sure why we had `max-height` on `.skewed-overlay` since we have `height: 100%`. This caused the gradients to stop on very [long pages](https://dev.p4.greenpeace.org/international/explore/about/worldwide/).