### PR TITLE
PLANET-2637 authorpage remove overridden posts

### DIFF
--- a/author.php
+++ b/author.php
@@ -9,6 +9,9 @@
  * @since    Timber 0.1
  */
 
+use Timber\Timber;
+use Timber\PostQuery;
+
 wp_register_script( 'load_more', get_template_directory_uri() . '/assets/js/load_more.js', [ 'jquery', 'main' ], '0.0.1', true );
 wp_enqueue_script( 'load_more' );
 
@@ -21,7 +24,7 @@ $post_args = [
 ];
 
 if ( isset( $wp_query->query_vars['author'] ) ) {
-	$author              = new TimberUser( $wp_query->query_vars['author'] );
+	$author              = new P4_User( $wp_query->query_vars['author'] );
 	$context['author']   = $author;
 	$context['title']    = 'Author Archives: ' . $author->name();
 	$post_args['author'] = $wp_query->query_vars['author'];
@@ -32,14 +35,14 @@ if ( get_query_var( 'page' ) ) {
 	$page               = get_query_var( 'page' );
 	$post_args['paged'] = $page;
 
-	$posts = new Timber\PostQuery( $post_args );
+	$posts = new PostQuery( $post_args, 'P4_Post' );
 	foreach ( $posts as $post ) {
 		$context['post'] = $post;
 		Timber::render( $templates, $context );
 	}
 } else {
 	$templates        = [ 'author.twig', 'archive.twig' ];
-	$context['posts'] = new Timber\PostQuery( $post_args );
+	$context['posts'] = new PostQuery( $post_args, 'P4_Post' );
 
 	Timber::render( $templates, $context );
 }

--- a/templates/tease-author.twig
+++ b/templates/tease-author.twig
@@ -1,4 +1,4 @@
-{% if not (post.get_author_override) %}
+{% if not (post.author.is_fake) %}
 	<li id="result-row-{{ post.ID }}" class="media search-result-list-item">
 		<img class="d-flex search-result-item-image" src="{{ post.thumbnail.src('thumbnail') }}"
 			alt="{{ fn('esc_attr', post.thumbnail.alt|default( post.title ) )|raw }}" />


### PR DESCRIPTION
Remove overridden posts from Author page. This happened because we were using TimberPost instead of P4_Post. TimberPost does not have post.get_author_override nor post.author.is_fake