### PR TITLE
PLANET-2412 Change tag_id attribute to tags for articles block in tag page

### DIFF
--- a/tag.php
+++ b/tag.php
@@ -66,7 +66,7 @@ if ( is_tag() ) {
 	] );
 
 	$campaign->add_block( Articles::BLOCK_NAME, [
-		'tag_id' => $context['tag']->term_id,
+		'tags' => $context['tag']->term_id,
 	] );
 
 	$cfc_args = [


### PR DESCRIPTION
Change tag_id attribute to tags for articles block in tag page.

This should be merged together with
https://github.com/greenpeace/planet4-plugin-blocks/pull/300