### PR TITLE
PLANET-1875 fix covers load more

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -27,32 +27,45 @@ function slickify(element) {
 }
 
 $(document).ready(function () {
-    // Add click event for load more button in blocks.
-    $( '.btn-load-more-click' ).off( 'click' ).on( 'click', function () {
-        var $row = $( '.row-hidden', $( this ).closest( '.container' ) );
+	// Add click event for load more button in Content Four Column block.
+	$( '.btn-load-more-click' ).off( 'click' ).on( 'click', function () {
+		var $row = $( '.row-hidden', $( this ).closest( '.container' ) );
 
-        if ( 1 === $row.size() ) {
-            $( this ).closest( '.load-more-button-div' ).hide('fast');
-        }
+		if ( 1 === $row.size() ) {
+			$( this ).closest( '.load-more-button-div' ).hide('fast');
+		}
 
-        var row_id = $row.attr( 'id' );
-        if ( row_id !== undefined && row_id.indexOf( 'publications-row' ) !== -1 ) {
-            $row.first().removeClass( 'row-hidden' ).show( 'slow', function () {
-                slickify( '#' + row_id );
-            });
-        } else {
-            $row.first().show( 'fast' ).removeClass( 'row-hidden' );
-        }
-    });
+		var row_id = $row.attr( 'id' );
+		if ( row_id !== undefined && row_id.indexOf( 'publications-row' ) !== -1 ) {
+			$row.first().removeClass( 'row-hidden' ).show( 'slow', function () {
+				slickify( '#' + row_id );
+			});
+		} else {
+			$row.first().show( 'fast' ).removeClass( 'row-hidden' );
+		}
+	});
 
-    // Add click event for load more button in covers blocks.
+	$('.covers-block').each( function() {
+		var visible_covers = $('.cover-card-column:visible', $(this)).length;
+		if ( 0 === visible_covers % 3 ) {
+			$(this).attr('data-covers_per_row', 3);
+		} else if ( 0 === visible_covers % 2 ) {
+			$(this).attr('data-covers_per_row', 2);
+		}
+	});
+
+    // Add click event for load more button in Covers blocks.
     $('.btn-load-more-covers-click').off('click').on('click', function () {
-        var $row = $('.limit-visibility', $(this).closest('.container'));
+        var $row = $('.cover-card-column:hidden', $(this).closest('.container'));
+        var covers_per_row = $(this).closest('.covers-block').data('covers_per_row');
 
-        if ($row.size() > 0) {
-            $row.first().removeClass('limit-visibility');
-            $(this).closest('.load-more-covers-button-div').remove();
-        }
-    });
+		$(this).blur();
+		if ($row.length > 0) {
+			$row.slice( 0, covers_per_row ).show('slow');
+		}
+		if ( $row.length <= covers_per_row ) {
+			$(this).closest('.load-more-covers-button-div').hide('fast');
+		}
+	});
 });
 

--- a/tag.php
+++ b/tag.php
@@ -63,6 +63,7 @@ if ( is_tag() ) {
 		'title'       => __( 'Things you can do', 'planet4-master-theme' ),
 		'description' => __( 'We want you to take action because together we\'re strong.', 'planet4-master-theme' ),
 		'select_tag'  => $context['tag']->term_id,
+		'covers_view' => '0',   // Show 6 covers in Campaign page.
 	] );
 
 	$campaign->add_block( Articles::BLOCK_NAME, [


### PR DESCRIPTION
Fix Covers block Load more functionality. Reveal 3 or 2 more covers (depending on device) each time user clicks on Load more button. Display 6 covers on page load inside Campaign page.