### PR TITLE
PLANET-2927: Author Profile page: Load More button is wrong colour

### DIFF
--- a/assets/js/load_more.js
+++ b/assets/js/load_more.js
@@ -1,5 +1,5 @@
 const load_more = $('button.load-more-mt');
-load_more.off('mousedown').on('mousedown', function (e) {
+load_more.off('mousedown touchstart').on('mousedown touchstart', function (e) {
   e.preventDefault();
 
   const $content = $( this.dataset.content );
@@ -15,11 +15,10 @@ load_more.off('mousedown').on('mousedown', function (e) {
   }).done(function ( response ) {
     // Append the response at the bottom of the results and then show it.
     $content.append( response );
+    if (next_page === total_pages) {
+      load_more.fadeOut();
+    }
   }).fail(function ( jqXHR, textStatus, errorThrown ) {
     console.log(errorThrown); //eslint-disable-line no-console
   });
-
-  if (next_page === total_pages) {
-    load_more.fadeOut();
-  }
 });

--- a/assets/js/load_more.js
+++ b/assets/js/load_more.js
@@ -1,5 +1,5 @@
 const load_more = $('button.load-more-mt');
-load_more.off('click').on('click', function (e) {
+load_more.off('mousedown').on('mousedown', function (e) {
   e.preventDefault();
 
   const $content = $( this.dataset.content );


### PR DESCRIPTION
Notes:

Switched from 'click' to 'mousedown touchstart' to prevent the 'focus()' event from happening, as I tried a few ways of blurring the element (jQuery, vanilla, document.activeElement) and none seemed to work right.

We could also remove `:focus` from the CSS class, but I'm not sure if that's what we want here, as the button classes are too generic (`btn-secondary`, etc).

Ref: https://jira.greenpeace.org/browse/PLANET-2927
