### PR TITLE
PLANET-2127 - Add z-index to Submenu Sidebar

### DIFF
--- a/assets/scss/common/_submenu.scss
+++ b/assets/scss/common/_submenu.scss
@@ -57,6 +57,8 @@
   }
 
   &.submenu-sidebar {
+    z-index: 4;
+
     @include medium-and-up {
       float: right;
       max-width: 350px;


### PR DESCRIPTION
Altered `z-index` in order for the Sidebar to be above the content but not above the navigation bar.