### PR TITLE
PLANET-2347 Imagestest

### DIFF
--- a/classes/class-p4-image-compression.php
+++ b/classes/class-p4-image-compression.php
@@ -26,7 +26,24 @@ if ( ! class_exists( 'P4_Image_Compression' ) ) {
 				$filter_name = $this->filter;
 			}
 			parent::thumbnail_image( $dst_w, $dst_h, $filter_name, $strip_meta );
+
+			// The order of methods applied is: Resize -> Sharpen -> Compress.
 			try {
+				// Sharpen image after it has been resized.
+				if ( 'image/jpeg' === $this->mime_type ) {
+					if ( is_callable( array( $this->image, 'unsharpMaskImage' ) ) ) {
+						$this->image->unsharpMaskImage( 1, 0.45, 3, 0 );
+					}
+//					if ( is_callable( array( $this->image, 'adaptiveSharpenImage' ) ) ) {
+//						$this->image->adaptiveSharpenImage( 5, 1.5 );
+//					}
+				}
+			} catch ( Exception $e ) {
+				return new WP_Error( 'image_sharpening_error', $e->getMessage() );
+			}
+
+			try {
+				// Compress image after it has been sharpened.
 				if ( is_callable( [ $this->image, 'setInterlaceScheme' ] ) && defined( 'Imagick::INTERLACE_PLANE' ) ) {
 					$this->image->setInterlaceScheme( Imagick::INTERLACE_PLANE );
 				}

--- a/classes/class-p4-image-compression.php
+++ b/classes/class-p4-image-compression.php
@@ -8,7 +8,7 @@ if ( ! class_exists( 'P4_Image_Compression' ) ) {
 	class P4_Image_Compression extends WP_Image_Editor_Imagick {
 
 		/** @var string $filter */
-		//protected $filter = 'FILTER_LANCZOS';
+		protected $filter = 'FILTER_LANCZOS';
 
 		/**
 		 * Override default imagick compression and use progressive compression instead.
@@ -22,9 +22,9 @@ if ( ! class_exists( 'P4_Image_Compression' ) ) {
 		 * @return bool|WP_Error
 		 */
 		protected function thumbnail_image( $dst_w, $dst_h, $filter_name = 'FILTER_TRIANGLE', $strip_meta = true ) {
-//			if ( $this->filter ) {
-//				$filter_name = $this->filter;
-//			}
+			if ( $this->filter ) {
+				$filter_name = $this->filter;
+			}
 			parent::thumbnail_image( $dst_w, $dst_h, $filter_name, $strip_meta );
 			try {
 				if ( is_callable( [ $this->image, 'setInterlaceScheme' ] ) && defined( 'Imagick::INTERLACE_PLANE' ) ) {

--- a/classes/class-p4-image-compression.php
+++ b/classes/class-p4-image-compression.php
@@ -5,5 +5,27 @@ if ( ! class_exists( 'P4_Image_Compression' ) ) {
 	/**
 	 * Class P4_Image_Compression
 	 */
-	class P4_Image_Compression extends WP_Image_Editor_Imagick {}
+	class P4_Image_Compression extends WP_Image_Editor_Imagick {
+		/**
+		 * Override default imagick compression and use progressive compression instead.
+		 *
+		 * @since 1.9
+		 *
+		 * @param int    $dst_w       The destination width.
+		 * @param int    $dst_h       The destination height.
+		 * @param string $filter_name Optional. The Imagick filter to use when resizing. Default 'FILTER_TRIANGLE'.
+		 * @param bool   $strip_meta  Optional. Strip all profiles, excluding color profiles, from the image. Default true.
+		 * @return bool|WP_Error
+		 */
+		protected function thumbnail_image( $dst_w, $dst_h, $filter_name = 'FILTER_TRIANGLE', $strip_meta = true ) {
+			parent::thumbnail_image( $dst_w, $dst_h, $filter_name, $strip_meta );
+			try {
+				if ( is_callable( [ $this->image, 'setInterlaceScheme' ] ) && defined( 'Imagick::INTERLACE_PLANE' ) ) {
+					$this->image->setInterlaceScheme( Imagick::INTERLACE_PLANE );
+				}
+			} catch ( Exception $e ) {
+				return new WP_Error( 'image_resize_error', $e->getMessage() );
+			}
+		}
+	}
 }

--- a/classes/class-p4-image-compression.php
+++ b/classes/class-p4-image-compression.php
@@ -22,7 +22,10 @@ if ( ! class_exists( 'P4_Image_Compression' ) ) {
 		 * @return bool|WP_Error
 		 */
 		protected function thumbnail_image( $dst_w, $dst_h, $filter_name = 'FILTER_TRIANGLE', $strip_meta = true ) {
-			parent::thumbnail_image( $dst_w, $dst_h, $this->filter, $strip_meta );
+			if ( $this->filter ) {
+				$filter_name = $this->filter;
+			}
+			parent::thumbnail_image( $dst_w, $dst_h, $filter_name, $strip_meta );
 			try {
 				if ( is_callable( [ $this->image, 'setInterlaceScheme' ] ) && defined( 'Imagick::INTERLACE_PLANE' ) ) {
 					$this->image->setInterlaceScheme( Imagick::INTERLACE_PLANE );

--- a/classes/class-p4-image-compression.php
+++ b/classes/class-p4-image-compression.php
@@ -1,0 +1,9 @@
+<?php
+
+if ( ! class_exists( 'P4_Image_Compression' ) ) {
+
+	/**
+	 * Class P4_Image_Compression
+	 */
+	class P4_Image_Compression extends WP_Image_Editor_Imagick {}
+}

--- a/classes/class-p4-image-compression.php
+++ b/classes/class-p4-image-compression.php
@@ -6,6 +6,10 @@ if ( ! class_exists( 'P4_Image_Compression' ) ) {
 	 * Class P4_Image_Compression
 	 */
 	class P4_Image_Compression extends WP_Image_Editor_Imagick {
+
+		/** @var string $filter */
+		protected $filter = 'FILTER_LANCZOS';
+
 		/**
 		 * Override default imagick compression and use progressive compression instead.
 		 *
@@ -18,7 +22,7 @@ if ( ! class_exists( 'P4_Image_Compression' ) ) {
 		 * @return bool|WP_Error
 		 */
 		protected function thumbnail_image( $dst_w, $dst_h, $filter_name = 'FILTER_TRIANGLE', $strip_meta = true ) {
-			parent::thumbnail_image( $dst_w, $dst_h, $filter_name, $strip_meta );
+			parent::thumbnail_image( $dst_w, $dst_h, $this->filter, $strip_meta );
 			try {
 				if ( is_callable( [ $this->image, 'setInterlaceScheme' ] ) && defined( 'Imagick::INTERLACE_PLANE' ) ) {
 					$this->image->setInterlaceScheme( Imagick::INTERLACE_PLANE );

--- a/classes/class-p4-image-compression.php
+++ b/classes/class-p4-image-compression.php
@@ -34,9 +34,6 @@ if ( ! class_exists( 'P4_Image_Compression' ) ) {
 					if ( is_callable( array( $this->image, 'unsharpMaskImage' ) ) ) {
 						$this->image->unsharpMaskImage( 1, 0.45, 3, 0 );
 					}
-//					if ( is_callable( array( $this->image, 'adaptiveSharpenImage' ) ) ) {
-//						$this->image->adaptiveSharpenImage( 5, 1.5 );
-//					}
 				}
 			} catch ( Exception $e ) {
 				return new WP_Error( 'image_sharpening_error', $e->getMessage() );

--- a/classes/class-p4-image-compression.php
+++ b/classes/class-p4-image-compression.php
@@ -8,7 +8,7 @@ if ( ! class_exists( 'P4_Image_Compression' ) ) {
 	class P4_Image_Compression extends WP_Image_Editor_Imagick {
 
 		/** @var string $filter */
-		protected $filter = 'FILTER_LANCZOS';
+		//protected $filter = 'FILTER_LANCZOS';
 
 		/**
 		 * Override default imagick compression and use progressive compression instead.
@@ -22,9 +22,9 @@ if ( ! class_exists( 'P4_Image_Compression' ) ) {
 		 * @return bool|WP_Error
 		 */
 		protected function thumbnail_image( $dst_w, $dst_h, $filter_name = 'FILTER_TRIANGLE', $strip_meta = true ) {
-			if ( $this->filter ) {
-				$filter_name = $this->filter;
-			}
+//			if ( $this->filter ) {
+//				$filter_name = $this->filter;
+//			}
 			parent::thumbnail_image( $dst_w, $dst_h, $filter_name, $strip_meta );
 			try {
 				if ( is_callable( [ $this->image, 'setInterlaceScheme' ] ) && defined( 'Imagick::INTERLACE_PLANE' ) ) {

--- a/functions.php
+++ b/functions.php
@@ -126,7 +126,7 @@ class P4_Master_Site extends TimberSite {
 		add_action( 'do_meta_boxes',            array( $this, 'remove_default_tags_box' ) );
 		add_action( 'pre_insert_term',          array( $this, 'disallow_insert_term' ), 1, 2 );
 		add_filter( 'wp_image_editors',         array( $this, 'allowedEditors' ) );
-		add_filter( 'jpeg_quality',             function( $arg ) { return 90; } );
+		//add_filter( 'jpeg_quality',             function( $arg ) { return 90; } );
 		add_action( 'after_setup_theme',        array( $this, 'add_image_sizes' ) );
 		add_action( 'admin_head' ,              array( $this, 'remove_add_post_element' ) );
 		add_filter( 'post_gallery',             array( $this, 'carousel_post_gallery' ), 10, 2 );
@@ -199,8 +199,8 @@ class P4_Master_Site extends TimberSite {
 	 * Force WordPress to use P4_Image_Compression as image manipulation editor.
 	 */
 	public function allowedEditors() {
-		//return [ 'P4_Image_Compression' ];
-		return [ 'WP_Image_Editor_Imagick' ];
+		return [ 'P4_Image_Compression' ];
+		//return [ 'WP_Image_Editor_Imagick' ];
 	}
 
 	/**

--- a/functions.php
+++ b/functions.php
@@ -126,7 +126,6 @@ class P4_Master_Site extends TimberSite {
 		add_action( 'do_meta_boxes',            array( $this, 'remove_default_tags_box' ) );
 		add_action( 'pre_insert_term',          array( $this, 'disallow_insert_term' ), 1, 2 );
 		add_filter( 'wp_image_editors',         array( $this, 'allowedEditors' ) );
-		add_filter( 'jpeg_quality',             function( $arg ) { return 90; } );
 		add_action( 'after_setup_theme',        array( $this, 'add_image_sizes' ) );
 		add_action( 'admin_head' ,              array( $this, 'remove_add_post_element' ) );
 		add_filter( 'post_gallery',             array( $this, 'carousel_post_gallery' ), 10, 2 );
@@ -199,7 +198,7 @@ class P4_Master_Site extends TimberSite {
 	 * Force WordPress to use P4_Image_Compression as image manipulation editor.
 	 */
 	public function allowedEditors() {
-		return [ 'WP_Image_Editor_Imagick' ];
+		return [ 'P4_Image_Compression' ];
 	}
 
 	/**

--- a/functions.php
+++ b/functions.php
@@ -199,7 +199,7 @@ class P4_Master_Site extends TimberSite {
 	 * Force WordPress to use P4_Image_Compression as image manipulation editor.
 	 */
 	public function allowedEditors() {
-		return [ 'P4_Image_Compression' ];
+		return [ 'WP_Image_Editor_Imagick' ];
 	}
 
 	/**

--- a/functions.php
+++ b/functions.php
@@ -126,7 +126,6 @@ class P4_Master_Site extends TimberSite {
 		add_action( 'do_meta_boxes',            array( $this, 'remove_default_tags_box' ) );
 		add_action( 'pre_insert_term',          array( $this, 'disallow_insert_term' ), 1, 2 );
 		add_filter( 'wp_image_editors',         array( $this, 'allowedEditors' ) );
-		//add_filter( 'jpeg_quality',             function( $arg ) { return 90; } );
 		add_action( 'after_setup_theme',        array( $this, 'add_image_sizes' ) );
 		add_action( 'admin_head' ,              array( $this, 'remove_add_post_element' ) );
 		add_filter( 'post_gallery',             array( $this, 'carousel_post_gallery' ), 10, 2 );
@@ -200,7 +199,6 @@ class P4_Master_Site extends TimberSite {
 	 */
 	public function allowedEditors() {
 		return [ 'P4_Image_Compression' ];
-		//return [ 'WP_Image_Editor_Imagick' ];
 	}
 
 	/**

--- a/functions.php
+++ b/functions.php
@@ -196,11 +196,10 @@ class P4_Master_Site extends TimberSite {
 	}
 
 	/**
-	 * Force wordpress to use ImageMagick
-	 * as image manipulation editor.
+	 * Force WordPress to use P4_Image_Compression as image manipulation editor.
 	 */
 	public function allowedEditors() {
-		return array('WP_Image_Editor_Imagick');
+		return [ 'P4_Image_Compression' ];
 	}
 
 	/**

--- a/functions.php
+++ b/functions.php
@@ -126,6 +126,7 @@ class P4_Master_Site extends TimberSite {
 		add_action( 'do_meta_boxes',            array( $this, 'remove_default_tags_box' ) );
 		add_action( 'pre_insert_term',          array( $this, 'disallow_insert_term' ), 1, 2 );
 		add_filter( 'wp_image_editors',         array( $this, 'allowedEditors' ) );
+		add_filter( 'jpeg_quality',             function( $arg ) { return 90; } );
 		add_action( 'after_setup_theme',        array( $this, 'add_image_sizes' ) );
 		add_action( 'admin_head' ,              array( $this, 'remove_add_post_element' ) );
 		add_filter( 'post_gallery',             array( $this, 'carousel_post_gallery' ), 10, 2 );
@@ -198,7 +199,8 @@ class P4_Master_Site extends TimberSite {
 	 * Force WordPress to use P4_Image_Compression as image manipulation editor.
 	 */
 	public function allowedEditors() {
-		return [ 'P4_Image_Compression' ];
+		//return [ 'P4_Image_Compression' ];
+		return [ 'WP_Image_Editor_Imagick' ];
 	}
 
 	/**

--- a/functions.php
+++ b/functions.php
@@ -126,6 +126,7 @@ class P4_Master_Site extends TimberSite {
 		add_action( 'do_meta_boxes',            array( $this, 'remove_default_tags_box' ) );
 		add_action( 'pre_insert_term',          array( $this, 'disallow_insert_term' ), 1, 2 );
 		add_filter( 'wp_image_editors',         array( $this, 'allowedEditors' ) );
+		add_filter( 'jpeg_quality',             function( $arg ) { return 60; } );
 		add_action( 'after_setup_theme',        array( $this, 'add_image_sizes' ) );
 		add_action( 'admin_head' ,              array( $this, 'remove_add_post_element' ) );
 		add_filter( 'post_gallery',             array( $this, 'carousel_post_gallery' ), 10, 2 );


### PR DESCRIPTION
https://greenpeace.github.io/planet4-imagestest-results/

The solution applied in the 6th image produces much better quality than P4 currently produces
and at the same time -47% size on retina-large images, -38% size on large images and -17% on medium images (on large and medium images results about the size of the 2 tested images are conflicting though).
```
Resize: Lanczos
Sharpening: unsharpMask( Radius 1, Sigma 0.45, Amount 3, Threshold 0 )
Compression: Interlace_Plane
Quality: 60
```