### PR TITLE
Add dns-prefetch for happy point iframe

### DIFF
--- a/templates/html-header.twig
+++ b/templates/html-header.twig
@@ -72,5 +72,6 @@
 	<link rel="pingback" href="{{ site.pingback_url }}">
 	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 	<link rel="shortcut icon" type="image/ico" href="favicon.ico"/>
+	<link rel="dns-prefetch" href="//act.greenpeace.org">
 	{{ wp_head }}
 </head>


### PR DESCRIPTION
We currently load the happy point iframe asynchronously when the block gets visible to the user. This is just a minor trick that instruct the browser to do dns resolving beforehand making the iframe to load a bit faster.