### PR TITLE
Add class name on nav links

### DIFF
--- a/templates/navigation-bar.twig
+++ b/templates/navigation-bar.twig
@@ -30,7 +30,7 @@
 				{% include 'countries.twig' %}
 			</li>
 			{% for key,item in navbar_menu.get_items %}
-				<li class="nav-item {{ item == item.current ? 'active' : '' }}">
+				<li class="nav-item {{ item.class }} {{ item == item.current ? 'active' : '' }}">
 					<a class="nav-link" href="{{ item.get_link }}">{{ item.title|raw }}</a>
 				</li>
 			{% endfor %}


### PR DESCRIPTION
I removed hard-coded class names from nav links on e87304b9a5a57c4fa4de194ff98e8a8acd43c68e, since it's not easy to have those along with language switcher. But these are used as selectors on selenium tests. So I'm adding `item.class` so we can add these classes back through the admin.