### PR TITLE
PLANET-1709 - Make placeholder css more explicit

### DIFF
--- a/assets/scss/pages/post/_comments-form.scss
+++ b/assets/scss/pages/post/_comments-form.scss
@@ -30,6 +30,18 @@
     &:focus {
       background-color: transparentize($white, .6);
     }
+
+    &::placeholder {
+      color: $dark-shade-black;
+    }
+
+    &::-webkit-input-placeholder {
+      color: $dark-shade-black;
+    }
+
+    &::-ms-input-placeholder {
+      color: $dark-shade-black;
+    }
   }
 
   label {
@@ -92,12 +104,5 @@
       width: 40%;
       margin-top: 30px;
     }
-  }
-
-  ::placeholder,
-  ::-webkit-input-placeholder,
-  :-ms-input-placeholder,
-  ::-ms-input-placeholder {
-    color: $dark-shade-black;
   }
 }


### PR DESCRIPTION
There is a conflict with bootstrap's own placeholder styling than require this to be more explicit.