### PR TITLE
PLANET-2372 Consider current language in search page url

### DIFF
--- a/classes/class-p4-sitemap.php
+++ b/classes/class-p4-sitemap.php
@@ -143,7 +143,7 @@ if ( ! class_exists( 'P4_Sitemap' ) ) {
 				foreach ( $article_types as $article_type ) {
 					$article_types_data[] = [
 						'name' => $article_type->name,
-						'link' => get_site_url() . '/?s=&orderby=post_date&f[ptype][' . rawurlencode( $article_type->name ) . ']=' . $article_type->term_id,
+						'link' => get_home_url() . '/?s=&orderby=post_date&f[ptype][' . rawurlencode( $article_type->name ) . ']=' . $article_type->term_id,
 					];
 				}
 			}

--- a/single.php
+++ b/single.php
@@ -51,7 +51,7 @@ $context['filter_url'] = add_query_arg( [
 		's'                                   => ' ',
 		'orderby'                             => 'relevant',
 		'f[ptype]['.$context['page_type'].']' => $context['page_term_id'],
-	], get_site_url()
+	], get_home_url()
 );
 
 


### PR DESCRIPTION
[Related PR](https://github.com/greenpeace/planet4-plugin-blocks/pull/293)

The `get_home_url()` function consider current page language in base url.

([Reference](https://wpml.org/wpml-hook/wpml_home_url/))