### PR TITLE
PLANET-2926: Load More button is wrong size

### DIFF
--- a/templates/author.twig
+++ b/templates/author.twig
@@ -44,7 +44,7 @@
 
 		{% if posts.pagination.total > 1 %}
 			<div class="row">
-				<div class="col-lg-8">
+				<div class="col-md-12 col-lg-5 col-xl-5 mt-3">
 					<button
 						data-content=".multiple-search-result .list-unstyled"
 						data-page="1"

--- a/templates/taxonomy.twig
+++ b/templates/taxonomy.twig
@@ -29,7 +29,7 @@
 
 		{% if posts.pagination.total > 1 %}
 			<div class="row">
-				<div class="col-lg-8">
+				<div class="col-md-12 col-lg-5 col-xl-5 mt-3">
 					<button
 						data-content=".multiple-search-result .list-unstyled"
 						data-page="1"


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-2926 and https://jira.greenpeace.org/browse/PLANET-2930

Fixed the bootstrap grid classes on the Load More wrapper.