### PR TITLE
PLANEt-2368 - Hide posts with override from Author's page

### DIFF
--- a/classes/class-p4-post.php
+++ b/classes/class-p4-post.php
@@ -143,6 +143,19 @@ if ( ! class_exists( 'P4_Post' ) ) {
 		}
 
 		/**
+		 * Get post's author override status.
+		 *
+		 * @return bool
+		 */
+		public function get_author_override() {
+			$author_override = get_post_meta( $this->id, 'p4_author_override', true );
+			if ( $author_override ) {
+				return true;
+			}
+			return false;
+		}
+
+		/**
 		 * Get post/page custom planet4 type.
 		 * ACTION, DOCUMENT, PAGE, POST
 		 *

--- a/templates/tease-author.twig
+++ b/templates/tease-author.twig
@@ -1,27 +1,31 @@
-<li id="result-row-{{ post.ID }}" class="media search-result-list-item">
-	<img class="d-flex search-result-item-image" src="{{ post.thumbnail.src('thumbnail') }}"
-		 alt="{{ fn('esc_attr', post.thumbnail.alt|default( post.title ) )|raw }}" />
+{% if not (post.get_author_override) %}
+    <li id="result-row-{{ post.ID }}" class="media search-result-list-item">
+        <img class="d-flex search-result-item-image" src="{{ post.thumbnail.src('thumbnail') }}"
+            alt="{{ fn('esc_attr', post.thumbnail.alt|default( post.title ) )|raw }}" />
 
-	<div id="tease-{{ post.ID }}" class="media-body search-result-item-body tease tease-{{ post.post_type }}">
-		<div class="search-result-tags">
-			<span class="search-result-item-title">{{ post.get_custom_type }}</span>
+        <div id="tease-{{ post.ID }}" class="media-body search-result-item-body tease tease-{{ post.post_type }}">
+            <div class="search-result-tags">
+                <span class="search-result-item-title">{{ post.get_custom_type }}</span>
 
-			{% for page_type in post.get_custom_terms %}
-				<a href="/?s=&orderby=relevant&f[ptype][{{ page_type.name }}]={{ page_type.term_id }}" class="search-result-item-head no-btn">{{ page_type.name|e('wp_kses_post')|raw }}</a>
-			{% endfor %}
+                {{ post.get_author_override }}
 
-			{% for tag in post.tags %}
-				<a href="{{ tag.link }}" class="search-result-item-tag">#{{ tag.name|e('wp_kses_post')|raw }}</a>{% if ( not loop.last ) %},{% endif %}
-			{% endfor %}
-		</div>
+                {% for page_type in post.get_custom_terms %}
+                    <a href="/?s=&orderby=relevant&f[ptype][{{ page_type.name }}]={{ page_type.term_id }}" class="search-result-item-head no-btn">{{ page_type.name|e('wp_kses_post')|raw }}</a>
+                {% endfor %}
 
-		<a href="{{ post.link() }}" class="search-result-item-headline">{{ post.title|e('wp_kses_post')|raw }}</a>
+                {% for tag in post.tags %}
+                    <a href="{{ tag.link }}" class="search-result-item-tag">#{{ tag.name|e('wp_kses_post')|raw }}</a>{% if ( not loop.last ) %},{% endif %}
+                {% endfor %}
+            </div>
 
-		<div class="search-result-item-info">
-			<span class="search-result-item-date">{{ post.post_date|date('d/m/Y') }}</span>
-		</div>
+            <a href="{{ post.link() }}" class="search-result-item-headline">{{ post.title|e('wp_kses_post')|raw }}</a>
 
-		<p class="search-result-item-content">{{ post.preview()|truncate( 25, true )|raw }}</p>
+            <div class="search-result-item-info">
+                <span class="search-result-item-date">{{ post.post_date|date('d/m/Y') }}</span>
+            </div>
 
-	</div>
-</li>
+            <p class="search-result-item-content">{{ post.preview()|truncate( 25, true )|raw }}</p>
+
+        </div>
+    </li>
+{% endif %}


### PR DESCRIPTION
Author page should not include posts with author override. I added a function to use as a filter. Not sure if that's the more efficient way :)

The change on the template is just a wrap around and `if not (post.get_author_override)`. 