### PR TITLE
[PLANET-1581] Float only action cards on sidebar

### DIFF
--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -373,7 +373,7 @@ $(function() {
 
 $(function() {
   // Force the Cover card to follow scroll
-  var $sidebar = $("#action-card");
+  var $sidebar = $('.post-content').find('> #action-card');
   var $window = $(window);
   var offset = $sidebar.offset();
   var topPadding = 100;


### PR DESCRIPTION
Since we allow editors to add the cover card as a post element anywhere in the post we need to make sure we only float the cards that are added as block on the sidebar.