### PR TITLE
PLANET-2614: Refined results page

### DIFF
--- a/archive.php
+++ b/archive.php
@@ -33,6 +33,9 @@ if ( is_day() ) {
 } else if ( is_post_type_archive() ) {
 	$context['title'] = post_type_archive_title( '', false );
 	array_unshift( $templates, 'archive-' . get_post_type() . '.twig' );
+} else if ( is_tax('p4-page-type') ) {
+	$context['page_type'] = get_queried_object();
+	array_unshift( $templates, 'page_type.twig' );
 }
 
 $context['posts'] = Timber::get_posts();

--- a/templates/page_type.twig
+++ b/templates/page_type.twig
@@ -1,0 +1,32 @@
+{% extends "base.twig" %}
+
+{% block content %}
+
+	<div class="clearfix"></div>
+	<div class="skewed-overlay"></div>
+
+	<header class="page-header">
+		<div class="container">
+			<h1 class="page-header-title">{{ page_type.name }}</h1>
+			<div class="row">
+				<div class="col-md-12">
+					<p>{{ page_type.description }}</p>
+				</div>
+			</div>
+		</div>
+	</header>
+
+	<div class="page-template">
+		<h3>{{ __( 'Results', 'planet4-master-theme' ) }}</h3>
+
+		<div class="row">
+			<div class="col-lg-8 multiple-search-result">
+				<ul class="list-unstyled">
+					{% for post in posts %}
+						{% include 'tease-page-type.twig' %}
+					{% endfor %}
+				</ul>
+			</div>
+		</div>
+	</div>
+{% endblock %}

--- a/templates/single.twig
+++ b/templates/single.twig
@@ -14,7 +14,7 @@
 			<div class="container">
 				<div class="top-page-tags">
 					{% if ( page_type ) %}
-						<a class="tag-item tag-item--main page-type" href="{{ filter_url }}">{{ page_type|e('wp_kses_post')|raw }}</a>
+						<a class="tag-item tag-item--main page-type" href="/{{ page_type }}">{{ page_type|e('wp_kses_post')|raw }}</a>
 					{% endif %}
 
 					{% if ( post.issues_nav_data ) %}

--- a/templates/tease-author.twig
+++ b/templates/tease-author.twig
@@ -8,7 +8,7 @@
 				{{ post.get_author_override }}
 
 				{% for page_type in post.get_custom_terms %}
-					<a href="/?s=&orderby=relevant&f[ptype][{{ page_type.name }}]={{ page_type.term_id }}" class="search-result-item-head no-btn tag-item tag-item--main page-type">{{ page_type.name|e('wp_kses_post')|raw }}</a>
+					<a href="/{{ page_type.slug }}" class="search-result-item-head no-btn tag-item tag-item--main page-type">{{ page_type.name|e('wp_kses_post')|raw }}</a>
 				{% endfor %}
 
 				{% if (post.tags) %}

--- a/templates/tease-page-type.twig
+++ b/templates/tease-page-type.twig
@@ -6,7 +6,7 @@
 		<div class="search-result-tags top-page-tags">
 			{{ post.get_author_override }}
 
-			<a href="/?s=&orderby=relevant&f[ptype][{{ page_type.name }}]={{ page_type.term_id }}" class="search-result-item-head no-btn tag-item tag-item--main page-type">{{ page_type.name|e('wp_kses_post')|raw }}</a>
+			<a href="/{{ page_type.slug }}" class="search-result-item-head no-btn tag-item tag-item--main page-type">{{ page_type.name|e('wp_kses_post')|raw }}</a>
 
 			{% if (post.tags) %}
 				<div class="tag-wrap tags">

--- a/templates/tease-page-type.twig
+++ b/templates/tease-page-type.twig
@@ -1,0 +1,29 @@
+<li id="result-row-{{ post.ID }}" class="media search-result-list-item">
+	<img class="d-flex search-result-item-image" src="{{ post.thumbnail.src('thumbnail') }}"
+		alt="{{ fn('esc_attr', post.thumbnail.alt|default( post.title ) )|raw }}" />
+
+	<div id="tease-{{ post.ID }}" class="media-body search-result-item-body tease tease-{{ post.post_type }}">
+		<div class="search-result-tags top-page-tags">
+			{{ post.get_author_override }}
+
+			<a href="/?s=&orderby=relevant&f[ptype][{{ page_type.name }}]={{ page_type.term_id }}" class="search-result-item-head no-btn tag-item tag-item--main page-type">{{ page_type.name|e('wp_kses_post')|raw }}</a>
+
+			{% if (post.tags) %}
+				<div class="tag-wrap tags">
+					{% for tag in post.tags %}
+						<a href="{{ tag.link }}" class="search-result-item-tag tag-item tag">#{{ tag.name|e('wp_kses_post')|raw }}</a>
+					{% endfor %}
+				</div>
+			{% endif %}
+		</div>
+
+		<a href="{{ post.link() }}" class="search-result-item-headline">{{ post.title|e('wp_kses_post')|raw }}</a>
+
+		<div class="search-result-item-info">
+			<span class="search-result-item-date">{{ post.post_date|date('d/m/Y') }}</span>
+		</div>
+
+		<p class="search-result-item-content">{{ post.preview()|truncate( 25, true )|raw }}</p>
+
+	</div>
+</li>


### PR DESCRIPTION
Hi! Starting this PR to show you what I've found so far.

Please read the issue for context: https://jira.greenpeace.org/browse/PLANET-2614

I created a new `page_type` template for the `?p4-page-type=[page_type}` archive requests.
This is the URL provided by WP Admin when clicking "View" on a Page Type.

To reach this page with a friendly URL like `/story` a Redirect rule has to be set in the Redirection plugin as:

```
Source: ^/(press|publication|story)/?$
Target: index.php?p4-page-type=$1
```

Another method would be to add a `'rewrite' => [ 'slug' => 'page_type' ]` parameter to the custom taxonomy's `rewrite` arg, which will resolve to URLs like `/page_type/story`, but I don't know if this could have side effects.

I changed the slug from all the places I've found it, except for the search page, where a click is being simulated in JS to automatically check the proper checkbox and submit the form. 

Please have a look and let me know what you think!