### PR TITLE
PLANET-1963 smarter post breadcrumps

### DIFF
--- a/classes/class-p4-post.php
+++ b/classes/class-p4-post.php
@@ -8,31 +8,37 @@ if ( ! class_exists( 'P4_Post' ) ) {
 	 */
 	class P4_Post extends \Timber\Post {
 
+		/** @var array $issues_nav_data */
+		protected $issues_nav_data;
+
 		/**
 		 * Checks if post is the act page.
-		 * @return boolean
+		 *
+		 * @return bool
 		 */
-		public function is_act_page() {
+		public function is_act_page() : bool {
 			$act_page_id = planet4_get_option( 'act_page' );
 
-			return $this->id === absint( $act_page_id );
+			return absint( $act_page_id ) === $this->id;
 		}
 
 		/**
 		 * Checks if post is the explore page.
-		 * @return boolean
+		 *
+		 * @return bool
 		 */
-		public function is_explore_page() {
+		public function is_explore_page() : bool {
 			$explore_page_id = planet4_get_option( 'explore_page' );
 
-			return $this->id === absint( $explore_page_id );
+			return absint( $explore_page_id ) === $this->id;
 		}
 
 		/**
 		 * Checks if post is a take action page (child of act page).
-		 * @return boolean
+		 *
+		 * @return bool
 		 */
-		public function is_take_action_page() {
+		public function is_take_action_page() : bool {
 			$act_page_id = planet4_get_option( 'act_page' );
 			$pages       = [];
 
@@ -41,7 +47,7 @@ if ( ! class_exists( 'P4_Post' ) ) {
 					'post_type'   => 'page',
 					'post_parent' => $act_page_id,
 					'numberposts' => - 1,
-					'fields'      => 'ids'
+					'fields'      => 'ids',
 				];
 
 				$pages = get_posts( $take_action_pages_args );
@@ -50,13 +56,10 @@ if ( ! class_exists( 'P4_Post' ) ) {
 			return in_array( $this->id, $pages );
 		}
 
-
 		/**
 		 * Loads in context information on the navigation links for Issue pages relevant to current Post's categories.
-		 *
-		 * @param array $context An indexed array with all data needed to render current page.
 		 */
-		public function load_nav_issues_links( &$context ) {
+		public function set_issues_links() {
 			// Retrieve P4 settings in order to check that we add only categories that are children of the Issues category.
 			$options         = get_option( 'planet4_options' );
 			$explore_page_id = $options['explore_page'] ?? '';
@@ -71,22 +74,19 @@ if ( ! class_exists( 'P4_Post' ) ) {
 				}
 				// Get the Issue pages that are relevant to the Categories of the current Post.
 				if ( $categories_ids && $explore_page_id ) {
-					$args   = [
+					$args = [
 						'post_parent'  => $explore_page_id,
 						'post_type'    => 'page',
 						'post_status'  => 'publish',
 					];
-					if ( count( $categories_ids ) > 1 ) {
-						$args['category__in'] = $categories_ids;
-					} elseif ( 1 === count( $categories_ids ) ) {
-						$args['cat'] = (int) $categories_ids[0];
-					}
+
+					$args['category__in'] = $categories_ids;
 					$issues = ( new WP_Query( $args ) )->posts;
 
 					if ( $issues ) {
 						foreach ( $issues as $issue ) {
 							if ( $issue && $this->post_parent !== (int) $explore_page_id ) {
-								$context['issues'][] = [
+								$this->issues_nav_data[] = [
 									'name' => $issue->post_title,
 									'link' => get_permalink( $issue ),
 								];

--- a/page-templates/evergreen.php
+++ b/page-templates/evergreen.php
@@ -36,26 +36,10 @@ $context        = Timber::get_context();
 $post           = new P4_Post();
 $page_meta_data = get_post_meta( $post->ID );
 
-// Retrieve P4 settings in order to check that we add only categories that are children of the Issues category.
-$options    = get_option( 'planet4_options' );
-$categories = get_the_category( $post->ID );
+// Load Navigation Issues links.
+$post->load_nav_issues_links( $context );
 
-// Handle navigation links.
-if ( $categories ) {
-	foreach ( $categories as $category ) {
-		if ( $category && ( $category->parent === (int) $options['issues_parent_category'] ) ) {     // Add links only for categories that are Issues.
-			// Get Issue.
-			$issue = get_page_by_title( $category->name );                  // Category and Issue need to have the same name.
-			if ( $issue ) {
-				$context['issues'][] = [
-					'name' => $issue->post_title,
-					'link' => get_permalink( $issue ),
-				];
-			}
-		}
-	}
-}
-// Get Campaigns.
+// Get Navigation Campaigns links.
 $page_tags = wp_get_post_tags( $post->ID );
 $tags      = [];
 

--- a/page-templates/evergreen.php
+++ b/page-templates/evergreen.php
@@ -36,8 +36,8 @@ $context        = Timber::get_context();
 $post           = new P4_Post();
 $page_meta_data = get_post_meta( $post->ID );
 
-// Load Navigation Issues links.
-$post->load_nav_issues_links( $context );
+// Set Navigation Issues links.
+$post->set_issues_links();
 
 // Get Navigation Campaigns links.
 $page_tags = wp_get_post_tags( $post->ID );
@@ -53,7 +53,7 @@ if ( is_array( $page_tags ) && $page_tags ) {
 	$context['campaigns'] = $tags;
 }
 
-$context['page']                = $post;
+$context['post']                = $post;
 $context['header_title']        = is_front_page() ? '' : ( $page_meta_data['p4_title'][0] ?? $post->title );
 $context['header_subtitle']     = $page_meta_data['p4_subtitle'][0] ?? '';
 $context['header_description']  = $page_meta_data['p4_description'][0] ?? '';

--- a/page.php
+++ b/page.php
@@ -41,50 +41,14 @@ function add_body_classes_for_page( $classes ) {
 }
 add_filter( 'body_class', 'add_body_classes_for_page' );
 
-$context = Timber::get_context();
-$post    = new P4_Post();
-
+$context        = Timber::get_context();
+$post           = new P4_Post();
 $page_meta_data = get_post_meta( $post->ID );
-$categories     = get_the_category( $post->ID );
 
-$option_values   = get_option( 'planet4_options' );
-$options         = [];
-$explore_page_id = $option_values['explore_page'] ?? '';
+// Load Navigation Issues links.
+$post->load_nav_issues_links( $context );
 
-// Handle navigation links.
-if ( $categories ) {
-	$categories_ids = [];
-
-	foreach ( $categories as $category ) {
-		$categories_ids[] = $category->term_id;
-	}
-	// Get the Issue pages that are relevant to the Categories of the current Post.
-	if ( $categories_ids ) {
-		$args   = [
-			'post_parent'  => $explore_page_id,
-			'post_type'    => 'page',
-			'post_status'  => 'publish',
-		];
-		if ( count( $categories_ids ) > 1 ) {
-			$args['category__in'] = $categories_ids;
-		} elseif ( 1 === count( $categories_ids ) ) {
-			$args['cat'] = (int) $categories_ids[0];
-		}
-		$issues = ( new WP_Query( $args ) )->posts;
-
-		if ( $issues ) {
-			foreach ( $issues as $issue ) {
-				if ( $issue && $post->post_parent != $explore_page_id) {
-					$context['issues'][] = [
-						'name' => $issue->post_title,
-						'link' => get_permalink( $issue ),
-					];
-				}
-			}
-		}
-	}
-}
-// Get Campaigns.
+// Get Navigation Campaigns links.
 $page_tags = wp_get_post_tags( $post->ID );
 $tags      = [];
 

--- a/page.php
+++ b/page.php
@@ -45,8 +45,8 @@ $context        = Timber::get_context();
 $post           = new P4_Post();
 $page_meta_data = get_post_meta( $post->ID );
 
-// Load Navigation Issues links.
-$post->load_nav_issues_links( $context );
+// Set Navigation Issues links.
+$post->set_issues_links();
 
 // Get Navigation Campaigns links.
 $page_tags = wp_get_post_tags( $post->ID );

--- a/single.php
+++ b/single.php
@@ -26,27 +26,11 @@ add_filter( 'body_class', 'add_body_classes_for_post' );
 
 // Initializing variables.
 $context         = Timber::get_context();
-$post            = Timber::query_post(false, 'P4_Post');
+$post            = new P4_Post();
 $context['post'] = $post;
 
-// Get Post categories.
-$categories       = get_the_category( $post->ID );
-
-// Handle navigation links.
-if ( $categories ) {
-	foreach ( $categories as $category ) {
-		if ( $category && ( $category->name !== $post->post_title ) ) {     // Do not add links inside the Issue page itself.
-			// Get Issue.
-			$issue = get_page_by_title( $category->name );                  // Category and Issue need to have the same name.
-			if ( $issue ) {
-				$context['issues'][] = [
-					'name' => $issue->post_title,
-					'link' => get_permalink( $issue ),
-				];
-			}
-		}
-	}
-}
+// Load Navigation Issues links.
+$post->load_nav_issues_links( $context );
 
 // Get the cmb2 custom fields data
 // Articles block parameters to populate the articles block

--- a/single.php
+++ b/single.php
@@ -23,14 +23,13 @@ function add_body_classes_for_post( $classes ) {
 }
 add_filter( 'body_class', 'add_body_classes_for_post' );
 
-
 // Initializing variables.
 $context         = Timber::get_context();
 $post            = new P4_Post();
 $context['post'] = $post;
 
-// Load Navigation Issues links.
-$post->load_nav_issues_links( $context );
+// Set Navigation Issues links.
+$post->set_issues_links();
 
 // Get the cmb2 custom fields data
 // Articles block parameters to populate the articles block

--- a/single.php
+++ b/single.php
@@ -25,7 +25,8 @@ add_filter( 'body_class', 'add_body_classes_for_post' );
 
 // Initializing variables.
 $context         = Timber::get_context();
-$post            = new P4_Post();
+/** @var P4_Post $post */
+$post            = Timber::query_post( false, 'P4_Post' );
 $context['post'] = $post;
 
 // Set Navigation Issues links.

--- a/templates/blocks/header.twig
+++ b/templates/blocks/header.twig
@@ -11,10 +11,10 @@
 			</div>
 		{% endif %}
 		<div class="container">
-			{% if ( issues or campaigns ) %}
+			{% if ( post.issues_nav_data or campaigns ) %}
 				<div class="top-page-tags">
-					{% if ( issues ) %}
-						{% for issue in issues %}
+					{% if ( post.issues_nav_data ) %}
+						{% for issue in post.issues_nav_data %}
 							<a class="tag-item tag-item--main" href="{{ issue.link|default('#') }}">{{ issue.name|e('wp_kses_post')|raw }}</a>
 						{% endfor %}
 					{% endif %}

--- a/templates/evergreen.twig
+++ b/templates/evergreen.twig
@@ -1,13 +1,13 @@
 {% extends "base.twig" %}
 
 {% block content %}
-	<article id="page-{{ page.ID }}">
+	<article id="page-{{ post.ID }}">
 		<div class="container">
 			<div class="post-content">
 				<div class="row">
 					<div class="col-lg-9">
 						<article class="post-details">
-							{{ page.content|e('wp_kses_post')|raw }}
+							{{ post.content|e('wp_kses_post')|raw }}
 						</article>
 					</div>
 				</div>

--- a/templates/single.twig
+++ b/templates/single.twig
@@ -17,8 +17,8 @@
 						<a class="tag-item tag-item--main" href="{{ filter_url }}">{{ page_type }}</a>
 					{% endif %}
 
-					{% if ( issues ) %}
-						{% for issue in issues %}
+					{% if ( post.issues_nav_data ) %}
+						{% for issue in post.issues_nav_data %}
 							<a class="tag-item tag-item--main" href="{{ issue.link|default('#') }}">{{ issue.name|e('wp_kses_post')|raw }}</a>
 						{% endfor %}
 					{% endif %}


### PR DESCRIPTION
Implement smarter logic for loading navigation links of Issue pages that are relevant to current P4_Post (page, post, evergreen) categories. Moved logic inside P4_Post class from where it can be accessed by all pages.

- This way we no longer need to match Category Names with Issue page names. -