### PR TITLE
PLANET-2614: Refined results page

### DIFF
--- a/classes/class-p4-custom-taxonomy.php
+++ b/classes/class-p4-custom-taxonomy.php
@@ -164,7 +164,7 @@ if ( ! class_exists( 'P4_Custom_Taxonomy' ) ) {
 				'labels'       => $p4_page_type,
 				'show_ui'      => true,
 				'query_var'    => true,
-				'rewrite'      => false,
+				'rewrite'      => [ 'slug' => 'page_type' ],
 				'meta_box_cb'  => [ $this, 'create_taxonomy_metabox_markup' ],
 			];
 

--- a/classes/class-p4-sitemap.php
+++ b/classes/class-p4-sitemap.php
@@ -143,7 +143,7 @@ if ( ! class_exists( 'P4_Sitemap' ) ) {
 				foreach ( $article_types as $article_type ) {
 					$article_types_data[] = [
 						'name' => $article_type->name,
-						'link' => rtrim( get_home_url(), '/' ) . '/?s=&orderby=post_date&f[ptype][' . rawurlencode( $article_type->name ) . ']=' . $article_type->term_id,
+						'link' => get_term_link($article_type->term_id),
 					];
 				}
 			}

--- a/single.php
+++ b/single.php
@@ -44,6 +44,7 @@ $context['post_image_id']    = $page_meta_data['p4_background_image_override_id'
 $take_action_page            = $page_meta_data['p4_take_action_page'][0] ?? '';
 $context['page_type']        = $page_terms_data[0]->name ?? '';
 $context['page_term_id']     = $page_terms_data[0]->term_id ?? '';
+$context['page_type_slug']   = $page_terms_data[0]->slug ?? '';
 $context['page_category']    = $category->name ?? __( 'Post page', 'planet4-master-theme' );
 $context['social_accounts']  = $post->get_social_accounts( $context['footer_social_menu'] );
 

--- a/taxonomy.php
+++ b/taxonomy.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * The template for displaying Taxonomy pages.
+ *
+ * Used to display taxonomy-type pages
+ * 
+ * Learn more: http://codex.wordpress.org/Template_Hierarchy
+ */
+
+$templates = array( 'page_type.twig', 'index.twig' );
+
+$context = Timber::get_context();
+$context['page_type'] = get_queried_object();
+$context['posts'] = Timber::get_posts();
+
+Timber::render( $templates, $context );

--- a/templates/page_type.twig
+++ b/templates/page_type.twig
@@ -1,0 +1,32 @@
+{% extends "base.twig" %}
+
+{% block content %}
+
+	<div class="clearfix"></div>
+	<div class="skewed-overlay"></div>
+
+	<header class="page-header">
+		<div class="container">
+			<h1 class="page-header-title">{{ page_type.name }}</h1>
+			<div class="row">
+				<div class="col-md-12">
+					<p>{{ page_type.description }}</p>
+				</div>
+			</div>
+		</div>
+	</header>
+
+	<div class="page-template">
+		<h3>{{ __( 'Results', 'planet4-master-theme' ) }}</h3>
+
+		<div class="row">
+			<div class="col-lg-8 multiple-search-result">
+				<ul class="list-unstyled">
+					{% for post in posts %}
+						{% include 'tease-page-type.twig' %}
+					{% endfor %}
+				</ul>
+			</div>
+		</div>
+	</div>
+{% endblock %}

--- a/templates/single.twig
+++ b/templates/single.twig
@@ -14,7 +14,7 @@
 			<div class="container">
 				<div class="top-page-tags">
 					{% if ( page_type ) %}
-						<a class="tag-item tag-item--main page-type" href="{{ filter_url }}">{{ page_type|e('wp_kses_post')|raw }}</a>
+						<a class="tag-item tag-item--main page-type" href="{{ fn('get_term_link', page_type.term_id) }}">{{ page_type|e('wp_kses_post')|raw }}</a>
 					{% endif %}
 
 					{% if ( post.issues_nav_data ) %}

--- a/templates/tease-author.twig
+++ b/templates/tease-author.twig
@@ -8,7 +8,7 @@
 				{{ post.get_author_override }}
 
 				{% for page_type in post.get_custom_terms %}
-					<a href="/?s=&orderby=relevant&f[ptype][{{ page_type.name }}]={{ page_type.term_id }}" class="search-result-item-head no-btn tag-item tag-item--main page-type">{{ page_type.name|e('wp_kses_post')|raw }}</a>
+					<a href="{{ fn('get_term_link', page_type.term_id, 'p4-page-type') }}" class="search-result-item-head no-btn tag-item tag-item--main page-type">{{ page_type.name|e('wp_kses_post')|raw }}</a>
 				{% endfor %}
 
 				{% if (post.tags) %}

--- a/templates/tease-page-type.twig
+++ b/templates/tease-page-type.twig
@@ -1,0 +1,32 @@
+<li id="result-row-{{ post.ID }}" class="media search-result-list-item">
+	<img class="d-flex search-result-item-image" src="{{ post.thumbnail.src('thumbnail') }}"
+		alt="{{ fn('esc_attr', post.thumbnail.alt|default( post.title ) )|raw }}" />
+
+	<div id="tease-{{ post.ID }}" class="media-body search-result-item-body tease tease-{{ post.post_type }}">
+		<div class="search-result-tags top-page-tags">
+			{{ post.get_author_override }}
+
+			<a href="{{ fn('get_term_link', page_type.term_id) }}"
+			   class="search-result-item-head no-btn tag-item tag-item--main page-type">
+			   {{ page_type.name|e('wp_kses_post')|raw }}
+			</a>
+
+			{% if (post.tags) %}
+				<div class="tag-wrap tags">
+					{% for tag in post.tags %}
+						<a href="{{ tag.link }}" class="search-result-item-tag tag-item tag">#{{ tag.name|e('wp_kses_post')|raw }}</a>
+					{% endfor %}
+				</div>
+			{% endif %}
+		</div>
+
+		<a href="{{ post.link() }}" class="search-result-item-headline">{{ post.title|e('wp_kses_post')|raw }}</a>
+
+		<div class="search-result-item-info">
+			<span class="search-result-item-date">{{ post.post_date|date('d/m/Y') }}</span>
+		</div>
+
+		<p class="search-result-item-content">{{ post.preview()|truncate( 25, true )|raw }}</p>
+
+	</div>
+</li>


### PR DESCRIPTION
Please read the issue for context: https://jira.greenpeace.org/browse/PLANET-2614

Added a `page_type` slug parameter to the custom taxonomy's `register_taxonomy` method.

Using `taxonomy.php` as a catcher for taxonomies requests using the default behavior of WP template hierarchy.

I changed the Page Type slug from most pages from being a filter url to a pure slug except for the search page, where the slug simulates a click in the "Page Type" checkbox.

Let me know what you think!

![page-types-posts](https://user-images.githubusercontent.com/340766/47279043-36783300-d5a4-11e8-97a7-5156539aaa11.gif)
