### PR TITLE
PLANET-2729 - Timber v1.8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,6 @@
 	"require": {
 			"leafo/scssphp": "^0.7.4",
 			"matthiasmullie/minify": "^1.3",
-			"wpackagist-plugin/timber-library": "1.7.1"
+			"wpackagist-plugin/timber-library": "1.8.1"
 	}
 }


### PR DESCRIPTION
I removed Timber from all child themes, and now we can safely upgrade.