### PR TITLE
[PLANET-1642] Map p4 page types to categories

### DIFF
--- a/assets/admin/js/edit_post.js
+++ b/assets/admin/js/edit_post.js
@@ -39,8 +39,7 @@ $(document).ready(function () {
 					var select_value = p4_page_type_mapping.filter(function (e) {return e.category_id == category_id});
 					$("select[name='p4-page-type']").val(select_value[0].p4_page_type_slug);
 					remove_categories(categories_array, category_name);
-				}
-				else {
+				} else {
 					$("select[name='p4-page-type']").val('-1');
 				}
 			}

--- a/assets/admin/js/edit_post.js
+++ b/assets/admin/js/edit_post.js
@@ -1,26 +1,30 @@
 $(document).ready(function () {
 
 
+	// Parse p4_page_type passed to a variable server-side.
+	if (undefined !== p4_page_type_mapping) {
+		p4_page_type_mapping = JSON.parse(p4_page_type_mapping);
+	}
+
+	// Remove/uncheck categories that are mapped to planet4 page types.
 	function remove_categories(categories_array, category_name) {
-		var categories_to_be_removed = categories_array.filter(e => e.category !== category_name);
+		var categories_to_be_removed = categories_array.filter(function (e) {
+			return e.category !== category_name
+		});
 		categories_to_be_removed.forEach(function (category) {
-			$("#categorychecklist input[id="+category.id+"]").prop('checked', false);
+			$("#categorychecklist input[value=" + category.id + "]").prop('checked', false);
 		});
 	}
 
-	// Populate array with planet4 page types
-	var p4_page_types = $('select[name="p4-page-type"] option').map(
-		function () {
-			return $.trim($(this).text()).toLowerCase();
-		}).get().filter(e => 'none' !== e);
-
-	// Populate array with categories that are also planet4 page types
+	// Populate array with categories that are also planet4 page types.
 	var categories_array = $('#categorychecklist input[type=checkbox]').map(
 		function () {
 			var category = $.trim($(this).parent().text()).toLowerCase();
-			var category_id = $.trim($(this).attr('id'));
-			if (p4_page_types.includes(category)) {
-				return {id: category_id, category: category}
+			var category_id = parseInt($.trim($(this).attr('value')));
+			if (undefined !== p4_page_type_mapping) {
+				if (p4_page_type_mapping.map(function (e) {return e.category_id}).includes(category_id)) {
+					return {id: category_id, category: category}
+				}
 			}
 		}).get();
 
@@ -28,31 +32,18 @@ $(document).ready(function () {
 	// If a category is chosen that is also a p4-page-type, then change also the p4-page-type attribute of the page.
 	$('#categorychecklist input[type=checkbox]').on("change", function () {
 		var category_name = $.trim($(this).parent().text()).toLowerCase();
-
-		if ($(this).prop("checked") === true) {
-			if (p4_page_types.includes(category_name) ) {
-				var select_value = category_name.split(" ").join("-");
-				$("select[name='p4-page-type']").val(select_value);
-				remove_categories(categories_array, category_name);
+		var category_id = parseInt($.trim($(this).attr('value')));
+		if (undefined !== p4_page_type_mapping) {
+			if (p4_page_type_mapping.map(function (e) {return e.category_id}).includes(category_id)) {
+				if ($(this).prop("checked") === true) {
+					var select_value = p4_page_type_mapping.filter(function (e) {return e.category_id == category_id});
+					$("select[name='p4-page-type']").val(select_value[0].p4_page_type_slug);
+					remove_categories(categories_array, category_name);
+				}
+				else {
+					$("select[name='p4-page-type']").val('-1');
+				}
 			}
 		}
 	});
-
-	// Change event listener for planet4 page type select box.
-	// Select the proper category when a planet4 page type is selected and deselect the rest categories that are
-	// planet4 page types.
-	$("select[name='p4-page-type']").on("change", function () {
-		var page_type = $.trim($(this).find(":selected").text()).toLowerCase();
-		if (page_type === 'none') {
-			return;
-		}
-
-		remove_categories(categories_array, page_type);
-		categories_array.forEach(function (category) {
-			if (page_type === category.category) {
-				$("input[id="+category.id+"]").prop('checked', true);
-			}
-		});
-	});
-
 });

--- a/assets/admin/js/planet4_settings.js
+++ b/assets/admin/js/planet4_settings.js
@@ -1,0 +1,33 @@
+jQuery(document).ready(function () {
+
+
+	$("select[name^=p4_page_type_]").on("change", function () {
+		var p4_page_type_mapping = populate_mapping_field();
+		$('#p4-page-types-mapping').val(JSON.stringify(p4_page_type_mapping));
+	});
+
+	function populate_mapping_field() {
+
+		var result = [];
+		$('select[name^=p4_page_type_]').each(function () {
+			var slug = $(this).attr("name");
+			slug = slug.replace('p4_page_type_', '').replace('_category', '');
+			var category_slug = $.trim($(this).find(":selected").text()).toLowerCase();
+			var p4_page_type_id = p4_page_types.filter(function (e) {
+				return e.slug == slug;
+			});
+			var category_id = categories.filter(function (e) {
+				return e.slug == category_slug;
+			});
+			p4_page_type_id = p4_page_type_id.length === 0 ? '' : p4_page_type_id[0].term_id;
+			category_id = category_id.length === 0 ? '' : category_id[0].term_id;
+			result.push({
+				p4_page_type_id: p4_page_type_id,
+				p4_page_type_slug: slug,
+				category_slug: category_slug,
+				category_id: category_id
+			})
+		});
+		return result;
+	}
+});

--- a/assets/admin/js/planet4_settings.js
+++ b/assets/admin/js/planet4_settings.js
@@ -12,13 +12,22 @@ jQuery(document).ready(function () {
 		$('select[name^=p4_page_type_]').each(function () {
 			var slug = $(this).attr("name");
 			slug = slug.replace('p4_page_type_', '').replace('_category', '');
-			var category_slug = $.trim($(this).find(":selected").text()).toLowerCase();
-			var p4_page_type_id = p4_page_types.filter(function (e) {
-				return e.slug == slug;
-			});
-			var category_id = categories.filter(function (e) {
-				return e.slug == category_slug;
-			});
+			var category_slug = $.trim($(this).find(':selected').val());
+
+			var p4_page_type_id = [];
+			if (undefined !== p4_page_types) {
+				// Variable p4_page_types is passed from backend.
+				p4_page_type_id = p4_page_types.filter(function (e) {
+					return e.slug == slug;
+				});
+			}
+			var category_id = [];
+			if (undefined !== categories) {
+				// Variable categories is passed from backend.
+				category_id = categories.filter(function (e) {
+					return e.slug == category_slug;
+				});
+			}
 			p4_page_type_id = p4_page_type_id.length === 0 ? '' : p4_page_type_id[0].term_id;
 			category_id = category_id.length === 0 ? '' : category_id[0].term_id;
 			result.push({

--- a/classes/class-p4-settings.php
+++ b/classes/class-p4-settings.php
@@ -38,7 +38,7 @@ if ( ! class_exists( 'P4_Settings' ) ) {
 			// Set our title
 			$this->title   = __( 'Planet4', 'planet4-master-theme' );
 
-			$this->fields = apply_filters( 'planet4_options', [
+			$this->fields = [
 				[
 					'name'    => __( 'Select Act Page', 'planet4-master-theme' ),
 					'id'      => 'act_page',
@@ -113,7 +113,7 @@ if ( ! class_exists( 'P4_Settings' ) ) {
 					],
 				],
 
-			] );
+			];
 			$this->hooks();
 		}
 
@@ -123,6 +123,7 @@ if ( ! class_exists( 'P4_Settings' ) ) {
 		public function hooks() {
 			add_action( 'admin_init', [ $this, 'init' ] );
 			add_action( 'admin_menu', [ $this, 'add_options_page' ] );
+			add_action( 'registered_taxonomy', [ $this,'add_p4_page_types_categories_fields'] );
 			add_filter( 'cmb2_render_act_page_dropdown', [ $this, 'p4_render_act_page_dropdown' ], 10, 2 );
 			add_filter( 'cmb2_render_explore_page_dropdown', [ $this, 'p4_render_explore_page_dropdown' ], 10, 2 );
 			add_filter( 'cmb2_render_category_select_taxonomy', [ $this, 'p4_render_category_dropdown' ], 10, 2 );
@@ -214,6 +215,46 @@ if ( ! class_exists( 'P4_Settings' ) ) {
 				'show_names' => true,
 				'fields'     => $this->fields,
 			];
+		}
+
+		/**
+		 * Register fields for mapping between planet4 page types and categories.
+		 * Hook for p4-page-type taxonomy register.
+		 */
+		public function add_p4_page_types_categories_fields( $taxonomy ) {
+			if ( 'p4-page-type' !== $taxonomy ) {
+				return;
+			}
+
+			$p4        = [];
+			$i         = 1;
+			$all_types = get_terms( [ 'taxonomy' => 'p4-page-type', 'hide_empty' => false ] );
+			foreach ( $all_types as $term ) {
+				$temp_attributes = [
+					'name'           => $term->name,
+					'desc'           => 'Map ' . $term->name . ' planet4 page type to a category',
+					'id'             => 'p4_page_type_' . $term->slug . '_category',
+					'taxonomy'       => 'category',
+					'type'           => 'taxonomy_select',
+					'remove_default' => 'true',
+				];
+				if ( $i === 1 ) {
+					$temp_attributes['before_row'] = '<hr><p>Planet4 page types - Categories mapping</p>
+							<p>When a post is assigned to one of the selected categories, 
+							the post will be assigned the mapped planet4 page type.</p>';
+				}
+				if ( $i === count( $all_types ) ) {
+					$temp_attributes['after_row'] = '<hr>';
+				}
+				$p4[] = $temp_attributes;
+				$i++;
+			}
+			$p4[]         = [
+				'id'   => 'p4-page-types-mapping',
+				'type' => 'hidden',
+			];
+			$this->fields = array_merge( $this->fields, $p4 );
+			$this->fields = apply_filters( 'planet4_options', $this->fields );
 		}
 	}
 }

--- a/classes/class-p4-settings.php
+++ b/classes/class-p4-settings.php
@@ -123,7 +123,7 @@ if ( ! class_exists( 'P4_Settings' ) ) {
 		public function hooks() {
 			add_action( 'admin_init', [ $this, 'init' ] );
 			add_action( 'admin_menu', [ $this, 'add_options_page' ] );
-			add_action( 'registered_taxonomy', [ $this,'add_p4_page_types_categories_fields'] );
+			add_action( 'registered_taxonomy', [ $this, 'add_p4_page_types_categories_fields' ] );
 			add_filter( 'cmb2_render_act_page_dropdown', [ $this, 'p4_render_act_page_dropdown' ], 10, 2 );
 			add_filter( 'cmb2_render_explore_page_dropdown', [ $this, 'p4_render_explore_page_dropdown' ], 10, 2 );
 			add_filter( 'cmb2_render_category_select_taxonomy', [ $this, 'p4_render_category_dropdown' ], 10, 2 );
@@ -220,6 +220,8 @@ if ( ! class_exists( 'P4_Settings' ) ) {
 		/**
 		 * Register fields for mapping between planet4 page types and categories.
 		 * Hook for p4-page-type taxonomy register.
+		 *
+		 * @param string $taxonomy Taxonomy slug.
 		 */
 		public function add_p4_page_types_categories_fields( $taxonomy ) {
 			if ( 'p4-page-type' !== $taxonomy ) {
@@ -228,7 +230,10 @@ if ( ! class_exists( 'P4_Settings' ) ) {
 
 			$p4        = [];
 			$i         = 1;
-			$all_types = get_terms( [ 'taxonomy' => 'p4-page-type', 'hide_empty' => false ] );
+			$all_types = get_terms( [
+				'taxonomy'   => 'p4-page-type',
+				'hide_empty' => false,
+			] );
 			foreach ( $all_types as $term ) {
 				$temp_attributes = [
 					'name'           => $term->name,
@@ -239,7 +244,7 @@ if ( ! class_exists( 'P4_Settings' ) ) {
 					'type'           => 'taxonomy_select',
 					'remove_default' => 'true',
 				];
-				if ( $i === 1 ) {
+				if ( 1 === $i ) {
 					$temp_attributes['before_row'] = '<hr><p>' .
 													 __( 'Planet4 page types - Categories mapping' ) .
 													 '</p><p>' .
@@ -247,7 +252,7 @@ if ( ! class_exists( 'P4_Settings' ) ) {
 													      the post will be assigned the mapped planet4 page type.' ) .
 													 '</p>';
 				}
-				if ( $i === count( $all_types ) ) {
+				if ( count( $all_types ) === $i ) {
 					$temp_attributes['after_row'] = '<hr>';
 				}
 				$p4[] = $temp_attributes;

--- a/classes/class-p4-settings.php
+++ b/classes/class-p4-settings.php
@@ -232,16 +232,20 @@ if ( ! class_exists( 'P4_Settings' ) ) {
 			foreach ( $all_types as $term ) {
 				$temp_attributes = [
 					'name'           => $term->name,
-					'desc'           => 'Map ' . $term->name . ' planet4 page type to a category',
+					// translators: placeholder is a term which does not need translation in context.
+					'desc'           => sprintf( __( 'Map %s planet4 page type to a category' ), $term->name ),
 					'id'             => 'p4_page_type_' . $term->slug . '_category',
 					'taxonomy'       => 'category',
 					'type'           => 'taxonomy_select',
 					'remove_default' => 'true',
 				];
 				if ( $i === 1 ) {
-					$temp_attributes['before_row'] = '<hr><p>Planet4 page types - Categories mapping</p>
-							<p>When a post is assigned to one of the selected categories, 
-							the post will be assigned the mapped planet4 page type.</p>';
+					$temp_attributes['before_row'] = '<hr><p>' .
+													 __( 'Planet4 page types - Categories mapping' ) .
+													 '</p><p>' .
+													 __( 'When a post is assigned to one of the selected categories, 
+													      the post will be assigned the mapped planet4 page type.' ) .
+													 '</p>';
 				}
 				if ( $i === count( $all_types ) ) {
 					$temp_attributes['after_row'] = '<hr>';

--- a/functions.php
+++ b/functions.php
@@ -304,8 +304,7 @@ class P4_Master_Site extends TimberSite {
 		if ( 'post.php' === $hook || 'post-new.php' === $hook ) {
 			wp_enqueue_script( 'edit_post', $this->theme_dir . '/assets/admin/js/edit_post.js', array( 'jquery' ), '0.0.1', true );
 			wp_localize_script( 'edit_post', 'p4_page_type_mapping', planet4_get_option( 'p4-page-types-mapping' ) );
-		}
-		else if ( 'settings_page_planet4_options' === $hook ) {
+		} elseif ( 'settings_page_planet4_options' === $hook ) {
 
 			// Get planet4 page types.
 			$terms = get_terms( [


### PR DESCRIPTION
- Add planet4 settings js. 
- Add fields in planet4 settings page for mapping p4 page types to wordpress categories.
- Change save_post hook to assign the proper p4 page type to the post according to the mapping.
- In edit post page only one of the mapped categories can be chosen and p4-page-type will be changed according to the mapping.

[Issue 1642](https://jira.greenpeace.org/browse/PLANET-1642)