### PR TITLE
PLANET-3004 Fix truncate post excerpt for character based languages

### DIFF
--- a/templates/tease-author.twig
+++ b/templates/tease-author.twig
@@ -23,7 +23,7 @@
 			<span class="search-result-item-date">{{ post.post_date|date }}</span>
 		</div>
 
-		<p class="search-result-item-content">{{ post.post_excerpt|truncate( 30, true )|e('wp_kses_post')|raw }}</p>
+		<p class="search-result-item-content">{{ post.post_excerpt|excerpt( 30 )|e('wp_kses_post')|raw }}</p>
 
 	</div>
 </li>

--- a/templates/tease-search.twig
+++ b/templates/tease-search.twig
@@ -73,7 +73,7 @@
 				</div>
 			</div>
 
-			<p class="search-result-item-content">{{ post.preview().read_more('')|truncate( 25, true )|raw }}</p>
+			<p class="search-result-item-content">{{ post.preview().read_more('')|excerpt( 25 )|raw }}</p>
 		</div>
 	</li>
 {% if ( ( loop.index0 % 5 == 4 ) or loop.last ) %}

--- a/templates/tease-taxonomy-post.twig
+++ b/templates/tease-taxonomy-post.twig
@@ -34,7 +34,7 @@
 			<span class="search-result-item-date">{{ post.post_date|date }}</span>
 		</div>
 
-		<p class="search-result-item-content">{{ post.post_excerpt|truncate( 30, true )|e('wp_kses_post')|raw }}</p>
+		<p class="search-result-item-content">{{ post.post_excerpt|excerpt( 30 )|e('wp_kses_post')|raw }}</p>
 
 	</div>
 </li>


### PR DESCRIPTION
Truncate and excerpt are pretty identical, but excerpt uses [wp_trim_words](https://developer.wordpress.org/reference/functions/wp_trim_words/) which splits the content for character based languages correctly.