### PR TITLE
Add stylelint

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,0 +1,90 @@
+{
+  "rules": {
+    "color-hex-case": "lower",
+    "color-no-invalid-hex": true,
+
+    "font-family-no-duplicate-names": true,
+    "font-family-name-quotes": "always-where-recommended",
+
+    "function-calc-no-unspaced-operator": true,
+    "function-comma-space-after": "always",
+    "function-comma-space-before": "never",
+    "function-name-case": "lower",
+    "function-parentheses-space-inside": "never",
+    "function-whitespace-after": "always",
+    "function-url-no-scheme-relative": true,
+    "function-url-quotes": "always",
+
+    "number-no-trailing-zeros": true,
+
+    "string-no-newline": true,
+    "string-quotes": "double",
+
+    "length-zero-no-unit": true,
+
+    "unit-case": "lower",
+    "unit-no-unknown": true,
+
+    "value-keyword-case": "lower",
+
+    "value-list-comma-space-after": "always-single-line",
+    "value-list-comma-space-before": "never",
+
+    "property-case": "lower",
+    "property-no-unknown": true,
+
+    "keyframe-declaration-no-important": true,
+
+    "declaration-colon-space-after": "always",
+    "declaration-colon-space-before": "never",
+
+    "declaration-block-trailing-semicolon": "always",
+    "declaration-block-single-line-max-declarations": 1,
+    "declaration-block-semicolon-space-before": "never",
+    "declaration-block-semicolon-newline-after": "always-multi-line",
+    "declaration-block-no-shorthand-property-overrides": true,
+    "declaration-block-no-duplicate-properties": [true, {"ignore": ["consecutive-duplicates-with-different-values"]}],
+
+    "block-no-empty": true,
+    "block-closing-brace-empty-line-before": "never",
+    "block-closing-brace-newline-after": "always",
+    "block-closing-brace-newline-before": "always-multi-line",
+    "block-closing-brace-space-before": "always-single-line",
+    "block-opening-brace-newline-after": "always-multi-line",
+    "block-opening-brace-space-after": "always-single-line",
+    "block-opening-brace-space-before": "always",
+
+    "selector-attribute-brackets-space-inside": "never",
+    "selector-attribute-operator-space-after": "never",
+    "selector-attribute-operator-space-before": "never",
+    "selector-combinator-space-after": "always",
+    "selector-combinator-space-before": "always",
+    "selector-pseudo-class-no-unknown": true,
+    "selector-pseudo-element-no-unknown": true,
+    "selector-pseudo-class-case": "lower",
+    "selector-pseudo-element-case": "lower",
+    "selector-type-case": "lower",
+    "selector-type-no-unknown": true,
+    "selector-max-empty-lines": 0,
+
+    "rule-empty-line-before": ["always", {"except": ["first-nested", "after-single-line-comment"]}],
+
+    "media-feature-name-case": "lower",
+    "media-feature-name-no-unknown": true,
+    "media-feature-colon-space-after": "always",
+    "media-feature-colon-space-before": "never",
+    "media-feature-parentheses-space-inside": "never",
+
+    "comment-no-empty": true,
+
+    "indentation": 2,
+    "max-nesting-depth": 7,
+    "no-duplicate-selectors": true,
+    "no-eol-whitespace": true,
+    "no-extra-semicolons": true,
+    "no-unknown-animations": true,
+    "no-invalid-double-slash-comments": true,
+    "no-missing-end-of-source-newline": true,
+    "max-empty-lines": 1
+  }
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ php:
     - 7.0
     - 7.1
 
+notifications:
+    email: false
+
 env:
     - WP_VERSION=latest WP_MULTISITE=0
     - WP_VERSION=latest WP_MULTISITE=1
@@ -13,6 +16,8 @@ env:
 before_script:
     - bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
     - composer install --dev
+    - npm install -g stylelint
 
 script:
     - phpunit
+    - stylelint 'assets/scss/**/*.scss' 'assets/css/*.css'

--- a/assets/css/dashboard.css
+++ b/assets/css/dashboard.css
@@ -1,5 +1,16 @@
-.cp-item div { background-color: rgb(250, 250, 250); }
+.cp-item div {
+  background-color: rgb(250, 250, 250);
+}
 
-.cp-subitem-response { display: none; float: right; }
-.cp-success { color: #236b2d; }
-.cp-error { color: #be2d26; }
+.cp-subitem-response {
+  display: none;
+  float: right;
+}
+
+.cp-success {
+  color: #236b2d;
+}
+
+.cp-error {
+  color: #be2d26;
+}

--- a/assets/scss/common/_article-listing.scss
+++ b/assets/scss/common/_article-listing.scss
@@ -1,7 +1,7 @@
 .article-listing-intro {
   display: flex;
 
-  &>div:first-of-type {
+  & > div:first-of-type {
     padding-left: 0;
   }
 }
@@ -11,7 +11,7 @@
   flex-direction: column;
   justify-content: space-between;
   background-color: transparentize($white, .2);
-  box-shadow: 0 3px 10px rgba(0,0,0,0.1);
+  box-shadow: 0 3px 10px rgba(0, 0, 0, 0.1);
   margin: 12px 0;
 
   @include medium-and-up {

--- a/assets/scss/common/_block-media.scss
+++ b/assets/scss/common/_block-media.scss
@@ -1,11 +1,11 @@
 .block-media {
-	padding: 50px 15px;
+  padding: 50px 15px;
 
-	@include small-and-up {
-		padding: 50px 0;
-	}
+  @include small-and-up {
+    padding: 50px 0;
+  }
 
-	img {
-		width: 100%;
-	}
+  img {
+    width: 100%;
+  }
 }

--- a/assets/scss/common/_campaign-covers-4col-wrap.scss
+++ b/assets/scss/common/_campaign-covers-4col-wrap.scss
@@ -1,16 +1,17 @@
 .campaign-covers-4col-wrap {
-	position: relative;
-	background-color: $light-grey;
-	&:before {
-		@include x-large-and-up {
-			content: "";
-			position: absolute;
-			top: 0;
-			left: -70%;
-			width: 100%;
-			height: 100%;
-			transform: skew(25deg);
-			background-image: linear-gradient( to bottom, #cdc8c4, #dedbd2 );
-		}
-	}
+  position: relative;
+  background-color: $light-grey;
+
+  &:before {
+    @include x-large-and-up {
+      content: "";
+      position: absolute;
+      top: 0;
+      left: -70%;
+      width: 100%;
+      height: 100%;
+      transform: skew(25deg);
+      background-image: linear-gradient(to bottom, #cdc8c4, #dedbd2);
+    }
+  }
 }

--- a/assets/scss/common/_carousel-header.scss
+++ b/assets/scss/common/_carousel-header.scss
@@ -5,6 +5,7 @@ $slide-transition-speed: 1s;
   width: $size;
   margin-left: 100% - $size;
 }
+
 @mixin preview-width($size) {
   width: $size * (100% / $size);
 }
@@ -14,7 +15,7 @@ $slide-transition-speed: 1s;
   width: 100vw;
 
   &::after {
-    content: '';
+    content: "";
     display: block;
     margin-bottom: 40px;
 
@@ -65,11 +66,13 @@ $slide-transition-speed: 1s;
       opacity: 1;
       transition: unset;
     }
+
     &.next {
       z-index: 1;
       opacity: 1;
       transition: unset;
     }
+
     &.fade-out {
       opacity: 0;
       transition: opacity #{ $slide-transition-speed / 2 };
@@ -78,7 +81,7 @@ $slide-transition-speed: 1s;
     // Display the slide's background image, grayscaling in supported browsers.
     &::before {
       @include fill-container;
-      content: '';
+      content: "";
       background-image: inherit;
       background-size: cover;
       filter: grayscale(100%);
@@ -87,7 +90,7 @@ $slide-transition-speed: 1s;
     // Put a colored gradient in front of the background image.
     &::after {
       @include fill-container;
-      content: '';
+      content: "";
       z-index: 0;
       background: linear-gradient(210deg, rgba(136, 196, 213, 0.2) 0%, rgba(184, 216, 232, 1) 100%);
     }
@@ -133,7 +136,7 @@ $slide-transition-speed: 1s;
       // Put a colored gradient in front of the background image.
       &::after {
         @include fill-container;
-        content: '';
+        content: "";
         opacity: 0;
         background: linear-gradient(210deg, rgba(136, 196, 213, 0.2) 0%, rgba(184, 216, 232, 1) 100%);
       }
@@ -157,10 +160,12 @@ $slide-transition-speed: 1s;
         width: 100%;
         margin: 0;
       }
+
       .carousel-preview {
         transform: skew(0);
         transition: transform $slide-transition-speed, width $slide-transition-speed, filter $slide-transition-speed;
         width: 100%;
+        filter: grayscale(100%);
 
         &::after {
           z-index: 1;
@@ -168,9 +173,7 @@ $slide-transition-speed: 1s;
           transition: opacity $slide-transition-speed;
         }
       }
-      .carousel-preview {
-        filter: grayscale(100%);
-      }
+
       @include small-and-up {
         .carousel-caption {
           opacity: 0;
@@ -327,7 +330,7 @@ $slide-transition-speed: 1s;
       width: 40px;
       height: 40px;
       cursor: pointer;
-      background: url('images/carousel-marker-next.png');
+      background: url("images/carousel-marker-next.png");
       background-size: cover;
 
       @include small-and-up {
@@ -346,6 +349,7 @@ $slide-transition-speed: 1s;
         background: url("images/carousel-marker-next.png");
         width: 65px;
         height: 65px;
+
         &:hover {
           background-position-x: 66px;
         }

--- a/assets/scss/common/_carousel.scss
+++ b/assets/scss/common/_carousel.scss
@@ -48,7 +48,8 @@
   .carousel-item-next,
   .carousel-item-prev {
     display: block;
-    img{
+
+    img {
       width: 100%;
     }
   }
@@ -61,14 +62,14 @@
     width: 100%;
     font-family: $roboto;
     padding: 30px 200px 30px 50px;
-    background : -moz-linear-gradient(66.31% -110.5% -120deg,rgba(10, 51, 81, 0) 0%,rgba(10, 51, 81, 1) 100%);
-    background : -webkit-linear-gradient(-120deg, rgba(10, 51, 81, 0) 0%, rgba(10, 51, 81, 1) 100%);
-    background : -webkit-gradient(linear,66.31% -110.5% ,33.69% 210.5% ,color-stop(0,rgba(10, 51, 81, 0) ),color-stop(1,rgba(10, 51, 81, 1) ));
-    background : -o-linear-gradient(-120deg, rgba(10, 51, 81, 0) 0%, rgba(10, 51, 81, 1) 100%);
-    background : -ms-linear-gradient(-120deg, rgba(10, 51, 81, 0) 0%, rgba(10, 51, 81, 1) 100%);
+    background: -moz-linear-gradient(66.31% -110.5% -120deg, rgba(10, 51, 81, 0) 0%, rgba(10, 51, 81, 1) 100%);
+    background: -webkit-linear-gradient(-120deg, rgba(10, 51, 81, 0) 0%, rgba(10, 51, 81, 1) 100%);
+    background: -webkit-gradient(linear, 66.31% -110.5%, 33.69% 210.5%, color-stop(0, rgba(10, 51, 81, 0)), color-stop(1, rgba(10, 51, 81, 1)));
+    background: -o-linear-gradient(-120deg, rgba(10, 51, 81, 0) 0%, rgba(10, 51, 81, 1) 100%);
+    background: -ms-linear-gradient(-120deg, rgba(10, 51, 81, 0) 0%, rgba(10, 51, 81, 1) 100%);
+    background: linear-gradient(210deg, rgba(10, 51, 81, 0.2) 0%, rgba(10, 51, 81, 1) 100%);
+    filter: progid:dximagetransform.microsoft.gradient(startColorstr="#0a3351", endColorstr="#0a3351", GradientType=1);
     -ms-filter: "progid:DXImageTransform.Microsoft.gradient(startColorstr='#0A3351', endColorstr='#0A3351' ,GradientType=0)";
-    background : linear-gradient(210deg, rgba(10, 51, 81, 0.2) 0%, rgba(10, 51, 81, 1) 100%);
-    filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#0A3351',endColorstr='#0A3351' , GradientType=1);
 
     @include mobile-only {
       position: absolute;
@@ -185,7 +186,7 @@
   }
 
   .carousel-control-prev-icon {
-    background: url('images/carousel-marker-prev.png');
+    background: url("images/carousel-marker-prev.png");
     background-size: cover;
 
     @include small-and-up {
@@ -200,6 +201,7 @@
     @include large-and-up {
       margin-left: 133px;
       background: url("images/carousel-marker-prev.png");
+
       &:hover {
         background-position-x: 66px;
       }
@@ -211,7 +213,7 @@
   }
 
   .carousel-control-next-icon {
-    background: url('images/carousel-marker-next.png');
+    background: url("images/carousel-marker-next.png");
     background-size: cover;
 
     @include small-and-up {
@@ -226,6 +228,7 @@
     @include large-and-up {
       margin-right: 133px;
       background: url("images/carousel-marker-next.png");
+
       &:hover {
         background-position-x: 66px;
       }

--- a/assets/scss/common/_content-four-column.scss
+++ b/assets/scss/common/_content-four-column.scss
@@ -19,7 +19,7 @@
     .four-column-content-symbol {
       position: relative;
       margin: 0 0 24px 0;
-      box-shadow: 0 5px 20px 0 rgba(114,114,114,0.5);
+      box-shadow: 0 5px 20px 0 rgba(114, 114, 114, 0.5);
 
       @include small-and-up {
         margin: 20px 0;
@@ -46,20 +46,19 @@
     }
 
     .four-column-content-info {
-
       .four-column-hover {
         text-decoration: underline;
       }
 
       h4 {
-        font-size : rem(14);
+        font-size: rem(14);
         line-height: 1.2;
         font-weight: 500;
         padding: 0;
         margin: 0;
 
         @include medium-and-up {
-          font-size : rem(18);
+          font-size: rem(18);
           font-weight: 500;
           color: $black;
         }

--- a/assets/scss/common/_content-three-column.scss
+++ b/assets/scss/common/_content-three-column.scss
@@ -17,7 +17,6 @@
   }
 
   .three-column-box {
-
     .three-column-info {
       margin-bottom: 24px;
       padding-left: 0;

--- a/assets/scss/common/_cookie-block.scss
+++ b/assets/scss/common/_cookie-block.scss
@@ -1,4 +1,4 @@
-$cookie-bkg: #C0DBE2;
+$cookie-bkg: #c0dbe2;
 $cookie-blue: #094464;
 
 .cookie-block {
@@ -11,6 +11,7 @@ $cookie-blue: #094464;
   padding: 10px 0;
   background: $cookie-bkg url("images/cookie-right-gradient.png") no-repeat right;
   max-height: 50px;
+
   p {
     font-size: rem(17);
     font-weight: 500;
@@ -20,6 +21,7 @@ $cookie-blue: #094464;
     font-family: $roboto;
     line-height: 30px;
   }
+
   a {
     font-size: rem(17);
     font-weight: bold;
@@ -30,6 +32,7 @@ $cookie-blue: #094464;
       text-decoration: underline;
     }
   }
+
   .btn {
     height: 32px;
     line-height: 32px;
@@ -49,21 +52,25 @@ $cookie-blue: #094464;
   .cookie-block {
     max-height: 120px;
     background: $cookie-bkg url("images/cookie-right-gradient-sm.png") no-repeat right;
+
     div.col-9 {
       margin: 0 auto;
       max-width: 95%;
       flex: 95%;
     }
+
     div.col {
       margin: 0 auto;
       max-width: 95%;
     }
+
     p {
       font-size: rem(14);
       text-align: left;
       line-height: 16.8px;
       margin-bottom: 10px;
     }
+
     a {
       font-size: rem(14);
     }
@@ -74,11 +81,13 @@ $cookie-blue: #094464;
   .cookie-block {
     max-height: 56px;
     background: $cookie-bkg url("images/cookie-right-gradient-md.png") no-repeat right;
+
     p {
       font-size: rem(15);
       text-align: left;
       line-height: 18px;
     }
+
     a {
       font-size: rem(15);
     }
@@ -89,27 +98,30 @@ $cookie-blue: #094464;
   .cookie-block {
     max-height: 50px;
     background: $cookie-bkg url("images/cookie-right-gradient.png") no-repeat right;
+
     p {
       font-size: rem(14.5);
       text-align: center;
       line-height: 30px;
     }
+
     a {
       font-size: rem(14.5);
     }
   }
 }
 
-
 @include x-large-and-up {
   .cookie-block {
     max-height: 50px;
     background: $cookie-bkg url("images/cookie-right-gradient.png") no-repeat right;
+
     p {
       font-size: rem(17);
       text-align: center;
       line-height: 30px;
     }
+
     a {
       font-size: rem(17);
     }

--- a/assets/scss/common/_covers.scss
+++ b/assets/scss/common/_covers.scss
@@ -61,6 +61,7 @@
     .cover-card-column:nth-child(-n+7) {
       display: block;
     }
+
     .cover-card-column:nth-child(n+7) {
       display: none;
     }
@@ -177,7 +178,7 @@
     transition: box-shadow 150ms linear;
     padding-bottom: 70px;
 
-    &:not(.single-cover){
+    &:not(.single-cover) {
       box-shadow: none;
 
       &:hover {

--- a/assets/scss/common/_footer.scss
+++ b/assets/scss/common/_footer.scss
@@ -34,13 +34,13 @@
     display: inline-block;
   }
 
-   a {
-     transition: color 100ms linear;
+  a {
+    transition: color 100ms linear;
 
-     &:hover {
-       color: $white;
-     }
-   }
+    &:hover {
+      color: $white;
+    }
+  }
 }
 
 .footer-links,

--- a/assets/scss/common/_happy-point-block.scss
+++ b/assets/scss/common/_happy-point-block.scss
@@ -1,4 +1,3 @@
-
 // Mixins because extending is not possible inside media queries
 @mixin happy-point-block-background-image {
   background: url("images/happy-point-block-bg.jpg") center center no-repeat;
@@ -9,73 +8,84 @@
 }
 
 .happy-point-block-wrap {
+  @include background-before-opacity($light-blue-bg);
+  margin: 0 -120px 0 -100px;
 
-    @include background-before-opacity($light-blue-bg);
-    
-    margin:0 -120px 0 -100px;
-    .container {
-      height: inherit;
-      .row {
-        height: inherit;
-      }
-    }
-    .pt-20 {
-      height: inherit;
+  .container {
+    height: inherit;
 
-      iframe {
-       height: 390px;
-      }
-    }
-    h2 {
-      width: 75%;
-    }
-    p {
-      font-family: $roboto;
-      font-size: rem(13);
-      line-height: 1.15rem;
-      color: $shadow-color;
-    }
-    img {
-      position: absolute;
-      height: 500px;
-      width: 100%;
-      object-fit: none;
-    }
-    form {
-      input, .custom-select {
-        height: 42px;
-        border-radius: 0;
-        border-color: transparent;
-      }
+    .row {
+      height: inherit;
     }
   }
+
+  .pt-20 {
+    height: inherit;
+
+    iframe {
+      height: 390px;
+    }
+  }
+
+  h2 {
+    width: 75%;
+  }
+
+  p {
+    font-family: $roboto;
+    font-size: rem(13);
+    line-height: 1.15rem;
+    color: $shadow-color;
+  }
+
+  img {
+    position: absolute;
+    height: 500px;
+    width: 100%;
+    object-fit: none;
+  }
+
+  form {
+    input, .custom-select {
+      height: 42px;
+      border-radius: 0;
+      border-color: transparent;
+    }
+  }
+}
 
 @media (max-width: 767px) {
   .happy-point-block-wrap {
     height: 444px;
     padding-left: 25px;
     padding-right: 25px;
+
     .pt-20 {
       padding: 126px 102px 0 96px;
     }
+
     h2 {
       font-size: rem(26);
       line-height: 2rem;
       margin-bottom: 24px;
     }
+
     h5 {
       font-size: rem(16);
       line-height: 1.5rem;
     }
+
     .subscriber-btn {
       margin-top: 0;
       margin-bottom: 16px;
       width: 100%;
       padding: 10px;
     }
+
     p {
       text-align: left;
     }
+
     form {
       input, .custom-select {
         margin-bottom: 16px;
@@ -90,7 +100,7 @@
       iframe {
         position: absolute;
         width: 100vw;
-        bottom: 0px;
+        bottom: 0;
       }
     }
   }
@@ -99,26 +109,31 @@
 @include medium-and-up {
   .happy-point-block-wrap {
     max-height: 480px;
+
     .pt-20 {
       padding-top: 220px;
       padding-left: 0;
       padding-right: 0;
     }
+
     h2 {
       font-size: rem(28);
       line-height: 2.125rem;
       margin-bottom: 20px;
-      color:$black;
+      color: $black;
     }
+
     h5 {
       font-size: rem(18);
       line-height: 1.75rem;
     }
+
     .subscriber-btn {
       width: 100%;
       margin-top: 16px;
       margin-bottom: 16px;
     }
+
     p {
       text-align: center;
     }
@@ -128,20 +143,24 @@
 @include large-and-up {
   .happy-point-block-wrap {
     max-height: 500px;
+
     .pt-20 {
       padding-top: 260px;
       padding-left: 0;
       padding-right: 0;
     }
+
     h2 {
       font-size: rem(34);
       line-height: 2.125rem;
       margin-bottom: 30px;
     }
+
     h5 {
       font-size: rem(18);
       line-height: 1.5rem;
     }
+
     .subscriber-btn {
       margin-top: 0;
       margin-bottom: 16px;
@@ -149,6 +168,7 @@
       height: 42px;
       line-height: 42px;
     }
+
     p {
       text-align: left;
     }
@@ -158,16 +178,20 @@
   .happy-point-block-wrap {
     @include happy-point-block-background-image;
     @include background-before-opacity($light-blue-bg);
+
     .pt-20 {
       padding-top: 270px;
     }
+
     h2 {
       font-size: rem(36);
       margin-bottom: 42px;
     }
+
     h5 {
       font-size: rem(18);
     }
+
     .subscriber-btn {
       margin-top: 0;
       margin-bottom: 8px;
@@ -175,6 +199,7 @@
       height: 42px;
       line-height: 42px;
     }
+
     p {
       text-align: left;
     }

--- a/assets/scss/common/_header.scss
+++ b/assets/scss/common/_header.scss
@@ -1,72 +1,83 @@
-.main-header{
+.main-header {
   color: $dark-blue;
   padding-top: 120px;
   padding-bottom: 70px;
-  h1{
+
+  h1 {
     font-size: rem(64);
     margin-bottom: 48px;
   }
-  h3{
+
+  h3 {
     font-size: rem(44);
     margin-bottom: 56px;
   }
-  p{
+
+  p {
     font-size: rem(22);
     margin-bottom: 72px;
   }
-
 }
 
 @include mobile-only {
-  .main-header{
+  .main-header {
     padding-top: 120px;
     padding-bottom: 80px;
-	    h1{
-	      font-size: rem(40);
-	      margin-bottom: 50px;
-	    }
-	    h3{
-	      font-size: rem(22);
-	      margin-bottom: 130px;
-	    }
-	    p{
-	      display: none;
-	    }
-	} 
+
+    h1 {
+      font-size: rem(40);
+      margin-bottom: 50px;
+    }
+
+    h3 {
+      font-size: rem(22);
+      margin-bottom: 130px;
+    }
+
+    p {
+      display: none;
+    }
+  }
 }
 
 @include medium-and-up {
-  .main-header{
-  	padding-top: 80px;
+  .main-header {
+    padding-top: 80px;
     padding-bottom: 80px;
-	    h1{
-	      font-size: rem(48);
-	      margin-bottom: 40px;
-	    }
-	    h3{
-	      font-size: rem(24);
-	      margin-bottom: 50px;
-	    }
-	    p{
-	      font-size: rem(27.5);
-	    }
-	}   
+
+    h1 {
+      font-size: rem(48);
+      margin-bottom: 40px;
+    }
+
+    h3 {
+      font-size: rem(24);
+      margin-bottom: 50px;
+    }
+
+    p {
+      font-size: rem(27.5);
+    }
+  }
 }
 
 @include large-and-up {
-  .main-header{
+  .main-header {
     padding-top: 100px;
     padding-bottom: 80px;
-	    h1{
-	      font-size: rem(56);
-	      margin-bottom: 50px;
-	    }
-	    h3{
-	      font-size: rem(30);
-	      margin-bottom: 50px;
-	    }
-	    p{
-	      font-size: rem(20);
-	    }
-  	}
+
+    h1 {
+      font-size: rem(56);
+      margin-bottom: 50px;
+    }
+
+    h3 {
+      font-size: rem(30);
+      margin-bottom: 50px;
+    }
+
+    p {
+      font-size: rem(20);
+    }
+  }
 }

--- a/assets/scss/common/_navbar.scss
+++ b/assets/scss/common/_navbar.scss
@@ -13,7 +13,7 @@ $menu-height-large: rem(60);
   flex-direction: row;
   justify-content: space-between;
 
-  background: transparentize($top-nav, 0.20);
+  background: transparentize($top-nav, 0.2);
   height: $menu-height-small;
 
   // Use (min-width: 783px) for parity with WP's .admin-bar
@@ -75,12 +75,14 @@ $menu-height-large: rem(60);
   color: $white;
   z-index: 1;
 
-  fa {
+  .fa {
     font-size: rem(18);
   }
 }
 
 .navbar-dropdown-toggle {
+  order: -1;
+
   // When menu is open, turn the button into the background overlay
   &[aria-expanded="true"] {
     z-index: 2;
@@ -110,7 +112,7 @@ $menu-height-large: rem(60);
 .navbar-search-toggle {
   cursor: pointer;
   border: 0;
-  background: url('images/search.svg') center center no-repeat;
+  background: url("images/search.svg") center center no-repeat;
   background-size: 28px;
   margin-left: auto;
 
@@ -141,10 +143,6 @@ $menu-height-large: rem(60);
   }
 }
 
-.navbar-dropdown-toggle {
-  order: -1;
-}
-
 .navbar-dropdown {
   display: none;
   margin: 0;
@@ -165,22 +163,49 @@ $menu-height-large: rem(60);
     height: 100vh;
     width: 300px;
   }
+
   // Use (min-width: 783px) for parity with WP's .admin-bar
   @media screen and (min-width: #{$small-width}) and (max-width: 782px) {
     height: 100vh;
     width: 375px;
   }
+
   // Use (min-width: 783px) for parity with WP's .admin-bar
   @media screen and (min-width: 783px) and (max-width: #{$large-width}) {
     width: 400px;
   }
+
+  ::-webkit-scrollbar {
+    width: 9px;
+  }
+
+  ::-webkit-scrollbar-track {
+    -webkit-border-radius: 5px;
+    border-radius: 5px;
+    background: rgba(255, 255, 255, 0.1);
+  }
+
+  ::-webkit-scrollbar-thumb {
+    -webkit-border-radius: 5px;
+    border-radius: 5px;
+    background: rgba(255, 255, 255, 0.2);
+  }
+
+  ::-webkit-scrollbar-thumb:hover {
+    background: rgba(255, 255, 255, 0.4);
+  }
+
+  ::-webkit-scrollbar-thumb:window-inactive {
+    background: rgba(255, 255, 255, 0.05);
+  }
+
   // Dropdown height permutations, with and without WP admin bar
   .admin-bar & {
     @media screen and (max-width: 782px) {
-      height: calc( 100vh - 46px );
+      height: calc(100vh - 46px);
     }
     @media screen and (min-width: 783px) and (max-width: #{$large-width}) {
-      height: calc( 100vh - 32px );
+      height: calc(100vh - 32px);
     }
   }
 
@@ -192,7 +217,7 @@ $menu-height-large: rem(60);
     position: absolute;
     top: 0;
     left: 0;
-    background: $deep-sea-green url('images/dropdown-gradient.svg') no-repeat;
+    background: $deep-sea-green url("images/dropdown-gradient.svg") no-repeat;
     overflow-y: auto;
     overflow-x: hidden;
     z-index: 2;
@@ -203,7 +228,7 @@ $menu-height-large: rem(60);
       right: 0;
       height: $menu-height-small;
       width: $menu-height-small;
-      background: url('images/close-icon.svg') center center no-repeat;
+      background: url("images/close-icon.svg") center center no-repeat;
       z-index: 2;
       border: 0;
 
@@ -225,7 +250,7 @@ $menu-height-large: rem(60);
       top: 0;
       bottom: 0;
       width: 8px;
-      background: transparentize( $black, 0.9 );
+      background: transparentize($black, 0.9);
       z-index: 0;
     }
 
@@ -243,7 +268,7 @@ $menu-height-large: rem(60);
         height: 1.75em;
         width: 50px;
         display: inline-block;
-        background: url('images/country-icon.svg') center center no-repeat;
+        background: url("images/country-icon.svg") center center no-repeat;
         border-right: 1px solid transparentize($white, 0.9);
         background-size: contain;
 
@@ -415,7 +440,7 @@ $menu-height-large: rem(60);
     content: "";
     width: 8px;
     height: 8px;
-    background: url('images/down-arrow-green.svg') no-repeat center center;
+    background: url("images/down-arrow-green.svg") no-repeat center center;
     background-size: contain;
     display: inline-block;
     margin-left: 10px;
@@ -427,7 +452,7 @@ $menu-height-large: rem(60);
     color: $white;
 
     &::after {
-      background-image: url('images/down-arrow-white.svg');
+      background-image: url("images/down-arrow-white.svg");
     }
   }
 
@@ -509,16 +534,16 @@ $menu-height-large: rem(60);
   @include large-and-up {
     position: absolute;
     height: 344px;
-    max-height: 344px;
     width: 90%;
     padding: 2em;
     left: 10%;
     overflow-x: hidden;
     overflow-y: hidden !important;
-    max-height: calc( 100vh - #{$menu-height-large} );
+    max-height: 344px;
+    max-height: calc(100vh - #{$menu-height-large});
 
     .admin-bar & {
-      max-height: calc( 100vh - #{$menu-height-large} - 32px );
+      max-height: calc(100vh - #{$menu-height-large} - 32px);
     }
 
     > ul {
@@ -529,33 +554,5 @@ $menu-height-large: rem(60);
     padding: 2em 4em 4em;
     width: 80%;
     left: 10%;
-  }
-}
-
-// For always showing the scrollbar in country selector
-
-.navbar-dropdown {
-  ::-webkit-scrollbar {
-    width:9px;
-  }
-
-  ::-webkit-scrollbar-track {
-    -webkit-border-radius:5px;
-    border-radius:5px;
-    background:rgba(255,255,255,0.1);
-  }
-
-  ::-webkit-scrollbar-thumb {
-    -webkit-border-radius:5px;
-    border-radius:5px;
-    background:rgba(255,255,255,0.2);
-  }
-
-  ::-webkit-scrollbar-thumb:hover {
-    background:rgba(255,255,255,0.4);
-  }
-
-  ::-webkit-scrollbar-thumb:window-inactive {
-    background:rgba(255,255,255,0.05);
   }
 }

--- a/assets/scss/common/_page-header.scss
+++ b/assets/scss/common/_page-header.scss
@@ -52,7 +52,7 @@
     @include x-large-and-up {
       font-size: rem(36);
       margin-bottom: 30px;
-    	line-height: 1.1;
+      line-height: 1.1;
     }
   }
 }
@@ -95,7 +95,6 @@
   display: block;
   margin: auto;
 }
-
 
 .top-page-tags {
   font-size: rem(14);

--- a/assets/scss/common/_skewed-overlay.scss
+++ b/assets/scss/common/_skewed-overlay.scss
@@ -6,13 +6,7 @@
   position: absolute;
   z-index: 1;
   overflow: hidden;
-  mask-image: linear-gradient(
-    170deg,
-    rgba(0,0,0,1),
-    rgba(0,0,0,1),
-    rgba(0,0,0,.2),
-    rgba(0,0,0,0)
-  );
+  mask-image: linear-gradient(170deg, rgba(0, 0, 0, 1), rgba(0, 0, 0, 1), rgba(0, 0, 0, .2), rgba(0, 0, 0, 0));
   mask-size: 100%;
   mask-repeat: no-repeat;
   mask-position: left top;

--- a/assets/scss/common/_split-carousel.scss
+++ b/assets/scss/common/_split-carousel.scss
@@ -5,31 +5,35 @@
     margin-bottom: 33px;
     line-height: 1.2;
   }
+
   &.not-header {
-  padding-top: 0;
-  overflow: hidden;
-  margin-bottom: 0;
-  padding-bottom: 153px;
+    padding-top: 0;
+    overflow: hidden;
+    margin-bottom: 0;
+    padding-bottom: 153px;
+
     .carousel-item {
       .carousel-item-credit {
         position: absolute;
         right: 0;
         top: 0;
-        color: $white;
         font-size: rem(11);
         margin: -20px 5px 15px 15px;
         font-weight: normal;
         color: $credit-color;
       }
     }
+
     .carousel-item.active,
     .carousel-item-next,
     .carousel-item-prev {
       display: block;
-      img{
+
+      img {
         width: 100%;
       }
     }
+
     .carousel-caption {
       text-align: left;
       left: auto;
@@ -37,13 +41,15 @@
       right: 0;
       width: 100%;
       padding: 30px 200px 30px 50px;
-      background : linear-gradient(210deg, rgba(10, 51, 81, 0.2) 0%, rgba(10, 51, 81, 1) 100%);
+      background: linear-gradient(210deg, rgba(10, 51, 81, 0.2) 0%, rgba(10, 51, 81, 1) 100%);
     }
+
     .carousel-indicators {
       right: 0;
       bottom: 0;
       left: auto;
       margin-right: 33%;
+
       li {
         width: 8px;
         height: 8px;
@@ -51,46 +57,56 @@
         background: $white;
         margin: 0 15px;
         cursor: pointer;
+
         &.active {
           background: $carousel-active;
         }
       }
     }
+
     .carousel-control-next {
       background: transparent;
       width: 45%;
       margin-right: -25%;
-      transform:skew(-209deg);
+      transform: skew(-209deg);
       background-position: right;
     }
+
     .carousel-control-prev-icon,
     .carousel-control-next-icon {
       width: 45px;
       height: 45px;
       background: none;
     }
+
     .carousel-control-prev,
     .carousel-control-next {
       opacity: 1;
       height: 100%;
+
       .carousel-control-next-icon {
-        transform:skew(209deg);
+        transform: skew(209deg);
         margin-right: 45%;
         background: url("images/carousel-marker-next-S-M.png");
       }
+
       .carousel-control-prev-icon {
         background: url("images/carousel-marker-next-S-M.png");
         transform: rotate(180deg);
       }
     }
+
     .carousel-inner {
       overflow: initial;
+
       .carousel-caption {
         bottom: -115px;
         padding: 18px 15px;
+
         h3 {
           font-size: rem(17);
         }
+
         p {
           font-size: rem(13);
           width: 100%;
@@ -100,12 +116,15 @@
     }
   }
 }
+
 .light-blue-bg {
   background: $light-blue-bg;
 }
+
 .px0 {
   padding: 0 !important;
 }
+
 .mt15 {
   margin-top: 15px;
 }
@@ -113,26 +132,31 @@
 @media (min-width: $small-width) {
   .split-carousel-wrap {
     h1 {
-      font-size:  rem(34);
+      font-size: rem(34);
       margin-left: 0;
       margin-bottom: 22px;
     }
+
     &.not-header {
       margin-bottom: 0;
       padding-bottom: 129px;
-      .carousel-inner{
+
+      .carousel-inner {
         .carousel-item-credit {
           margin: 16px 15px;
           color: $white;
           font-size: rem(12);
         }
+
         .carousel-caption {
           bottom: 0;
           width: 100%;
           padding: 20px 35px;
+
           h3 {
             font-size: rem(19);
           }
+
           p {
             font-size: rem(14);
             width: 100%;
@@ -140,10 +164,12 @@
           }
         }
       }
+
       .carousel-control-prev,
       .carousel-control-next {
         top: 0;
       }
+
       .carousel-indicators {
         bottom: -128px;
         right: 0;
@@ -156,26 +182,31 @@
 @include large-and-up {
   .split-carousel-wrap {
     h1 {
-      font-size:  rem(34);
+      font-size: rem(34);
       margin-left: 0;
       margin-bottom: 22px;
     }
+
     &.not-header {
       margin-bottom: 0;
       padding-bottom: 129px;
-      .carousel-inner{
+
+      .carousel-inner {
         .carousel-item-credit {
           margin: 16px 15px;
           color: $white;
           font-size: rem(12);
         }
+
         .carousel-caption {
           bottom: 0;
           width: 100%;
           padding: 20px 35px;
+
           h3 {
             font-size: rem(19);
           }
+
           p {
             font-size: rem(14);
             width: 100%;
@@ -183,15 +214,18 @@
           }
         }
       }
+
       .carousel-control-prev,
       .carousel-control-next {
         top: 0;
+
         .carousel-control-next-icon {
           margin-right: 45%;
           height: 45px;
           width: 45px;
           background: url("images/carousel-marker-next-S-M.png");
         }
+
         .carousel-control-prev-icon {
           background: url("images/carousel-marker-next-S-M.png");
           transform: rotate(180deg);
@@ -199,6 +233,7 @@
           width: 45px;
         }
       }
+
       .carousel-indicators {
         bottom: -128px;
         right: 0;
@@ -206,9 +241,11 @@
       }
     }
   }
+
   .px0 {
     padding: 0 15px !important;
   }
+
   .ml-15 {
     margin-left: 0;
   }
@@ -217,29 +254,34 @@
 @include large-and-up {
   .split-carousel-wrap {
     h1 {
-      font-size:  rem(36);
+      font-size: rem(36);
       margin-left: 0;
       margin-bottom: 25px;
     }
-      &.not-header {
+
+    &.not-header {
       margin-bottom: 0;
       padding-bottom: 143px;
-      .carousel-inner{
+
+      .carousel-inner {
         .carousel-item-credit {
           margin: 16px 15px;
           color: $white;
           font-size: rem(13);
         }
+
         .carousel-caption {
           bottom: 0;
           width: 100%;
           height: 144px;
           padding: 26px 45px;
+
           h3 {
             font-size: rem(20);
             line-height: normal;
             margin-bottom: 10px;
           }
+
           p {
             font-size: rem(16);
             width: 80%;
@@ -247,6 +289,7 @@
           }
         }
       }
+
       .carousel-control-prev,
       .carousel-control-next {
         .carousel-control-next-icon {
@@ -254,21 +297,25 @@
           height: 65px;
           width: 65px;
           background: url("images/carousel-marker-next.png");
-          &:hover{
-            background-position-x:66px;
+
+          &:hover {
+            background-position-x: 66px;
           }
         }
+
         .carousel-control-prev-icon {
           background: url("images/carousel-marker-next.png");
-           transform: rotate(180deg);
+          transform: rotate(180deg);
           height: 65px;
           width: 65px;
-          &:hover{
-            background-position-x:66px;
+
+          &:hover {
+            background-position-x: 66px;
           }
         }
         top: 0;
       }
+
       .carousel-indicators {
         bottom: -128px;
         right: 0;
@@ -276,9 +323,11 @@
       }
     }
   }
+
   .px0 {
     padding: 0 15px !important;
   }
+
   .ml-15 {
     margin-left: 0;
   }
@@ -287,29 +336,34 @@
 @include x-large-and-up {
   .split-carousel-wrap {
     h1 {
-      font-size:  rem(38);
+      font-size: rem(38);
       margin-left: 0;
       margin-bottom: 30px;
     }
+
     &.not-header {
-    margin-bottom: 0;
-    padding-bottom: 195px;
+      margin-bottom: 0;
+      padding-bottom: 195px;
+
       .carousel-inner {
         .carousel-item-credit {
           margin: 16px 15px;
           color: $white;
           font-size: rem(14);
         }
+
         .carousel-caption {
           bottom: 0;
           width: 100%;
           height: 195px;
           padding: 31px 96px;
+
           h3 {
             font-size: rem(22);
             margin-bottom: 15px;
             line-height: normal;
           }
+
           p {
             font-size: rem(17);
             width: 60%;
@@ -318,6 +372,7 @@
           }
         }
       }
+
       .carousel-control-prev,
       .carousel-control-next {
         .carousel-control-next-icon {
@@ -326,6 +381,7 @@
           width: 65px;
           background: url("images/carousel-marker-next.png");
         }
+
         .carousel-control-prev-icon {
           background: url("images/carousel-marker-next.png");
           transform: rotate(180deg);
@@ -334,6 +390,7 @@
         }
         top: 0;
       }
+
       .carousel-indicators {
         bottom: -170px;
         right: 0;
@@ -341,9 +398,11 @@
       }
     }
   }
+
   .px0 {
     padding: 0 15px !important;
   }
+
   .ml-15 {
     margin-left: 0;
   }

--- a/assets/scss/common/_split-two-column.scss
+++ b/assets/scss/common/_split-two-column.scss
@@ -241,12 +241,12 @@
     }
 
     &:after {
-      font-family: 'greenpeace-icon';
-      content: '\e901';
+      font-family: greenpeace-icon;
+      content: "\e901";
       color: $yellow;
       position: absolute;
       top: 50%;
-      transform: translate( 0, -50% );
+      transform: translate(0, -50%);
       right: 15px;
       pointer-events: none;
     }
@@ -293,7 +293,6 @@
       width: 100%;
       background: linear-gradient(100deg, rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0.3), rgba(255, 255, 255, 0));
     }
-
   }
 
   .item--right {
@@ -314,7 +313,7 @@
       z-index: 1;
       height: 100%;
       width: 25%;
-      background: linear-gradient(180deg, rgba(255, 255, 255, 0.15), rgba(255, 255, 255, 0.05),rgba(255, 255, 255, 0));
+      background: linear-gradient(180deg, rgba(255, 255, 255, 0.15), rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0));
     }
   }
 
@@ -326,7 +325,7 @@
 
   .split-two-column-item-content {
     top: 50%;
-    transform: translate( 0, -50% ) skew(-30deg, 0deg);
+    transform: translate(0, -50%) skew(-30deg, 0deg);
     z-index: 1;
     width: 40%;
   }

--- a/assets/scss/common/_static-four-column.scss
+++ b/assets/scss/common/_static-four-column.scss
@@ -10,7 +10,7 @@
   }
 
   @include x-large-and-up {
-    margin: 0px 0 80px 0;
+    margin: 0 0 80px 0;
   }
 
   h2 {

--- a/assets/scss/common/_subheader.scss
+++ b/assets/scss/common/_subheader.scss
@@ -3,7 +3,6 @@
 */
 
 .subheader {
-
   h2 {
     font-size: rem(22);
     line-height: 1.38;

--- a/assets/scss/common/_tag-cloud.scss
+++ b/assets/scss/common/_tag-cloud.scss
@@ -1,24 +1,30 @@
 .tag-cloud {
   padding-top: 104px;
+
   .tag-cloud-title {
     h2 {
       color: $black;
       font-size: rem(32);
     }
+
     .tag-cloud-list {
       a {
         color: $brown-bg-tags-link;
         text-decoration: none;
         margin-right: 5px;
+
         &.tag-xsmall {
           font-size: rem(12);
         }
+
         &.tag-small {
           font-size: rem(16);
         }
+
         &.tag-mid {
           font-size: rem(24);
         }
+
         &.tag-big {
           font-size: rem(28);
         }

--- a/assets/scss/common/_video-block.scss
+++ b/assets/scss/common/_video-block.scss
@@ -1,5 +1,4 @@
 .video-block {
-
   h2 {
     padding-left: 15px;
 

--- a/assets/scss/external/_happy-point-form.scss
+++ b/assets/scss/external/_happy-point-form.scss
@@ -1,132 +1,132 @@
 /**
- * CSS for the Happy Point embedded form.
- *
- * These styles are meant to be included in the ifram itself are thusly pure CSS.
- *
- * @todo:: remove this from the built files when we have the iframe embedded.
- */
+* CSS for the Happy Point embedded form.
+*
+* These styles are meant to be included in the ifram itself are thusly pure CSS.
+*
+* @todo:: remove this from the built files when we have the iframe embedded.
+*/
 
 .subscribe-form {
-	margin: -15px;
-	position: relative;
+  margin: -15px;
+  position: relative;
 }
 
 .subscribe-form label {
-	display: none;
+  display: none;
 }
 
 .subscribe-form .en__field {
-	width: 100%;
-	float: left;
-	padding: 0 15px;
-	margin-bottom: 10px;
+  width: 100%;
+  float: left;
+  padding: 0 15px;
+  margin-bottom: 10px;
 }
 
 .subscribe-form .en__field__input {
-	width: 100%;
-	height: 42px;
-	border-radius: 0;
-	border: 0;
-	padding: 10px;
+  width: 100%;
+  height: 42px;
+  border-radius: 0;
+  border: 0;
+  padding: 10px;
 }
 
 .subscribe-form .en__field--select {
-	float: left;
-	padding: 0 15px;
+  float: left;
+  padding: 0 15px;
 }
 
 .subscribe-form .en__submit {
-	width: 25%;
-	float: left;
-	padding: 0 15px;
+  width: 25%;
+  float: left;
+  padding: 0 15px;
 }
 
 .subscribe-form .en__submit button {
-	background-color: #F36D3A;
-	height: 42px;
-	line-height: 1;
-	color: #fff;
-	text-transform: uppercase;
-	width: 100%;
-	font-size: 16px;
-	border: 1px solid transparent;
-	padding: 0 15px;
-	border-radius: 5px;
+  background-color: #f36d3a;
+  height: 42px;
+  line-height: 1;
+  color: #fff;
+  text-transform: uppercase;
+  width: 100%;
+  font-size: 16px;
+  border: 1px solid transparent;
+  padding: 0 15px;
+  border-radius: 5px;
 }
 
 .subscribe-form .en__submit button:hover {
-	background-color: #e02d00;
+  background-color: #e02d00;
 }
 
 .subscribe-text {
-	float: right;
-	padding-left: 15px;
+  float: right;
+  padding-left: 15px;
 }
 
 @media (max-width: 575px) {
-	.subscribe-form .en__submit {
-		width: 100%;
-		margin-bottom: 10px;
-	}
+  .subscribe-form .en__submit {
+    width: 100%;
+    margin-bottom: 10px;
+  }
 
-	.subscribe-form .en__submit button {
-		width: 100%;
-	}
+  .subscribe-form .en__submit button {
+    width: 100%;
+  }
 
-	.subscribe-text {
-		float: unset;
-		width: 94%;
-		padding-right: 15px;
-	}
+  .subscribe-text {
+    float: unset;
+    width: 94%;
+    padding-right: 15px;
+  }
 }
 
 @media (min-width: 576px) {
-	.subscribe-form .en__submit {
-		width: 100%;
-		margin-bottom: 10px;
-		text-align: center;
-	}
+  .subscribe-form .en__submit {
+    width: 100%;
+    margin-bottom: 10px;
+    text-align: center;
+  }
 }
 
 @media (min-width: 768px) {
-	.subscribe-form .en__field {
-		width: 50%;
-		margin-bottom: 16px;
-	}
+  .subscribe-form .en__field {
+    width: 50%;
+    margin-bottom: 16px;
+  }
 
-	.subscribe-form .en__submit button {
-		width: 330px;
-	}
+  .subscribe-form .en__submit button {
+    width: 330px;
+  }
 
-	.subscribe-text {
-		margin: 0 auto;
-		width: 330px;
-		float: unset;
-		padding: 0;
-	}
+  .subscribe-text {
+    margin: 0 auto;
+    width: 330px;
+    float: unset;
+    padding: 0;
+  }
 }
 
 @media (min-width: 992px) {
-	.subscribe-form .en__field {
-		width: 41%;
-	}
+  .subscribe-form .en__field {
+    width: 41%;
+  }
 
-	.subscribe-form .en__field--select {
-		width: 33%;
-	}
+  .subscribe-form .en__field--select {
+    width: 33%;
+  }
 
-	.subscribe-form .en__submit {
-		width: 25%;
-		margin-bottom: 10px;
-	}
+  .subscribe-form .en__submit {
+    width: 25%;
+    margin-bottom: 10px;
+  }
 
-	.subscribe-form .en__submit button {
-		width: 100%;
-	}
+  .subscribe-form .en__submit button {
+    width: 100%;
+  }
 
-	.subscribe-text {
-		float: right;
-		width: 24%;
-		padding-right: 15px;
-	}
+  .subscribe-text {
+    float: right;
+    width: 24%;
+    padding-right: 15px;
+  }
 }

--- a/assets/scss/modules/_buttons.scss
+++ b/assets/scss/modules/_buttons.scss
@@ -54,9 +54,10 @@ Stylesheet: Button Styles
 /**
  * Primary, orange button.
  */
+
 .btn-primary {
   background-color: $orange;
-  box-shadow: 0 2px 5px rgba(0,0,0,.25);
+  box-shadow: 0 2px 5px rgba(0, 0, 0, .25);
 
   &:hover,
   &:focus {
@@ -73,6 +74,7 @@ Stylesheet: Button Styles
 /**
  * Secondary, semi-transparent button. Most buttons are this button.
  */
+
 .btn-secondary {
   background-color: transparentize($white, .7);
   border-color: $dark-blue;
@@ -94,10 +96,11 @@ Stylesheet: Button Styles
 /**
  * Similar to the primary button, but transparent by default.
  */
+
 .btn-action {
   background-color: transparentize($white, .8);
   border-color: $white;
-  box-shadow: 0 2px 5px rgba(0,0,0,.25);
+  box-shadow: 0 2px 5px rgba(0, 0, 0, .25);
 
   &:hover,
   &:focus {
@@ -114,12 +117,13 @@ Stylesheet: Button Styles
 /**
  * Donate button used in the navbar.
  */
+
 .btn-donate {
   background-color: $aquamarine;
   color: $grey;
   font-size: rem(16);
   line-height: 1.6;
-  box-shadow: 0 2px 5px rgba(0,0,0,.25);
+  box-shadow: 0 2px 5px rgba(0, 0, 0, .25);
   transition: color background-color font-weight 100ms;
 
   &:hover,
@@ -140,6 +144,7 @@ Stylesheet: Button Styles
 /**
  * Top navigation dropdown toggle button used in the navbar.
  */
+
 .btn-navbar-toggle {
   cursor: pointer;
   color: $gp-green;
@@ -152,11 +157,6 @@ Stylesheet: Button Styles
   &:active {
     color: $white;
     box-shadow: none;
-  }
-
-  &:hover,
-  &:focus,
-  &:active {
     background-color: $x-dark-blue;
     border: 1px solid transparent;
   }
@@ -165,13 +165,14 @@ Stylesheet: Button Styles
     background-color: $dark-blue;
     border-radius: 4px;
     border: 1px solid transparent;
-    box-shadow: 0 2px 5px rgba(0,0,0,.25);
+    box-shadow: 0 2px 5px rgba(0, 0, 0, .25);
   }
 }
 
 /**
  * Filter and filter-clearing buttons used in the search-results.
  */
+
 .btn-filter-item {
   background-color: transparent;
   border-color: $blue-tiber;
@@ -196,7 +197,7 @@ Stylesheet: Button Styles
     font-size: .7em;
     right: 10px;
     top: 50%;
-    transform: translate( 0, -40% );
+    transform: translate(0, -40%);
   }
 }
 
@@ -223,7 +224,7 @@ Stylesheet: Button Styles
     font-size: .6em;
     right: 10px;
     top: 50%;
-    transform: translate( 0, -40% );
+    transform: translate(0, -40%);
   }
 }
 
@@ -232,7 +233,8 @@ Stylesheet: Button Styles
   border: transparent;
   padding: 0;
   cursor: pointer;
+
   &:focus {
-    outline:none;
+    outline: none;
   }
 }

--- a/assets/scss/pages/_404.scss
+++ b/assets/scss/pages/_404.scss
@@ -1,5 +1,4 @@
 .page-404-page {
-
   .page-header-background {
     left: -200px;
 

--- a/assets/scss/pages/_evergreen.scss
+++ b/assets/scss/pages/_evergreen.scss
@@ -10,14 +10,7 @@
       );
     }
 
-    mask-image: linear-gradient(
-      170deg,
-      rgba(0, 0, 0, 1),
-      rgba(0, 0, 0, .2),
-      rgba(0, 0, 0, 0),
-      rgba(0, 0, 0, 0),
-      rgba(0, 0, 0, 0)
-    );
+    mask-image: linear-gradient(170deg, rgba(0, 0, 0, 1), rgba(0, 0, 0, .2), rgba(0, 0, 0, 0), rgba(0, 0, 0, 0), rgba(0, 0, 0, 0));
     mask-size: 100%;
     mask-repeat: no-repeat;
     mask-position: left top;

--- a/assets/scss/pages/_page.scss
+++ b/assets/scss/pages/_page.scss
@@ -9,15 +9,15 @@ div.page-template {
 
   @include medium-and-up {
     width: 720px;
-  };
+  }
 
   @include large-and-up {
     width: 960px;
-  };
+  }
 
   @include x-large-and-up {
     width: 1140px;
-  };
+  }
 
   .container {
     padding-left: 0;

--- a/assets/scss/pages/_take-action.scss
+++ b/assets/scss/pages/_take-action.scss
@@ -123,6 +123,7 @@
       font-weight: bold;
       margin-right: 5px;
     }
+
     .category-topic-title-seprater {
       background: $percentage-text;
       width: 5px;
@@ -178,9 +179,9 @@
       background: -webkit-gradient(linear, 66.31% -110.5%, 33.69% 210.5%, color-stop(0, rgba(10, 51, 81, 0)), color-stop(1, rgba(10, 51, 81, 1)));
       background: -o-linear-gradient(-120deg, rgba(10, 51, 81, 0) 0%, rgba(10, 51, 81, 1) 100%);
       background: -ms-linear-gradient(-120deg, rgba(10, 51, 81, 0) 0%, rgba(10, 51, 81, 1) 100%);
-      -ms-filter: "progid:DXImageTransform.Microsoft.gradient(startColorstr='#0A3351', endColorstr='#0A3351' ,GradientType=0)";
       background: linear-gradient(210deg, rgba(10, 51, 81, 0) 0%, rgba(10, 51, 81, 1) 100%);
-      filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#0A3351', endColorstr='#0A3351', GradientType=1);
+      filter: progid:dximagetransform.microsoft.gradient(startColorstr="#0a3351", endColorstr="#0a3351", GradientType=1);
+      -ms-filter: "progid:DXImageTransform.Microsoft.gradient(startColorstr='#0A3351', endColorstr='#0A3351' ,GradientType=0)";
 
       @include small-and-up {
         padding: 30px;
@@ -263,6 +264,7 @@
           }
         }
       }
+
       .carousel-control-next-icon {
         i {
           background-position: -21px 1px;
@@ -380,11 +382,11 @@
 
     @include large-and-up {
       cursor: pointer;
-      margin: 35px 0 0px 0;
+      margin: 35px 0 0 0;
     }
 
     @include x-large-and-up {
-      margin: 16px 0 0px 0;
+      margin: 16px 0 0 0;
     }
 
     .step-number {
@@ -476,7 +478,6 @@
           margin-top: 54px;
         }
       }
-
     }
 
     &:hover {
@@ -495,6 +496,7 @@
         color: $white;
         opacity: 0.7;
       }
+
       .step-info {
         p {
           color: $grey-60;

--- a/assets/scss/pages/post/_article-content.scss
+++ b/assets/scss/pages/post/_article-content.scss
@@ -84,7 +84,7 @@
     }
 
     @include x-large-and-up {
-      font-size: rem(18)
+      font-size: rem(18);
     }
 
     iframe {
@@ -118,7 +118,6 @@
   .alignleft {
     float: left;
     margin: 10px 10px 0 0;
-
   }
 
   .alignright {
@@ -234,6 +233,7 @@
     dt {
       margin: 0;
     }
+
     br + br {
       display: none;
     }
@@ -305,7 +305,7 @@
   }
 
   @include x-large-and-up {
-    font-size: rem(18)
+    font-size: rem(18);
   }
 
   img {

--- a/assets/scss/pages/post/_author-block.scss
+++ b/assets/scss/pages/post/_author-block.scss
@@ -54,7 +54,6 @@
   }
 
   @include medium-and-up {
-
     img {
       width: auto;
     }

--- a/assets/scss/pages/post/post.scss
+++ b/assets/scss/pages/post/post.scss
@@ -2,22 +2,16 @@
   .skewed-overlay {
     &:before {
       @include skewed-gradient(
-      transparent,
-      transparentize($dark-blue, .7),
-      transparentize($dark-blue, .7),
-      transparentize($dark-blue, .95),
-      transparentize($dark-blue, .8)
+        transparent,
+        transparentize($dark-blue, .7),
+        transparentize($dark-blue, .7),
+        transparentize($dark-blue, .95),
+        transparentize($dark-blue, .8)
       );
     }
 
-    mask-image: linear-gradient(
-    170deg,
-    rgba(0,0,0,1),
-    rgba(0,0,0,.2),
-    rgba(0,0,0,0),
-    rgba(0,0,0,0),
-    rgba(0,0,0,0)
-    );
+    mask-image: linear-gradient(170deg, rgba(0, 0, 0, 1), rgba(0, 0, 0, .2), rgba(0, 0, 0, 0), rgba(0, 0, 0, 0), rgba(0, 0, 0, 0));
+
     mask-size: 100%;
     mask-repeat: no-repeat;
     mask-position: left top;

--- a/assets/scss/pages/search/_filter-modal.scss
+++ b/assets/scss/pages/search/_filter-modal.scss
@@ -1,61 +1,61 @@
 .filter-modal {
-	.modal-dialog {
-		max-width: 90%;
-	}
+  .modal-dialog {
+    max-width: 90%;
+  }
 
-	.modal-body {
-		padding: 30px 15px;
+  .modal-body {
+    padding: 30px 15px;
 
-		@include small-and-up {
-			padding: 50px
-		}
-	}
+    @include small-and-up {
+      padding: 50px;
+    }
+  }
 
-	.modal-title {
-		font-size: rem(26);
-		margin-bottom: 24px;
+  .modal-title {
+    font-size: rem(26);
+    margin-bottom: 24px;
 
-		@include small-and-up {
-			font-size: rem(34);
-		}
-	}
+    @include small-and-up {
+      font-size: rem(34);
+    }
+  }
 
-	.cancelbtn {
-		min-width: 45%;
-		border-color: $orange;
-		color: $orange;
+  .cancelbtn {
+    min-width: 45%;
+    border-color: $orange;
+    color: $orange;
 
-		&:hover {
-			background: transparent;
-			color: $black;
-		}
-	}
+    &:hover {
+      background: transparent;
+      color: $black;
+    }
+  }
 
-	.applybtn {
-		width: 50%;
-		float: right;
-	}
+  .applybtn {
+    width: 50%;
+    float: right;
+  }
 
-	.closebtn {
-		float: right;
-		margin-top: -62px;
-		border-radius: 50%;
-		padding: 8px 14px;
-		margin-right: 0;
-		transition: color, border-color, background-color 150ms linear;
+  .closebtn {
+    float: right;
+    margin-top: -62px;
+    border-radius: 50%;
+    padding: 8px 14px;
+    margin-right: 0;
+    transition: color, border-color, background-color 150ms linear;
 
-		@include small-and-up {
-			padding: -15px
-		}
+    @include small-and-up {
+      padding: -15px;
+    }
 
-		&:hover {
-			background-color: $orange;
-			border-color: $orange;
-			color: $white;
-		}
+    &:hover {
+      background-color: $orange;
+      border-color: $orange;
+      color: $white;
+    }
 
-		i {
-			font-size: rem(12);
-		}
-	}
+    i {
+      font-size: rem(12);
+    }
+  }
 }

--- a/assets/scss/pages/search/_filter-sidebar.scss
+++ b/assets/scss/pages/search/_filter-sidebar.scss
@@ -1,240 +1,232 @@
 .filter-sidebar {
-	position: relative;
+  position: relative;
 
-	h4 {
-		font-size: rem(28);
-		margin-bottom: 48px;
-		font-weight: bold;
-	}
+  h4 {
+    font-size: rem(28);
+    margin-bottom: 48px;
+    font-weight: bold;
+  }
 
-	.filteritem {
-		a {
-			display: block;
-			border: 1px solid $faded-jade;
-			border-top: 0;
-			border-bottom-width: 4px;
-			padding: 11px 30px;
-			text-transform: uppercase;
-			text-decoration: none;
-			color: $header-footer-bg;
-			font-weight: bold;
-			position: relative;
-			font-size: rem(16);
-			margin-bottom: 24px;
+  .filteritem {
+    a {
+      display: block;
+      border: 1px solid $faded-jade;
+      border-top: 0;
+      border-bottom-width: 4px;
+      padding: 11px 30px;
+      text-transform: uppercase;
+      text-decoration: none;
+      color: $header-footer-bg;
+      font-weight: bold;
+      position: relative;
+      font-size: rem(16);
+      margin-bottom: 24px;
 
-			@include small-and-up {
-				padding: 13px 30px;
-				font-size: rem(18);
-				margin-bottom: 32px;
-			}
+      @include small-and-up {
+        padding: 13px 30px;
+        font-size: rem(18);
+        margin-bottom: 32px;
+      }
 
-			@include large-and-up {
-				padding: 11px 30px;
-				font-size: rem(20);
-			}
+      @include large-and-up {
+        padding: 11px 30px;
+        font-size: rem(20);
+      }
 
-			span {
-				position: absolute;
-				width: 14px;
-				height: 14px;
-				right: 0;
-				top: 0;
-				background-color: transparent;
-				margin: 16px;
+      span {
+        position: absolute;
+        width: 14px;
+        height: 14px;
+        right: 0;
+        top: 0;
+        background-color: transparent;
+        margin: 16px;
 
-				&:before,
-				&:after {
-					content: "";
-					position: absolute;
-					background-color: $black;
-					transition: transform 0.25s ease-out;
-				}
+        &:before,
+        &:after {
+          content: "";
+          position: absolute;
+          background-color: $black;
+          transition: transform 0.25s ease-out;
+        }
 
-				/* vertical line */
-				&:before {
-					top: 0;
-					left: 50%;
-					width: 4px;
-					height: 100%;
-					margin-left: -2px;
-				}
+        &:before {
+          top: 0;
+          left: 50%;
+          width: 4px;
+          height: 100%;
+          margin-left: -2px;
+          transform: rotate(90deg);
+        }
 
-				/* horizontal line */
-				&:after {
-					top: 50%;
-					left: 0;
-					width: 100%;
-					height: 4px;
-					margin-top: -2px;
-				}
+        &:after {
+          top: 50%;
+          left: 0;
+          width: 100%;
+          height: 4px;
+          margin-top: -2px;
+        }
+      }
 
-				&:before {
-					transform: rotate(90deg);
-				}
-			}
+      &.collapsed {
+        border-bottom-width: 2px;
 
-			&.collapsed {
-				border-bottom-width: 2px;
+        span {
+          &:before {
+            transform: rotate(180deg);
+          }
 
-				span {
-					&:before {
-						transform: rotate(180deg);
-					}
+          &:after {
+            transform: rotate(180deg);
+          }
+        }
+      }
+    }
 
-					&:after {
-						transform: rotate(180deg);
-					}
-				}
-			}
-		}
+    .custom-control-indicator {
+      appearance: none;
+      border: 1px solid $black;
+      background-color: transparent;
+    }
 
-		.custom-control-indicator {
-			appearance: none;
-			border: 1px solid $black;
-			background-color: transparent;
-		}
+    .p4-custom-control-input:checked {
+      & + .custom-control-indicator {
+        background-color: $faded-jade;
+        border-color: $faded-jade;
+      }
 
-		.p4-custom-control-input:checked {
-			& + .custom-control-indicator {
-				background-color: $faded-jade;
-				border-color: $faded-jade;
-			}
+      & ~ .custom-control-description {
+        font-weight: bold;
+      }
+    }
 
-			& ~ .custom-control-description {
-				font-weight: bold;
-			}
-		}
+    ul {
+      li {
+        height: 42px;
+        display: block;
+      }
+    }
 
-		ul {
-			li {
-				height: 42px;
-				display: block;
-			}
-		}
+    .custom-control-description {
+      color: $grey;
 
-		.custom-control-description {
-			color: $grey;
+      @include small-and-up {
+        font-size: rem(16);
+      }
 
-			@include small-and-up {
-				font-size: rem(16);
-			}
+      @include x-large-and-up {
+        font-size: rem(18);
+      }
+    }
+  }
 
-			@include x-large-and-up {
-				font-size: rem(18);
-			}
-		}
-	}
+  .filter-button {
+    position: absolute;
+    top: 0;
+    left: 0;
+    margin-top: 29px;
+    z-index: 2;
 
-	.filter-button {
-		position: absolute;
-		top:0;
-		left: 0;
-		margin-top: 29px;
-		z-index: 2;
+    @include small-and-up {
+      margin-top: -14px;
+    }
 
-		@include small-and-up {
-			margin-top: -14px;
-		}
+    .btn-filter {
+      font-size: rem(16);
+      height: 40px;
+      width: 130px;
+      line-height: 40px;
+      background: $orange;
+      font-weight: bold;
+      padding: 0 10px;
+      text-transform: uppercase;
+      color: $white;
 
-		.btn-filter {
-			font-size: rem(16);
-			height: 40px;
-			width: 130px;
-			line-height: 40px;
-			background: $orange;
-			font-weight: bold;
-			padding: 0 10px;
-			text-transform: uppercase;
-			color: $white;
+      &:hover {
+        color: $black;
+        cursor: pointer;
+      }
 
-			&:hover {
-				color: $black;
-			}
+      i {
+        font-size: rem(20);
+        vertical-align: middle;
+        margin-right: 20px;
+      }
 
-			i {
-				font-size: rem(20);
-				vertical-align: middle;
-				margin-right: 20px;
-			}
+      @include small-and-up {
+        font-size: rem(16);
+        height: 48px;
+        width: 150px;
+        line-height: 48px;
 
-			&:hover {
-				cursor: pointer;
-			}
+        &:hover {
+          background: $orange-hover;
+          color: $white;
+        }
+      }
 
-			@include small-and-up {
-				font-size: rem(16);
-				height: 48px;
-				width: 150px;
-				line-height: 48px;
+      &.disabled {
+        background: $grey-40;
 
-				&:hover {
-					background: $orange-hover;
-					color: $white;
-				}
-			}
+        &:hover {
+          color: $white;
+          cursor: not-allowed;
+        }
+      }
+    }
+  }
 
-			&.disabled {
-				background: $grey-40;
+  .active-filter {
+    h5 {
+      font-size: rem(20);
+      color: $grey-40;
+      margin-bottom: 20px;
+    }
 
-				&:hover {
-					color: $white;
-					cursor: not-allowed;
-				}
-			}
-		}
-	}
+    .activefilter-list {
+      margin-bottom: 20px;
+      border-bottom: 1px solid $grey-20;
+      padding-bottom: 10px;
 
-	.active-filter{
-		h5 {
-			font-size: rem(20);
-			color: $grey-40;
-			margin-bottom: 20px;
-		}
+      .activefilter-tag,
+      .clearall {
+        font-size: rem(18);
+        font-style: normal;
+        color: $blue-tiber;
+        border: 1px solid $blue-tiber;
+        border-radius: 6px;
+        padding: 0 40px 0 20px;
+        display: inline-block;
+        margin-right: 8px;
+        margin-bottom: 16px;
+        line-height: 42px;
+        text-decoration: none;
+        position: relative;
+        min-width: 40%;
 
-		.activefilter-list {
-			margin-bottom: 20px;
-			border-bottom: 1px solid $grey-20;
-			padding-bottom: 10px;
+        i {
+          font-size: rem(12);
+          position: absolute;
+          right: 0;
+          top: 0;
+          margin: 15px;
+        }
+      }
 
-			.activefilter-tag,
-			.clearall {
-				font-size: rem(18);
-				font-style: normal;
-				color: $blue-tiber;
-				border: 1px solid $blue-tiber;
-				border-radius: 6px;
-				padding: 0 40px 0 20px;
-				display: inline-block;
-				margin-right: 8px;
-				margin-bottom: 16px;
-				line-height: 42px;
-				text-decoration: none;
-				position: relative;
-				min-width: 40%;
+      .activefilter-tag {
+        background-color: transparent;
+        cursor: pointer;
+        text-align: left;
+      }
 
-				i {
-					font-size: rem(12);
-					position: absolute;
-					right: 0;
-					top: 0;
-					margin: 15px;
-				}
-			}
-
-			.activefilter-tag {
-				background-color: transparent;
-				cursor: pointer;
-				text-align: left;
-			}
-
-			.clearall {
-				text-align: center;
-				width: 100%;
-				background: $med-blue;
-				color: $white;
-				text-transform: uppercase;
-				cursor: pointer;
-			}
-		}
-	}
+      .clearall {
+        text-align: center;
+        width: 100%;
+        background: $med-blue;
+        color: $white;
+        text-transform: uppercase;
+        cursor: pointer;
+      }
+    }
+  }
 }

--- a/assets/scss/pages/search/_filtered-tags.scss
+++ b/assets/scss/pages/search/_filtered-tags.scss
@@ -1,40 +1,40 @@
 .search-info {
-	font-size: rem(14);
-	margin-bottom: 0;
-	font-family: $roboto;
-	font-style: italic;
-	color: $grey-60;
-	line-height: normal;
+  font-size: rem(14);
+  margin-bottom: 0;
+  font-family: $roboto;
+  font-style: italic;
+  color: $grey-60;
+  line-height: normal;
 
-	@include medium-and-up {
-		font-size: rem(18);
-	}
+  @include medium-and-up {
+    font-size: rem(18);
+  }
 
-	@include large-and-up {
-		font-size: rem(28);
-	}
+  @include large-and-up {
+    font-size: rem(28);
+  }
 
-	@include x-large-and-up {
-		font-size: rem(32);
-	}
+  @include x-large-and-up {
+    font-size: rem(32);
+  }
 
-	.btn-filter-item {
-		font-size: rem(14);
-		line-height: 1.6;
-		font-style: normal;
-		text-transform: none;
-		margin-left: 10px;
-		padding: 0 30px 0 10px;
-		border-width: 2px;
+  .btn-filter-item {
+    font-size: rem(14);
+    line-height: 1.6;
+    font-style: normal;
+    text-transform: none;
+    margin-left: 10px;
+    padding: 0 30px 0 10px;
+    border-width: 2px;
 
-		@include small-and-up {
-			font-size: rem(16);
-			line-height: 1.9;
-			padding: 0 40px 0 15px;
-		}
+    @include small-and-up {
+      font-size: rem(16);
+      line-height: 1.9;
+      padding: 0 40px 0 15px;
+    }
 
-		@include large-and-up {
-			font-size: rem(22);
-		}
-	}
+    @include large-and-up {
+      font-size: rem(22);
+    }
+  }
 }

--- a/assets/scss/pages/search/_search-bar.scss
+++ b/assets/scss/pages/search/_search-bar.scss
@@ -1,99 +1,99 @@
 .search-bar {
-	width: 100%;
-	background: transparentize($white, .7);
-	border-radius: 5px;
-	border: 1px solid $faded-jade;
-	padding: 24px 15px;
+  width: 100%;
+  background: transparentize($white, .7);
+  border-radius: 5px;
+  border: 1px solid $faded-jade;
+  padding: 24px 15px;
 
-	@include small-and-up {
-		padding: 32px;
-	}
+  @include small-and-up {
+    padding: 32px;
+  }
 
-	input {
-		font-size: rem(16);
-		height: 2.75em;
-		line-height: 2.75;
-		appearance: none;
+  input {
+    font-size: rem(16);
+    height: 2.75em;
+    line-height: 2.75;
+    appearance: none;
 
-		@include large-and-up {
-			font-size: rem(18);
-			height: 3em;
-			line-height: 3;
-		}
-	}
+    @include large-and-up {
+      font-size: rem(18);
+      height: 3em;
+      line-height: 3;
+    }
+  }
 
-	.btn-secondary {
-		background-color: transparentize($white, .8);
-		border-color: $grey-20;
-		color: $black;
-		text-transform: capitalize;
-		width: 50%;
-		cursor: pointer;
-		margin-bottom: 10px;
+  .btn-secondary {
+    background-color: transparentize($white, .8);
+    border-color: $grey-20;
+    color: $black;
+    text-transform: capitalize;
+    width: 50%;
+    cursor: pointer;
+    margin-bottom: 10px;
 
-		@include small-and-up {
-			margin-bottom: 0;
-		}
+    @include small-and-up {
+      margin-bottom: 0;
+    }
 
-		&.active {
-			background-color: $dark-blue;
-			border-color: transparent;
-			color: $white;
+    &.active {
+      background-color: $dark-blue;
+      border-color: transparent;
+      color: $white;
 
-			&:before {
-				content:"";
-				position: absolute;
-				top: 0;
-				left: 0;
-				width: 8px;
-				height: 8px;
-				border-radius: 5px;
-				background-color: $white;
-				margin-top: 18px;
-				margin-left: 5px;
+      &:before {
+        content: "";
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 8px;
+        height: 8px;
+        border-radius: 5px;
+        background-color: $white;
+        margin-top: 18px;
+        margin-left: 5px;
 
-				@include large-and-up {
-					margin-top: 25px;
-					margin-left: 12px;
-				}
-			}
+        @include large-and-up {
+          margin-top: 25px;
+          margin-left: 12px;
+        }
+      }
 
-			&:hover {
-				z-index: 2;
-				background-color: $dark-blue;
-			}
-		}
+      &:hover {
+        z-index: 2;
+        background-color: $dark-blue;
+      }
+    }
 
-		&:hover {
-			z-index: 0;
-			background-color: $grey-20;
-		}
-	}
+    &:hover {
+      z-index: 0;
+      background-color: $grey-20;
+    }
+  }
 
-	.search-btn,
-	.btn-secondary {
-		font-size: rem(16);
-		line-height: 2.75;
+  .search-btn,
+  .btn-secondary {
+    font-size: rem(16);
+    line-height: 2.75;
 
-		@include large-and-up {
-			font-size: rem(18);
-			line-height: 3;
-		}
+    @include large-and-up {
+      font-size: rem(18);
+      line-height: 3;
+    }
 
-		i {
-			font-size: rem(18);
-			font-weight: normal;
-			line-height: 0;
-			float: left;
-			margin-top: 22px;
+    i {
+      font-size: rem(18);
+      font-weight: normal;
+      line-height: 0;
+      float: left;
+      margin-top: 22px;
 
-			@include large-and-up {
-				margin-top: 27px;
-			}
-		}
-	}
+      @include large-and-up {
+        margin-top: 27px;
+      }
+    }
+  }
 
-	.search-btn {
-		box-shadow: 0 8px 15px rgba(0, 0, 0, 0.1);
-	}
+  .search-btn {
+    box-shadow: 0 8px 15px rgba(0, 0, 0, 0.1);
+  }
 }

--- a/assets/scss/pages/search/_search-results.scss
+++ b/assets/scss/pages/search/_search-results.scss
@@ -62,7 +62,7 @@
       }
 
       &.search-result-list-item-bg {
-        @include background('images/search-list.jpg');
+        @include background("images/search-list.jpg");
         padding: 24px 15px 30px;
         margin: 0;
         box-shadow: 0 8px 15px rgba(0, 0, 0, 0.1);
@@ -122,7 +122,7 @@
     margin-top: 25px;
 
     @include large-and-up {
-      margin-top: 35px
+      margin-top: 35px;
     }
   }
 }
@@ -246,7 +246,7 @@
     }
 
     &:after {
-      content:"";
+      content: "";
       position: absolute;
       top: 0;
       right: 0;

--- a/assets/scss/pages/search/_sort-filter.scss
+++ b/assets/scss/pages/search/_sort-filter.scss
@@ -1,74 +1,74 @@
 div.search-filter-results {
-	margin-top: 48px;
-	z-index: auto;
+  margin-top: 48px;
+  z-index: auto;
 
-	@include small-and-up {
-		margin-top: 75px;
-	}
+  @include small-and-up {
+    margin-top: 75px;
+  }
 
-	@include large-and-up {
-		margin-top: 100px;
-	}
+  @include large-and-up {
+    margin-top: 100px;
+  }
 }
 
 .sort-filter {
-	width: 50%;
-	float: right;
+  width: 50%;
+  float: right;
 
-	@include small-and-up {
-		width: 100%;
-		float: none;
-	}
+  @include small-and-up {
+    width: 100%;
+    float: none;
+  }
 
-	label {
-		font-size: rem(18);
-		margin-right: 90px;
-		font-weight: bold;
+  label {
+    font-size: rem(18);
+    margin-right: 90px;
+    font-weight: bold;
 
-		@include small-and-up {
-			margin-right: 0;
-		}
+    @include small-and-up {
+      margin-right: 0;
+    }
 
-		@include large-and-up {
-			font-size: rem(26);
-		}
+    @include large-and-up {
+      font-size: rem(26);
+    }
 
-		@include large-and-up {
-			font-size: rem(28);
-		}
-	}
+    @include large-and-up {
+      font-size: rem(28);
+    }
+  }
 
-	select {
-		height: 40px;
-		width: 151px;
-		font-size: rem(16);
-		padding: 0 10px;
-		border-radius: 6px;
-		border-color: $faded-jade;
-		background: transparent;
+  select {
+    height: 40px;
+    width: 151px;
+    font-size: rem(16);
+    padding: 0 10px;
+    border-radius: 6px;
+    border-color: $faded-jade;
+    background: transparent;
 
-		@include small-and-up {
-			width: 210px;
-		}
+    @include small-and-up {
+      width: 210px;
+    }
 
-		@include large-and-up {
-			height: 44px;
-			width: 224px;
-			font-size: rem(20);
-		}
+    @include large-and-up {
+      height: 44px;
+      width: 224px;
+      font-size: rem(20);
+    }
 
-		@include large-and-up {
-			width: 270px;
-			font-size: rem(22);
-		}
-	}
+    @include large-and-up {
+      width: 270px;
+      font-size: rem(22);
+    }
+  }
 
-	div {
-		text-align: right;
-		margin-top: -7px;
+  div {
+    text-align: right;
+    margin-top: -7px;
 
-		@include small-and-up {
-			text-align: inherit;
-		}
-	}
+    @include small-and-up {
+      text-align: inherit;
+    }
+  }
 }

--- a/assets/scss/pages/search/_suggested-terms.scss
+++ b/assets/scss/pages/search/_suggested-terms.scss
@@ -1,53 +1,53 @@
 .suggested-search-terms {
-	margin: 50px 0 104px;
+  margin: 50px 0 104px;
 
-	h3 {
-		font-size: rem(26);
-		margin-bottom: 16px;
+  h3 {
+    font-size: rem(26);
+    margin-bottom: 16px;
 
-		@include small-and-up {
-			font-size: rem(34);
-		}
+    @include small-and-up {
+      font-size: rem(34);
+    }
 
-		@include large-and-up {
-			font-size: rem(36);
-		}
-	}
+    @include large-and-up {
+      font-size: rem(36);
+    }
+  }
 }
 
 .suggested-list {
-	background-color: transparentize($white, .6);
-	padding: 32px 17px;
-	margin: 0;
+  background-color: transparentize($white, .6);
+  padding: 32px 17px;
+  margin: 0;
 
-	ul {
-		margin-bottom: 0;
-	}
+  ul {
+    margin-bottom: 0;
+  }
 
-	li {
-		text-align: center;
+  li {
+    text-align: center;
 
-		@include medium-and-up {
-			text-align: left;
-		}
+    @include medium-and-up {
+      text-align: left;
+    }
 
-		a {
-			color: $blue-elm;
-			text-decoration: none;
-			font-size: rem(18);
-			line-height: 2.3;
+    a {
+      color: $blue-elm;
+      text-decoration: none;
+      font-size: rem(18);
+      line-height: 2.3;
 
-			@include medium-and-up {
-				font-size: rem(22);
-			}
+      @include medium-and-up {
+        font-size: rem(22);
+      }
 
-			@include large-and-up {
-				font-size: rem(18);
-			}
+      @include large-and-up {
+        font-size: rem(18);
+      }
 
-			@include x-large-and-up {
-				font-size: rem(22);
-			}
-		}
-	}
+      @include x-large-and-up {
+        font-size: rem(22);
+      }
+    }
+  }
 }

--- a/assets/scss/pages/sign-petition/_sign-petition.scss
+++ b/assets/scss/pages/sign-petition/_sign-petition.scss
@@ -4,6 +4,7 @@ $placeholder-color: #001317;
   &.page-header {
     padding-top: 61px;
     padding-bottom: 0;
+
     .custom-title {
       max-width: 90%;
       margin-top: 49px;
@@ -18,19 +19,21 @@ $placeholder-color: #001317;
       @include medium-and-up {
         font-size: rem(40);
         max-width: 75%;
-        margin-top: 80px; 
+        margin-top: 80px;
       }
+
       @include large-and-up {
         font-size: rem(48);
         max-width: 75%;
-        margin-top: 80px; 
+        margin-top: 80px;
       }
 
       @include x-large-and-up {
         font-size: rem(66);
-        margin-top: 120px; 
+        margin-top: 120px;
       }
     }
+
     .subhead-custom-title {
       font-size: rem(26);
       margin-bottom: 32px;
@@ -44,13 +47,16 @@ $placeholder-color: #001317;
       @include x-large-and-up {
         font-size: rem(36);
       }
+
       &.normaltxt {
         font-weight: normal;
+
         span {
           font-weight: bold;
         }
-      }  
+      }
     }
+
     .subhead-para {
       font-size: rem(16);
       line-height: 22px;
@@ -68,18 +74,23 @@ $placeholder-color: #001317;
         line-height: 34px;
       }
     }
+
     .petition-form {
-      background-color:rgba(0,19,23,0.6);
+      background-color: rgba(0, 19, 23, 0.6);
       padding: 16px;
+
       @include medium-and-up {
         margin-bottom: 64px;
       }
+
       @include large-and-up {
         margin-bottom: 80px;
       }
+
       @include x-large-and-up {
         margin-bottom: 88px;
       }
+
       .form-group {
         margin-bottom: 20px;
         @include medium-and-up {
@@ -92,21 +103,24 @@ $placeholder-color: #001317;
         @include x-large-and-up {
           margin-bottom: 32px;
         }
+
         .form-control {
           height: 48px;
           border-radius: 0;
-          color:rgb(0,19,23);
+          color: rgb(0, 19, 23);
           font-size: rem(16);
           font-family: $roboto;
           @include large-and-up {
             height: 56px;
             font-size: rem(18);
           }
+
           &::placeholder {
             font-family: $roboto;
             color: $placeholder-color;
           }
         }
+
         .form-check-label {
           font-size: rem(14);
           font-style: italic;
@@ -116,8 +130,10 @@ $placeholder-color: #001317;
         }
 
         .styled-checkbox {
-          position: absolute; // take it out of document flow
-          opacity: 0; // hide it
+          // take it out of document flow
+          position: absolute;
+          // hide it
+          opacity: 0;
 
           & + label {
             position: relative;
@@ -127,7 +143,7 @@ $placeholder-color: #001317;
 
           // Box.
           & + label:before {
-            content: '';
+            content: "";
             margin-right: 10px;
             display: inline-block;
             vertical-align: text-top;
@@ -138,7 +154,7 @@ $placeholder-color: #001317;
 
           // Box hover
           &:hover + label:before {
-            background: #02484E;
+            background: #02484e;
           }
 
           // Box focus
@@ -148,7 +164,7 @@ $placeholder-color: #001317;
 
           // Box checked
           &:checked + label:before {
-            background: #02484E;
+            background: #02484e;
           }
 
           // Disabled state label.
@@ -165,27 +181,23 @@ $placeholder-color: #001317;
 
           // Checkmark. Could be replaced with an image
           &:checked + label:after {
-            content: '';
+            content: "";
             position: absolute;
             left: 5px;
             top: 9px;
             background: white;
             width: 2px;
             height: 2px;
-            box-shadow: 
-            2px 0 0 white,
-            4px 0 0 white,
-            4px -2px 0 white,
-            4px -4px 0 white,
-            4px -6px 0 white,
-            4px -8px 0 white;
+            box-shadow: 2px 0 0 white, 4px 0 0 white, 4px -2px 0 white, 4px -4px 0 white, 4px -6px 0 white, 4px -8px 0 white;
             transform: rotate(45deg);
           }
         }
       }
+
       .btn {
         margin-bottom: 8px;
       }
+
       .message-box {
         max-height: 350px;
         overflow-y: scroll;
@@ -193,6 +205,7 @@ $placeholder-color: #001317;
         margin-bottom: 20px;
         color: $grey;
         padding: 16px;
+
         p {
           font-family: $roboto;
           font-size: rem(16);
@@ -202,39 +215,45 @@ $placeholder-color: #001317;
             line-height: 22px;
           }
         }
+
         .message-label {
           color: $grey-40;
           font-size: rem(12);
         }
       }
-      .customselect-country { 
+
+      .customselect-country {
         position: relative;
+
         .select-gred {
           color: $white;
-          background: rgba(0,99,110,1);
-          background: -moz-linear-gradient(left, rgba(0,99,110,1) 0%, rgba(44,148,171,1) 100%);
-          background: -webkit-gradient(left top, right top, color-stop(0%, rgba(0,99,110,1)), color-stop(100%, rgba(44,148,171,1)));
-          background: -webkit-linear-gradient(left, rgba(0,99,110,1) 0%, rgba(44,148,171,1) 100%);
-          background: -o-linear-gradient(left, rgba(0,99,110,1) 0%, rgba(44,148,171,1) 100%);
-          background: -ms-linear-gradient(left, rgba(0,99,110,1) 0%, rgba(44,148,171,1) 100%);
-          background: linear-gradient(to right, rgba(0,99,110,1) 0%, rgba(44,148,171,1) 100%);
-          filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#00636e', endColorstr='#2c94ab', GradientType=1 );
-          height:48px; 
+          background: rgba(0, 99, 110, 1);
+          background: -moz-linear-gradient(left, rgba(0, 99, 110, 1) 0%, rgba(44, 148, 171, 1) 100%);
+          background: -webkit-gradient(left top, right top, color-stop(0%, rgba(0, 99, 110, 1)), color-stop(100%, rgba(44, 148, 171, 1)));
+          background: -webkit-linear-gradient(left, rgba(0, 99, 110, 1) 0%, rgba(44, 148, 171, 1) 100%);
+          background: -o-linear-gradient(left, rgba(0, 99, 110, 1) 0%, rgba(44, 148, 171, 1) 100%);
+          background: -ms-linear-gradient(left, rgba(0, 99, 110, 1) 0%, rgba(44, 148, 171, 1) 100%);
+          background: linear-gradient(to right, rgba(0, 99, 110, 1) 0%, rgba(44, 148, 171, 1) 100%);
+          filter: progid:dximagetransform.microsoft.gradient(startColorstr="#00636e", endColorstr="#2c94ab", GradientType=1);
+          height: 48px;
           width: 100%;
           display: block;
           padding: 0 16px;
           margin-bottom: 32px;
           cursor: pointer;
+
           span {
             line-height: 48px;
           }
+
           &.active {
             .arrow-selected {
               transform: rotate(90deg);
             }
           }
+
           .arrow-selected {
-            background: url(images/selectarrow.png);
+            background: url("images/selectarrow.png");
             width: 18px;
             height: 18px;
             float: right;
@@ -242,6 +261,7 @@ $placeholder-color: #001317;
             transition: all 1s ease;
           }
         }
+
         .option-contry {
           background: $white;
           width: 100%;
@@ -253,10 +273,12 @@ $placeholder-color: #001317;
           z-index: 2;
           overflow-y: auto;
           display: none;
-          box-shadow: 0px 1px $grey-20;
+          box-shadow: 0 1px $grey-20;
+
           &.active {
             display: block;
           }
+
           ul {
             li {
               a {
@@ -266,25 +288,29 @@ $placeholder-color: #001317;
                 border-bottom: 1px solid $grey-20;
                 cursor: pointer;
                 display: block;
-              }  
+              }
             }
           }
         }
       }
     }
+
     p.thankmsg {
       margin-bottom: 56px;
     }
+
     .socialshare {
       margin-bottom: 120px;
       clear: both;
       height: auto;
+
       a {
         width: 40%;
         display: block;
         text-decoration: none;
         margin-right: 20px;
         float: left;
+
         img {
           width: 100%;
         }

--- a/assets/scss/partials/_custom.scss
+++ b/assets/scss/partials/_custom.scss
@@ -1,12 +1,11 @@
 // Bootstrap overrides
 //
 // Copy variables from `_variables.scss` to this file to override default values
-// without modifying source files. 
+// without modifying source files.
 // Remove !default from the copied values.
 
 // Overiding the background color just an example
 // changed from #292b2c to #292b2d for demo
-
 .visible-md-only,
 .md-navigation {
   display: none;

--- a/assets/scss/partials/_font-icon.scss
+++ b/assets/scss/partials/_font-icon.scss
@@ -1,17 +1,17 @@
 @font-face {
-  font-family: 'greenpeace-icon';
-  src:  url('fonts/greenpeace-icon.eot?x1zqe3');
-  src:  url('fonts/greenpeace-icon.eot?x1zqe3#iefix') format('embedded-opentype'),
-    url('fonts/greenpeace-icon.ttf?x1zqe3') format('truetype'),
-    url('fonts/greenpeace-icon.woff?x1zqe3') format('woff'),
-    url('fonts/greenpeace-icon.svg?x1zqe3#greenpeace-icon') format('svg');
+  font-family: greenpeace-icon;
+  src: url("fonts/greenpeace-icon.eot?x1zqe3");
+  src: url("fonts/greenpeace-icon.eot?x1zqe3#iefix") format("embedded-opentype"),
+    url("fonts/greenpeace-icon.ttf?x1zqe3") format("truetype"),
+    url("fonts/greenpeace-icon.woff?x1zqe3") format("woff"),
+    url("fonts/greenpeace-icon.svg?x1zqe3#greenpeace-icon") format("svg");
   font-weight: normal;
   font-style: normal;
 }
 
 [class^="icon-"], [class*=" icon-"] {
   /* use !important to prevent issues with browser extensions that change fonts */
-  font-family: 'greenpeace-icon' !important;
+  font-family: greenpeace-icon !important;
   speak: none;
   font-style: normal;
   font-weight: normal;
@@ -23,28 +23,35 @@
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
+
 .icon-arrow-marker .path1:before {
   content: "\e905";
   color: rgb(0, 0, 0);
   opacity: 0.25;
 }
+
 .icon-arrow-marker .path2:before {
   content: "\e906";
   margin-left: -1em;
   color: rgb(0, 0, 0);
 }
+
 .icon-doc-ic:before {
   content: "\e900";
 }
+
 .icon-arrow-icon:before {
   content: "\e901";
 }
+
 .icon-filter:before {
   content: "\e902";
 }
+
 .icon-search:before {
   content: "\e903";
 }
+
 .icon-cross:before {
   content: "\e904";
 }

--- a/assets/scss/partials/_functions.scss
+++ b/assets/scss/partials/_functions.scss
@@ -1,46 +1,47 @@
 /**
- * Global functions.
- */
+* Global functions.
+*/
 
 /**
- * Test if `$value` is a valid direction
- *
- * @param {*} $value - Value to test
- * @return {Bool}
- */
-@function is-direction( $value ) {
-	$is-keyword: index((to top, to top right, to right top, to right, to bottom right, to right bottom, to bottom, to bottom left, to left bottom, to left, to left top, to top left), $value);
-	$is-angle: type-of( $value ) == 'number' and index( 'deg' 'grad' 'turn' 'rad', unit( $value ) );
+* Test if `$value` is a valid direction
+*
+* @param {*} $value - Value to test
+* @return {Bool}
+*/
 
-	@return $is-keyword or $is-angle;
+@function is-direction( $value ) {
+  $is-keyword: index((to top, to top right, to right top, to right, to bottom right, to right bottom, to bottom, to bottom left, to left bottom, to left, to left top, to top left), $value);
+  $is-angle: type-of($value) == "number" and index("deg" "grad" "turn" "rad", unit($value));
+
+  @return $is-keyword or $is-angle;
 }
 
 /**
- * Convert a direction to legacy syntax
- *
- * @param {Keyword | Angle} $value - Value to convert
- * @require {function} is-direction
- * @require {function} convert-angle
- */
+* Convert a direction to legacy syntax
+*
+* @param {Keyword | Angle} $value - Value to convert
+* @require {function} is-direction
+* @require {function} convert-angle
+*/
 @function legacy-direction( $value ) {
-	$conversion-map: (
-		to top : bottom,
-		to top right : bottom left,
-		to right top : left bottom,
-		to right : left,
-		to bottom right : top left,
-		to right bottom : left top,
-		to bottom : top,
-		to bottom left : top right,
-		to left bottom : right top,
-		to left : right,
-		to left top : right bottom,
-		to top left : bottom right
-	);
+  $conversion-map: (
+    to top : bottom,
+    to top right : bottom left,
+    to right top : left bottom,
+    to right : left,
+    to bottom right : top left,
+    to right bottom : left top,
+    to bottom : top,
+    to bottom left : top right,
+    to left bottom : right top,
+    to left : right,
+    to left top : right bottom,
+    to top left : bottom right
+  );
 
-	@if map-has-key($conversion-map, $value) {
-		@return map-get($conversion-map, $value);
-	}
+  @if map-has-key($conversion-map, $value) {
+    @return map-get($conversion-map, $value);
+  }
 
-	@return 90deg - $value;
+  @return 90deg - $value;
 }

--- a/assets/scss/partials/_hacks.scss
+++ b/assets/scss/partials/_hacks.scss
@@ -1,12 +1,13 @@
 /**
- * Hacks file for modifying and overriding external styles.
- */
+* Hacks file for modifying and overriding external styles.
+*/
 
 /**
- * Keep the admin bar fixed on mobile screens for consistency.
- */
+* Keep the admin bar fixed on mobile screens for consistency.
+*/
+
 @media screen and (max-width: 600px) {
-	#wpadminbar {
-		position: fixed;
-	}
+  #wpadminbar {
+    position: fixed;
+  }
 }

--- a/assets/scss/partials/_mixins.scss
+++ b/assets/scss/partials/_mixins.scss
@@ -6,7 +6,7 @@ Stylesheet: Mixins Stylesheet
 ******************************************************************/
 
 /*********************
- Media Queries
+Media Queries
 *********************/
 
 // Mobile-only (up to 576px)
@@ -49,7 +49,7 @@ TRANSITION
 *********************/
 
 /*
- * USAGE: @include transition(all 0.2s ease-in-out);
+* USAGE: @include transition(all 0.2s ease-in-out);
 */
 
 @mixin transition($transition...) {
@@ -61,8 +61,8 @@ TRANSITION
 }
 
 /**
- * Cause an element to match the size of its stacking context parent.
- */
+* Cause an element to match the size of its stacking context parent.
+*/
 @mixin fill-container() {
   position: absolute;
   top: 0;
@@ -72,8 +72,8 @@ TRANSITION
 }
 
 /**
- * Build a linear gradient with a direction and any number of color stops.
- */
+* Build a linear gradient with a direction and any number of color stops.
+*/
 @mixin linear-gradient( $direction, $color-stops... ) {
   background: nth(nth($color-stops, 1), 1); /* Old browsers */
   background: -moz-linear-gradient(legacy-direction($direction), $color-stops); /* FF3.6-15 */
@@ -82,10 +82,10 @@ TRANSITION
 }
 
 /**
- * Create a gradient with hard stops that lines up
- *
- * Colors layout from top-right to bottom-left.
- */
+* Create a gradient with hard stops that lines up
+*
+* Colors layout from top-right to bottom-left.
+*/
 @mixin skewed-gradient( $color1, $color2, $color3, $color4, $color5 ) {
   @include linear-gradient(
     245deg,
@@ -164,12 +164,12 @@ TRANSITION
 }
 
 @mixin background($imgpath,$position:center,$repeat: no-repeat, $size: cover) {
-    background: {
-        image: url($imgpath);
-        position: $position;
-        repeat: $repeat;
-        size: $size;
-    }
+  background: {
+    image: url($imgpath);
+    position: $position;
+    repeat: $repeat;
+    size: $size;
+  }
 }
 
 /*********************
@@ -177,31 +177,30 @@ Skew mixin
 *********************/
 
 @mixin skew($side: right, $deg: -20deg, $right: -15px, $left: -15px, $width: 30px, $bg: $white) {
-    position: relative;
+  position: relative;
 
-    &:before {
-        z-index: -1;
-        content: '';
-        position: absolute;
-        top: 0;
-        bottom: 0;
+  &:before {
+    z-index: -1;
+    content: "";
+    position: absolute;
+    top: 0;
+    bottom: 0;
 
-        @if $side == right {
-            right: $right;
-        }
-        @else if $side == left {
-            left: $left;
-        }
-
-        display: block;
-        width: $width;
-        background: $bg;
-        -webkit-transform: skew($deg);
-            -ms-transform: skew($deg);
-                transform: skew($deg);
+    @if $side == right {
+      right: $right;
     }
-}
+    @else if $side == left {
+      left: $left;
+    }
 
+    display: block;
+    width: $width;
+    background: $bg;
+    -webkit-transform: skew($deg);
+    -ms-transform: skew($deg);
+    transform: skew($deg);
+  }
+}
 
 /*********************
 mixin for Font Size in rem
@@ -222,9 +221,9 @@ $baseFontSize : 16;
 }
 
 /* Generates mutilevel nested comments
-  level-1 is the first level comment with a margin of 50px
-  level-2 is the first level comment with a margin of 100px
-  and so on...
+level-1 is the first level comment with a margin of 50px
+level-2 is the first level comment with a margin of 100px
+and so on...
 */
 $comment-nest-level: 6;
 $nested-comment-left-margin: 50px;

--- a/assets/scss/partials/_typography.scss
+++ b/assets/scss/partials/_typography.scss
@@ -7,15 +7,17 @@ Stylesheet: Typography
 Import a Font or Icons
 
 ******************************************************************/
-@import url('https://fonts.googleapis.com/css?family=Roboto:300,400,500,700,900');
-@import url('https://fonts.googleapis.com/css?family=Lora:400,400i,700&subset=latin-ext');
+@import url("https://fonts.googleapis.com/css?family=Roboto:300,400,500,700,900");
+@import url("https://fonts.googleapis.com/css?family=Lora:400,400i,700&subset=latin-ext");
 
 // font stacks
+/* stylelint-disable value-keyword-case*/
 $sans-serif: "Helvetica Neue", Helvetica, Arial, sans-serif;
-$serif:      "Georgia", Cambria, Times New Roman, Times, serif;
+$serif:      "Georgia", Cambria, "Times New Roman", Times, serif;
 $roboto:     "Roboto", sans-serif;
 $lora:       "Lora", serif;
 
+/* stylelint-enable value-keyword-case*/
 html {
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;

--- a/assets/scss/partials/_variables.scss
+++ b/assets/scss/partials/_variables.scss
@@ -9,14 +9,14 @@ base values, and defaults.
 ******************************************************************/
 
 /**
- * A note on colors:
- *
- * Every single color on this site should use a color variable as defined
- * in this file for brand consistency and code maintenance.
- *
- * Once a color is defined here, it should not change and will remain
- * consistent.
- */
+* A note on colors:
+*
+* Every single color on this site should use a color variable as defined
+* in this file for brand consistency and code maintenance.
+*
+* Once a color is defined here, it should not change and will remain
+* consistent.
+*/
 
 // Primary Colors.
 $black:       #000;
@@ -101,27 +101,25 @@ $maroon:      #3f0901;
 
 // Need to be re-assigned colors.
 $blue:      #2980b9;
-$brown-bg:  #FAF7EC;
+$brown-bg:  #faf7ec;
 $red:       #ad2330;
-$med-blue:  #0A3351;
+$med-blue:  #0a3351;
 
 // Social buttons
 $facebook: #3b5998;
 $twitter: #55acee;
 $email: #ea7179;
 
-
 /**
- * From this point on only the above color variables should be used in the codebase.
- */
-
+* From this point on only the above color variables should be used in the codebase.
+*/
 
 // Used colors
 $active:                #aed4c7;
 $blue-bg-anchor:        #30a7af;
 $blue-bg:               #03484f;
 $blue-heading:          #004950;
-$blue-text:             #12757B;
+$blue-text:             #12757b;
 $border-color:          #07403a;
 $brown-bg-tags-text:    $yellow;
 $card-header-bg:        #c7dcd3;
@@ -130,34 +128,34 @@ $carousel-active:       #064364; // Duplicate
 $darkb-blue-text:       #264042;
 $fixed-nav-bg:          #247670;
 $header-footer-bg:      #030403;
-$light-blue-bg:         #D6E6F2;
-$light-blue:            #67B2AF;
+$light-blue-bg:         #d6e6f2;
+$light-blue:            #67b2af;
 $nav-link:              #a6df20;
 $percentage-text:       #017e7a;
-$step-normal-bg:        #E4E7DA;
-$steps-deactive-text:   #0A4F45;
+$step-normal-bg:        #e4e7da;
+$steps-deactive-text:   #0a4f45;
 $top-nav:               #1e5f65;
 $light-grey:            #e0ddd4;
 
 // Used once.
 $body-bg:               #b0d4c8;
-$brown-bg-tags-link:    #E88D75;
+$brown-bg-tags-link:    #e88d75;
 $container-bg:          $body-blue;
-$dark-para-text:        #011D1E;
+$dark-para-text:        #011d1e;
 $green-link-hover:      #77dd11;
 $heading:               #004d53;
-$step-number:           #A7A7A7;
-$brown-header:          #5C1F10;
+$step-number:           #a7a7a7;
+$brown-header:          #5c1f10;
 
 // Colors to be fixed/addressed:
 $article-heading-color:	#152431;
-$credit-color:          #5A5A5A;
+$credit-color:          #5a5a5a;
 $search-text-colour:    #115247;
 $blue-top-nav:          $dark-blue;
 $dark-shade-black:      #1a1a1a;
-$carousel-indi-color:   #8BCC49;
+$carousel-indi-color:   #8bcc49;
 $shadow-color:          $grey-60;
-$hover-nav:             #052A30;
+$hover-nav:             #052a30;
 
 // Media queries
 $extra-small-width:  320px;

--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -137,9 +137,9 @@ body {
   }
 
   &.home {
-    background-image: repeating-linear-gradient(119deg, transparent -53%, rgba(157, 187, 190, 0.1) 55%, rgba(236, 241, 243, 1) 0), repeating-linear-gradient(119deg, transparent -50%, rgba(157, 187, 190, 0.1) 30%, rgba(236, 241, 243, 0) 20%),repeating-linear-gradient(119deg, transparent -445%, rgba(157, 187, 190, 0.1) 27%, rgba(236, 241, 243, 0) 10%),repeating-linear-gradient(119deg, transparent -45%, rgba(157, 187, 190, 0.1) 17%, rgba(236, 241, 243, 0.5) 0), url('images/home.png');
+    background-image: repeating-linear-gradient(119deg, transparent -53%, rgba(157, 187, 190, 0.1) 55%, rgba(236, 241, 243, 1) 0), repeating-linear-gradient(119deg, transparent -50%, rgba(157, 187, 190, 0.1) 30%, rgba(236, 241, 243, 0) 20%), repeating-linear-gradient(119deg, transparent -445%, rgba(157, 187, 190, 0.1) 27%, rgba(236, 241, 243, 0) 10%), repeating-linear-gradient(119deg, transparent -45%, rgba(157, 187, 190, 0.1) 17%, rgba(236, 241, 243, 0.5) 0), url("images/home.png");
     background-repeat: repeat-x;
-    background-color: #ECF1F3;
+    background-color: #ecf1f3;
   }
 }
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,14 +1,32 @@
 /* global require */
 
 var gulp = require('gulp');
+var stylelint = require('gulp-stylelint');
+
+var lintPathsCSS = [
+  'assets/scss/**/*.scss',
+  'assets/css/*.css'
+];
+
+gulp.task('css:lint', () => {
+  return gulp.src(lintPathsCSS)
+    .pipe(stylelint({
+      reporters: [{ formatter: 'string', console: true}]
+    }));
+});
 
 gulp.task('assets', function(){
-    var p = require('./package.json');
-    var assets = p.assets;
-    return gulp.src(assets, {cwd : 'node_modules/**'})
-        .pipe(gulp.dest('assets/lib'));
+  var p = require('./package.json');
+  var assets = p.assets;
+  return gulp.src(assets, {cwd : 'node_modules/**'})
+    .pipe(gulp.dest('assets/lib'));
+});
+
+gulp.task('test', function() {
+  gulp.start('css:lint');
 });
 
 gulp.task('default', function() {
-    gulp.start('assets');
+  gulp.start('assets');
+  gulp.start('test');
 });

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
 	"author": "Greenpeace International",
 	"license": "MIT",
 	"devDependencies": {
-		"gulp": "^3.9.1"
+		"gulp": "^3.9.1",
+		"gulp-stylelint": "^7.0.0",
+		"stylelint": "^9.1.1"
 	},
 	"dependencies": {
 		"bootstrap": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,24 @@
 # yarn lockfile v1
 
 
+ajv-keywords@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.1.0.tgz#ac2b27939c543e95d2c06e7f7f5c27be4aa543be"
+
+ajv@^6.0.1:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.2.1.tgz#28a6abc493a2abe0fb4c8507acaedb43fa550671"
+  dependencies:
+    fast-deep-equal "^1.0.0"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.3.0"
+
+ansi-colors@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-1.1.0.tgz#6374b4dd5d4718ff3ce27a671a3b1cad077132a9"
+  dependencies:
+    ansi-wrap "^0.1.0"
+
 ansi-gray@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/ansi-gray/-/ansi-gray-0.1.1.tgz#2962cf54ec9792c48510a3deb524436861ef7251"
@@ -12,11 +30,21 @@ ansi-regex@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
 
+ansi-regex@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
+
 ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
 
-ansi-wrap@0.1.0:
+ansi-styles@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
+  dependencies:
+    color-convert "^1.9.0"
+
+ansi-wrap@0.1.0, ansi-wrap@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/ansi-wrap/-/ansi-wrap-0.1.0.tgz#a82250ddb0015e9a27ca82e82ea603bbfa45efaf"
 
@@ -24,11 +52,23 @@ archy@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/archy/-/archy-1.0.0.tgz#f9c8c13757cc1dd7bc379ac77b2c62a5c2868c40"
 
+argparse@^1.0.7:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
+  dependencies:
+    sprintf-js "~1.0.2"
+
+arr-diff@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-2.0.0.tgz#8f3b827f955a8bd669697e4a4256ac3ceae356cf"
+  dependencies:
+    arr-flatten "^1.0.1"
+
 arr-diff@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-4.0.0.tgz#d6461074febfec71e7e15235761a329a5dc7c520"
 
-arr-flatten@^1.1.0:
+arr-flatten@^1.0.1, arr-flatten@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/arr-flatten/-/arr-flatten-1.1.0.tgz#36048bbff4e7b47e136644316c99669ea5ae91f1"
 
@@ -44,17 +84,43 @@ array-each@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/array-each/-/array-each-1.0.1.tgz#a794af0c05ab1752846ee753a1f211a05ba0c44f"
 
+array-find-index@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/array-find-index/-/array-find-index-1.0.2.tgz#df010aa1287e164bbda6f9723b0a96a1ec4187a1"
+
+array-iterate@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/array-iterate/-/array-iterate-1.1.1.tgz#865bf7f8af39d6b0982c60902914ac76bc0108f6"
+
 array-slice@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/array-slice/-/array-slice-1.1.0.tgz#e368ea15f89bc7069f7ffb89aec3a6c7d4ac22d4"
 
-array-uniq@^1.0.2:
+array-union@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/array-union/-/array-union-1.0.2.tgz#9a34410e4f4e3da23dea375be5be70f24778ec39"
+  dependencies:
+    array-uniq "^1.0.1"
+
+array-uniq@^1.0.1, array-uniq@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/array-uniq/-/array-uniq-1.0.3.tgz#af6ac877a25cc7f74e058894753858dfdb24fdb6"
+
+array-unique@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.2.1.tgz#a1d97ccafcbc2625cc70fadceb36a50c58b01a53"
 
 array-unique@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.3.2.tgz#a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428"
+
+arrify@^1.0.0, arrify@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
+
+asap@~2.0.3:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
 
 assign-symbols@^1.0.0:
   version "1.0.0"
@@ -63,6 +129,21 @@ assign-symbols@^1.0.0:
 atob@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.0.3.tgz#19c7a760473774468f20b2d2d03372ad7d4cbf5d"
+
+autoprefixer@^8.0.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-8.1.0.tgz#374cf35be1c0e8fce97408d876f95f66f5cb4641"
+  dependencies:
+    browserslist "^3.1.1"
+    caniuse-lite "^1.0.30000810"
+    normalize-range "^0.1.2"
+    num2fraction "^1.2.2"
+    postcss "^6.0.19"
+    postcss-value-parser "^3.2.3"
+
+bail@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/bail/-/bail-1.0.2.tgz#f7d6c1731630a9f9f0d4d35ed1f962e2074a1764"
 
 balanced-match@^1.0.0:
   version "1.0.0"
@@ -88,12 +169,20 @@ bootstrap@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.0.0.tgz#ceb03842c145fcc1b9b4e15da2a05656ba68469a"
 
-brace-expansion@^1.0.0:
+brace-expansion@^1.0.0, brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
+
+braces@^1.8.2:
+  version "1.8.5"
+  resolved "https://registry.yarnpkg.com/braces/-/braces-1.8.5.tgz#ba77962e12dff969d6b76711e914b737857bf6a7"
+  dependencies:
+    expand-range "^1.8.1"
+    preserve "^0.2.0"
+    repeat-element "^1.1.2"
 
 braces@^2.3.1:
   version "2.3.1"
@@ -112,6 +201,17 @@ braces@^2.3.1:
     split-string "^3.0.2"
     to-regex "^3.0.1"
 
+browserslist@^3.1.1:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-3.1.2.tgz#893f29399d640ed35fe06bacd7eb1d78609a47e5"
+  dependencies:
+    caniuse-lite "^1.0.30000813"
+    electron-to-chromium "^1.3.36"
+
+builtin-modules@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
+
 cache-base@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/cache-base/-/cache-base-1.0.1.tgz#0a7f46416831c8b662ee36fe4e7c59d76f666ab2"
@@ -126,7 +226,27 @@ cache-base@^1.0.1:
     union-value "^1.0.0"
     unset-value "^1.0.0"
 
-chalk@^1.0.0:
+camelcase-keys@^4.0.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/camelcase-keys/-/camelcase-keys-4.2.0.tgz#a2aa5fb1af688758259c32c141426d78923b9b77"
+  dependencies:
+    camelcase "^4.1.0"
+    map-obj "^2.0.0"
+    quick-lru "^1.0.0"
+
+camelcase@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
+
+caniuse-lite@^1.0.30000810, caniuse-lite@^1.0.30000813:
+  version "1.0.30000813"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000813.tgz#7b25e27fdfb8d133f3c932b01f77452140fcc6c9"
+
+ccount@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/ccount/-/ccount-1.0.2.tgz#53b6a2f815bb77b9c2871f7b9a72c3a25f1d8e89"
+
+chalk@^1.0.0, chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
   dependencies:
@@ -136,6 +256,34 @@ chalk@^1.0.0:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
+chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.3.1:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.2.tgz#250dc96b07491bfd601e648d66ddf5f60c7a5c65"
+  dependencies:
+    ansi-styles "^3.2.1"
+    escape-string-regexp "^1.0.5"
+    supports-color "^5.3.0"
+
+character-entities-html4@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/character-entities-html4/-/character-entities-html4-1.1.1.tgz#359a2a4a0f7e29d3dc2ac99bdbe21ee39438ea50"
+
+character-entities-legacy@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/character-entities-legacy/-/character-entities-legacy-1.1.1.tgz#f40779df1a101872bb510a3d295e1fccf147202f"
+
+character-entities@^1.0.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/character-entities/-/character-entities-1.2.1.tgz#f76871be5ef66ddb7f8f8e3478ecc374c27d6dca"
+
+character-reference-invalid@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/character-reference-invalid/-/character-reference-invalid-1.1.1.tgz#942835f750e4ec61a308e60c2ef8cc1011202efc"
+
+circular-json@^0.3.1:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.3.3.tgz#815c99ea84f6809529d2f45791bdf82711352d66"
+
 class-utils@^0.3.5:
   version "0.3.6"
   resolved "https://registry.yarnpkg.com/class-utils/-/class-utils-0.3.6.tgz#f93369ae8b9a7ce02fd41faad0ca83033190c463"
@@ -144,6 +292,13 @@ class-utils@^0.3.5:
     define-property "^0.2.5"
     isobject "^3.0.0"
     static-extend "^0.1.1"
+
+clone-regexp@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/clone-regexp/-/clone-regexp-1.0.0.tgz#eae0a2413f55c0942f818c229fefce845d7f3b1c"
+  dependencies:
+    is-regexp "^1.0.0"
+    is-supported-regexp-flag "^1.0.0"
 
 clone-stats@^0.0.1:
   version "0.0.1"
@@ -157,12 +312,26 @@ clone@^1.0.0, clone@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.3.tgz#298d7e2231660f40c003c2ed3140decf3f53085f"
 
+collapse-white-space@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/collapse-white-space/-/collapse-white-space-1.0.3.tgz#4b906f670e5a963a87b76b0e1689643341b6023c"
+
 collection-visit@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/collection-visit/-/collection-visit-1.0.0.tgz#4bc0373c164bc3291b4d368c829cf1a80a59dca0"
   dependencies:
     map-visit "^1.0.0"
     object-visit "^1.0.0"
+
+color-convert@^1.9.0:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.1.tgz#c1261107aeb2f294ebffec9ed9ecad529a6097ed"
+  dependencies:
+    color-name "^1.1.1"
+
+color-name@^1.1.1:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
 
 color-support@^1.1.3:
   version "1.1.3"
@@ -184,6 +353,21 @@ core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
+cosmiconfig@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-4.0.0.tgz#760391549580bbd2df1e562bc177b13c290972dc"
+  dependencies:
+    is-directory "^0.3.1"
+    js-yaml "^3.9.0"
+    parse-json "^4.0.0"
+    require-from-string "^2.0.1"
+
+currently-unhandled@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/currently-unhandled/-/currently-unhandled-0.4.1.tgz#988df33feab191ef799a61369dd76c17adf957ea"
+  dependencies:
+    array-find-index "^1.0.1"
+
 dateformat@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-2.2.0.tgz#4065e2013cf9fb916ddfd82efb506ad4c6769062"
@@ -194,9 +378,30 @@ debug@^2.2.0, debug@^2.3.3:
   dependencies:
     ms "2.0.0"
 
+debug@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  dependencies:
+    ms "2.0.0"
+
+decamelize-keys@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/decamelize-keys/-/decamelize-keys-1.1.0.tgz#d171a87933252807eb3cb61dc1c1445d078df2d9"
+  dependencies:
+    decamelize "^1.1.0"
+    map-obj "^1.0.0"
+
+decamelize@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
+
 decode-uri-component@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
+
+deep-extend@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.5.0.tgz#6ef4a09b05f98b0e358d6d93d4ca3caec6672803"
 
 defaults@^1.0.0:
   version "1.0.3"
@@ -223,6 +428,18 @@ define-property@^2.0.2:
     is-descriptor "^1.0.2"
     isobject "^3.0.1"
 
+del@^2.0.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/del/-/del-2.2.2.tgz#c12c981d067846c84bcaf862cff930d907ffd1a8"
+  dependencies:
+    globby "^5.0.0"
+    is-path-cwd "^1.0.0"
+    is-path-in-cwd "^1.0.0"
+    object-assign "^4.0.1"
+    pify "^2.0.0"
+    pinkie-promise "^2.0.0"
+    rimraf "^2.2.8"
+
 deprecated@^0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/deprecated/-/deprecated-0.0.1.tgz#f9c9af5464afa1e7a971458a8bdef2aa94d5bb19"
@@ -231,11 +448,56 @@ detect-file@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/detect-file/-/detect-file-1.0.0.tgz#f0d66d03672a825cb1b73bdb3fe62310c8e552b7"
 
+dir-glob@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-2.0.0.tgz#0b205d2b6aef98238ca286598a8204d29d0a0034"
+  dependencies:
+    arrify "^1.0.1"
+    path-type "^3.0.0"
+
+dom-serializer@0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.1.0.tgz#073c697546ce0780ce23be4a28e293e40bc30c82"
+  dependencies:
+    domelementtype "~1.1.1"
+    entities "~1.1.1"
+
+domelementtype@1, domelementtype@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.3.0.tgz#b17aed82e8ab59e52dd9c19b1756e0fc187204c2"
+
+domelementtype@~1.1.1:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.1.3.tgz#bd28773e2642881aec51544924299c5cd822185b"
+
+domhandler@^2.3.0:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-2.4.1.tgz#892e47000a99be55bbf3774ffea0561d8879c259"
+  dependencies:
+    domelementtype "1"
+
+domutils@^1.5.1:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.7.0.tgz#56ea341e834e06e6748af7a1cb25da67ea9f8c2a"
+  dependencies:
+    dom-serializer "0"
+    domelementtype "1"
+
+dot-prop@^4.1.1:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-4.2.0.tgz#1f19e0c2e1aa0e32797c49799f2837ac6af69c57"
+  dependencies:
+    is-obj "^1.0.0"
+
 duplexer2@0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/duplexer2/-/duplexer2-0.0.2.tgz#c614dcf67e2fb14995a91711e5a617e8a60a31db"
   dependencies:
     readable-stream "~1.1.9"
+
+electron-to-chromium@^1.3.36:
+  version "1.3.37"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.37.tgz#4a92734e0044c8cf0b1553be57eae21a4c6e5fab"
 
 end-of-stream@~0.1.5:
   version "0.1.5"
@@ -243,9 +505,35 @@ end-of-stream@~0.1.5:
   dependencies:
     once "~1.3.0"
 
-escape-string-regexp@^1.0.2:
+entities@^1.1.1, entities@~1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
+
+error-ex@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.1.tgz#f855a86ce61adc4e8621c3cda21e7a7612c3a8dc"
+  dependencies:
+    is-arrayish "^0.2.1"
+
+escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
+
+esprima@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.0.tgz#4499eddcd1110e0b218bacf2fa7f7f59f55ca804"
+
+execall@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/execall/-/execall-1.0.0.tgz#73d0904e395b3cab0658b08d09ec25307f29bb73"
+  dependencies:
+    clone-regexp "^1.0.0"
+
+expand-brackets@^0.1.4:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/expand-brackets/-/expand-brackets-0.1.5.tgz#df07284e342a807cd733ac5af72411e581d1177b"
+  dependencies:
+    is-posix-bracket "^0.1.0"
 
 expand-brackets@^2.1.4:
   version "2.1.4"
@@ -258,6 +546,12 @@ expand-brackets@^2.1.4:
     regex-not "^1.0.0"
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
+
+expand-range@^1.8.1:
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/expand-range/-/expand-range-1.8.2.tgz#a299effd335fe2721ebae8e257ec79644fc85337"
+  dependencies:
+    fill-range "^2.1.0"
 
 expand-tilde@^2.0.0, expand-tilde@^2.0.2:
   version "2.0.2"
@@ -282,6 +576,12 @@ extend@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
 
+extglob@^0.3.1:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/extglob/-/extglob-0.3.2.tgz#2e18ff3d2f49ab2765cec9023f011daa8d8349a1"
+  dependencies:
+    is-extglob "^1.0.0"
+
 extglob@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/extglob/-/extglob-2.0.4.tgz#ad00fe4dc612a9232e8718711dc5cb5ab0285543"
@@ -295,13 +595,42 @@ extglob@^2.0.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
-fancy-log@^1.1.0:
+fancy-log@^1.1.0, fancy-log@^1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/fancy-log/-/fancy-log-1.3.2.tgz#f41125e3d84f2e7d89a43d06d958c8f78be16be1"
   dependencies:
     ansi-gray "^0.1.1"
     color-support "^1.1.3"
     time-stamp "^1.0.0"
+
+fast-deep-equal@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz#c053477817c86b51daa853c81e059b733d023614"
+
+fast-json-stable-stringify@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
+
+file-entry-cache@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-2.0.0.tgz#c392990c3e684783d838b8c84a45d8a048458361"
+  dependencies:
+    flat-cache "^1.2.1"
+    object-assign "^4.0.1"
+
+filename-regex@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/filename-regex/-/filename-regex-2.0.1.tgz#c1c4b9bee3e09725ddb106b75c1e301fe2f18b26"
+
+fill-range@^2.1.0:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-2.2.3.tgz#50b77dfd7e469bc7492470963699fe7a8485a723"
+  dependencies:
+    is-number "^2.1.0"
+    isobject "^2.0.0"
+    randomatic "^1.1.3"
+    repeat-element "^1.1.2"
+    repeat-string "^1.5.2"
 
 fill-range@^4.0.0:
   version "4.0.0"
@@ -315,6 +644,12 @@ fill-range@^4.0.0:
 find-index@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/find-index/-/find-index-0.1.1.tgz#675d358b2ca3892d795a1ab47232f8b6e2e0dde4"
+
+find-up@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7"
+  dependencies:
+    locate-path "^2.0.0"
 
 findup-sync@^2.0.0:
   version "2.0.0"
@@ -343,9 +678,24 @@ flagged-respawn@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/flagged-respawn/-/flagged-respawn-1.0.0.tgz#4e79ae9b2eb38bf86b3bb56bf3e0a56aa5fcabd7"
 
+flat-cache@^1.2.1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-1.3.0.tgz#d3030b32b38154f4e3b7e9c709f490f7ef97c481"
+  dependencies:
+    circular-json "^0.3.1"
+    del "^2.0.2"
+    graceful-fs "^4.1.2"
+    write "^0.2.1"
+
 for-in@^1.0.1, for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
+
+for-own@^0.1.4:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/for-own/-/for-own-0.1.5.tgz#5265c681a4f294dabbf17c9509b6763aa84510ce"
+  dependencies:
+    for-in "^1.0.1"
 
 for-own@^1.0.0:
   version "1.0.0"
@@ -359,15 +709,36 @@ fragment-cache@^0.2.1:
   dependencies:
     map-cache "^0.2.2"
 
+fs.realpath@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
+
 gaze@^0.5.1:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/gaze/-/gaze-0.5.2.tgz#40b709537d24d1d45767db5a908689dfe69ac44f"
   dependencies:
     globule "~0.1.0"
 
+get-stdin@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-5.0.1.tgz#122e161591e21ff4c52530305693f20e6393a398"
+
 get-value@^2.0.3, get-value@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/get-value/-/get-value-2.0.6.tgz#dc15ca1c672387ca76bd37ac0a395ba2042a2c28"
+
+glob-base@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/glob-base/-/glob-base-0.3.0.tgz#dbb164f6221b1c0b1ccf82aea328b497df0ea3c4"
+  dependencies:
+    glob-parent "^2.0.0"
+    is-glob "^2.0.0"
+
+glob-parent@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-2.0.0.tgz#81383d72db054fcccf5336daa902f182f6edbb28"
+  dependencies:
+    is-glob "^2.0.0"
 
 glob-stream@^3.1.5:
   version "3.1.18"
@@ -401,6 +772,17 @@ glob@^4.3.1:
     minimatch "^2.0.1"
     once "^1.3.0"
 
+glob@^7.0.3, glob@^7.0.5, glob@^7.1.2:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
 glob@~3.1.21:
   version "3.1.21"
   resolved "https://registry.yarnpkg.com/glob/-/glob-3.1.21.tgz#d29e0a055dea5138f4d07ed40e8982e83c2066cd"
@@ -427,6 +809,32 @@ global-prefix@^1.0.1:
     is-windows "^1.0.1"
     which "^1.2.14"
 
+globby@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-5.0.0.tgz#ebd84667ca0dbb330b99bcfc68eac2bc54370e0d"
+  dependencies:
+    array-union "^1.0.1"
+    arrify "^1.0.0"
+    glob "^7.0.3"
+    object-assign "^4.0.1"
+    pify "^2.0.0"
+    pinkie-promise "^2.0.0"
+
+globby@^7.0.0:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-7.1.1.tgz#fb2ccff9401f8600945dfada97440cca972b8680"
+  dependencies:
+    array-union "^1.0.1"
+    dir-glob "^2.0.0"
+    glob "^7.1.2"
+    ignore "^3.3.5"
+    pify "^3.0.0"
+    slash "^1.0.0"
+
+globjoin@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/globjoin/-/globjoin-0.1.4.tgz#2f4494ac8919e3767c5cbb691e9f463324285d43"
+
 globule@~0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/globule/-/globule-0.1.0.tgz#d9c8edde1da79d125a151b79533b978676346ae5"
@@ -441,15 +849,39 @@ glogg@^1.0.0:
   dependencies:
     sparkles "^1.0.0"
 
+gonzales-pe@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/gonzales-pe/-/gonzales-pe-4.2.3.tgz#41091703625433285e0aee3aa47829fc1fbeb6f2"
+  dependencies:
+    minimist "1.1.x"
+
 graceful-fs@^3.0.0:
   version "3.0.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-3.0.11.tgz#7613c778a1afea62f25c630a086d7f3acbbdd818"
   dependencies:
     natives "^1.1.0"
 
+graceful-fs@^4.1.2:
+  version "4.1.11"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
+
 graceful-fs@~1.2.0:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-1.2.3.tgz#15a4806a57547cb2d2dbf27f42e89a8c3451b364"
+
+gulp-stylelint@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/gulp-stylelint/-/gulp-stylelint-7.0.0.tgz#4249dc36a983e6a2c28a449f73d9a369bb14b458"
+  dependencies:
+    chalk "^2.3.0"
+    deep-extend "^0.5.0"
+    fancy-log "^1.3.2"
+    mkdirp "^0.5.1"
+    plugin-error "^1.0.1"
+    promise "^8.0.1"
+    source-map "^0.5.6"
+    strip-ansi "^4.0.0"
+    through2 "^2.0.3"
 
 gulp-util@^3.0.0:
   version "3.0.8"
@@ -508,6 +940,14 @@ has-ansi@^2.0.0:
   dependencies:
     ansi-regex "^2.0.0"
 
+has-flag@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-1.0.0.tgz#9d9e793165ce017a00f00418c43f942a7b1d11fa"
+
+has-flag@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
+
 has-gulplog@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/has-gulplog/-/has-gulplog-0.1.0.tgz#6414c82913697da51590397dafb12f22967811ce"
@@ -547,6 +987,41 @@ homedir-polyfill@^1.0.1:
   dependencies:
     parse-passwd "^1.0.0"
 
+hosted-git-info@^2.1.4:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.6.0.tgz#23235b29ab230c576aab0d4f13fc046b0b038222"
+
+html-tags@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/html-tags/-/html-tags-2.0.0.tgz#10b30a386085f43cede353cc8fa7cb0deeea668b"
+
+htmlparser2@^3.9.2:
+  version "3.9.2"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.9.2.tgz#1bdf87acca0f3f9e53fa4fcceb0f4b4cbb00b338"
+  dependencies:
+    domelementtype "^1.3.0"
+    domhandler "^2.3.0"
+    domutils "^1.5.1"
+    entities "^1.1.1"
+    inherits "^2.0.1"
+    readable-stream "^2.0.2"
+
+ignore@^3.3.3, ignore@^3.3.5:
+  version "3.3.7"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.7.tgz#612289bfb3c220e186a58118618d5be8c1bab021"
+
+imurmurhash@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
+
+indent-string@^3.0.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-3.2.0.tgz#4a5fd6d27cc332f37e5419a504dbb837105c9289"
+
+indexes-of@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/indexes-of/-/indexes-of-1.0.1.tgz#f30f716c8e2bd346c7b67d3df3915566a7c05607"
+
 inflight@^1.0.4:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
@@ -558,7 +1033,7 @@ inherits@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-1.0.2.tgz#ca4309dadee6b54cc0b8d247e8d7c7a0975bdc9b"
 
-inherits@2, inherits@~2.0.1, inherits@~2.0.3:
+inherits@2, inherits@^2.0.1, inherits@~2.0.1, inherits@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
@@ -589,9 +1064,34 @@ is-accessor-descriptor@^1.0.0:
   dependencies:
     kind-of "^6.0.0"
 
-is-buffer@^1.1.5:
+is-alphabetical@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-alphabetical/-/is-alphabetical-1.0.1.tgz#c77079cc91d4efac775be1034bf2d243f95e6f08"
+
+is-alphanumeric@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-alphanumeric/-/is-alphanumeric-1.0.0.tgz#4a9cef71daf4c001c1d81d63d140cf53fd6889f4"
+
+is-alphanumerical@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-alphanumerical/-/is-alphanumerical-1.0.1.tgz#dfb4aa4d1085e33bdb61c2dee9c80e9c6c19f53b"
+  dependencies:
+    is-alphabetical "^1.0.0"
+    is-decimal "^1.0.0"
+
+is-arrayish@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
+
+is-buffer@^1.1.4, is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
+
+is-builtin-module@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-builtin-module/-/is-builtin-module-1.0.0.tgz#540572d34f7ac3119f8f76c30cbc1b1e037affbe"
+  dependencies:
+    builtin-modules "^1.0.0"
 
 is-data-descriptor@^0.1.4:
   version "0.1.4"
@@ -604,6 +1104,10 @@ is-data-descriptor@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz#d84876321d0e7add03990406abbbbd36ba9268c7"
   dependencies:
     kind-of "^6.0.0"
+
+is-decimal@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-decimal/-/is-decimal-1.0.1.tgz#f5fb6a94996ad9e8e3761fbfbd091f1fca8c4e82"
 
 is-descriptor@^0.1.0:
   version "0.1.6"
@@ -621,6 +1125,20 @@ is-descriptor@^1.0.0, is-descriptor@^1.0.2:
     is-data-descriptor "^1.0.0"
     kind-of "^6.0.2"
 
+is-directory@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/is-directory/-/is-directory-0.3.1.tgz#61339b6f2475fc772fd9c9d83f5c8575dc154ae1"
+
+is-dotfile@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/is-dotfile/-/is-dotfile-1.0.3.tgz#a6a2f32ffd2dfb04f5ca25ecd0f6b83cf798a1e1"
+
+is-equal-shallow@^0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz#2238098fc221de0bcfa5d9eac4c45d638aa1c534"
+  dependencies:
+    is-primitive "^2.0.0"
+
 is-extendable@^0.1.0, is-extendable@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/is-extendable/-/is-extendable-0.1.1.tgz#62b110e289a471418e3ec36a617d472e301dfc89"
@@ -631,15 +1149,39 @@ is-extendable@^1.0.1:
   dependencies:
     is-plain-object "^2.0.4"
 
+is-extglob@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-1.0.0.tgz#ac468177c4943405a092fc8f29760c6ffc6206c0"
+
 is-extglob@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
+
+is-fullwidth-code-point@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
+
+is-glob@^2.0.0, is-glob@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-2.0.1.tgz#d096f926a3ded5600f3fdfd91198cb0888c2d863"
+  dependencies:
+    is-extglob "^1.0.0"
 
 is-glob@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-3.1.0.tgz#7ba5ae24217804ac70707b96922567486cc3e84a"
   dependencies:
     is-extglob "^2.1.0"
+
+is-hexadecimal@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-hexadecimal/-/is-hexadecimal-1.0.1.tgz#6e084bbc92061fbb0971ec58b6ce6d404e24da69"
+
+is-number@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-number/-/is-number-2.1.0.tgz#01fcbbb393463a548f2f466cce16dece49db908f"
+  dependencies:
+    kind-of "^3.0.2"
 
 is-number@^3.0.0:
   version "3.0.0"
@@ -651,11 +1193,35 @@ is-number@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-4.0.0.tgz#0026e37f5454d73e356dfe6564699867c6a7f0ff"
 
+is-obj@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
+
 is-odd@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-odd/-/is-odd-2.0.0.tgz#7646624671fd7ea558ccd9a2795182f2958f1b24"
   dependencies:
     is-number "^4.0.0"
+
+is-path-cwd@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-path-cwd/-/is-path-cwd-1.0.0.tgz#d225ec23132e89edd38fda767472e62e65f1106d"
+
+is-path-in-cwd@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz#6477582b8214d602346094567003be8a9eac04dc"
+  dependencies:
+    is-path-inside "^1.0.0"
+
+is-path-inside@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-1.0.1.tgz#8ef5b7de50437a3fdca6b4e865ef7aa55cb48036"
+  dependencies:
+    path-is-inside "^1.0.1"
+
+is-plain-obj@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
 
 is-plain-object@^2.0.1, is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   version "2.0.4"
@@ -663,11 +1229,27 @@ is-plain-object@^2.0.1, is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   dependencies:
     isobject "^3.0.1"
 
+is-posix-bracket@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz#3334dc79774368e92f016e6fbc0a88f5cd6e6bc4"
+
+is-primitive@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-primitive/-/is-primitive-2.0.0.tgz#207bab91638499c07b2adf240a41a87210034575"
+
+is-regexp@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-regexp/-/is-regexp-1.0.0.tgz#fd2d883545c46bac5a633e7b9a09e87fa2cb5069"
+
 is-relative@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-relative/-/is-relative-1.0.0.tgz#a1bb6935ce8c5dba1e8b9754b9b2dcc020e2260d"
   dependencies:
     is-unc-path "^1.0.0"
+
+is-supported-regexp-flag@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-supported-regexp-flag/-/is-supported-regexp-flag-1.0.0.tgz#8b520c85fae7a253382d4b02652e045576e13bb8"
 
 is-unc-path@^1.0.0:
   version "1.0.0"
@@ -679,9 +1261,17 @@ is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
 
+is-whitespace-character@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-whitespace-character/-/is-whitespace-character-1.0.1.tgz#9ae0176f3282b65457a1992cdb084f8a5f833e3b"
+
 is-windows@^1.0.1, is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
+
+is-word-character@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-word-character/-/is-word-character-1.0.1.tgz#5a03fa1ea91ace8a6eb0c7cd770eb86d65c8befb"
 
 isarray@0.0.1:
   version "0.0.1"
@@ -709,6 +1299,25 @@ jquery@^3.3.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.3.1.tgz#958ce29e81c9790f31be7792df5d4d95fc57fbca"
 
+js-base64@^2.1.9:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.4.3.tgz#2e545ec2b0f2957f41356510205214e98fad6582"
+
+js-yaml@^3.9.0:
+  version "3.11.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.11.0.tgz#597c1a8bd57152f26d622ce4117851a51f5ebaef"
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
+
+json-parse-better-errors@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.1.tgz#50183cd1b2d25275de069e9e71b467ac9eab973a"
+
+json-schema-traverse@^0.3.0:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz#349a6d44c53a51de89b40805c5d5e59b417d3340"
+
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.1.0, kind-of@^3.2.0:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
@@ -729,6 +1338,10 @@ kind-of@^6.0.0, kind-of@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
 
+known-css-properties@^0.6.0:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/known-css-properties/-/known-css-properties-0.6.1.tgz#31b5123ad03d8d1a3f36bd4155459c981173478b"
+
 lazy-cache@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/lazy-cache/-/lazy-cache-2.0.2.tgz#b9190a4f913354694840859f8a8f7084d8822264"
@@ -747,6 +1360,22 @@ liftoff@^2.1.0:
     object.map "^1.0.0"
     rechoir "^0.6.2"
     resolve "^1.1.7"
+
+load-json-file@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-4.0.0.tgz#2f5f45ab91e33216234fd53adab668eb4ec0993b"
+  dependencies:
+    graceful-fs "^4.1.2"
+    parse-json "^4.0.0"
+    pify "^3.0.0"
+    strip-bom "^3.0.0"
+
+locate-path@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-2.0.0.tgz#2b568b265eec944c6d9c0de9c3dbbbca0354cd8e"
+  dependencies:
+    p-locate "^2.0.0"
+    path-exists "^3.0.0"
 
 lodash._basecopy@^3.0.0:
   version "3.0.1"
@@ -831,9 +1460,30 @@ lodash.templatesettings@^3.0.0:
     lodash._reinterpolate "^3.0.0"
     lodash.escape "^3.0.0"
 
+lodash@^4.17.4:
+  version "4.17.5"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
+
 lodash@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-1.0.2.tgz#8f57560c83b59fc270bd3d561b690043430e2551"
+
+log-symbols@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-2.2.0.tgz#5740e1c5d6f0dfda4ad9323b5332107ef6b4c40a"
+  dependencies:
+    chalk "^2.0.1"
+
+longest-streak@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/longest-streak/-/longest-streak-2.0.2.tgz#2421b6ba939a443bb9ffebf596585a50b4c38e2e"
+
+loud-rejection@^1.0.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/loud-rejection/-/loud-rejection-1.6.0.tgz#5b46f80147edee578870f086d04821cf998e551f"
+  dependencies:
+    currently-unhandled "^0.4.1"
+    signal-exit "^3.0.0"
 
 lru-cache@2:
   version "2.7.3"
@@ -849,11 +1499,70 @@ map-cache@^0.2.0, map-cache@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/map-cache/-/map-cache-0.2.2.tgz#c32abd0bd6525d9b051645bb4f26ac5dc98a0dbf"
 
+map-obj@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
+
+map-obj@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-2.0.0.tgz#a65cd29087a92598b8791257a523e021222ac1f9"
+
 map-visit@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/map-visit/-/map-visit-1.0.0.tgz#ecdca8f13144e660f1b5bd41f12f3479d98dfb8f"
   dependencies:
     object-visit "^1.0.0"
+
+markdown-escapes@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/markdown-escapes/-/markdown-escapes-1.0.1.tgz#1994df2d3af4811de59a6714934c2b2292734518"
+
+markdown-table@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/markdown-table/-/markdown-table-1.1.1.tgz#4b3dd3a133d1518b8ef0dbc709bf2a1b4824bc8c"
+
+mathml-tag-names@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/mathml-tag-names/-/mathml-tag-names-2.0.1.tgz#8d41268168bf86d1102b98109e28e531e7a34578"
+
+mdast-util-compact@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/mdast-util-compact/-/mdast-util-compact-1.0.1.tgz#cdb5f84e2b6a2d3114df33bd05d9cb32e3c4083a"
+  dependencies:
+    unist-util-modify-children "^1.0.0"
+    unist-util-visit "^1.1.0"
+
+meow@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/meow/-/meow-4.0.0.tgz#fd5855dd008db5b92c552082db1c307cba20b29d"
+  dependencies:
+    camelcase-keys "^4.0.0"
+    decamelize-keys "^1.0.0"
+    loud-rejection "^1.0.0"
+    minimist "^1.1.3"
+    minimist-options "^3.0.1"
+    normalize-package-data "^2.3.4"
+    read-pkg-up "^3.0.0"
+    redent "^2.0.0"
+    trim-newlines "^2.0.0"
+
+micromatch@^2.3.11:
+  version "2.3.11"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-2.3.11.tgz#86677c97d1720b363431d04d0d15293bd38c1565"
+  dependencies:
+    arr-diff "^2.0.0"
+    array-unique "^0.2.1"
+    braces "^1.8.2"
+    expand-brackets "^0.1.4"
+    extglob "^0.3.1"
+    filename-regex "^2.0.0"
+    is-extglob "^1.0.0"
+    is-glob "^2.0.1"
+    kind-of "^3.0.2"
+    normalize-path "^2.0.1"
+    object.omit "^2.0.0"
+    parse-glob "^3.0.4"
+    regex-cache "^0.4.2"
 
 micromatch@^3.0.4:
   version "3.1.9"
@@ -879,6 +1588,12 @@ minimatch@^2.0.1:
   dependencies:
     brace-expansion "^1.0.0"
 
+minimatch@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
+  dependencies:
+    brace-expansion "^1.1.7"
+
 minimatch@~0.2.11:
   version "0.2.14"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-0.2.14.tgz#c74e780574f63c6f9a090e90efbe6ef53a6a756a"
@@ -886,11 +1601,22 @@ minimatch@~0.2.11:
     lru-cache "2"
     sigmund "~1.0.0"
 
+minimist-options@^3.0.1:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/minimist-options/-/minimist-options-3.0.2.tgz#fba4c8191339e13ecf4d61beb03f070103f3d954"
+  dependencies:
+    arrify "^1.0.1"
+    is-plain-obj "^1.1.0"
+
 minimist@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
-minimist@^1.1.0:
+minimist@1.1.x:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.1.3.tgz#3bedfd91a92d39016fcfaa1c681e8faa1a1efda8"
+
+minimist@^1.1.0, minimist@^1.1.3:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
@@ -901,7 +1627,7 @@ mixin-deep@^1.2.0:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
 
-mkdirp@^0.5.0:
+mkdirp@^0.5.0, mkdirp@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
@@ -938,9 +1664,40 @@ natives@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/natives/-/natives-1.1.1.tgz#011acce1f7cbd87f7ba6b3093d6cd9392be1c574"
 
+normalize-package-data@^2.3.2, normalize-package-data@^2.3.4:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.4.0.tgz#12f95a307d58352075a04907b84ac8be98ac012f"
+  dependencies:
+    hosted-git-info "^2.1.4"
+    is-builtin-module "^1.0.0"
+    semver "2 || 3 || 4 || 5"
+    validate-npm-package-license "^3.0.1"
+
+normalize-path@^2.0.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-2.1.1.tgz#1ab28b556e198363a8c1a6f7e6fa20137fe6aed9"
+  dependencies:
+    remove-trailing-separator "^1.0.1"
+
+normalize-range@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/normalize-range/-/normalize-range-0.1.2.tgz#2d10c06bdfd312ea9777695a4d28439456b75942"
+
+normalize-selector@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/normalize-selector/-/normalize-selector-0.2.0.tgz#d0b145eb691189c63a78d201dc4fdb1293ef0c03"
+
+num2fraction@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/num2fraction/-/num2fraction-1.2.2.tgz#6f682b6a027a4e9ddfa4564cd2589d1d4e669ede"
+
 object-assign@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-3.0.0.tgz#9bedd5ca0897949bca47e7ff408062d549f587f2"
+
+object-assign@^4.0.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
 object-copy@^0.1.0:
   version "0.1.0"
@@ -971,6 +1728,13 @@ object.map@^1.0.0:
   dependencies:
     for-own "^1.0.0"
     make-iterator "^1.0.0"
+
+object.omit@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/object.omit/-/object.omit-2.0.1.tgz#1a9c744829f39dbb858c76ca3579ae2a54ebd1fa"
+  dependencies:
+    for-own "^0.1.4"
+    is-extendable "^0.1.1"
 
 object.pick@^1.2.0, object.pick@^1.3.0:
   version "1.3.0"
@@ -1006,6 +1770,33 @@ os-homedir@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
 
+p-limit@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-1.2.0.tgz#0e92b6bedcb59f022c13d0f1949dc82d15909f1c"
+  dependencies:
+    p-try "^1.0.0"
+
+p-locate@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
+  dependencies:
+    p-limit "^1.1.0"
+
+p-try@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
+
+parse-entities@^1.0.2:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/parse-entities/-/parse-entities-1.1.1.tgz#8112d88471319f27abae4d64964b122fe4e1b890"
+  dependencies:
+    character-entities "^1.0.0"
+    character-entities-legacy "^1.0.0"
+    character-reference-invalid "^1.0.0"
+    is-alphanumerical "^1.0.0"
+    is-decimal "^1.0.0"
+    is-hexadecimal "^1.0.0"
+
 parse-filepath@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/parse-filepath/-/parse-filepath-1.0.2.tgz#a632127f53aaf3d15876f5872f3ffac763d6c891"
@@ -1014,6 +1805,22 @@ parse-filepath@^1.0.1:
     map-cache "^0.2.0"
     path-root "^0.1.1"
 
+parse-glob@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/parse-glob/-/parse-glob-3.0.4.tgz#b2c376cfb11f35513badd173ef0bb6e3a388391c"
+  dependencies:
+    glob-base "^0.3.0"
+    is-dotfile "^1.0.0"
+    is-extglob "^1.0.0"
+    is-glob "^2.0.0"
+
+parse-json@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-4.0.0.tgz#be35f5425be1f7f6c747184f98a788cb99477ee0"
+  dependencies:
+    error-ex "^1.3.1"
+    json-parse-better-errors "^1.0.1"
+
 parse-passwd@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/parse-passwd/-/parse-passwd-1.0.0.tgz#6d5b934a456993b23d37f40a382d6f1666a8e5c6"
@@ -1021,6 +1828,18 @@ parse-passwd@^1.0.0:
 pascalcase@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
+
+path-exists@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"
+
+path-is-absolute@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
+
+path-is-inside@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
 
 path-parse@^1.0.5:
   version "1.0.5"
@@ -1036,6 +1855,39 @@ path-root@^0.1.1:
   dependencies:
     path-root-regex "^0.1.0"
 
+path-type@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/path-type/-/path-type-3.0.0.tgz#cef31dc8e0a1a3bb0d105c0cd97cf3bf47f4e36f"
+  dependencies:
+    pify "^3.0.0"
+
+pify@^2.0.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
+
+pify@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pify/-/pify-3.0.0.tgz#e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176"
+
+pinkie-promise@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/pinkie-promise/-/pinkie-promise-2.0.1.tgz#2135d6dfa7a358c069ac9b178776288228450ffa"
+  dependencies:
+    pinkie "^2.0.0"
+
+pinkie@^2.0.0:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
+
+plugin-error@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/plugin-error/-/plugin-error-1.0.1.tgz#77016bd8919d0ac377fdcdd0322328953ca5781c"
+  dependencies:
+    ansi-colors "^1.0.1"
+    arr-diff "^4.0.0"
+    arr-union "^3.1.0"
+    extend-shallow "^3.0.2"
+
 popper.js@^1.12.9:
   version "1.12.9"
   resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.12.9.tgz#0dfbc2dff96c451bb332edcfcfaaf566d331d5b3"
@@ -1044,6 +1896,89 @@ posix-character-classes@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
 
+postcss-html@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/postcss-html/-/postcss-html-0.12.0.tgz#39b6adb4005dfc5464df7999c0f81c95bced7e50"
+  dependencies:
+    htmlparser2 "^3.9.2"
+    remark "^8.0.0"
+    unist-util-find-all-after "^1.0.1"
+
+postcss-less@^1.1.0:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/postcss-less/-/postcss-less-1.1.3.tgz#6930525271bfe38d5793d33ac09c1a546b87bb51"
+  dependencies:
+    postcss "^5.2.16"
+
+postcss-media-query-parser@^0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz#27b39c6f4d94f81b1a73b8f76351c609e5cef244"
+
+postcss-reporter@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-reporter/-/postcss-reporter-5.0.0.tgz#a14177fd1342829d291653f2786efd67110332c3"
+  dependencies:
+    chalk "^2.0.1"
+    lodash "^4.17.4"
+    log-symbols "^2.0.0"
+    postcss "^6.0.8"
+
+postcss-resolve-nested-selector@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.1.tgz#29ccbc7c37dedfac304e9fff0bf1596b3f6a0e4e"
+
+postcss-safe-parser@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/postcss-safe-parser/-/postcss-safe-parser-3.0.1.tgz#b753eff6c7c0aea5e8375fbe4cde8bf9063ff142"
+  dependencies:
+    postcss "^6.0.6"
+
+postcss-sass@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/postcss-sass/-/postcss-sass-0.3.0.tgz#dc2582ee0e61541aa88bafdc5a8aebb53deaae75"
+  dependencies:
+    gonzales-pe "^4.2.3"
+    postcss "^6.0.16"
+
+postcss-scss@^1.0.2:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/postcss-scss/-/postcss-scss-1.0.4.tgz#6310fe1a15be418707a2cfd77f21dd4a06d1e09d"
+  dependencies:
+    postcss "^6.0.19"
+
+postcss-selector-parser@^3.1.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz#4f875f4afb0c96573d5cf4d74011aee250a7e865"
+  dependencies:
+    dot-prop "^4.1.1"
+    indexes-of "^1.0.1"
+    uniq "^1.0.1"
+
+postcss-value-parser@^3.2.3, postcss-value-parser@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz#87f38f9f18f774a4ab4c8a232f5c5ce8872a9d15"
+
+postcss@^5.2.16:
+  version "5.2.18"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-5.2.18.tgz#badfa1497d46244f6390f58b319830d9107853c5"
+  dependencies:
+    chalk "^1.1.3"
+    js-base64 "^2.1.9"
+    source-map "^0.5.6"
+    supports-color "^3.2.3"
+
+postcss@^6.0.14, postcss@^6.0.16, postcss@^6.0.19, postcss@^6.0.6, postcss@^6.0.8:
+  version "6.0.19"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.19.tgz#76a78386f670b9d9494a655bf23ac012effd1555"
+  dependencies:
+    chalk "^2.3.1"
+    source-map "^0.6.1"
+    supports-color "^5.2.0"
+
+preserve@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
+
 pretty-hrtime@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz#b7e3ea42435a4c9b2759d99e0f201eb195802ee1"
@@ -1051,6 +1986,38 @@ pretty-hrtime@^1.0.0:
 process-nextick-args@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz#a37d732f4271b4ab1ad070d35508e8290788ffaa"
+
+promise@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/promise/-/promise-8.0.1.tgz#e45d68b00a17647b6da711bf85ed6ed47208f450"
+  dependencies:
+    asap "~2.0.3"
+
+quick-lru@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-1.1.0.tgz#4360b17c61136ad38078397ff11416e186dcfbb8"
+
+randomatic@^1.1.3:
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/randomatic/-/randomatic-1.1.7.tgz#c7abe9cc8b87c0baa876b19fde83fd464797e38c"
+  dependencies:
+    is-number "^3.0.0"
+    kind-of "^4.0.0"
+
+read-pkg-up@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-3.0.0.tgz#3ed496685dba0f8fe118d0691dc51f4a1ff96f07"
+  dependencies:
+    find-up "^2.0.0"
+    read-pkg "^3.0.0"
+
+read-pkg@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-3.0.0.tgz#9cbc686978fee65d16c00e2b19c237fcf6e38389"
+  dependencies:
+    load-json-file "^4.0.0"
+    normalize-package-data "^2.3.2"
+    path-type "^3.0.0"
 
 "readable-stream@>=1.0.33-1 <1.1.0-0":
   version "1.0.34"
@@ -1061,7 +2028,7 @@ process-nextick-args@~2.0.0:
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
-readable-stream@^2.1.5:
+readable-stream@^2.0.2, readable-stream@^2.1.5:
   version "2.3.5"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.5.tgz#b4f85003a938cbb6ecbce2a124fb1012bd1a838d"
   dependencies:
@@ -1088,6 +2055,19 @@ rechoir@^0.6.2:
   dependencies:
     resolve "^1.1.6"
 
+redent@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/redent/-/redent-2.0.0.tgz#c1b2007b42d57eb1389079b3c8333639d5e1ccaa"
+  dependencies:
+    indent-string "^3.0.0"
+    strip-indent "^2.0.0"
+
+regex-cache@^0.4.2:
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/regex-cache/-/regex-cache-0.4.4.tgz#75bdc58a2a1496cec48a12835bc54c8d562336dd"
+  dependencies:
+    is-equal-shallow "^0.1.3"
+
 regex-not@^1.0.0, regex-not@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/regex-not/-/regex-not-1.0.2.tgz#1f4ece27e00b0b65e0247a6810e6a85d83a5752c"
@@ -1095,11 +2075,62 @@ regex-not@^1.0.0, regex-not@^1.0.2:
     extend-shallow "^3.0.2"
     safe-regex "^1.1.0"
 
+remark-parse@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/remark-parse/-/remark-parse-4.0.0.tgz#99f1f049afac80382366e2e0d0bd55429dd45d8b"
+  dependencies:
+    collapse-white-space "^1.0.2"
+    is-alphabetical "^1.0.0"
+    is-decimal "^1.0.0"
+    is-whitespace-character "^1.0.0"
+    is-word-character "^1.0.0"
+    markdown-escapes "^1.0.0"
+    parse-entities "^1.0.2"
+    repeat-string "^1.5.4"
+    state-toggle "^1.0.0"
+    trim "0.0.1"
+    trim-trailing-lines "^1.0.0"
+    unherit "^1.0.4"
+    unist-util-remove-position "^1.0.0"
+    vfile-location "^2.0.0"
+    xtend "^4.0.1"
+
+remark-stringify@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/remark-stringify/-/remark-stringify-4.0.0.tgz#4431884c0418f112da44991b4e356cfe37facd87"
+  dependencies:
+    ccount "^1.0.0"
+    is-alphanumeric "^1.0.0"
+    is-decimal "^1.0.0"
+    is-whitespace-character "^1.0.0"
+    longest-streak "^2.0.1"
+    markdown-escapes "^1.0.0"
+    markdown-table "^1.1.0"
+    mdast-util-compact "^1.0.0"
+    parse-entities "^1.0.2"
+    repeat-string "^1.5.4"
+    state-toggle "^1.0.0"
+    stringify-entities "^1.0.1"
+    unherit "^1.0.4"
+    xtend "^4.0.1"
+
+remark@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/remark/-/remark-8.0.0.tgz#287b6df2fe1190e263c1d15e486d3fa835594d6d"
+  dependencies:
+    remark-parse "^4.0.0"
+    remark-stringify "^4.0.0"
+    unified "^6.0.0"
+
+remove-trailing-separator@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz#c24bce2a283adad5bc3f58e0d48249b92379d8ef"
+
 repeat-element@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/repeat-element/-/repeat-element-1.1.2.tgz#ef089a178d1483baae4d93eb98b4f9e4e11d990a"
 
-repeat-string@^1.6.1:
+repeat-string@^1.5.2, repeat-string@^1.5.4, repeat-string@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
 
@@ -1107,12 +2138,24 @@ replace-ext@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/replace-ext/-/replace-ext-0.0.1.tgz#29bbd92078a739f0bcce2b4ee41e837953522924"
 
+replace-ext@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/replace-ext/-/replace-ext-1.0.0.tgz#de63128373fcbf7c3ccfa4de5a480c45a67958eb"
+
+require-from-string@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.1.tgz#c545233e9d7da6616e9d59adfb39fc9f588676ff"
+
 resolve-dir@^1.0.0, resolve-dir@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/resolve-dir/-/resolve-dir-1.0.1.tgz#79a40644c362be82f26effe739c9bb5382046f43"
   dependencies:
     expand-tilde "^2.0.0"
     global-modules "^1.0.0"
+
+resolve-from@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
 
 resolve-url@^0.2.1:
   version "0.2.1"
@@ -1128,6 +2171,12 @@ ret@~0.1.10:
   version "0.1.15"
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
 
+rimraf@^2.2.8:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
+  dependencies:
+    glob "^7.0.5"
+
 safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
@@ -1137,6 +2186,10 @@ safe-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/safe-regex/-/safe-regex-1.1.0.tgz#40a3669f3b077d1e943d44629e157dd48023bf2e"
   dependencies:
     ret "~0.1.10"
+
+"semver@2 || 3 || 4 || 5":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
 
 semver@^4.1.0:
   version "4.3.6"
@@ -1173,6 +2226,20 @@ set-value@^2.0.0:
 sigmund@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/sigmund/-/sigmund-1.0.1.tgz#3ff21f198cad2175f9f3b781853fd94d0d19b590"
+
+signal-exit@^3.0.0, signal-exit@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
+
+slash@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
+
+slice-ansi@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-1.0.0.tgz#044f1a49d8842ff307aad6b505ed178bd950134d"
+  dependencies:
+    is-fullwidth-code-point "^2.0.0"
 
 slick-carousel@^1.8.1:
   version "1.8.1"
@@ -1223,15 +2290,53 @@ source-map@^0.5.6:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
 
+source-map@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
+
 sparkles@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/sparkles/-/sparkles-1.0.0.tgz#1acbbfb592436d10bbe8f785b7cc6f82815012c3"
+
+spdx-correct@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-3.0.0.tgz#05a5b4d7153a195bc92c3c425b69f3b2a9524c82"
+  dependencies:
+    spdx-expression-parse "^3.0.0"
+    spdx-license-ids "^3.0.0"
+
+spdx-exceptions@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz#2c7ae61056c714a5b9b9b2b2af7d311ef5c78fe9"
+
+spdx-expression-parse@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz#99e119b7a5da00e05491c9fa338b7904823b41d0"
+  dependencies:
+    spdx-exceptions "^2.1.0"
+    spdx-license-ids "^3.0.0"
+
+spdx-license-ids@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz#7a7cd28470cc6d3a1cfe6d66886f6bc430d3ac87"
+
+specificity@^0.3.1:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/specificity/-/specificity-0.3.2.tgz#99e6511eceef0f8d9b57924937aac2cb13d13c42"
 
 split-string@^3.0.1, split-string@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/split-string/-/split-string-3.1.0.tgz#7cb09dda3a86585705c64b39a6466038682e8fe2"
   dependencies:
     extend-shallow "^3.0.0"
+
+sprintf-js@~1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
+
+state-toggle@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/state-toggle/-/state-toggle-1.0.0.tgz#d20f9a616bb4f0c3b98b91922d25b640aa2bc425"
 
 static-extend@^0.1.1:
   version "0.1.2"
@@ -1244,6 +2349,13 @@ stream-consume@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/stream-consume/-/stream-consume-0.1.1.tgz#d3bdb598c2bd0ae82b8cac7ac50b1107a7996c48"
 
+string-width@^2.1.0, string-width@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
+  dependencies:
+    is-fullwidth-code-point "^2.0.0"
+    strip-ansi "^4.0.0"
+
 string_decoder@~0.10.x:
   version "0.10.31"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
@@ -1254,11 +2366,26 @@ string_decoder@~1.0.3:
   dependencies:
     safe-buffer "~5.1.0"
 
+stringify-entities@^1.0.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/stringify-entities/-/stringify-entities-1.3.1.tgz#b150ec2d72ac4c1b5f324b51fb6b28c9cdff058c"
+  dependencies:
+    character-entities-html4 "^1.0.0"
+    character-entities-legacy "^1.0.0"
+    is-alphanumerical "^1.0.0"
+    is-hexadecimal "^1.0.0"
+
 strip-ansi@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
   dependencies:
     ansi-regex "^2.0.0"
+
+strip-ansi@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-4.0.0.tgz#a8479022eb1ac368a871389b635262c505ee368f"
+  dependencies:
+    ansi-regex "^3.0.0"
 
 strip-bom@^1.0.0:
   version "1.0.0"
@@ -1267,9 +2394,99 @@ strip-bom@^1.0.0:
     first-chunk-stream "^1.0.0"
     is-utf8 "^0.2.0"
 
+strip-bom@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
+
+strip-indent@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-2.0.0.tgz#5ef8db295d01e6ed6cbf7aab96998d7822527b68"
+
+style-search@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/style-search/-/style-search-0.1.0.tgz#7958c793e47e32e07d2b5cafe5c0bf8e12e77902"
+
+stylelint@^9.1.1:
+  version "9.1.1"
+  resolved "https://registry.yarnpkg.com/stylelint/-/stylelint-9.1.1.tgz#bfabb7eb8ea6251a4732f4b2a0468963a30d3da9"
+  dependencies:
+    autoprefixer "^8.0.0"
+    balanced-match "^1.0.0"
+    chalk "^2.0.1"
+    cosmiconfig "^4.0.0"
+    debug "^3.0.0"
+    execall "^1.0.0"
+    file-entry-cache "^2.0.0"
+    get-stdin "^5.0.1"
+    globby "^7.0.0"
+    globjoin "^0.1.4"
+    html-tags "^2.0.0"
+    ignore "^3.3.3"
+    imurmurhash "^0.1.4"
+    known-css-properties "^0.6.0"
+    lodash "^4.17.4"
+    log-symbols "^2.0.0"
+    mathml-tag-names "^2.0.1"
+    meow "^4.0.0"
+    micromatch "^2.3.11"
+    normalize-selector "^0.2.0"
+    pify "^3.0.0"
+    postcss "^6.0.16"
+    postcss-html "^0.12.0"
+    postcss-less "^1.1.0"
+    postcss-media-query-parser "^0.2.3"
+    postcss-reporter "^5.0.0"
+    postcss-resolve-nested-selector "^0.1.1"
+    postcss-safe-parser "^3.0.1"
+    postcss-sass "^0.3.0"
+    postcss-scss "^1.0.2"
+    postcss-selector-parser "^3.1.0"
+    postcss-value-parser "^3.3.0"
+    resolve-from "^4.0.0"
+    signal-exit "^3.0.2"
+    specificity "^0.3.1"
+    string-width "^2.1.0"
+    style-search "^0.1.0"
+    sugarss "^1.0.0"
+    svg-tags "^1.0.0"
+    table "^4.0.1"
+
+sugarss@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/sugarss/-/sugarss-1.0.1.tgz#be826d9003e0f247735f92365dc3fd7f1bae9e44"
+  dependencies:
+    postcss "^6.0.14"
+
 supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
+
+supports-color@^3.2.3:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.2.3.tgz#65ac0504b3954171d8a64946b2ae3cbb8a5f54f6"
+  dependencies:
+    has-flag "^1.0.0"
+
+supports-color@^5.2.0, supports-color@^5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.3.0.tgz#5b24ac15db80fa927cf5227a4a33fd3c4c7676c0"
+  dependencies:
+    has-flag "^3.0.0"
+
+svg-tags@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/svg-tags/-/svg-tags-1.0.0.tgz#58f71cee3bd519b59d4b2a843b6c7de64ac04764"
+
+table@^4.0.1:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/table/-/table-4.0.3.tgz#00b5e2b602f1794b9acaf9ca908a76386a7813bc"
+  dependencies:
+    ajv "^6.0.1"
+    ajv-keywords "^3.0.0"
+    chalk "^2.1.0"
+    lodash "^4.17.4"
+    slice-ansi "1.0.0"
+    string-width "^2.1.1"
 
 through2@^0.6.1:
   version "0.6.5"
@@ -1278,7 +2495,7 @@ through2@^0.6.1:
     readable-stream ">=1.0.33-1 <1.1.0-0"
     xtend ">=4.0.0 <4.1.0-0"
 
-through2@^2.0.0:
+through2@^2.0.0, through2@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.3.tgz#0004569b37c7c74ba39c43f3ced78d1ad94140be"
   dependencies:
@@ -1317,9 +2534,44 @@ to-regex@^3.0.1:
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
 
+trim-newlines@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-2.0.0.tgz#b403d0b91be50c331dfc4b82eeceb22c3de16d20"
+
+trim-trailing-lines@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/trim-trailing-lines/-/trim-trailing-lines-1.1.0.tgz#7aefbb7808df9d669f6da2e438cac8c46ada7684"
+
+trim@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.1.tgz#5858547f6b290757ee95cccc666fb50084c460dd"
+
+trough@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/trough/-/trough-1.0.1.tgz#a9fd8b0394b0ae8fff82e0633a0a36ccad5b5f86"
+
 unc-path-regex@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/unc-path-regex/-/unc-path-regex-0.1.2.tgz#e73dd3d7b0d7c5ed86fbac6b0ae7d8c6a69d50fa"
+
+unherit@^1.0.4:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/unherit/-/unherit-1.1.0.tgz#6b9aaedfbf73df1756ad9e316dd981885840cd7d"
+  dependencies:
+    inherits "^2.0.1"
+    xtend "^4.0.1"
+
+unified@^6.0.0:
+  version "6.1.6"
+  resolved "https://registry.yarnpkg.com/unified/-/unified-6.1.6.tgz#5ea7f807a0898f1f8acdeefe5f25faa010cc42b1"
+  dependencies:
+    bail "^1.0.0"
+    extend "^3.0.0"
+    is-plain-obj "^1.1.0"
+    trough "^1.0.0"
+    vfile "^2.0.0"
+    x-is-function "^1.0.4"
+    x-is-string "^0.1.0"
 
 union-value@^1.0.0:
   version "1.0.0"
@@ -1330,9 +2582,45 @@ union-value@^1.0.0:
     is-extendable "^0.1.1"
     set-value "^0.4.3"
 
+uniq@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/uniq/-/uniq-1.0.1.tgz#b31c5ae8254844a3a8281541ce2b04b865a734ff"
+
 unique-stream@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unique-stream/-/unique-stream-1.0.0.tgz#d59a4a75427447d9aa6c91e70263f8d26a4b104b"
+
+unist-util-find-all-after@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/unist-util-find-all-after/-/unist-util-find-all-after-1.0.1.tgz#4e5512abfef7e0616781aecf7b1ed751c00af908"
+  dependencies:
+    unist-util-is "^2.0.0"
+
+unist-util-is@^2.0.0, unist-util-is@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/unist-util-is/-/unist-util-is-2.1.1.tgz#0c312629e3f960c66e931e812d3d80e77010947b"
+
+unist-util-modify-children@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/unist-util-modify-children/-/unist-util-modify-children-1.1.1.tgz#66d7e6a449e6f67220b976ab3cb8b5ebac39e51d"
+  dependencies:
+    array-iterate "^1.0.0"
+
+unist-util-remove-position@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/unist-util-remove-position/-/unist-util-remove-position-1.1.1.tgz#5a85c1555fc1ba0c101b86707d15e50fa4c871bb"
+  dependencies:
+    unist-util-visit "^1.1.0"
+
+unist-util-stringify-position@^1.0.0, unist-util-stringify-position@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/unist-util-stringify-position/-/unist-util-stringify-position-1.1.1.tgz#3ccbdc53679eed6ecf3777dd7f5e3229c1b6aa3c"
+
+unist-util-visit@^1.1.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-1.3.0.tgz#41ca7c82981fd1ce6c762aac397fc24e35711444"
+  dependencies:
+    unist-util-is "^2.1.1"
 
 unset-value@^1.0.0:
   version "1.0.0"
@@ -1366,6 +2654,32 @@ v8flags@^2.0.2:
   resolved "https://registry.yarnpkg.com/v8flags/-/v8flags-2.1.1.tgz#aab1a1fa30d45f88dd321148875ac02c0b55e5b4"
   dependencies:
     user-home "^1.1.1"
+
+validate-npm-package-license@^3.0.1:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz#81643bcbef1bdfecd4623793dc4648948ba98338"
+  dependencies:
+    spdx-correct "^3.0.0"
+    spdx-expression-parse "^3.0.0"
+
+vfile-location@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/vfile-location/-/vfile-location-2.0.2.tgz#d3675c59c877498e492b4756ff65e4af1a752255"
+
+vfile-message@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/vfile-message/-/vfile-message-1.0.0.tgz#a6adb0474ea400fa25d929f1d673abea6a17e359"
+  dependencies:
+    unist-util-stringify-position "^1.1.1"
+
+vfile@^2.0.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/vfile/-/vfile-2.3.0.tgz#e62d8e72b20e83c324bc6c67278ee272488bf84a"
+  dependencies:
+    is-buffer "^1.1.4"
+    replace-ext "1.0.0"
+    unist-util-stringify-position "^1.0.0"
+    vfile-message "^1.0.0"
 
 vinyl-fs@^0.3.0:
   version "0.3.14"
@@ -1405,6 +2719,20 @@ wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
 
-"xtend@>=4.0.0 <4.1.0-0", xtend@~4.0.1:
+write@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/write/-/write-0.2.1.tgz#5fc03828e264cea3fe91455476f7a3c566cb0757"
+  dependencies:
+    mkdirp "^0.5.1"
+
+x-is-function@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/x-is-function/-/x-is-function-1.0.4.tgz#5d294dc3d268cbdd062580e0c5df77a391d1fa1e"
+
+x-is-string@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/x-is-string/-/x-is-string-0.1.0.tgz#474b50865af3a49a9c4657f05acd145458f77d82"
+
+"xtend@>=4.0.0 <4.1.0-0", xtend@^4.0.1, xtend@~4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"


### PR DESCRIPTION
This adds a `.stylelintrc` file to check css syntax. This can be used in 3 ways:

1. During development. Most editors have linting capabilities and expect to find this file as a guide.
2. Locally right before commit using: `gulp test`. I amended `gulpfile.js` for that.
3. On a PR Travis can run `stylelint`. I amended `.travis.yml` for that.

I added a pretty standard stylelint configuration, slightly adjusted to the code styling we already use. This PR seems to have a lot of changes since we have many inconsistencies in our code (eg. many scss files have tabs instead of spaces). But the actual changes are minimal.