### PR TITLE
PLANET-1708 Footer: change background and link color

### DIFF
--- a/assets/scss/common/_footer.scss
+++ b/assets/scss/common/_footer.scss
@@ -128,7 +128,7 @@
   }
 
   a {
-    color: $spray;
+    color: $white;
   }
 }
 


### PR DESCRIPTION
So the site need to meet all the readability standards. The existing two links in the footer to "Otherwise Stated" and "CC-BY International License" are currently in #86EEE7 which when used on such small type on a background colour of #1E5F65 fails to pass WCAG AAA standard. So we have to change the link colour to white #FFFFFF which has an underline that switches on on mouse hover.