### PR TITLE
PLANET-2805 - Load More functionality - Decide and document approach

### DIFF
--- a/taxonomy.php
+++ b/taxonomy.php
@@ -7,10 +7,37 @@
  * Learn more: http://codex.wordpress.org/Template_Hierarchy
  */
 
-$templates = array( 'page_type.twig', 'index.twig' );
-
 $context = Timber::get_context();
-$context['page_type'] = get_queried_object();
-$context['posts'] = Timber::get_posts();
+$page_type = get_queried_object();
+$context['page_type'] = $page_type;
 
-Timber::render( $templates, $context );
+$post_args = [ 
+    'posts_per_page' => 1, 
+    'tax_query' => [
+		[
+			'taxonomy' => 'p4-page-type',
+			'field'    => 'slug',
+			'terms'    => 'press',
+        ],
+    ],
+    'post_type' => 'post',
+    'paged' => 1
+];
+
+if ( get_query_var('page') ) {
+    $templates = [ 'tease-page-type.twig' ];
+    $page = get_query_var('page');
+    $post_args['paged'] = $page;
+
+    $posts = new Timber\PostQuery( $post_args );
+
+    foreach($posts as $post) {
+        $context['post'] = $post;
+        Timber::render( $templates, $context );
+    }
+} else {
+    $templates = [ 'page_type.twig' ];
+    $context['posts'] = new Timber\PostQuery( $post_args );
+    
+    Timber::render( $templates, $context );
+}

--- a/templates/page_type.twig
+++ b/templates/page_type.twig
@@ -21,12 +21,38 @@
 
 		<div class="row">
 			<div class="col-lg-8 multiple-search-result">
-				<ul class="list-unstyled">
+				<ul class="list-unstyled PostsList">
 					{% for post in posts %}
 						{% include 'tease-page-type.twig' %}
 					{% endfor %}
 				</ul>
 			</div>
 		</div>
+
+		<div class="row">
+			<div class="col-lg-8">
+				<button data-page="1" class="LoadMoreButton btn btn-medium btn-small btn-secondary mb-5">SHOW 5 MORE RESULTS</button>
+			</div>
+		</div>
 	</div>
+
+	<script>
+		$ = jQuery;
+		const loadMore = $('.LoadMoreButton')
+
+		loadMore.on('click', (e) => {
+			const nextPage = parseInt(loadMore[0].dataset.page) + 1
+			const totalPages = {{ posts.pagination.total }}
+			const url = `{{ fn('get_term_link', page_type.term_id, 'p4-page-type') }}?page=${ nextPage }`
+			loadMore[0].dataset.page = nextPage
+
+			$.get(url, (response) => {
+				$(".PostsList").append( response )
+			})
+
+			if (nextPage == totalPages) {
+				loadMore.fadeOut()
+			}
+		})
+	</script>
 {% endblock %}


### PR DESCRIPTION
WIP - opening this PR to chat about implementations.

Disregard the hardcoded rows per page and the fact that I inlined the script into a template and the CamelCase classnames, I guess working with React just tricked my brain into having html + behavior on the same file and _componentesque_ names. This is just for demoing.

I did a few tests on the WP REST API, but I wanted to know what your previous thoughts were on this. If we use the REST API and the JSON response to render on the client side, we'll need to use some sort of template (whether is jQuery, EJS, etc) to render the posts rows (`tease-page-type.twig`, or `tease-author.twig`), which will duplicate the code of those templates, so we'll need to change code in both places on every updated.

On the other hand, I tried a more Wordpress-like approach using server-side rendering (which is back since progressive web apps!), the very same template with a query var for the page and some of Timber's tools (Pagination, PostsQuery). This way we would only be maintaining our typical templates.

Attaching the result. Let me know your thoughts.

![load-more-ssr](https://user-images.githubusercontent.com/340766/47564398-4329bd80-d8fb-11e8-871d-b789180a7309.gif)
