### PR TITLE
PLANET-2146 - Make sure current language is always displayed

### DIFF
--- a/assets/scss/common/_navbar.scss
+++ b/assets/scss/common/_navbar.scss
@@ -372,6 +372,10 @@ $menu-height-large: rem(60);
     margin: 0;
     padding: 0;
   }
+
+  .wpml-ls-current-language {
+    display: list-item;
+  }
 }
 
 .nav-search-wrap {


### PR DESCRIPTION
This fixes the fact that WPML is injecting some custom css that overrides the visibility of current.