### PR TITLE
PLANET-1754 Updated footer copyright text

### DIFF
--- a/templates/footer.twig
+++ b/templates/footer.twig
@@ -18,10 +18,7 @@
 			{% endfor %}
 		</ul>
 
-		<p class="copyright-text col-md-8">
-			<i class="fa fa-creative-commons"></i>
-			{{ copyright_text|e('wp_kses_post')|raw }}
-		</p>
-		<p class="gp-year">Greenpeace {{"now"|date('Y')}}</p>
+		{{ copyright_text|e('wp_kses_post')|raw }}
+
 	</div>
 </footer>


### PR DESCRIPTION
[JIRA #1754](https://jira.greenpeace.org/browse/PLANET-1754)

Now, the footer copyright text need to change in Planet4 wp-admin settings as -
```
<p class="copyright-text col-md-8">
    Unless <a href="https://dev.p4.greenpeace.org/international/explore/about/copyright/">otherwise stated</a>, the content of the website is licensed under a <a href="https://creativecommons.org/licenses/by/2.0/">CC-BY International License</a>
</p>
<p class="gp-year"><i class="fa fa-creative-commons"></i> Greenpeace International 2018</p>
```