### PR TITLE
PLANET-2146 - Adjust navbar to fit a Language selector flag

### DIFF
--- a/assets/scss/common/_navbar.scss
+++ b/assets/scss/common/_navbar.scss
@@ -346,7 +346,7 @@ $menu-height-large: rem(60);
     }
 
     .nav-link {
-      padding: 0 20px;
+      padding: 0 15%;
       min-width: 20%;
       text-align: center;
       border-bottom: 2px solid transparent;

--- a/templates/navigation-bar.twig
+++ b/templates/navigation-bar.twig
@@ -30,13 +30,8 @@
 				{% include 'countries.twig' %}
 			</li>
 			{% for key,item in navbar_menu.get_items %}
-				{% if key == 0 %}
-					{% set class_name = 'act-nav-link' %}
-				{% else %}
-					{% set class_name = 'explore-nav-link' %}
-				{% endif %}
-				<li class="nav-item {{ class_name }} {{ item == item.current ? 'active' : '' }}">
-					<a class="nav-link" href="{{ item.get_link }}">{{ item.title }}</a>
+				<li class="nav-item {{ item == item.current ? 'active' : '' }}">
+					<a class="nav-link" href="{{ item.get_link }}">{{ item.title|raw }}</a>
 				</li>
 			{% endfor %}
 			<li class="nav-item">


### PR DESCRIPTION
This removes custom hard-coded class names for the nav items, that we don't use anyway.
Adds a raw filter, which should be safe for item titles. in order to render language flag image.
The current language won't be displayed at all, so in a bilingual scenario we would only have one flag there.

![lang](https://user-images.githubusercontent.com/939357/39750693-8e429ee0-52be-11e8-8354-a5411d4353d7.jpg)
