### PR TITLE
PLANET-2240 Prevent cookies setting

### DIFF
--- a/assets/js/partials/cookies.js
+++ b/assets/js/partials/cookies.js
@@ -19,7 +19,7 @@ $(document).ready(function() {
   function createCookie(name, value) {
     var date = new Date();
     date.setTime(date.getTime() + (365 * 24 * 60 * 60 * 1000));
-    document.cookie = encodeURI(name) + '=' + encodeURI(value) + ';domain=.' + document.domain + ';path=/;' + ";expires=" + date.toGMTString();
+    document.cookie = encodeURI(name) + '=' + encodeURI(value) + ';domain=.' + document.domain + ';path=/;' + ';expires=' + date.toGMTString();
   }
 
 

--- a/assets/js/partials/cookies.js
+++ b/assets/js/partials/cookies.js
@@ -1,24 +1,27 @@
+function readCookie(name) {
+  var nameEQ = name + '=';
+  var ca = document.cookie.split(';');
+  for (var i = 0; i < ca.length; i++) {
+    var c = ca[i];
+    while (c.charAt(0) == ' ') {
+      c = c.substring(1, c.length);
+    }
+    if (c.indexOf(nameEQ) == 0) {
+      return c.substring(nameEQ.length, c.length);
+    }
+  }
+  return null;
+}
+
 $(document).ready(function() {
   'use strict';
 
   function createCookie(name, value) {
-    document.cookie = encodeURI(name) + '=' + encodeURI(value) + ';domain=.' + document.domain + ';path=/;';
+    var date = new Date();
+    date.setTime(date.getTime() + (365 * 24 * 60 * 60 * 1000));
+    document.cookie = encodeURI(name) + '=' + encodeURI(value) + ';domain=.' + document.domain + ';path=/;' + ";expires=" + date.toGMTString();
   }
 
-  function readCookie(name) {
-    var nameEQ = name + '=';
-    var ca = document.cookie.split(';');
-    for(var i=0;i < ca.length;i++) {
-      var c = ca[i];
-      while (c.charAt(0)==' ') {
-        c = c.substring(1,c.length);
-      }
-      if (c.indexOf(nameEQ) == 0) {
-        return c.substring(nameEQ.length,c.length);
-      }
-    }
-    return null;
-  }
 
   $(function() {
     var cookie = readCookie('greenpeace');

--- a/assets/js/partials/cookies.js
+++ b/assets/js/partials/cookies.js
@@ -1,29 +1,28 @@
+function createCookie(name, value, days) {
+  var date = new Date();
+  date.setTime(date.getTime() + (days * 24 * 60 * 60 * 1000));
+  document.cookie = encodeURI(name) + '=' + encodeURI(value) + ';domain=.' + document.domain + ';path=/;' + '; expires=' + date.toGMTString();
+}
+
 function readCookie(name) {
   var nameEQ = name + '=';
   var ca = document.cookie.split(';');
   for (var i = 0; i < ca.length; i++) {
     var c = ca[i];
-    while (c.charAt(0) == ' ') {
+    while (c.charAt(0) === ' ') {
       c = c.substring(1, c.length);
     }
-    if (c.indexOf(nameEQ) == 0) {
+    if (c.indexOf(nameEQ) === 0) {
       return c.substring(nameEQ.length, c.length);
     }
   }
   return null;
 }
 
-$(document).ready(function() {
+$(document).ready(function () {
   'use strict';
 
-  function createCookie(name, value) {
-    var date = new Date();
-    date.setTime(date.getTime() + (365 * 24 * 60 * 60 * 1000));
-    document.cookie = encodeURI(name) + '=' + encodeURI(value) + ';domain=.' + document.domain + ';path=/;' + ';expires=' + date.toGMTString();
-  }
-
-
-  $(function() {
+  $(function () {
     var cookie = readCookie('greenpeace');
     if (cookie == null) {
       $('.cookie-block').show();
@@ -35,6 +34,6 @@ $(document).ready(function() {
   $('#hidecookie').click(function () {
     $('.cookie-block').slideUp('slow');
     $('footer').css('margin-bottom', '0');
-    createCookie('greenpeace', 'policy-accepted');
+    createCookie('greenpeace', '1', 365);
   });
 });

--- a/assets/js/partials/cookies.js
+++ b/assets/js/partials/cookies.js
@@ -34,6 +34,6 @@ $(document).ready(function () {
   $('#hidecookie').click(function () {
     $('.cookie-block').slideUp('slow');
     $('footer').css('margin-bottom', '0');
-    createCookie('greenpeace', '1', 365);
+    createCookie('greenpeace', '2', 365);
   });
 });

--- a/assets/js/partials/happy_point.js
+++ b/assets/js/partials/happy_point.js
@@ -23,13 +23,13 @@ $(document).ready(function() {
   var cookie = readCookie('greenpeace');
   const url = $('#happy-point').data('src');
 
-  if (url && cookie !== null) {
+  if (url && '2' !== cookie) {
     window.addEventListener('load', load_happy_point);
     window.addEventListener('resize', load_happy_point);
     window.addEventListener('scroll', load_happy_point);
   }
 
-  if (cookie == null) {
+  if ('2' !== cookie) {
     $('#happy-point').append('<div>This content is blocked due to cookie policy.</div>');
   }
 });

--- a/assets/js/partials/happy_point.js
+++ b/assets/js/partials/happy_point.js
@@ -19,11 +19,16 @@ $(document).ready(function() {
     }
   }
 
+  var cookie = readCookie('greenpeace');
   const url = $('#happy-point').data('src');
 
-  if (url) {
+  if (url && cookie !== null) {
     window.addEventListener('load', load_happy_point);
     window.addEventListener('resize', load_happy_point);
     window.addEventListener('scroll', load_happy_point);
+  }
+
+  if (cookie == null) {
+    $('#happy-point').append('<div>This content is blocked due to cookie policy.</div>');
   }
 });

--- a/assets/js/partials/happy_point.js
+++ b/assets/js/partials/happy_point.js
@@ -1,6 +1,6 @@
 /* global readCookie */
-// Load happy point iframe only when visible
 
+// Load happy point iframe only when visible
 $(document).ready(function() {
   'use strict';
 
@@ -20,16 +20,25 @@ $(document).ready(function() {
     }
   }
 
+  var p4 = p4 || {};
   var cookie = readCookie('greenpeace');
   const url = $('#happy-point').data('src');
+  if ('undefined' !== p4.enforce_cookies_policy && 'true' === p4.enforce_cookies_policy) {
 
-  if (url && '2' !== cookie) {
-    window.addEventListener('load', load_happy_point);
-    window.addEventListener('resize', load_happy_point);
-    window.addEventListener('scroll', load_happy_point);
-  }
+    if (url && '2' === cookie) {
+      window.addEventListener('load', load_happy_point);
+      window.addEventListener('resize', load_happy_point);
+      window.addEventListener('scroll', load_happy_point);
+    }
 
-  if ('2' !== cookie) {
-    $('#happy-point').append('<div>This content is blocked due to cookie policy.</div>');
+    if ('2' !== cookie) {
+      $('#happy-point').append('<div>This content is blocked due to cookie policy.</div>');
+    }
+  } else {
+    if (url) {
+      window.addEventListener('load', load_happy_point);
+      window.addEventListener('resize', load_happy_point);
+      window.addEventListener('scroll', load_happy_point);
+    }
   }
 });

--- a/assets/js/partials/happy_point.js
+++ b/assets/js/partials/happy_point.js
@@ -1,3 +1,4 @@
+/* global readCookie */
 // Load happy point iframe only when visible
 
 $(document).ready(function() {

--- a/assets/scss/common/_cookies.scss
+++ b/assets/scss/common/_cookies.scss
@@ -4,9 +4,11 @@
   margin-bottom: 40px;
   padding: 20px;
 
-  .cookies-block-title {}
-  .cookies-block-description {}
-  .cookies-checkbox-description {}
+  //.cookies-block-title {}
+
+  //.cookies-block-description {}
+
+  //.cookies-checkbox-description {}
 }
 
-.cookies-filtered-content {}
+//.cookies-filtered-content {}

--- a/assets/scss/common/_cookies.scss
+++ b/assets/scss/common/_cookies.scss
@@ -1,0 +1,12 @@
+.cookies-block {
+  background-color: rgba(255, 255, 255, 0.9);
+  box-shadow: 5px 5px 5px 0 rgba(128, 128, 128, 0.5);
+  margin-bottom: 40px;
+  padding: 20px;
+
+  .cookies-block-title {}
+  .cookies-block-description {}
+  .cookies-checkbox-description {}
+}
+
+.cookies-filtered-content {}

--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -58,6 +58,7 @@ Text Domain: planet4-master-theme
 @import "common/tags-list";
 @import "common/share-buttons";
 @import "common/submenu";
+@import "common/cookies";
 
 /**
  * Page-specific styles

--- a/classes/class-p4-cookies.php
+++ b/classes/class-p4-cookies.php
@@ -1,0 +1,165 @@
+<?php
+
+if ( ! class_exists( 'P4_Cookies' ) ) {
+
+	/**
+	 * Class P4_Cookies
+	 *
+	 * @since 1.9
+	 */
+	class P4_Cookies {
+
+		const COOKIE_NAME = 'greenpeace';
+
+		/** The text that will replace blocked content.
+		 *
+		 * @var string
+		 */
+		private $filtered_text;
+
+
+		/**
+		 * P4_Cookies constructor.
+		 */
+		public function __construct() {
+			$this->filtered_text = 'This content is filtered out because of cookies policy';
+			$this->hooks();
+		}
+
+		/**
+		 * Register actions for WordPress hooks and filters.
+		 */
+		private function hooks() {
+			// If our cookie is not set then register the following filters.
+			if ( false === $this->read_cookie( self::COOKIE_NAME ) ) {
+
+				add_filter( 'gal_set_login_cookie', [ $this, 'filter_gal_set_login_cookie', 10, 1 ] );
+				add_filter( 'embed_oembed_html', [ $this, 'filter_embed' ], 10, 3 );
+				add_filter( 'the_content', [ $this, 'filter_iframes_and_embeds' ] );
+			}
+		}
+
+
+		/**
+		 * Filter action for embed_oembed_html hook. Remove embeds from restricted providers.
+		 *
+		 * @param string $html The cached HTML result.
+		 * @param string $url  The attempted embed URL.
+		 * @param array  $attr An array of shortcode attributes.
+		 *
+		 * @since 1.9
+		 *
+		 * @return string
+		 */
+		public function filter_embed( $html, $url, $attr ) {
+			$allowed    = true;
+			$dissalowed = $this->get_providers_data();
+			foreach ( $dissalowed as $provider ) {
+				foreach ( $provider['urls'] as $purl ) {
+					if ( false !== stristr( $url, $purl ) ) {
+						$allowed = false;
+					}
+				}
+			}
+			if ( $allowed ) {
+				return $html;
+			}
+
+			return '<div class="">' . __( $this->filtered_text, 'planet4-master-theme' ) . '</div>';
+		}
+
+		/**
+		 * Filter setting google login cookie.
+		 *
+		 * @param bool $dosetcookie Whether to set the cookie or not.
+		 *
+		 * @since 1.9
+		 *
+		 * @return bool
+		 */
+		public function filter_google_login_set_login_cookie( $dosetcookie ) {
+			global $pagenow;
+
+			return 'wp-login.php' === $pagenow;
+		}
+
+
+		/**
+		 * Get an entry from $_COOKIE super global
+		 *
+		 * @param string $name Cookie name.
+		 *
+		 * @since 1.9
+		 *
+		 * @return bool Return false if entry does not exist, otherwise return cookie value.
+		 */
+		public function read_cookie( $name = '' ) {
+			if ( isset( $_COOKIE[ $name ] ) ) {
+				return $_COOKIE[ $name ];
+			} else {
+				return false;
+			}
+		}
+
+
+		/**
+		 * Filter action for the_content hook. Remove iframes/embeds from the post content.
+		 *
+		 * @param string $content The post content.
+		 *
+		 * @since 1.9
+		 *
+		 * @return mixed
+		 */
+		public function filter_iframes_and_embeds( $content ) {
+
+			// Regex for iframes and embeds inside content.
+			$pattern = '~<embed.*>[^>]*</embed>|<iframe.*>[^>]*</iframe>~';
+
+			preg_match_all( $pattern, $content, $matches );
+
+			foreach ( $matches[0] as $match ) {
+				$replacement = '<div class="">' . __( $this->filtered_text, 'planet4-master-theme' ) . '</div>';
+
+				// Replace match.
+				$content = str_replace( $match, $replacement, $content );
+			}
+
+			return $content;
+		}
+
+
+		/**
+		 * Define a set of content providers for which content will be blocked.
+		 *
+		 * @return array
+		 */
+		private function get_providers_data() {
+			return [
+				'youtube'     => [
+					'name' => 'youtube',
+					'urls' =>
+						[
+							'youtu.be',
+							'youtube.com',
+						],
+				],
+				'googledocs'  => [
+					'name' => 'googledocs',
+					'urls' =>
+						[
+							'docs.google.com',
+						],
+				],
+				'googledrive' => [
+					'name' => 'googledrive',
+					'urls' =>
+						[
+							'drive.google.com',
+						],
+				],
+			];
+		}
+
+	}
+}

--- a/classes/class-p4-cookies.php
+++ b/classes/class-p4-cookies.php
@@ -22,7 +22,6 @@ if ( ! class_exists( 'P4_Cookies' ) ) {
 		 * P4_Cookies constructor.
 		 */
 		public function __construct() {
-			$this->filtered_text = 'This content is filtered out because of cookies policy';
 			$this->hooks();
 		}
 
@@ -31,7 +30,7 @@ if ( ! class_exists( 'P4_Cookies' ) ) {
 		 */
 		private function hooks() {
 			// If our cookie is not set then register the following filters.
-			if ( false === $this->read_cookie( self::COOKIE_NAME ) ) {
+			if ( '2' !== $this->read_cookie( self::COOKIE_NAME ) ) {
 
 				add_filter( 'gal_set_login_cookie', [ $this, 'filter_gal_set_login_cookie', 10, 1 ] );
 				add_filter( 'embed_oembed_html', [ $this, 'filter_embed' ], 10, 3 );
@@ -65,7 +64,8 @@ if ( ! class_exists( 'P4_Cookies' ) ) {
 				return $html;
 			}
 
-			return '<div class="">' . __( $this->filtered_text, 'planet4-master-theme' ) . '</div>';
+			return '<div class="cookies-filtered-content">' .
+					__( 'This content is filtered out because of cookies policy.', 'planet4-master-theme' ) . '</div>';
 		}
 
 		/**
@@ -119,7 +119,8 @@ if ( ! class_exists( 'P4_Cookies' ) ) {
 			preg_match_all( $pattern, $content, $matches );
 
 			foreach ( $matches[0] as $match ) {
-				$replacement = '<div class="">' . __( $this->filtered_text, 'planet4-master-theme' ) . '</div>';
+				$replacement = '<div class="cookies-filtered-content">' .
+							  __( 'This content is filtered out because of cookies policy.', 'planet4-master-theme' ) . '</div>';
 
 				// Replace match.
 				$content = str_replace( $match, $replacement, $content );

--- a/classes/class-p4-cookies.php
+++ b/classes/class-p4-cookies.php
@@ -17,7 +17,6 @@ if ( ! class_exists( 'P4_Cookies' ) ) {
 		 */
 		private $filtered_text;
 
-
 		/**
 		 * P4_Cookies constructor.
 		 */
@@ -29,6 +28,13 @@ if ( ! class_exists( 'P4_Cookies' ) ) {
 		 * Register actions for WordPress hooks and filters.
 		 */
 		private function hooks() {
+			$options                = get_option( 'planet4_options' );
+			$enforce_cookies_policy = isset( $options['enforce_cookies_policy'] ) ? true : false;
+
+			// Do not add any hook if enforce cookies setting is not set.
+			if ( false === $enforce_cookies_policy ) {
+				return;
+			}
 			// If our cookie is not set then register the following filters.
 			if ( '2' !== $this->read_cookie( self::COOKIE_NAME ) ) {
 

--- a/classes/class-p4-settings.php
+++ b/classes/class-p4-settings.php
@@ -196,7 +196,12 @@ if ( ! class_exists( 'P4_Settings' ) ) {
 					],
 					'desc'       => __( 'Minimum image width should be 1920px', 'planet4-master-theme' ),
 				],
-
+				[
+					'name'       => __( 'Enforce Cookies Policy', 'planet4-master-theme' ),
+					'desc' => 'GDPR related setting. By enabling this option specific content will be blocked and will require user consent to be shown.',
+					'id'   => 'enforce_cookies_policy',
+					'type' => 'checkbox',
+				],
 			];
 			$this->hooks();
 		}

--- a/functions.php
+++ b/functions.php
@@ -268,7 +268,6 @@ class P4_Master_Site extends TimberSite {
 		$options                         = get_option( 'planet4_options' );
 		$context['donatelink']           = $options['donate_button'] ?? '#';
 		$context['google_tag_value']     = ! empty( $gtm ) && $cookie_consent ? $gtm : '';
-		$context['google_tag_value']     = $options['google_tag_manager_identifier'] ?? '';
 		$context['website_navbar_title'] = $options['website_navigation_title'] ?? __( 'International (English)', 'planet4-master-theme' );
 
 		// Footer context.

--- a/functions.php
+++ b/functions.php
@@ -260,10 +260,16 @@ class P4_Master_Site extends TimberSite {
 		$context['sort_options'] = $this->sort_options;
 		$context['default_sort'] = P4_Search::DEFAULT_SORT;
 
-		$options                          = get_option( 'planet4_options' );
-		$context['donatelink']            = $options['donate_button'] ?? '#';
-		$context['google_tag_value']      = $options['google_tag_manager_identifier'] ?? '';
-		$context['website_navbar_title']  = $options['website_navigation_title'] ?? __( 'International (English)', 'planet4-master-theme' );
+
+		// Do not embed google tag manager js if 'greenpeace' cookie is not set.
+		$cookie_consent = isset( $_COOKIE['greenpeace'] );
+		$gtm            = $options['google_tag_manager_identifier'] ?? '';
+
+		$options                         = get_option( 'planet4_options' );
+		$context['donatelink']           = $options['donate_button'] ?? '#';
+		$context['google_tag_value']     = ! empty( $gtm ) && $cookie_consent ? $gtm : '';
+		$context['google_tag_value']     = $options['google_tag_manager_identifier'] ?? '';
+		$context['website_navbar_title'] = $options['website_navigation_title'] ?? __( 'International (English)', 'planet4-master-theme' );
 
 		// Footer context.
 		$context['copyright_text_line1']  = $options['copyright_line1'] ?? '';
@@ -922,4 +928,5 @@ new P4_Master_Site( [
 	'P4_Settings',
 	'P4_Control_Panel',
 	'P4_Post_Report_Controller',
+	'P4_Cookies',
 ] );

--- a/functions.php
+++ b/functions.php
@@ -262,12 +262,12 @@ class P4_Master_Site extends TimberSite {
 
 
 		// Do not embed google tag manager js if 'greenpeace' cookie is not set.
-		$cookie_consent = isset( $_COOKIE['greenpeace'] );
+		$cookie_consent = isset( $_COOKIE['greenpeace'] ) ? $_COOKIE['greenpeace'] : false;
 		$gtm            = $options['google_tag_manager_identifier'] ?? '';
 
 		$options                         = get_option( 'planet4_options' );
 		$context['donatelink']           = $options['donate_button'] ?? '#';
-		$context['google_tag_value']     = ! empty( $gtm ) && $cookie_consent ? $gtm : '';
+		$context['google_tag_value']     = ! empty( $gtm ) && '2' === $cookie_consent ? $gtm : '';
 		$context['website_navbar_title'] = $options['website_navigation_title'] ?? __( 'International (English)', 'planet4-master-theme' );
 
 		// Footer context.


### PR DESCRIPTION
[Issue 2240](https://jira.greenpeace.org/browse/PLANET-2240)
- Prevent happy point iframe loading if cookie policy is not accepted.
- Prevents google tag manager js embed if cookie policy is not accepted.
- Remove iframes/embeds from post content (could be changed to remove only iframes/embeds that come from specific urls).
- Set google login plugin cookie only in wp-login page.
- Set cookie expire time to 1 year.
