### PR TITLE
PLANET-2377 - Use Lora as the default font

### DIFF
--- a/assets/scss/common/_carousel-header.scss
+++ b/assets/scss/common/_carousel-header.scss
@@ -286,6 +286,7 @@ $slide-transition-speed: 1s;
       left: 0;
       right: 0;
       position: absolute;
+      font-family: $roboto;
 
       @include small-and-up {
         width: 80%;

--- a/assets/scss/common/_content-four-column.scss
+++ b/assets/scss/common/_content-four-column.scss
@@ -80,7 +80,6 @@
 
       p {
         font-size: rem(16);
-        font-family: $lora;
 
         @include large-and-up {
           font-size: rem(14);

--- a/assets/scss/common/_covers.scss
+++ b/assets/scss/common/_covers.scss
@@ -205,6 +205,7 @@
   text-decoration: none;
   text-shadow: 1.5px 1.5px 1.5px $black;
   font-weight: 800;
+  font-family: $roboto;
 
   &:hover {
     color: $yellow;

--- a/assets/scss/common/_navbar.scss
+++ b/assets/scss/common/_navbar.scss
@@ -8,14 +8,13 @@ $menu-height-large: rem(60);
   z-index: 5;
   padding: 0;
   text-transform: uppercase;
-
   display: flex;
   flex-direction: row;
   justify-content: space-between;
   align-items: normal;
-
   background: transparentize($dark-blue, 0.2);
   height: $menu-height-small;
+  font-family: $roboto;
 
   // Use (min-width: 783px) for parity with WP's .admin-bar
   @media screen and (min-width: 783px) {

--- a/assets/scss/common/_page-header.scss
+++ b/assets/scss/common/_page-header.scss
@@ -99,6 +99,7 @@
 .top-page-tags {
   font-size: rem(14);
   margin-bottom: 6px;
+  font-family: $roboto;
 
   @include medium-and-up {
     font-size: rem(16);

--- a/assets/scss/pages/_take-action.scss
+++ b/assets/scss/pages/_take-action.scss
@@ -286,7 +286,6 @@
   }
 
   .col-md-12 {
-    font-family: $lora;
     padding-top: 30px;
 
     @include small-and-up {
@@ -451,7 +450,6 @@
     }
 
     p {
-      font-family: $lora;
       color: $dark-shade-black;
       font-size: rem(14);
       opacity: 0.75;
@@ -525,7 +523,6 @@
       margin-bottom: 10px;
 
       p {
-        font-family: $lora;
         color: $dark-shade-black;
         font-size: rem(14);
         line-height: rem(22);

--- a/assets/scss/pages/post/_article-content.scss
+++ b/assets/scss/pages/post/_article-content.scss
@@ -21,10 +21,13 @@
       width: 330px;
       min-height: 415px;
     }
+
+    .cover-card-tag {
+      font-family: $roboto;
+    }
   }
 
   ul, ol {
-    font-family: $lora;
     // Assumptions made for the font-size that it's behaviour is same
     // as the p tags in the content
     @include small-and-up {
@@ -138,7 +141,6 @@
   }
 
   blockquote {
-    font-family: $lora;
     font-size: rem(36);
     line-height: 1.5;
     font-style: italic;
@@ -301,7 +303,6 @@
 }
 
 .post-details {
-  font-family: $lora;
   line-height: 1.6;
 
   @include small-and-up {

--- a/assets/scss/pages/post/post.scss
+++ b/assets/scss/pages/post/post.scss
@@ -61,6 +61,7 @@
       margin: 0 0 16px 0;
       font-size: rem(13);
       font-weight: 300;
+      font-family: $roboto;
 
       a {
         color: inherit;

--- a/assets/scss/pages/search/_search.scss
+++ b/assets/scss/pages/search/_search.scss
@@ -48,7 +48,6 @@
     font-size: rem(16);
     margin-bottom: 24px;
     padding-left: 20px;
-    font-family: $lora;
     color: $grey-60;
     line-height: 1.8;
 

--- a/assets/scss/partials/_typography.scss
+++ b/assets/scss/partials/_typography.scss
@@ -29,7 +29,15 @@ html {
 
 p {
   hyphens: none;
-  font-family: $lora;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-family: $roboto;
 }
 
 h1,

--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -127,7 +127,7 @@ body {
 
 body {
   color: $dark-shade-black;
-  font-family: $roboto;
+  font-family: $lora;
   position: relative;
 
   &.white-bg {


### PR DESCRIPTION
Since we use Roboto on specific elements (headings, captions, buttons, etc) this PR switches the default font to Lora to make sure all text elements are displayed properly.