### PR TITLE
PLANET-2822 fix name collision

### DIFF
--- a/assets/js/load_more.js
+++ b/assets/js/load_more.js
@@ -1,9 +1,10 @@
-const loadMore = $('button.load-more');
-loadMore.on('click', function (e) {
+const load_more = $('button.load-more-mt');
+load_more.off('click').on('click', function (e) {
   e.preventDefault();
 
+  const $content = $( this.dataset.content );
   const nextPage = parseInt(this.dataset.page) + 1;
-  const totalPages = this.dataset.total;
+  const totalPages = parseInt(this.dataset.total);
   const url = this.dataset.url + `?page=${ nextPage }`;
   this.dataset.page = nextPage;
 
@@ -13,12 +14,12 @@ loadMore.on('click', function (e) {
     dataType: 'html'
   }).done(function ( response ) {
     // Append the response at the bottom of the results and then show it.
-    $( '.multiple-search-result .list-unstyled' ).append( response );
+    $content.append( response );
   }).fail(function ( jqXHR, textStatus, errorThrown ) {
     console.log(errorThrown); //eslint-disable-line no-console
   });
 
-  if (nextPage == totalPages) {
-    loadMore.fadeOut();
+  if (nextPage === totalPages) {
+	  load_more.fadeOut();
   }
 });

--- a/assets/js/load_more.js
+++ b/assets/js/load_more.js
@@ -3,10 +3,10 @@ load_more.off('click').on('click', function (e) {
   e.preventDefault();
 
   const $content = $( this.dataset.content );
-  const nextPage = parseInt(this.dataset.page) + 1;
-  const totalPages = parseInt(this.dataset.total);
-  const url = this.dataset.url + `?page=${ nextPage }`;
-  this.dataset.page = nextPage;
+  const next_page = parseInt(this.dataset.page) + 1;
+  const total_pages = parseInt(this.dataset.total);
+  const url = this.dataset.url + `?page=${ next_page }`;
+  this.dataset.page = next_page;
 
   $.ajax({
     url: url,
@@ -19,7 +19,7 @@ load_more.off('click').on('click', function (e) {
     console.log(errorThrown); //eslint-disable-line no-console
   });
 
-  if (nextPage === totalPages) {
-	  load_more.fadeOut();
+  if (next_page === total_pages) {
+    load_more.fadeOut();
   }
 });

--- a/taxonomy.php
+++ b/taxonomy.php
@@ -18,7 +18,7 @@ $context              = Timber::get_context();
 $context['page_type'] = get_queried_object();
 $context['wp_title']  = $context['page_type']->name;
 
-wp_register_script( 'load_more', get_template_directory_uri() . '/assets/js/load_more.js', [ 'jquery', 'main' ], '0.0.1', true );
+wp_register_script( 'load_more', get_template_directory_uri() . '/assets/js/load_more.js', [ 'jquery', 'main' ], '0.0.2', true );
 wp_enqueue_script( 'load_more' );
 
 $post_args = [

--- a/templates/author.twig
+++ b/templates/author.twig
@@ -44,10 +44,11 @@
 			<div class="row">
 				<div class="col-lg-8">
 					<button
+						data-content=".multiple-search-result .list-unstyled"
 						data-page="1"
 						data-total="{{ posts.pagination.total }}"
 						data-url="{{ author.path }}"
-						class="load-more btn btn-medium btn-small btn-secondary mb-5">Load More</button>
+						class="load-more-mt btn btn-medium btn-small btn-secondary mb-5">Load More</button>
 				</div>
 			</div>
 		{% endif %}

--- a/templates/author.twig
+++ b/templates/author.twig
@@ -48,7 +48,7 @@
 						data-page="1"
 						data-total="{{ posts.pagination.total }}"
 						data-url="{{ author.path }}"
-						class="load-more-mt btn btn-medium btn-small btn-secondary mb-5">Load More</button>
+						class="load-more-mt btn btn-medium btn-small btn-secondary mb-5">{{ __( 'Load More', 'planet4-master-theme' ) }}</button>
 				</div>
 			</div>
 		{% endif %}

--- a/templates/page_type.twig
+++ b/templates/page_type.twig
@@ -31,10 +31,11 @@
 			<div class="row">
 				<div class="col-lg-8">
 					<button
+						data-content=".multiple-search-result .list-unstyled"
 						data-page="1"
 						data-total="{{ posts.pagination.total }}"
 						data-url="{{ fn('get_term_link', page_type.term_id, 'p4-page-type') }}"
-						class="load-more btn btn-medium btn-small btn-secondary mb-5">Load More</button>
+						class="load-more-mt btn btn-medium btn-small btn-secondary mb-5">{{ __( 'Load More', 'planet4-master-theme' ) }}</button>
 				</div>
 			</div>
 		{% endif %}

--- a/templates/tease-page-type.twig
+++ b/templates/tease-page-type.twig
@@ -26,7 +26,7 @@
 					{% if not ( post.get_author_override ) %}
 						<a href="{{ post.author.path }}">{{ post.author }}</a>
 					{% else %}
-						{{ post.author }}
+						{{ post.author.name }}
 					{% endif %}
 				</span>
 			{% endif %}


### PR DESCRIPTION
Fix class name collision with Load more button of Blocks. Master Theme should use load-more-mt. Small improvements in js. Now can use the data-content attribute to indicate where the response should be appended to. Registered couple strings for translation.