### PR TITLE
PLANET-2915 Fix post excerpt/preview in page_type and author templates

### DIFF
--- a/templates/tease-author.twig
+++ b/templates/tease-author.twig
@@ -23,7 +23,7 @@
 			<span class="search-result-item-date">{{ post.post_date|date }}</span>
 		</div>
 
-		<p class="search-result-item-content">{{ post.preview()|truncate( 25, true )|raw }}</p>
+		<p class="search-result-item-content">{{ post.post_excerpt|truncate( 30, true )|e('wp_kses_post')|raw }}</p>
 
 	</div>
 </li>

--- a/templates/tease-page-type.twig
+++ b/templates/tease-page-type.twig
@@ -33,7 +33,7 @@
 			<span class="search-result-item-date">{{ post.post_date|date }}</span>
 		</div>
 
-		<p class="search-result-item-content">{{ post.preview()|truncate( 25, true )|raw }}</p>
+		<p class="search-result-item-content">{{ post.post_excerpt|truncate( 30, true )|e('wp_kses_post')|raw }}</p>
 
 	</div>
 </li>


### PR DESCRIPTION
Use post_excerpt in page_type author templates.
Made it consistent with tease articles block template.