### PR TITLE
PLANET-1823 auto set featured image

### DIFF
--- a/assets/admin/js/edit_post.js
+++ b/assets/admin/js/edit_post.js
@@ -49,40 +49,4 @@ $(document).ready(function () {
       }
     }
   });
-
-  // Custom handling of Featured Image selection, so that we know if Editor tried to override the
-  // auto-selected first image found within the Post's content.
-  $('#postimagediv').off('click', '#set-post-thumbnail').on('click', '#set-post-thumbnail', function () {
-    if ( typeof wp !== 'undefined' ) {
-
-      var media_modal = wp.media({
-	    title: localizations.media_title,
-	    library: {
-		  type: 'image'
-		},
-		multiple: false
-	  });
-
-  	  media_modal
-	  .on('select', function () {
-	    var selected_image = media_modal.state().get('selection').first().toJSON();
-
-	    // TODO - There might be a prettier way to override the modal's default behavior when selecting Image.
-		$('#set-post-thumbnail').parent().remove();
-		$('#postimagediv .inside')
-		  .prepend('<p class="hide-if-no-js"><a href="' + window.location.href + '/wp-admin/media-upload.php?post_id=' + selected_image.id + '"&amp;type=image&amp;TB_iframe=1" id="set-post-thumbnail" aria-describedby="set-post-thumbnail-desc" class="thickbox"><img width="169" height="266" src="' + selected_image.url + '" class="attachment-266x266 size-266x266" alt=""></a></p>')
-		  .append('<input type="hidden" name="user_set_featured_image" value="true" />');
-		$('#_thumbnail_id').val( selected_image.id );
-		$('input[name=user_removed_featured_image]').remove();
-	  })
-	  .open();
-    }
-
-    return false;
-  })
-  .on('click', '#remove-post-thumbnail', function () {
-    $('#postimagediv').append('<input type="hidden" name="user_removed_featured_image" value="true" />');
-    $('input[name=user_set_featured_image]').remove();
-  });
-
 });

--- a/functions.php
+++ b/functions.php
@@ -164,15 +164,10 @@ class P4_Master_Site extends TimberSite {
 		}
 
 		// Check if user has set the featured image manually or if he has removed it.
-		if ( isset( $_POST['user_set_featured_image'] ) ) {
-			update_post_meta( $post_id, 'user_set_featured_image', true );
-		} elseif ( isset( $_POST['user_removed_featured_image'] ) ) {
-			update_post_meta( $post_id, 'user_set_featured_image', false );
-		}
-		$user_set_featured_image = get_post_meta( $post_id, 'user_set_featured_image', true );
+		$has_user_set_featured_image = get_post_meta( $post_id, '_thumbnail_id', true );
 
 		// Apply this behavior to Posts only.
-		if ( 'post' === $post->post_type && ! $user_set_featured_image ) {
+		if ( 'post' === $post->post_type && ! $has_user_set_featured_image ) {
 
 			// Find all matches of <img> html tags within the post's content and get the url inside the src attribute.
 			preg_match_all( '/<img.+src=[\'"]([^\'"]+)[\'"].*>/i', $post->post_content, $matches );
@@ -180,8 +175,8 @@ class P4_Master_Site extends TimberSite {
 				$first_img_url = $matches[1][0];
 
 				// Use the attachment's url to find its id.
-				$statement     = $wpdb->prepare( "SELECT ID FROM $wpdb->posts WHERE guid='%s';", $first_img_url );
-				$result        = $wpdb->get_col( $statement );
+				$statement = $wpdb->prepare( "SELECT ID FROM $wpdb->posts WHERE guid='%s';", $first_img_url );
+				$result    = $wpdb->get_col( $statement );
 
 				if ( isset( $result[0] ) ) {
 					$attachment_id = $result[0];
@@ -384,11 +379,8 @@ class P4_Master_Site extends TimberSite {
 		wp_register_script( 'jquery-3', 'https://code.jquery.com/jquery-3.2.1.min.js', array(), '3.2.1', true );
 
 		if ( 'post.php' === $hook || 'post-new.php' === $hook ) {
-			wp_enqueue_script( 'edit_post', $this->theme_dir . '/assets/admin/js/edit_post.js', array( 'jquery' ), '0.0.2', true );
+			wp_enqueue_script( 'edit_post', $this->theme_dir . '/assets/admin/js/edit_post.js', array( 'jquery' ), '0.0.3', true );
 			wp_localize_script( 'edit_post', 'p4_page_type_mapping', planet4_get_option( 'p4-page-types-mapping' ) );
-			wp_localize_script( 'edit_post', 'localizations', [
-				'media_title'  => esc_html__( 'Select Image', 'planet4-master-theme' ),
-			] );
 		} elseif ( 'settings_page_planet4_options' === $hook ) {
 
 			// Get planet4 page types.

--- a/functions.php
+++ b/functions.php
@@ -164,10 +164,10 @@ class P4_Master_Site extends TimberSite {
 		}
 
 		// Check if user has set the featured image manually or if he has removed it.
-		$has_user_set_featured_image = get_post_meta( $post_id, '_thumbnail_id', true );
+		$user_set_featured_image = get_post_meta( $post_id, '_thumbnail_id', true );
 
 		// Apply this behavior to Posts only.
-		if ( 'post' === $post->post_type && ! $has_user_set_featured_image ) {
+		if ( 'post' === $post->post_type && ! $user_set_featured_image ) {
 
 			// Find all matches of <img> html tags within the post's content and get the url inside the src attribute.
 			preg_match_all( '/<img.+src=[\'"]([^\'"]+)[\'"].*>/i', $post->post_content, $matches );
@@ -181,9 +181,6 @@ class P4_Master_Site extends TimberSite {
 				if ( isset( $result[0] ) ) {
 					$attachment_id = $result[0];
 					set_post_thumbnail( $post_id, $attachment_id );
-				} else {
-					// If no image was found inside the post's content then unset the featured image.
-					update_post_meta( $post_id, '_thumbnail_id', '' );
 				}
 			}
 		}


### PR DESCRIPTION
Simplify the process of auto selecting the featured image while allowing the editor to override it at the same time.

@koyan You were right. I thought this would not work the very first time a new Post is created and there is an image inside the post content and a User selected featured image. But it does.

Still will need some testing, but I think it will be ok like that.