### PR TITLE
PLANET 1704 Fixing alignment of button on small screen size.

### DIFF
--- a/assets/scss/common/_covers.scss
+++ b/assets/scss/common/_covers.scss
@@ -209,8 +209,10 @@
 .cover-card-btn {
   position: absolute;
   bottom: 0;
-  margin: 15px 0;
-  width: 90%;
+  left: 0;
+  right: 0;
+  margin: 15px auto;
+  width: 92%;
   cursor: pointer;
 
   @include x-large-and-up {


### PR DESCRIPTION
Ticket [link](https://jira.greenpeace.org/browse/PLANET-1704) 

As per feedback from the design team changing the width of the button from `90%` to `92%`.
cc: @tolen 

![button92](https://user-images.githubusercontent.com/2052071/37452035-6e1308ec-2859-11e8-91a2-613ece075b67.png)
