### PR TITLE
fixing 404 http error - favicon.ico not found 

### DIFF
--- a/templates/html-header.twig
+++ b/templates/html-header.twig
@@ -88,7 +88,7 @@
 	<link href="https://fonts.googleapis.com/css?family=Roboto" rel="stylesheet">
 	<link rel="pingback" href="{{ site.pingback_url }}">
 	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
-	<link rel="shortcut icon" type="image/ico" href="favicon.ico"/>
+	<link rel="shortcut icon" type="image/ico" href="{{ theme.uri }}/favicon.ico"/>
 	<link rel="dns-prefetch" href="//act.greenpeace.org">
 	{{ wp_head }}
 </head>


### PR DESCRIPTION
This PR would fix the fact that the `favicon.ico` file is 404 not found.

Opening this link https://www.greenpeace.org/international/ and checking in console, the favicon is 404 and as  fallback the website keep loading another favicon that i may suppose it's in the wordpress root directory not in the theme directory. (don't know if wanted actually)

![screen shot 2018-11-21 at 01 45 26](https://user-images.githubusercontent.com/7761650/48813390-ffc64180-ed36-11e8-9adf-6d0c9276f105.png)


Shortly, the website is looking for https://www.greenpeace.org/international/favicon.ico constantly but that file doesn't exist.

Actually, i tried some of the context vars but i could have made something wrong there, so researching i found this issue explained https://github.com/timber/timber/issues/113

Finally `href="{{ theme.uri }}favicon.ico` seems to fix all of this, as it will surely point to the file path  on any page url.

I couldn't try  `{{ site.url }}` as a solution, it could be that you have a different server setup from mine, should work the same and should point to the favicon without a full-path, which probably looks way cleaner: http://greenpeace.org/favicon.ico 

Hope to had followed your contribution guidelines as much as possible.


