### PR TITLE
PLANET-2473 Added setting for donate text in p4settings

### DIFF
--- a/classes/class-p4-settings.php
+++ b/classes/class-p4-settings.php
@@ -149,6 +149,15 @@ if ( ! class_exists( 'P4_Settings' ) ) {
 				],
 
 				[
+					'name'       => __( 'Donate button text', 'planet4-master-theme-backend' ),
+					'id'         => 'donate_text',
+					'type'       => 'text',
+					'attributes' => [
+						'type' => 'text',
+					],
+				],
+
+				[
 					'name'       => __( '404 Background Image', 'planet4-master-theme-backend' ),
 					'id'         => '404_page_bg_image',
 					'type'       => 'file',


### PR DESCRIPTION
The text is not used anywhere at this stage. We want to add the setting in the first release, ask all NROs to fill it in, and actually use it on the next release, so that we make sure that there is no point where the button text is empty. 
(Currently the button text is using the language files)