### PR TITLE
PLANET-2637: Author Profile: missing posts

### DIFF
--- a/assets/js/author.js
+++ b/assets/js/author.js
@@ -1,0 +1,25 @@
+var $ = jQuery;
+const loadMore = $('button.load-more');
+loadMore.on('click', (e) => {
+  e.preventDefault();
+
+  const nextPage = parseInt(loadMore[0].dataset.page) + 1;
+  const totalPages = loadMore[0].dataset.total;
+  const url = loadMore[0].dataset.url + `?page=${ nextPage }`;
+  loadMore[0].dataset.page = nextPage;
+
+  $.ajax({
+    url: url,
+    type: 'GET',
+    dataType: 'html'
+  }).done(function ( response ) {
+    // Append the response at the bottom of the results and then show it.
+    $( '.multiple-search-result .list-unstyled' ).append( response );
+  }).fail(function ( jqXHR, textStatus, errorThrown ) {
+    console.log(errorThrown); //eslint-disable-line no-console
+  });
+
+  if (nextPage == totalPages) {
+    loadMore.fadeOut();
+  }
+});

--- a/assets/js/author.js
+++ b/assets/js/author.js
@@ -1,12 +1,11 @@
-var $ = jQuery;
 const loadMore = $('button.load-more');
-loadMore.on('click', (e) => {
+loadMore.on('click', function (e) {
   e.preventDefault();
 
-  const nextPage = parseInt(loadMore[0].dataset.page) + 1;
-  const totalPages = loadMore[0].dataset.total;
-  const url = loadMore[0].dataset.url + `?page=${ nextPage }`;
-  loadMore[0].dataset.page = nextPage;
+  const nextPage = parseInt(this.dataset.page) + 1;
+  const totalPages = this.dataset.total;
+  const url = this.dataset.url + `?page=${ nextPage }`;
+  this.dataset.page = nextPage;
 
   $.ajax({
     url: url,

--- a/author.php
+++ b/author.php
@@ -8,36 +8,39 @@
  * @subpackage  Timber
  * @since    Timber 0.1
  */
+
 wp_register_script( 'author', get_template_directory_uri() . '/assets/js/author.js', [ 'jquery' ], '0.0.1', true );
 wp_enqueue_script( 'author' );
 
-$context = Timber::get_context();
+$context          = Timber::get_context();
 $context['posts'] = Timber::get_posts( false, 'P4_Post' );
 
 $post_args = [
-    'posts_per_page' => 10,
-    'post_type' => 'post',
-    'paged' => 1
+	'posts_per_page' => 10,
+	'post_type'      => 'post',
+	'paged'          => 1,
 ];
 
 if ( isset( $wp_query->query_vars['author'] ) ) {
-	$author = new TimberUser( $wp_query->query_vars['author'] );
-	$context['author'] = $author;
-    $context['title'] = 'Author Archives: ' . $author->name();
-    $post_args['author'] = $wp_query->query_vars['author'];
+	$author              = new TimberUser( $wp_query->query_vars['author'] );
+	$context['author']   = $author;
+	$context['title']    = 'Author Archives: ' . $author->name();
+	$post_args['author'] = $wp_query->query_vars['author'];
 }
 
-if ( get_query_var('page') ) {
-    $templates = [ 'tease-author.twig' ];
-    $page = get_query_var('page');
-    $post_args['paged'] = $page;
-    $posts = new Timber\PostQuery( $post_args );
-	foreach($posts as $post) {
-        $context['post'] = $post;
-        Timber::render( $templates, $context );
-    }
+if ( get_query_var( 'page' ) ) {
+	$templates          = [ 'tease-author.twig' ];
+	$page               = get_query_var( 'page' );
+	$post_args['paged'] = $page;
+
+	$posts = new Timber\PostQuery( $post_args );
+	foreach ( $posts as $post ) {
+		$context['post'] = $post;
+		Timber::render( $templates, $context );
+	}
 } else {
-    $templates = [ 'author.twig', 'archive.twig' ];
-    $context['posts'] = new Timber\PostQuery( $post_args );
-    Timber::render( $templates, $context );
+	$templates        = [ 'author.twig', 'archive.twig' ];
+	$context['posts'] = new Timber\PostQuery( $post_args );
+
+	Timber::render( $templates, $context );
 }

--- a/author.php
+++ b/author.php
@@ -9,14 +9,13 @@
  * @since    Timber 0.1
  */
 
-wp_register_script( 'author', get_template_directory_uri() . '/assets/js/author.js', [ 'jquery' ], '0.0.1', true );
+wp_register_script( 'author', get_template_directory_uri() . '/assets/js/author.js', [ 'jquery', 'main' ], '0.0.1', true );
 wp_enqueue_script( 'author' );
 
 $context          = Timber::get_context();
-$context['posts'] = Timber::get_posts( false, 'P4_Post' );
 
 $post_args = [
-	'posts_per_page' => 10,
+	'posts_per_page' => 1,
 	'post_type'      => 'post',
 	'paged'          => 1,
 ];

--- a/author.php
+++ b/author.php
@@ -8,13 +8,36 @@
  * @subpackage  Timber
  * @since    Timber 0.1
  */
-global $wp_query;
+wp_register_script( 'author', get_template_directory_uri() . '/assets/js/author.js', [ 'jquery' ], '0.0.1', true );
+wp_enqueue_script( 'author' );
 
 $context = Timber::get_context();
 $context['posts'] = Timber::get_posts( false, 'P4_Post' );
+
+$post_args = [
+    'posts_per_page' => 10,
+    'post_type' => 'post',
+    'paged' => 1
+];
+
 if ( isset( $wp_query->query_vars['author'] ) ) {
 	$author = new TimberUser( $wp_query->query_vars['author'] );
 	$context['author'] = $author;
-	$context['title'] = 'Author Archives: ' . $author->name();
+    $context['title'] = 'Author Archives: ' . $author->name();
+    $post_args['author'] = $wp_query->query_vars['author'];
 }
-Timber::render( array( 'author.twig', 'archive.twig' ), $context );
+
+if ( get_query_var('page') ) {
+    $templates = [ 'tease-author.twig' ];
+    $page = get_query_var('page');
+    $post_args['paged'] = $page;
+    $posts = new Timber\PostQuery( $post_args );
+	foreach($posts as $post) {
+        $context['post'] = $post;
+        Timber::render( $templates, $context );
+    }
+} else {
+    $templates = [ 'author.twig', 'archive.twig' ];
+    $context['posts'] = new Timber\PostQuery( $post_args );
+    Timber::render( $templates, $context );
+}

--- a/templates/author.twig
+++ b/templates/author.twig
@@ -39,5 +39,17 @@
 				</ul>
 			</div>
 		</div>
+
+		{% if posts.pagination.total > 1 %}
+			<div class="row">
+				<div class="col-lg-8">
+					<button
+						data-page="1"
+						data-total="{{ posts.pagination.total }}"
+						data-url="{{ author.path }}"
+						class="load-more btn btn-medium btn-small btn-secondary mb-5">Load More</button>
+				</div>
+			</div>
+		{% endif %}
 	</div>
 {% endblock %}

--- a/templates/tease-author.twig
+++ b/templates/tease-author.twig
@@ -23,7 +23,7 @@
 			<a href="{{ post.link() }}" class="search-result-item-headline">{{ post.title|e('wp_kses_post')|raw }}</a>
 
 			<div class="search-result-item-info">
-				<span class="search-result-item-date">{{ post.post_date|date('d/m/Y') }}</span>
+				<span class="search-result-item-date">{{ post.post_date|date }}</span>
 			</div>
 
 			<p class="search-result-item-content">{{ post.preview()|truncate( 25, true )|raw }}</p>


### PR DESCRIPTION
Starting this PR to polish & finish our method to get posts for [Author](https://jira.greenpeace.org/browse/PLANET-2637) and [Page Type](https://jira.greenpeace.org/browse/PLANET-2822) pages.

I noticed we could be using the search class, but the `get_paged_posts` method is tied to the `search` pages templates. Maybe if we could separate the core functionality from the render, we could benefit from using the search logic already implemented in the search class, which looks more robust  in terms of validation, sanitization and caching. But maybe that's out of the scope of this issue.


