### PR TITLE
PLANET-1977 Fix documents urls in search results

### DIFF
--- a/templates/tease-search.twig
+++ b/templates/tease-search.twig
@@ -45,7 +45,7 @@
 
 			{% if ( is_document ) %}
 				{% set title = post.title|e('wp_kses_post')|raw %}
-				<a href="{{ post.guid }}" class="search-result-item-headline">{{ title|length > 30 ? title|striptags|slice(0, 30) ~ '...' : title }}</a>
+				<a href="{{ fn('wp_get_attachment_url', post.id) }}" class="search-result-item-headline">{{ title|length > 30 ? title|striptags|slice(0, 30) ~ '...' : title }}</a>
 			{% else %}
 				<a href="{{ post.link() }}" class="search-result-item-headline">{{ post.title|e('wp_kses_post')|raw }}</a>
 			{% endif %}
@@ -61,7 +61,7 @@
 				{%  set link_text = settings['take_action_covers_button_text'] %}
 				<a href="{{ post.link }}" class="btn btn-primary btn-medium btn-small">{{ link_text ?: __( 'take action', 'planet4-master-theme' ) }}</a>
 			{% elseif ( is_document ) %}
-				<a href="{{ post.guid }}" download class="btn btn-small btn-secondary">
+				<a href="{{ fn('wp_get_attachment_url', post.id) }}" download class="btn btn-small btn-secondary">
 					{{ __( 'Download', 'planet4-master-theme' ) }}
 				</a>
 			{% endif %}


### PR DESCRIPTION
Use wp_get_attachment_url in search results for documents to allow wp-stateless run it's hooks