### PR TITLE
PLANET-1719 - Lift Carousel controls close to the top

### DIFF
--- a/assets/scss/common/_carousel.scss
+++ b/assets/scss/common/_carousel.scss
@@ -196,6 +196,7 @@
     width: 40px;
     height: 40px;
     cursor: pointer;
+    margin-top: -50px;
 
     @include small-and-up {
       width: 45px;


### PR DESCRIPTION
This is a minor css fix needed by greenpeace/planet4-plugin-blocks#288