### PR TITLE
PLANET-2532 fix search item auto-opening

### DIFF
--- a/templates/tease-search.twig
+++ b/templates/tease-search.twig
@@ -56,7 +56,7 @@
 					<span class="search-result-item-date">{{ post.post_date|date('d/m/Y') }}</span>
 				</div>
 			{% endif %}
-			<p class="search-result-item-content">{{ post.preview()|truncate( 25, true )|raw }}</p>
+			<p class="search-result-item-content">{{ post.preview().read_more('')|truncate( 25, true )|raw }}</p>
 
 			{% if ( is_action ) %}
 				{%  set link_text = settings['take_action_covers_button_text'] %}


### PR DESCRIPTION
Fix issue that caused the last search result item to auto-open when its Excerpt had less that 25 words. Also, fixes an older issue when a search result item that followed an item with less that 25 words in its Excerpt, had smaller thumbnail image and mis-aligned excerpt.

This was caused by Timber's read more functionality causing Twig's truncate filter to break html.
There is a twig extension of this filter (truncate_html) that is safe for html in cases like this, but no need since we can fix it this way.