### PR TITLE
Bug/1956 iPhone breakpoint

### DIFF
--- a/templates/html-header.twig
+++ b/templates/html-header.twig
@@ -57,7 +57,14 @@
 
 	<link href="https://fonts.googleapis.com/css?family=Roboto" rel="stylesheet">
 	<link rel="pingback" href="{{ site.pingback_url }}">
-	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
+	<meta id="dynamic-mvp" name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 	<link rel="shortcut icon" type="image/ico" href="favicon.ico"/>
 	{{ wp_head }}
+	<script>
+		var iOS = /iPhone/.test(navigator.userAgent) && !window.MSStream;
+		if (iOS) {
+			var mvp = document.getElementById('dynamic-mvp');		
+			mvp.setAttribute('content','width=380');
+		}
+	</script>
 </head>


### PR DESCRIPTION
Changed viewport device width to `320px` as per suggestions [here](https://developer.apple.com/library/content/documentation/AppleApplications/Reference/SafariWebContent/UsingtheViewport/UsingtheViewport.html) & [here](https://jira.greenpeace.org/browse/PLANET-1956?focusedCommentId=62705&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-62705).

[ref1](https://www.quirksmode.org/mobile/viewports2.html), [ref2](https://developer.mozilla.org/en-US/docs/Mozilla/Mobile/Viewport_meta_tag) for extra dose of viewports; mind-boggling stuff ahead.