### PR TITLE
Planet4-1896 search action pages results

### DIFF
--- a/classes/class-p4-search.php
+++ b/classes/class-p4-search.php
@@ -557,7 +557,7 @@ if ( ! class_exists( 'P4_Search' ) ) {
 				// Post Type (+Action) <-> Content Type.
 				switch ( $post->post_type ) {
 					case 'page':
-						if ( 'act' === basename( get_permalink( $post->post_parent ) ) ) {
+						if ( $post->post_parent === (int) $options['act_page'] ) {
 							$content_type_text = __( 'ACTION', 'planet4-master-theme' );
 							$content_type      = 'action';
 							$context['content_types']['0']['results']++;


### PR DESCRIPTION
Fix the way we check if a search result is an Action page, by comparing it's parent with the selected Act page inside P4 Settings.