### PR TITLE
PLANET-2179 - Avoid double escaping opengraph titles

### DIFF
--- a/templates/blocks/share_buttons.twig
+++ b/templates/blocks/share_buttons.twig
@@ -7,7 +7,7 @@
 		<span class="sr-only">{{ __( 'Share on' ) }} Facebook</span>
 	</a>
 	<!-- Twitter -->
-	<a href="https://twitter.com/share?url={{ post.link }}&text={{ post.title }}"
+	<a href="https://twitter.com/share?url={{ post.link }}&text={{ post.title|raw }}"
 		 onclick="dataLayer.push({'event' : 'uaevent', 'eventCategory' : 'Social Share', 'eventAction': 'Twitter', 'eventLabel': '{{ post.link }}'});"
 		 target="_blank" class="share-btn twitter">
 		<i class="fab fa-twitter"></i>

--- a/templates/html-header.twig
+++ b/templates/html-header.twig
@@ -13,7 +13,7 @@
 		{% set image_data  = tag_image_id ? fn( 'wp_get_attachment_image_src', tag_image_id, 'full' ) : [] %}
 	{% endif %}
 
-	<meta property="og:title" content="{{ wp_title ? wp_title|e('esc_html')|raw : site.name }}" />
+	<meta property="og:title" content="{% if wp_title %}{{ wp_title|raw }} - {{ site.name }}{% else %}{{ site.name }}{% endif %}" />
 	<meta property="og:type" content="article" />
 	<meta property="og:url" content="{{ current_url }}" />
 	<meta property="og:description" content="{{ description|striptags|raw }}" />
@@ -24,7 +24,7 @@
 
 	<meta name="twitter:card" content="summary" />
 	<meta name="twitter:site" content="{{ site.name }}" />
-	<meta name="twitter:title" content="{{ wp_title ? wp_title|e('esc_html')|raw : site.name }}">
+	<meta name="twitter:title" content="{% if wp_title %}{{ wp_title|raw }} - {{ site.name }}{% else %}{{ site.name }}{% endif %}">
 	<meta name="twitter:description" content="{{ description|striptags|raw }}">
 	<meta name="twitter:creator" content="{{ author_override ?? fn( 'get_the_author_meta', 'display_name', post.post_author ) }}">
 	<meta name="twitter:image" content="{{ image_data[0] }}">


### PR DESCRIPTION
It seems that `title` is already escaped so we were double escaping some characters. So for instance instead of displaying the apostrophe sign as `&#8220;` we display it as `&amp;#8220;`, and Facebook can't render them properly.

Also twig seems to escapes variables inside the ternary operator, so I used a more classic syntax.

That's not easy to test locally with Facebook's opengraph debug tool. I'll need to re-check once this is live on stage.