### PR TITLE
PLANET-1928 fix covers m screens

### DIFF
--- a/assets/scss/common/_covers.scss
+++ b/assets/scss/common/_covers.scss
@@ -47,8 +47,17 @@
 // L & XL with show-all-covers class should show all covers
 // remove limit visibility class on load more button click
 .show-3-covers .limit-visibility {
-  .cover-card-column:nth-child(n+4) {
+  .cover-card-column:nth-child(n+3) {
     display: none;
+  }
+
+  @include large-and-up {
+    .cover-card-column:nth-child(-n+4) {
+      display: block;
+    }
+    .cover-card-column:nth-child(n+4) {
+      display: none;
+    }
   }
 }
 


### PR DESCRIPTION
Fix number of take action covers displayed on page load on M screens when 'Show 3 covers' option in Covers block is selected.

PS. I am entering your territory here. Looks like it works but if this is not correct then feel free to take over the issue.