### PR TITLE
PLANET-2767: enable bilingual author profiles

### DIFF
--- a/templates/blocks/author_profile.twig
+++ b/templates/blocks/author_profile.twig
@@ -6,7 +6,7 @@
 				<a href="{{ post.author.link }}" itemprop="name">{{ post.author.name }}</a>
 			</h5>
 			<p class="author-block-info-bio" itemprop="description">
-				{{ fn('wpautop', post.author.description)|e('wp_kses_post')|raw }}
+				{{ fn('wpautop', fn('the_author_meta', 'description', author.id))|e('wp_kses_post')|raw }}
 			</p>
 		</div>
 		<figure class="author-block-image">


### PR DESCRIPTION
Using the same translatable method in the author block.

Currently working at:

https://release.k8s.p4.greenpeace.org/canada/fr/communique-de-presse/6795/cop-24-malgre-lurgence-les-etats-tournent-le-dos-aux-attentes-des-populations/

