### PR TITLE
Add support for sidebar

### DIFF
--- a/templates/base.twig
+++ b/templates/base.twig
@@ -15,6 +15,7 @@
 	{% endif %}
 
 	{% include 'navigation-bar.twig' with data_nav_bar %}
+	{% include 'sidebar.twig' with data_nav_bar %}
 	<div class="hero-img-wrap">
 		<div class="clearfix"></div>
 	</div>


### PR DESCRIPTION
This adds the ability to child-theme developers to add a sidebar. Since `sidebar.twig` is emtpy on master-theme this adds no extra markup to our default template.