### PR TITLE
Update circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,8 +25,10 @@ job-references:
       sudo -E docker-php-ext-install mysqli
       sudo sh -c "printf '\ndeb http://ftp.us.debian.org/debian sid main\n' >> /etc/apt/sources.list"
       sudo apt-get update && sudo apt-get install mysql-client-5.7
-      sudo apt-get update && sudo apt-get install npm
+      curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
+      sudo apt-get update && sudo apt-get install build-essential nodejs
       sudo npm install -g stylelint eslint
+      composer install --dev
 
   php_job: &php_job
     environment:
@@ -40,19 +42,16 @@ job-references:
           name: "phpcs"
           command: |
             mkdir -p /tmp/test-results/phpcs
-            composer global require wp-coding-standards/wpcs
-            phpcs --config-set installed_paths $HOME/.composer/vendor/wp-coding-standards/wpcs
-            phpcs --report=junit --report-file=/tmp/test-results/phpcs/$CIRCLE_STAGE.xml
+            vendor/bin/phpcs --config-set installed_paths vendor/wp-coding-standards/wpcs
+            vendor/bin/phpcs --report=junit --report-file=/tmp/test-results/phpcs/$CIRCLE_STAGE.xml
       - run:
           name: "phpunit"
           when: always
           command: |
-            mkdir -p /tmp/test-results/phpunit /tmp/test-results/phpunit-multisite
-            composer global require "phpunit/phpunit=5.7.*"
+            mkdir -p /tmp/test-results/phpunit
             rm -rf $WP_TESTS_DIR $WP_CORE_DIR
             bash bin/install-wp-tests.sh wordpress_test root '' 127.0.0.1 latest
-            phpunit --log-junit /tmp/test-results/phpunit/$CIRCLE_STAGE.xml
-            WP_MULTISITE=1 phpunit --log-junit /tmp/test-results/phpunit-multisite/$CIRCLE_STAGE.xml
+            vendor/bin/phpunit --log-junit /tmp/test-results/phpunit/$CIRCLE_STAGE.xml
       - run:
           name: "styelint"
           when: always

--- a/composer.json
+++ b/composer.json
@@ -27,10 +27,7 @@
 	},
 	"extra": {
 		"installer-paths": {
-			"../../plugins/{$name}/": [
-				"wpackagist-plugin/*",
-				"type:wordpress-plugin"
-			]
+			"vendor/plugins/{$name}/": ["type:wordpress-plugin"]
 		}
 	},
 	"require": {
@@ -42,6 +39,7 @@
 		"squizlabs/php_codesniffer": "2.9.*",
 		"wp-coding-standards/wpcs": "0.13.*",
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.4.0",
-		"stevegrunwell/phpunit-markup-assertions": "^1.2"
+		"stevegrunwell/phpunit-markup-assertions": "^1.2",
+		"phpunit/phpunit": "^6.2"
 	}
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -36,7 +36,7 @@ function _register_theme() {
 		return $current_theme;
 	} );
 
-	$plugins_dir = dirname( __FILE__ ) . '/../../../plugins';
+	$plugins_dir = dirname( __FILE__ ) . '/../vendor/plugins';
 	$timber      = $plugins_dir . '/timber/timber.php';
 	if ( file_exists( $timber ) ) {
 		require_once( $timber );

--- a/tests/p4-testcase.php
+++ b/tests/p4-testcase.php
@@ -8,20 +8,10 @@ class P4_TestCase extends WP_UnitTestCase {
 	function setUp() {
 
 		parent::setUp();
-		self::_setupStarterTheme();
 		$this->initialize_planet4_data();
 		require_once( get_template_directory() . '/functions.php' );
 	}
 
-
-	static function _setupStarterTheme() {
-		$src  = __DIR__ . '/../../planet4-master-theme/';
-		if ( is_dir( $src ) ) {
-			switch_theme( 'planet4-master-theme' );
-		} else {
-			echo 'no its not';
-		}
-	}
 
 	/**
 	 * Use wp unit testcase factories to create data in database for the tests.


### PR DESCRIPTION
A followup for #673 
- Install repo's dependencies in circleci
- Use repo's phpcs version

Thoughts/Questions:
Phpunit version should be defined by repo's dependencies and not in ci config (leaving it as it is now for the moment)
Do we need the multi-site testing?