### PR TITLE
PLANET-2767: enable bilingual author profiles

### DIFF
--- a/templates/author.twig
+++ b/templates/author.twig
@@ -25,7 +25,7 @@
 			{% if ( author.description ) %}
 				<div class="row">
 					<div class="col-lg-8 col-md-6 col-sm-12 mt-md-0">
-						<p class="d-md-block author-bio">{{ fn('wpautop', author.description)|e('wp_kses_post')|raw }}</p>
+						<p class="d-md-block author-bio">{{ fn('wpautop', fn('the_author_meta', 'description', author.id))|e('wp_kses_post')|raw }}</p>
 					</div>
 				</div>
 			{% endif %}


### PR DESCRIPTION
In order to get to translate the author bio, I had to:

- Install and activate WPML's **String Translation** plugin. 
- Add authors as translatable strings in WPML's **String Translation** config:

![image](https://user-images.githubusercontent.com/340766/51345886-f0cfe700-1a7a-11e9-905c-892ae7eaa561.png)

- Scan the template for translatable strings, this should collect the authors strings for translation:

![image](https://user-images.githubusercontent.com/340766/51345955-207eef00-1a7b-11e9-887d-41c7c09c00c8.png)

- Go back to **String Translation** and edit the corresponding author bios:

![image](https://user-images.githubusercontent.com/340766/51346022-52905100-1a7b-11e9-9f1d-7eb7c4aaa9ac.png)

- In order for the language switcher to show, the author must have written posts in both languages. Heads up: if YOU translate a post to test this, remember to change the post's author to the corresponding author, otherwise, the translated post will belong to "admin", your user (this made me lose quite a bit of time...)

So, it's a very small change in the template, but quite a big process for the editors, I guess we should add an entry in the handbook to explain how to accomplish this. It is explained in [a few forum posts](https://wpml.org/forums/topic/translate-author-bio/) in WPML's site but it can be a little confusing, maybe we should just add a shorter, clearer version of the instructions on the handbook.  

Final result:

![author-bio-wpml](https://user-images.githubusercontent.com/340766/51346526-a51e3d00-1a7c-11e9-8e63-b4e79fc9f443.gif)
