### PR TITLE
[PLANET 1722] Use smaller height on iframes on mobile

### DIFF
--- a/assets/scss/pages/post/_article-content.scss
+++ b/assets/scss/pages/post/_article-content.scss
@@ -89,7 +89,7 @@
 
     iframe {
       width: 100%;
-      height: 240px;
+      height: 170px;
       text-align: center;
       display: block;
       margin: 0 auto;


### PR DESCRIPTION
It's hard to have perfect iframe height for the entire mobile breakpoint. I optimized it for `320px` and `360px` that most smartphones use.