### PR TITLE
PLANET-2892 - Add port to livereload

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -66,7 +66,7 @@ gulp.task('uglify', function(){
 });
 
 gulp.task('watch', function () {
-  livereload.listen();
+  livereload.listen({'port': 35730});
   gulp.watch(path_scss, ['css:lint', 'sass']);
   gulp.watch(path_js, ['js:lint', 'uglify']);
 });


### PR DESCRIPTION
This will allow us to run gulp for both `master-theme` and and `plugin-blocks`.