### PR TITLE
PLANET-2931: #360374 Page Type page: showing wrong content

### DIFF
--- a/taxonomy.php
+++ b/taxonomy.php
@@ -25,6 +25,7 @@ $post_args = [
 	'posts_per_page' => 10,
 	'post_type'      => 'post',
 	'paged'          => 1,
+	'p4-page-type'   => $context['page_type']->slug
 ];
 
 $context['dummy_thumbnail'] = get_template_directory_uri() . '/images/dummy-thumbnail.png';


### PR DESCRIPTION
We were not filtering for page type!

Ref: https://jira.greenpeace.org/browse/PLANET-2931

Note: I'm using the shorthand method, which is based on the `slug` field, I don't know if this could cause any side effects, I don't foresee any.

Otherwise, we could do a `term_id`-based query using:

```
'tax_query' => [
        [
            'taxonomy' => 'p4-page-type',
            'field' => 'term_id',
            'terms' => $context['page_type']->term_id
		]
	],
```