### PR TITLE
PLANET-2530: Include visual regression tests in the automated testing

### DIFF
--- a/backstop.js
+++ b/backstop.js
@@ -2,7 +2,7 @@
 
 var arguments = require('minimist')(process.argv.slice(2));
 
-var url = 'https://dev.p4.greenpeace.org/international';
+var url = 'https://k8s.p4.greenpeace.org/defaultcontent/';
 if (arguments.url) {
   url = arguments.url;
 }
@@ -10,11 +10,17 @@ if (arguments.url) {
 var paths = [
   '/',
   '/act/',
+  '/act/vestibulum-leo-libero/',
   '/explore/',
   '/explore/energy/',
-  '/tag/food/',
-  '/author/greenpeace-international/',
-  '/?s=food&orderby=relevant'
+  '/tag/coal/',
+  '/author/lreyes/',
+  '/community-policy/',
+  '/copyright/',
+  '/privacy-and-cookies/',
+  '/about-us-2/',
+  '/press-center/',
+  '/?s=food&orderby=relevant',
 ];
 
 var scenarios = [];
@@ -23,7 +29,7 @@ for (var i = 0; i < paths.length; i++) {
   scenarios.push({
     'label': paths[i],
     'url': url + paths[i],
-    'delay': 500
+    'delay': 500,
   });
 }
 
@@ -68,7 +74,7 @@ module.exports = {
   },
   'casperFlags': [],
   'engine': 'puppeteer',
-  'report': ['browser'],
+  'report': ['browser', 'CI'],
   'engineOptions': {
     'args': ['--no-sandbox']
   },

--- a/backstop.js
+++ b/backstop.js
@@ -15,11 +15,8 @@ var paths = [
   '/explore/energy/',
   '/tag/coal/',
   '/author/lreyes/',
-  '/community-policy/',
   '/copyright/',
   '/privacy-and-cookies/',
-  '/about-us-2/',
-  '/press-center/',
   '/?s=food&orderby=relevant',
 ];
 

--- a/backstop.js
+++ b/backstop.js
@@ -2,7 +2,7 @@
 
 var arguments = require('minimist')(process.argv.slice(2));
 
-var url = 'https://k8s.p4.greenpeace.org/defaultcontent/';
+var url = 'https://k8s.p4.greenpeace.org/uitests/';
 if (arguments.url) {
   url = arguments.url;
 }


### PR DESCRIPTION
Starting this PR so we can move the conversation here.

I added/updated a few URLs according to the default content, let me know which ones you think we should keep / update / add, etc.

I also added the option to create a CI report, I just wanted to test it as I saw it was present in Nikos's `planet-2530` branch. Do we need it? 