### PR TITLE
[PLANET-1707] Enforce typography styling on bare content

### DIFF
--- a/assets/scss/pages/post/_article-content.scss
+++ b/assets/scss/pages/post/_article-content.scss
@@ -294,6 +294,19 @@
 
 .post-details {
   font-family: $lora;
+  line-height: 1.6;
+
+  @include small-and-up {
+    font-size: rem(19);
+  }
+
+  @include medium-and-up {
+    font-size: rem(16);
+  }
+
+  @include x-large-and-up {
+    font-size: rem(18)
+  }
 
   img {
     max-width: 100%;


### PR DESCRIPTION
We have some rare cases where content may exist outside any markup. See the text below the first image [here](https://dev.p4.greenpeace.org/international/issues/ships/11635/charting-a-plastic-free-future-in-taiwan/). This minor fix ensures that at least the typography rules are correct.