### PR TITLE
[PLANET-1807] Update timber-library to 1.7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
 		}
 	},
 	"require": {
-		"wpackagist-plugin/timber-library": "1.5.*",
+		"wpackagist-plugin/timber-library": "1.7.0",
 		"wpackagist-plugin/cmb2": "2.3.0"
 	}
 }


### PR DESCRIPTION
I updated Timber locally and I didn't noticed anything weird