### PR TITLE
PLANET-1936 Allow happy point img to use container's full space for s & m sizes.

### DIFF
--- a/assets/scss/common/_happy-point-block.scss
+++ b/assets/scss/common/_happy-point-block.scss
@@ -33,7 +33,7 @@
     position: absolute;
     height: 500px;
     width: 100%;
-    object-fit: none;
+    object-fit: fill;
   }
 
   form {
@@ -169,8 +169,13 @@
     p {
       text-align: left;
     }
+
+    img {
+      object-fit: none;
+    }
   }
 }
+
 @include x-large-and-up {
   .happy-point-block-wrap {
     height: 620px;


### PR DESCRIPTION
Related to https://github.com/greenpeace/planet4-plugin-blocks/pull/256
[Issue 1936](https://jira.greenpeace.org/browse/PLANET-1936)