### PR TITLE
PLANET-3013: Social icons not aligned properly on Windows

### DIFF
--- a/assets/scss/layout/_footer.scss
+++ b/assets/scss/layout/_footer.scss
@@ -31,10 +31,10 @@
   margin: auto;
   text-align: center;
 
-  @supports (justify-content: space-evenly) {
+  @supports (justify-content: space-between) {
     & {
       display: flex;
-      justify-content: space-evenly;
+      justify-content: space-between;
     }
   }
 


### PR DESCRIPTION
Switched the footer icons spacing from `space-evenly` to `space-between`, it is slightly different, just a few pixels, but it's more consistent with MS Edge, it looks the same in all browsers.

Ref: https://jira.greenpeace.org/browse/PLANET-3013