### PR TITLE
PLANET-2758 Fix search page URL on a sitemap for multilanguage sites

### DIFF
--- a/classes/class-p4-sitemap.php
+++ b/classes/class-p4-sitemap.php
@@ -143,7 +143,7 @@ if ( ! class_exists( 'P4_Sitemap' ) ) {
 				foreach ( $article_types as $article_type ) {
 					$article_types_data[] = [
 						'name' => $article_type->name,
-						'link' => get_home_url() . '/?s=&orderby=post_date&f[ptype][' . rawurlencode( $article_type->name ) . ']=' . $article_type->term_id,
+						'link' => rtrim( get_home_url(), '/' ) . '/?s=&orderby=post_date&f[ptype][' . rawurlencode( $article_type->name ) . ']=' . $article_type->term_id,
 					];
 				}
 			}


### PR DESCRIPTION
URL before -
https://master.k8s.p4.greenpeace.org/luxembourg/fr//?s=&orderby=post_date&f[ptype][Arbeitsplatz%20Greenpeace]=70

URL after -
https://master.k8s.p4.greenpeace.org/luxembourg/fr/?s=&orderby=post_date&f[ptype][Arbeitsplatz%20Greenpeace]=70

(Remove extra slash[/] appended in url for multilingual sites)