### PR TITLE
404 favicon not found

### DIFF
--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -11,7 +11,7 @@ Tags: light, accessibility-ready
 Text Domain: planet4-master-theme
 */
 
-// Gloabal
+// Global
 @import "global/variables";
 @import "global/functions";
 @import "global/mixins";

--- a/templates/html-header.twig
+++ b/templates/html-header.twig
@@ -88,7 +88,7 @@
 	<link href="https://fonts.googleapis.com/css?family=Roboto" rel="stylesheet">
 	<link rel="pingback" href="{{ site.pingback_url }}">
 	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
-	<link rel="shortcut icon" type="image/ico" href="favicon.ico"/>
+	<link rel="shortcut icon" type="image/ico" href="{{ theme.uri }}/favicon.ico"/>
 	<link rel="dns-prefetch" href="//act.greenpeace.org">
 	{{ wp_head }}
 </head>


### PR DESCRIPTION
This PR would fix the fact that the `favicon.ico` file is 404 not found.

Opening this link https://www.greenpeace.org/international/ and checking in console, the favicon is 404 and as  fallback the website keep loading another favicon from a different Greenpeace website probably. (see image below)

![screen shot 2018-11-21 at 01 45 26](https://user-images.githubusercontent.com/7761650/48813390-ffc64180-ed36-11e8-9adf-6d0c9276f105.png)


More shortly, the website is looking for https://www.greenpeace.org/international/favicon.ico constantly but that file doesn't exist as it exists only in its root directory of the theme.

Now, first of all i looked into `functions.php` if was there any useful `$base_url` var to be used in order to prefix `href="favicon.ico` with something like `href="{{ base_site_url }}favicon.ico"` in order to give it a fixed url for any page people load.

Actually, i tried some of the context vars but i could make something wrong there and then i found this issue https://github.com/timber/timber/issues/113

Finally `href="{{ theme.uri }}favicon.ico` seems to fix all of this, as it will surely point to the file path everytime, but this is how i would fix it but it could be that you prefer another way, for example printing a custom var that you declare in `functions.php`

I tried following your contribution guidelines as much as possible.

I hope it was a fix to be done for you.


