### PR TITLE
PLANET-2574: IdeaPush with broken sidebar

### DIFF
--- a/sidebar.php
+++ b/sidebar.php
@@ -1,10 +1,9 @@
 <?php
 /**
- * The Template for displaying all single posts
+ * Placeholder file to avoid this error:
+ * "Notice: Theme without sidebar.php is deprecated since
+ *  version 3.0.0 with no alternative available.
+ *  Please include a sidebar.php template in your theme."
  *
- *
- * @package  WordPress
- * @subpackage  Timber
+ * No output.
  */
-
-Timber::render( array( 'sidebar.twig' ), $data );


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-2574

Ok, this is a long shot but here it goes: I don't have a local working Handbook DB for testing, so I just did some research on the surface, but my spider sense is telling me this could be the cause of the sidebar issue.

Looks like the `ip-tag` (IdeaPush tag) templates include `sidebar.php` in the render pipeline, which is a surprisingly old file:

<img width="992" alt="captura de pantalla 2018-11-28 a la s 23 29 58" src="https://user-images.githubusercontent.com/340766/49195938-cc536a80-f367-11e8-9811-beb2d46ecc1d.png">

IdeaPush includes it by calling: 

![image](https://user-images.githubusercontent.com/340766/49196278-20ab1a00-f369-11e8-8a81-5bd9c29148d5.png)

This is an example page: https://planet4.greenpeace.org/ip-tag/contribution/

Removing the file causes this error: 
```
Notice: Theme without sidebar.php is deprecated since version 3.0.0 with no alternative available. Please include a sidebar.php template in your theme. in /app/source/public/wp-includes/functions.php on line 3984
```

So, keeping the file but removing the output seems to do the trick, as we are using a different method than `get_sidebar()` to include the sidebar.

Also, not included in this PR, but: is this `sidebar` variable still in use? is it ever defined? I can't find its source.

https://github.com/greenpeace/planet4-master-theme/commit/bdd2b2a93a02b9e53de1195937d9c2e1307415fc#diff-165325163f96a207bc47e67bbe480772R17

Can someone with a working local Handbook test it? 🙏 Just comment the Timber `sidebar.php` line out. 



