### PR TITLE
PLANET-2824 - Break logo image to a new block template

### DIFF
--- a/templates/blocks/site_logo.twig
+++ b/templates/blocks/site_logo.twig
@@ -1,0 +1,1 @@
+<img src="{{ data_nav_bar.images }}gp-logo.svg" alt="Greenpeace">

--- a/templates/navigation-bar.twig
+++ b/templates/navigation-bar.twig
@@ -1,7 +1,7 @@
 {% block navigation_bar %}
 	<nav id="header" class="top-navigation navbar">
 		<a class="site-logo" href="{{ data_nav_bar.home_url }}">
-			<img src="{{ data_nav_bar.images }}gp-logo.svg" alt="Greenpeace"/>
+			{% include 'blocks/site_logo.twig' %}
 		</a>
 		<button
 				class="btn btn-navbar-toggle navbar-dropdown-toggle"


### PR DESCRIPTION
Since we have our first request from an NRO for custom logo, I splitted the logo image to a new block template so we can easily override it from child themes.