### PR TITLE
PLANET-3007 Add missing translatable strings

### DIFF
--- a/classes/class-p4-post-report-controller.php
+++ b/classes/class-p4-post-report-controller.php
@@ -73,7 +73,7 @@ if ( ! class_exists( 'P4_Post_Report_Controller' ) ) {
 		 */
 		function filter_post_params_endpoint( $query_params ) {
 			$query_params['date_query_column'] = [
-				'description' => __( 'The date query column.' ),
+				'description' => __( 'The date query column.', 'planet4-master-theme-backend' ),
 				'type'        => 'string',
 				'enum'        => [ 'post_date', 'post_date_gmt', 'post_modified', 'post_modified_gmt' ],
 			];

--- a/functions.php
+++ b/functions.php
@@ -803,7 +803,7 @@ class P4_Master_Site extends TimberSite {
 			return;
 		}
 		add_meta_box( 'restricted_tags_box',
-			__( 'Tags' ),
+			__( 'Tags', 'planet4-master-theme-backend' ),
 			[ $this, 'print_restricted_tags_box' ],
 			[ 'post', 'page' ],
 			'side'
@@ -890,7 +890,7 @@ class P4_Master_Site extends TimberSite {
 
 			return new WP_Error(
 				'disallow_insert_term',
-				__( 'Your role does not have permission to add terms to this taxonomy' )
+				__( 'Your role does not have permission to add terms to this taxonomy', 'planet4-master-theme-backend' )
 			);
 
 		}

--- a/languages/planet4-master-theme-backend.pot
+++ b/languages/planet4-master-theme-backend.pot
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Planet4 Master Theme backend\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-11-05 09:23+0000\n"
+"POT-Creation-Date: 2018-12-13 11:04+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: \n"
@@ -146,13 +146,25 @@ msgid ""
 "graph image"
 msgstr ""
 
+#: functions.php:806
+msgid "Tags"
+msgstr ""
+
 #: functions.php:835
 msgid "Add Page Element"
+msgstr ""
+
+#: functions.php:893
+msgid "Your role does not have permission to add terms to this taxonomy"
 msgstr ""
 
 #: classes/class-p4-post-report-controller.php:59
 #: classes/class-p4-post-report-controller.php:60
 msgid "Posts Report"
+msgstr ""
+
+#: classes/class-p4-post-report-controller.php:76
+msgid "The date query column."
 msgstr ""
 
 #: classes/class-p4-custom-taxonomy.php:42
@@ -195,109 +207,6 @@ msgstr ""
 
 #: classes/class-p4-custom-taxonomy.php:159
 msgid "Page Types"
-msgstr ""
-
-#: classes/class-p4-campaigns.php:21
-msgid "Select Image"
-msgstr ""
-
-#: classes/class-p4-campaigns.php:74
-msgid ""
-"Column block: Choose which Page Types will populate the content of the "
-"Column block. If no box is checked Publications will appear by default."
-msgstr ""
-
-#: classes/class-p4-campaigns.php:93 classes/class-p4-campaigns.php:132
-#: classes/class-p4-campaigns.php:194
-msgid "Image"
-msgstr ""
-
-#: classes/class-p4-campaigns.php:99 classes/class-p4-campaigns.php:114
-#: classes/class-p4-campaigns.php:136
-msgid "Select/Upload Image"
-msgstr ""
-
-#: classes/class-p4-campaigns.php:101 classes/class-p4-campaigns.php:138
-msgid "Associate this tag with an image."
-msgstr ""
-
-#: classes/class-p4-campaigns.php:108
-msgid "Image Subscribe"
-msgstr ""
-
-#: classes/class-p4-campaigns.php:116
-msgid "Choose a background image for the Subscribe block."
-msgstr ""
-
-#: classes/class-p4-campaigns.php:123
-msgid "Happy Point Opacity"
-msgstr ""
-
-#: classes/class-p4-campaigns.php:127
-msgid ""
-"We use an overlay to fade the image back. Use a number between 1 and 100, "
-"the higher the number, the more faded the image will look. If you leave this "
-"empty, the default of 30 will be used."
-msgstr ""
-
-#: classes/class-p4-control-panel.php:41
-msgid "Planet 4 Control Panel"
-msgstr ""
-
-#: classes/class-p4-control-panel.php:53
-msgid "Cache"
-msgstr ""
-
-#: classes/class-p4-control-panel.php:56
-msgid "Flush Object Cache"
-msgstr ""
-
-#: classes/class-p4-control-panel.php:58
-msgid "Are you sure you want to delete all Object Cache keys?"
-msgstr ""
-
-#: classes/class-p4-control-panel.php:61
-msgid "Check Object Cache"
-msgstr ""
-
-#: classes/class-p4-control-panel.php:68
-msgid "Engaging Networks"
-msgstr ""
-
-#: classes/class-p4-control-panel.php:71
-msgid "Check Engaging Networks"
-msgstr ""
-
-#: classes/class-p4-control-panel.php:78
-msgid "Search"
-msgstr ""
-
-#: classes/class-p4-control-panel.php:81
-msgid "Check Search Indexer"
-msgstr ""
-
-#: classes/class-p4-control-panel.php:126
-msgid "Object Cache flushed"
-msgstr ""
-
-#: classes/class-p4-control-panel.php:129
-msgid "Object Cache did not flush"
-msgstr ""
-
-#: classes/class-p4-control-panel.php:165
-msgid "Planet 4 is connected to Redis."
-msgstr ""
-
-#: classes/class-p4-control-panel.php:201
-msgid "Success"
-msgstr ""
-
-#: classes/class-p4-control-panel.php:248
-msgid "Indexer has stalled"
-msgstr ""
-
-#: classes/class-p4-control-panel.php:251
-msgid "Indexer is awake"
 msgstr ""
 
 #: classes/class-p4-settings.php:39
@@ -445,4 +354,115 @@ msgstr ""
 
 #: classes/class-p4-settings.php:308
 msgid "Select Pagetype"
+msgstr ""
+
+#: classes/class-p4-control-panel.php:43
+msgid "Planet 4 Control Panel"
+msgstr ""
+
+#: classes/class-p4-control-panel.php:56
+msgid "Cache"
+msgstr ""
+
+#: classes/class-p4-control-panel.php:59
+msgid "Flush Object Cache"
+msgstr ""
+
+#: classes/class-p4-control-panel.php:61
+msgid "Are you sure you want to delete all Object Cache keys?"
+msgstr ""
+
+#: classes/class-p4-control-panel.php:64
+msgid "Check Object Cache"
+msgstr ""
+
+#: classes/class-p4-control-panel.php:73
+msgid "Engaging Networks"
+msgstr ""
+
+#: classes/class-p4-control-panel.php:76
+msgid "Check Engaging Networks"
+msgstr ""
+
+#: classes/class-p4-control-panel.php:83
+msgid "Search"
+msgstr ""
+
+#: classes/class-p4-control-panel.php:86
+msgid "Check Search Indexer"
+msgstr ""
+
+#: classes/class-p4-control-panel.php:130
+msgid "Object Cache flushed"
+msgstr ""
+
+#: classes/class-p4-control-panel.php:133
+msgid "Object Cache did not flush"
+msgstr ""
+
+#: classes/class-p4-control-panel.php:168
+msgid "Planet 4 is connected to Redis."
+msgstr ""
+
+#: classes/class-p4-control-panel.php:204
+msgid "Success"
+msgstr ""
+
+#: classes/class-p4-control-panel.php:251
+msgid "Indexer has stalled"
+msgstr ""
+
+#: classes/class-p4-control-panel.php:254
+msgid "Indexer is awake"
+msgstr ""
+
+#: classes/class-p4-campaigns.php:21
+msgid "Select Image"
+msgstr ""
+
+#: classes/class-p4-campaigns.php:74
+msgid ""
+"Column block: Choose which Page Types will populate the content of the "
+"Column block. If no box is checked Publications will appear by default."
+msgstr ""
+
+#: classes/class-p4-campaigns.php:93 classes/class-p4-campaigns.php:132
+#: classes/class-p4-campaigns.php:194
+msgid "Image"
+msgstr ""
+
+#: classes/class-p4-campaigns.php:99 classes/class-p4-campaigns.php:114
+#: classes/class-p4-campaigns.php:136
+msgid "Select/Upload Image"
+msgstr ""
+
+#: classes/class-p4-campaigns.php:101 classes/class-p4-campaigns.php:138
+msgid "Associate this tag with an image."
+msgstr ""
+
+#: classes/class-p4-campaigns.php:108
+msgid "Image Subscribe"
+msgstr ""
+
+#: classes/class-p4-campaigns.php:116
+msgid "Choose a background image for the Subscribe block."
+msgstr ""
+
+#: classes/class-p4-campaigns.php:123
+msgid "Happy Point Opacity"
+msgstr ""
+
+#: classes/class-p4-campaigns.php:127
+msgid ""
+"We use an overlay to fade the image back. Use a number between 1 and 100, "
+"the higher the number, the more faded the image will look. If you leave this "
+"empty, the default of 30 will be used."
+msgstr ""
+
+#. Name of the template
+msgid "Evergreen Page"
+msgstr ""
+
+#. Name of the template
+msgid "Sitemap Page"
 msgstr ""

--- a/languages/planet4-master-theme.pot
+++ b/languages/planet4-master-theme.pot
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 "Project-Id-Version: Greenpeace Planet 4 Master Theme\n"
-"POT-Creation-Date: 2018-11-29 13:31+0000\n"
+"POT-Creation-Date: 2018-12-13 11:03+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -22,6 +22,14 @@ msgstr ""
 "X-Poedit-SearchPathExcluded-0: *.js\n"
 "Language: "
 
+#: single.php:33
+msgid "Post page"
+msgstr ""
+
+#: single.php:67
+msgid "Leave Your Reply"
+msgstr ""
+
 #: 404.php:16
 msgid "Sorry, we can't find that page!"
 msgstr ""
@@ -32,6 +40,26 @@ msgstr ""
 
 #: 404.php:18
 msgid "404 Page"
+msgstr ""
+
+#: tag.php:48
+msgid "Unknown Campaign page"
+msgstr ""
+
+#: tag.php:54
+msgid "Things you can do"
+msgstr ""
+
+#: tag.php:55
+msgid "We want you to take action because together we're strong."
+msgstr ""
+
+#: tag.php:83
+msgid "Related Campaigns"
+msgstr ""
+
+#: tag.php:84
+msgid "This Campaign is not assigned to an Issue"
 msgstr ""
 
 #: functions.php:85
@@ -56,34 +84,6 @@ msgstr ""
 
 #: functions.php:271
 msgid "International (English)"
-msgstr ""
-
-#: single.php:33
-msgid "Post page"
-msgstr ""
-
-#: single.php:67
-msgid "Leave Your Reply"
-msgstr ""
-
-#: tag.php:48
-msgid "Unknown Campaign page"
-msgstr ""
-
-#: tag.php:54
-msgid "Things you can do"
-msgstr ""
-
-#: tag.php:55
-msgid "We want you to take action because together we're strong."
-msgstr ""
-
-#: tag.php:83
-msgid "Related Campaigns"
-msgstr ""
-
-#: tag.php:84
-msgid "This Campaign is not assigned to an Issue"
 msgstr ""
 
 #: classes/class-p4-post.php:190 classes/class-p4-search.php:570
@@ -167,12 +167,145 @@ msgstr ""
 msgid "Articles"
 msgstr ""
 
-#: templates/author.twig:33
+#: templates/author.twig:36
 msgid "Posts by "
 msgstr ""
 
-#: templates/author.twig:53 templates/page_type.twig:38
+#: templates/author.twig:56 templates/taxonomy.twig:38
 msgid "Load More"
+msgstr ""
+
+#: templates/navigation-bar.twig:6
+msgid "Toggle navigation menu"
+msgstr ""
+
+#: templates/navigation-bar.twig:7 templates/search.twig:8
+#: templates/search.twig:45 templates/404.twig:17
+msgid "Search"
+msgstr ""
+
+#: templates/navigation-bar.twig:15
+msgid "Menu"
+msgstr ""
+
+#: templates/navigation-bar.twig:20
+msgid "Close Menu"
+msgstr ""
+
+#: templates/navigation-bar.twig:29
+msgid "Selected"
+msgstr ""
+
+#: templates/navigation-bar.twig:30
+msgid "Change Country"
+msgstr ""
+
+#: templates/navigation-bar.twig:60
+msgid "Toggle search form"
+msgstr ""
+
+#: templates/cookies.twig:8
+msgid "GOT IT!"
+msgstr ""
+
+#: templates/search.twig:16
+msgid "We're sorry we couldn't find any matches for your search term."
+msgstr ""
+
+#: templates/search.twig:18
+msgid "Check for typos, and try your search again"
+msgstr ""
+
+#: templates/search.twig:19
+msgid "Try searching for somthing else"
+msgstr ""
+
+#: templates/search.twig:20
+msgid "Search our archive. You'll be redirected to the archive site."
+msgstr ""
+
+#: templates/search.twig:24
+msgid "We also included results for "
+msgstr ""
+
+#: templates/search.twig:38
+msgid "This Site"
+msgstr ""
+
+#: templates/search.twig:39
+msgid "Archive"
+msgstr ""
+
+#: templates/search.twig:57
+msgid "Filters"
+msgstr ""
+
+#: templates/search.twig:63 templates/search.twig:164
+msgid "Refine your search"
+msgstr ""
+
+#: templates/search.twig:71
+msgid "ISSUE"
+msgstr ""
+
+#: templates/search.twig:92
+msgid "CATEGORY"
+msgstr ""
+
+#: templates/search.twig:113
+msgid "CONTENT TYPES"
+msgstr ""
+
+#: templates/search.twig:137
+msgid "CAMPAIGN"
+msgstr ""
+
+#: templates/search.twig:156
+msgid "Cancel"
+msgstr ""
+
+#: templates/search.twig:157
+msgid "Apply Filters"
+msgstr ""
+
+#: templates/search.twig:167
+msgid "ACTIVE FILTERS"
+msgstr ""
+
+#: templates/search.twig:176
+msgid "Clear All"
+msgstr ""
+
+#: templates/search.twig:183
+msgid "Issue"
+msgstr ""
+
+#: templates/search.twig:202
+msgid "Campaign"
+msgstr ""
+
+#: templates/search.twig:221
+msgid "Category"
+msgstr ""
+
+#: templates/search.twig:240
+msgid "Content type"
+msgstr ""
+
+#: templates/search.twig:263
+msgid "Sort by"
+msgstr ""
+
+#: templates/search.twig:300
+msgid "Suggested search terms"
+msgstr ""
+
+#: templates/tease-search.twig:67
+msgid "take action"
+msgstr ""
+
+#: templates/tease-search.twig:70
+msgid "Download"
 msgstr ""
 
 #: templates/base.twig:10
@@ -187,144 +320,60 @@ msgstr ""
 msgid "Skip to Footer"
 msgstr ""
 
-#: templates/cookies.twig:8
-msgid "GOT IT!"
-msgstr ""
-
-#: templates/navigation-bar.twig:13
-msgid "Menu"
-msgstr ""
-
-#: templates/navigation-bar.twig:18
-msgid "Close Menu"
-msgstr ""
-
-#: templates/navigation-bar.twig:27
-msgid "Selected"
-msgstr ""
-
-#: templates/navigation-bar.twig:28
-msgid "Change Country"
-msgstr ""
-
-#: templates/navigation-bar.twig:58
-msgid "Toggle search form"
-msgstr ""
-
-#: templates/navigation-bar.twig:66 templates/search.twig:44
-msgid "Search"
-msgstr ""
-
-#: templates/page_type.twig:18
-msgid "Results"
-msgstr ""
-
-#: templates/search.twig:15
-msgid "We're sorry we couldn't find any matches for your search term."
-msgstr ""
-
-#: templates/search.twig:17
-msgid "Check for typos, and try your search again"
-msgstr ""
-
-#: templates/search.twig:18
-msgid "Try searching for somthing else"
-msgstr ""
-
-#: templates/search.twig:19
-msgid "Search our archive. You'll be redirected to the archive site."
-msgstr ""
-
-#: templates/search.twig:23
-msgid "We also included results for "
-msgstr ""
-
-#: templates/search.twig:37
-msgid "This Site"
-msgstr ""
-
-#: templates/search.twig:38
-msgid "Archive"
-msgstr ""
-
-#: templates/search.twig:56
-msgid "Filters"
-msgstr ""
-
-#: templates/search.twig:62 templates/search.twig:163
-msgid "Refine your search"
-msgstr ""
-
-#: templates/search.twig:70
-msgid "ISSUE"
-msgstr ""
-
-#: templates/search.twig:91
-msgid "CATEGORY"
-msgstr ""
-
-#: templates/search.twig:112
-msgid "CONTENT TYPES"
-msgstr ""
-
-#: templates/search.twig:136
-msgid "CAMPAIGN"
-msgstr ""
-
-#: templates/search.twig:155
-msgid "Cancel"
-msgstr ""
-
-#: templates/search.twig:156
-msgid "Apply Filters"
-msgstr ""
-
-#: templates/search.twig:166
-msgid "ACTIVE FILTERS"
-msgstr ""
-
-#: templates/search.twig:175
-msgid "Clear All"
-msgstr ""
-
-#: templates/search.twig:182
-msgid "Issue"
-msgstr ""
-
-#: templates/search.twig:201
-msgid "Campaign"
-msgstr ""
-
-#: templates/search.twig:220
-msgid "Category"
-msgstr ""
-
-#: templates/search.twig:239
-msgid "Content type"
-msgstr ""
-
-#: templates/search.twig:262
-msgid "Sort by"
-msgstr ""
-
-#: templates/search.twig:299
-msgid "Suggested search terms"
-msgstr ""
-
-#: templates/single.twig:41
+#: templates/single.twig:41 templates/tease-taxonomy-post.twig:26
 msgid "by"
 msgstr ""
 
-#: templates/tease-search.twig:67
-msgid "take action"
+#: templates/single.twig:53 templates/comments_section.twig:2
+msgid "Comments"
 msgstr ""
 
-#: templates/tease-search.twig:70
-msgid "Download"
+#: templates/comments_section.twig:8
+msgid "Discussion"
+msgstr ""
+
+#: templates/taxonomy.twig:18
+msgid "Results"
+msgstr ""
+
+#: templates/blocks/share_buttons.twig:7 templates/blocks/share_buttons.twig:14
+msgid "Share on"
+msgstr ""
+
+#: templates/blocks/share_buttons.twig:21
+msgid "Share via"
 msgstr ""
 
 #: templates/blocks/author_profile.twig:4
 msgid "about the author"
+msgstr ""
+
+#: templates/comment_form/email_field.twig:2
+msgid "Email"
+msgstr ""
+
+#: templates/comment_form/email_field.twig:3
+msgid "Your Email"
+msgstr ""
+
+#: templates/comment_form/comment_field.twig:2
+msgid "Comment"
+msgstr ""
+
+#: templates/comment_form/comment_field.twig:3
+msgid "Your Comment"
+msgstr ""
+
+#: templates/comment_form/author_field.twig:2
+msgid "Name"
+msgstr ""
+
+#: templates/comment_form/author_field.twig:3
+msgid "Your Name"
+msgstr ""
+
+#: templates/comment_form/submit_button.twig:1
+msgid "Post Comment"
 msgstr ""
 
 #. Theme Name of the plugin/theme

--- a/templates/404.twig
+++ b/templates/404.twig
@@ -14,7 +14,8 @@
 				<div class="col-md-4">
 					{{ page_notfound_help }}
 					<form class="form search-form" action="{{ data_nav_bar.home_url }}">
-						<input class="form-control" placeholder="{{ __( 'Search', 'planet4-master-theme' )|e( 'html_attr' ) }}" name="s" aria-label="{{ __( 'Search', 'planet4-master-theme' )|e( 'html_attr' ) }}" type="text">
+						{% set search = __( 'Search', 'planet4-master-theme' ) %}
+						<input class="form-control" placeholder="{{ search|e( 'html_attr' ) }}" name="s" aria-label="{{ search|e( 'html_attr' ) }}" type="text">
 						<button class="search-form-btn" type="submit">
 							<i class="fa fa-search"></i>
 						</button>

--- a/templates/blocks/share_buttons.twig
+++ b/templates/blocks/share_buttons.twig
@@ -4,20 +4,20 @@
 		 onclick="dataLayer.push({'event' : 'uaevent', 'eventCategory' : 'Social Share', 'eventAction': 'Facebook', 'eventLabel': '{{ post.link }}'});"
 		 target="_blank" class="share-btn facebook">
 		<i class="fa fa-facebook"></i>
-		<span class="sr-only">{{ __( 'Share on' ) }} Facebook</span>
+		<span class="sr-only">{{ __( 'Share on', 'planet4-master-theme' ) }} Facebook</span>
 	</a>
 	<!-- Twitter -->
 	<a href="https://twitter.com/share?url={{ post.link }}&text={{ post.title|raw }} via @{{ social_accounts.twitter }}&related={{ social_accounts.twitter }}"
 		 onclick="dataLayer.push({'event' : 'uaevent', 'eventCategory' : 'Social Share', 'eventAction': 'Twitter', 'eventLabel': '{{ post.link }}'});"
 		 target="_blank" class="share-btn twitter">
 		<i class="fa fa-twitter"></i>
-		<span class="sr-only">{{ __( 'Share on' ) }} Twitter</span>
+		<span class="sr-only">{{ __( 'Share on', 'planet4-master-theme' ) }} Twitter</span>
 	</a>
 	<!-- Email -->
 	<a href="mailto:?subject={{ post.title }}&body={{ post.link }}"
 		 onclick="dataLayer.push({'event' : 'uaevent', 'eventCategory' : 'Social Share', 'eventAction': 'Email', 'eventLabel': '{{ post.link }}'});"
 		 target="_blank" class="share-btn email">
 		<i class="fa fa-envelope"></i>
-		<span class="sr-only">{{ __( 'Share via' ) }} Email</span>
+		<span class="sr-only">{{ __( 'Share via', 'planet4-master-theme' ) }} Email</span>
 	</a>
 </div>

--- a/templates/comment_form/author_field.twig
+++ b/templates/comment_form/author_field.twig
@@ -1,4 +1,5 @@
 <div class="form-group">
-	<label for="comments-name-input">{{ __( 'Name' )  }} *</label>
-	<input type="text" class="form-control" id="author" name="author" placeholder="{{ __( 'Your Name', 'planet4-master-theme' ) }}" required />
+	<label for="comments-name-input">{{ __( 'Name', 'planet4-master-theme' )  }} *</label>
+	{% set your_name = __( 'Your Name', 'planet4-master-theme' ) %}
+	<input type="text" class="form-control" id="author" name="author" placeholder="{{ your_name }}" required />
 </div>

--- a/templates/comment_form/comment_field.twig
+++ b/templates/comment_form/comment_field.twig
@@ -1,4 +1,5 @@
 <div class="form-group mb-0">
-	<label for="comments-textarea">{{ __( 'Comment' )  }} *</label>
-	<textarea class="form-control" id="comment" name="comment" rows="6" placeholder="{{ __( 'Your Comment', 'planet4-master-theme' )  }}" required></textarea>
+	<label for="comments-textarea">{{ __( 'Comment', 'planet4-master-theme' )  }} *</label>
+	{% set your_comment = __( 'Your Comment', 'planet4-master-theme' ) %}
+	<textarea class="form-control" id="comment" name="comment" rows="6" placeholder="{{ your_comment  }}" required></textarea>
 </div>

--- a/templates/comment_form/email_field.twig
+++ b/templates/comment_form/email_field.twig
@@ -1,4 +1,5 @@
 <div class="form-group mb-0">
-	<label for="comments-email-input">{{ __( 'Email' ) }} *</label>
-	<input type="email" class="form-control" id="email" name="email" placeholder="{{ __( 'Your Email', 'planet4-master-theme' ) }}" required />
+	<label for="comments-email-input">{{ __( 'Email', 'planet4-master-theme' ) }} *</label>
+	{% set your_email = __( 'Your Email', 'planet4-master-theme' ) %}
+	<input type="email" class="form-control" id="email" name="email" placeholder="{{ your_email }}" required />
 </div>

--- a/templates/comment_form/submit_button.twig
+++ b/templates/comment_form/submit_button.twig
@@ -1,1 +1,1 @@
-<button type="submit" class="btn btn-small btn-secondary">{{ __( 'Post Comment' ) }}</button>
+<button type="submit" class="btn btn-small btn-secondary">{{ __( 'Post Comment', 'planet4-master-theme' ) }}</button>

--- a/templates/comments_section.twig
+++ b/templates/comments_section.twig
@@ -1,11 +1,11 @@
 <div class="container page-section" id="comments">
-	<h2 class="page-section-header">{{ __( 'Comments' ) }}</h2>
+	<h2 class="page-section-header">{{ __( 'Comments', 'planet4-master-theme' ) }}</h2>
 	<div class="comments-block">
 		<div class="form-section">
 			{{ fn('comment_form', comments_args) }}
 		</div>
 		<section class="comments-section" itemscope itemtype="http://schema.org/UserComments">
-			<h3 class="comments-section-title">{{ __( 'Discussion' ) }}</h3>
+			<h3 class="comments-section-title">{{ __( 'Discussion', 'planet4-master-theme' ) }}</h3>
 			{% for cmt in comments %}
 				{% include "comment.twig" with {comment:cmt, index: loop.index} %}
 			{% endfor %}

--- a/templates/navigation-bar.twig
+++ b/templates/navigation-bar.twig
@@ -3,12 +3,14 @@
 		<a class="site-logo" href="{{ data_nav_bar.home_url }}">
 			{% include 'blocks/site_logo.twig' %}
 		</a>
+		{% set toggle_label = __( 'Toggle navigation menu', 'planet4-master-theme' ) %}
+		{% set search_label = __( 'Search', 'planet4-master-theme' ) %}
 		<button
 				class="btn btn-navbar-toggle navbar-dropdown-toggle"
 				data-toggle="open"
 				data-target="#navbar-dropdown"
 				aria-expanded="false"
-				aria-label="{{ __( 'Toggle navigation menu', 'planet4-master-theme' ) }}"
+				aria-label="{{ toggle_label }}"
 		>
 			<span>{{ __( 'Menu', 'planet4-master-theme' ) }}</span>
 		</button>
@@ -58,12 +60,12 @@
 			<span class="screen-reader-text">{{ __( 'Toggle search form', 'planet4-master-theme' ) }}</span>
 		</button>
 		<form id="search_form" action="{{ data_nav_bar.home_url }}" class="form nav-item nav-search-wrap">
-			<input type="text" class="form-control" placeholder="{{ __( 'Search', 'planet4-master-theme' ) }}"
+			<input type="text" class="form-control" placeholder="{{ search_label }}"
 				   value="{{ data_nav_bar.search_query|e('wp_kses_post')|raw }}" name="s" aria-label="Search">
 			<input id="orderby" type="hidden" name="orderby" value="{{ selected_sort ?? default_sort }}"/>
 			<button class="top-nav-search-btn" type="submit">
 				<i class="fa fa-search"></i>
-				<span class="screen-reader-text">{{ __( 'Search', 'planet4-master-theme' ) }}</span>
+				<span class="screen-reader-text">{{ search_label }}</span>
 			</button>
 		</form>
 	</nav>

--- a/templates/search.twig
+++ b/templates/search.twig
@@ -5,6 +5,7 @@
 	{% set collapsed = posts ? '' : 'collapsed' %}
 	{% set show      = posts ? 'show' : '' %}
 	{% set expanded  = posts ? true : false %}
+	{% set search_label = __( 'Search', 'planet4-master-theme' ) %}
 
 	<div class="search-block">
 		<div class="container">
@@ -28,7 +29,7 @@
 						<form id="search_form_inner" role="search" class="form" action="{{ data_nav_bar.home_url }}">
 							<div class="row">
 								<div class="{{ source_selection ? 'col-md-5' : 'col-md-9' }}">
-									<input type="search" class="form-control mb-2 mb-sm-0" placeholder="{{ __( 'Search', 'planet4-master-theme' ) }}" value="{{ search_query|e('wp_kses_post')|raw }}" name="s" aria-label="Search">
+									<input type="search" class="form-control mb-2 mb-sm-0" placeholder="{{ search_label }}" value="{{ search_query|e('wp_kses_post')|raw }}" name="s" aria-label="Search">
 									<input type="hidden" name="orderby" value="{{ selected_sort ?? default_sort }}" />
 								</div>
 								{% if ( source_selection ) %}

--- a/templates/single.twig
+++ b/templates/single.twig
@@ -50,7 +50,7 @@
 								<span class="separator">|</span>
 								<span id="comments-link" class="comment-link">
 									<img src="{{ data_nav_bar.images }}speech_bubble.svg">
-									<a class="quantity"> {{ post_comments_count }} <span class="display-text">{{ __( 'Comments' ) }}</span> </a>
+									<a class="quantity"> {{ post_comments_count }} <span class="display-text">{{ __( 'Comments', 'planet4-master-theme' ) }}</span> </a>
 								</span>
 							{% endif %}
 						</div>

--- a/templates/tease-taxonomy-post.twig
+++ b/templates/tease-taxonomy-post.twig
@@ -23,7 +23,7 @@
 
 		<div class="search-result-item-info">
 			{% if ( post.author ) %}
-				<span class="search-result-item-author">{{ __( 'by') }}
+				<span class="search-result-item-author">{{ __( 'by', 'planet4-master-theme' ) }}
 					{% if not ( post.get_author_override ) %}
 						<a href="{{ post.author.path }}">{{ post.author }}</a>
 					{% else %}


### PR DESCRIPTION
- Add master-theme's textdomains to strings without textdomain.
- Apply workaround for translate functions inside twig files. Extracted stings inside html attributes into twig variables.
https://wordpress.org/support/topic/timbertwig-compatibility/
- Update pot templates.

With these changes, it is safe to use loco-translate for pot templates generation.