### PR TITLE
PLANET-1823 auto set featured image

### DIFF
--- a/assets/admin/js/edit_post.js
+++ b/assets/admin/js/edit_post.js
@@ -53,34 +53,36 @@ $(document).ready(function () {
   // Custom handling of Featured Image selection, so that we know if Editor tried to override the
   // auto-selected first image found within the Post's content.
   $("#postimagediv").off("click", "#set-post-thumbnail").on("click", "#set-post-thumbnail", function () {
-  	if ( typeof wp !== "undefined" ) {
+    if ( typeof wp !== "undefined" ) {
 
-  		var media_modal = wp.media({
-			title: localizations.media_title,
-			library: {
-				type: "image"
-			},
-			multiple: false
-		});
+      var media_modal = wp.media({
+	    title: localizations.media_title,
+	    library: {
+		  type: "image"
+		},
+		multiple: false
+	  });
 
-  		media_modal
-			.on("select", function () {
-				var selected_image = media_modal.state().get("selection").first().toJSON();
+  	  media_modal
+	  .on("select", function () {
+	    var selected_image = media_modal.state().get("selection").first().toJSON();
 
-				// TODO - There might be a prettier way to override the modal's default behavior when selecting Image.
-				$("#set-post-thumbnail").parent().remove();
-				$("#postimagediv .inside")
-					.prepend('<p class="hide-if-no-js"><a href="' + window.location.href + '/wp-admin/media-upload.php?post_id=' + selected_image.id + '"&amp;type=image&amp;TB_iframe=1" id="set-post-thumbnail" aria-describedby="set-post-thumbnail-desc" class="thickbox"><img width="169" height="266" src="' + selected_image.url + '" class="attachment-266x266 size-266x266" alt=""></a></p>')
-					.append('<input type="hidden" name="user_set_featured_image" value="true" />');
-				$('#_thumbnail_id').val( selected_image.id );
-				$("input[name=user_removed_featured_image]").remove();
-			})
-			.open();
-  	}
+	    // TODO - There might be a prettier way to override the modal's default behavior when selecting Image.
+		$("#set-post-thumbnail").parent().remove();
+		$("#postimagediv .inside")
+		  .prepend('<p class="hide-if-no-js"><a href="' + window.location.href + '/wp-admin/media-upload.php?post_id=' + selected_image.id + '"&amp;type=image&amp;TB_iframe=1" id="set-post-thumbnail" aria-describedby="set-post-thumbnail-desc" class="thickbox"><img width="169" height="266" src="' + selected_image.url + '" class="attachment-266x266 size-266x266" alt=""></a></p>')
+		  .append('<input type="hidden" name="user_set_featured_image" value="true" />');
+		$('#_thumbnail_id').val( selected_image.id );
+		$("input[name=user_removed_featured_image]").remove();
+	  })
+	  .open();
+    }
 
-  	return false;
-  }).on("click", "#remove-post-thumbnail", function () {
-	  $("#postimagediv").append('<input type="hidden" name="user_removed_featured_image" value="true" />');
-	  $("input[name=user_set_featured_image]").remove();
+    return false;
+  })
+  .on("click", "#remove-post-thumbnail", function () {
+    $("#postimagediv").append('<input type="hidden" name="user_removed_featured_image" value="true" />');
+    $("input[name=user_set_featured_image]").remove();
   });
+
 });

--- a/assets/admin/js/edit_post.js
+++ b/assets/admin/js/edit_post.js
@@ -49,4 +49,38 @@ $(document).ready(function () {
       }
     }
   });
+
+  // Custom handling of Featured Image selection, so that we know if Editor tried to override the
+  // auto-selected first image found within the Post's content.
+  $("#postimagediv").off("click", "#set-post-thumbnail").on("click", "#set-post-thumbnail", function () {
+  	if ( typeof wp !== "undefined" ) {
+
+  		var media_modal = wp.media({
+			title: localizations.media_title,
+			library: {
+				type: "image"
+			},
+			multiple: false
+		});
+
+  		media_modal
+			.on("select", function () {
+				var selected_image = media_modal.state().get("selection").first().toJSON();
+
+				// TODO - There might be a prettier way to override the modal's default behavior when selecting Image.
+				$("#set-post-thumbnail").parent().remove();
+				$("#postimagediv .inside")
+					.prepend('<p class="hide-if-no-js"><a href="' + window.location.href + '/wp-admin/media-upload.php?post_id=' + selected_image.id + '"&amp;type=image&amp;TB_iframe=1" id="set-post-thumbnail" aria-describedby="set-post-thumbnail-desc" class="thickbox"><img width="169" height="266" src="' + selected_image.url + '" class="attachment-266x266 size-266x266" alt=""></a></p>')
+					.append('<input type="hidden" name="user_set_featured_image" value="true" />');
+				$('#_thumbnail_id').val( selected_image.id );
+				$("input[name=user_removed_featured_image]").remove();
+			})
+			.open();
+  	}
+
+  	return false;
+  }).on("click", "#remove-post-thumbnail", function () {
+	  $("#postimagediv").append('<input type="hidden" name="user_removed_featured_image" value="true" />');
+	  $("input[name=user_set_featured_image]").remove();
+  });
 });

--- a/assets/admin/js/edit_post.js
+++ b/assets/admin/js/edit_post.js
@@ -52,37 +52,37 @@ $(document).ready(function () {
 
   // Custom handling of Featured Image selection, so that we know if Editor tried to override the
   // auto-selected first image found within the Post's content.
-  $("#postimagediv").off("click", "#set-post-thumbnail").on("click", "#set-post-thumbnail", function () {
-    if ( typeof wp !== "undefined" ) {
+  $('#postimagediv').off('click', '#set-post-thumbnail').on('click', '#set-post-thumbnail', function () {
+    if ( typeof wp !== 'undefined' ) {
 
       var media_modal = wp.media({
 	    title: localizations.media_title,
 	    library: {
-		  type: "image"
+		  type: 'image'
 		},
 		multiple: false
 	  });
 
   	  media_modal
-	  .on("select", function () {
-	    var selected_image = media_modal.state().get("selection").first().toJSON();
+	  .on('select', function () {
+	    var selected_image = media_modal.state().get('selection').first().toJSON();
 
 	    // TODO - There might be a prettier way to override the modal's default behavior when selecting Image.
-		$("#set-post-thumbnail").parent().remove();
-		$("#postimagediv .inside")
+		$('#set-post-thumbnail').parent().remove();
+		$('#postimagediv .inside')
 		  .prepend('<p class="hide-if-no-js"><a href="' + window.location.href + '/wp-admin/media-upload.php?post_id=' + selected_image.id + '"&amp;type=image&amp;TB_iframe=1" id="set-post-thumbnail" aria-describedby="set-post-thumbnail-desc" class="thickbox"><img width="169" height="266" src="' + selected_image.url + '" class="attachment-266x266 size-266x266" alt=""></a></p>')
 		  .append('<input type="hidden" name="user_set_featured_image" value="true" />');
 		$('#_thumbnail_id').val( selected_image.id );
-		$("input[name=user_removed_featured_image]").remove();
+		$('input[name=user_removed_featured_image]').remove();
 	  })
 	  .open();
     }
 
     return false;
   })
-  .on("click", "#remove-post-thumbnail", function () {
-    $("#postimagediv").append('<input type="hidden" name="user_removed_featured_image" value="true" />');
-    $("input[name=user_set_featured_image]").remove();
+  .on('click', '#remove-post-thumbnail', function () {
+    $('#postimagediv').append('<input type="hidden" name="user_removed_featured_image" value="true" />');
+    $('input[name=user_set_featured_image]').remove();
   });
 
 });

--- a/functions.php
+++ b/functions.php
@@ -169,24 +169,27 @@ class P4_Master_Site extends TimberSite {
 		} elseif ( isset( $_POST['user_removed_featured_image'] ) ) {
 			update_post_meta( $post_id, 'user_set_featured_image', false );
 		}
-		$user_featured_image = get_post_meta( $post_id, 'user_set_featured_image', true );
+		$user_set_featured_image = get_post_meta( $post_id, 'user_set_featured_image', true );
 
 		// Apply this behavior to Posts only.
-		if ( 'post' === $post->post_type && ! $user_featured_image ) {
+		if ( 'post' === $post->post_type && ! $user_set_featured_image ) {
 
 			// Find all matches of <img> html tags within the post's content and get the url inside the src attribute.
 			preg_match_all( '/<img.+src=[\'"]([^\'"]+)[\'"].*>/i', $post->post_content, $matches );
-			$first_img_url = $matches[1][0];
-			// Use the attachment's url to find its id.
-			$statement     = $wpdb->prepare( "SELECT ID FROM $wpdb->posts WHERE guid='%s';", $first_img_url );
-			$result        = $wpdb->get_col( $statement );
-			$attachment_id = $result[0];
+			if ( isset( $matches[1][0] ) ) {
+				$first_img_url = $matches[1][0];
 
-			if ( $attachment_id ) {
-				set_post_thumbnail( $post_id, $attachment_id );
-			} else {
-				// If no image was found inside the post's content then unset the featured image.
-				update_post_meta( $post_id, '_thumbnail_id', '' );
+				// Use the attachment's url to find its id.
+				$statement     = $wpdb->prepare( "SELECT ID FROM $wpdb->posts WHERE guid='%s';", $first_img_url );
+				$result        = $wpdb->get_col( $statement );
+
+				if ( isset( $result[0] ) ) {
+					$attachment_id = $result[0];
+					set_post_thumbnail( $post_id, $attachment_id );
+				} else {
+					// If no image was found inside the post's content then unset the featured image.
+					update_post_meta( $post_id, '_thumbnail_id', '' );
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Automatically set as featured image of a Post the first image found within the Post's content. Allow Editors to override this by setting manually another featured image of their choosing.