### PR TITLE
Remove happy-point default background

### DIFF
--- a/assets/scss/common/_happy-point-block.scss
+++ b/assets/scss/common/_happy-point-block.scss
@@ -1,12 +1,3 @@
-// Mixins because extending is not possible inside media queries
-@mixin happy-point-block-background-image {
-  background: url("images/happy-point-block-bg.jpg") center center no-repeat;
-  background-size: cover;
-  height: 620px;
-  width: 100vw;
-  position: relative;
-}
-
 .happy-point-block-wrap {
   @include background-before-opacity($light-blue-bg);
   margin: 0 -120px 0 -100px;
@@ -182,7 +173,9 @@
 }
 @include x-large-and-up {
   .happy-point-block-wrap {
-    @include happy-point-block-background-image;
+    height: 620px;
+    width: 100vw;
+    position: relative;
     @include background-before-opacity($light-blue-bg);
 
     .pt-20 {


### PR DESCRIPTION
I moved the default fallback image to plugin-blocks, since we no longer use `background-image` for the happy-point.

See greenpeace/planet4-plugin-blocks#255