### PR TITLE
PLANET-1924 Articles block portrait images

### DIFF
--- a/assets/scss/common/_article-listing.scss
+++ b/assets/scss/common/_article-listing.scss
@@ -62,12 +62,15 @@
   }
 }
 
-.article-list-item-image {
-  order: 2;
+.article-list-item-image-max-width {
 
   img {
     width: 100%;
   }
+}
+
+.article-list-item-image {
+  order: 2;
 
   @include medium-and-up {
     flex-basis: 30%;
@@ -146,5 +149,41 @@
 
   @include x-large-and-up {
     font-size: rem(18);
+  }
+}
+
+.article-image-holder {
+  background-image: repeating-linear-gradient(0deg, transparent -53%, rgba(157, 187, 190, 0.1) 100%, rgba(236, 241, 243, 1) 0);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  @include small-and-up {
+
+    img {
+      max-height: 340px;
+      width: auto;
+    }
+  }
+  @include medium-and-up {
+
+    img {
+      max-height: 138px;
+      width: auto;
+    }
+  }
+  @include large-and-up {
+
+    img {
+      max-height: 186px;
+      width: auto;
+    }
+  }
+
+  @include x-large-and-up {
+    img {
+      max-height: 222px;
+      width: auto;
+    }
   }
 }

--- a/functions.php
+++ b/functions.php
@@ -191,6 +191,7 @@ class P4_Master_Site extends TimberSite {
 	 */
 	public function add_image_sizes() {
 		add_image_size( 'retina-large', 2048, 1366, false );
+		add_image_size( 'articles-medium-large', 510, 340, false );
 	}
 
 	/**


### PR DESCRIPTION
Add new image size for articles block images. 
Css rules for portrait images.
Constrain portrait images to keep a consistent ratio for image div across all screen sizes.

You can check how it looks [here](https://jira.greenpeace.org/browse/PLANET-1924?focusedCommentId=62674&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-62674)
[Issue 1814](https://jira.greenpeace.org/browse/PLANET-1814)
[Issue 1924](https://jira.greenpeace.org/browse/PLANET-1924)