### PR TITLE
PLANET-3172 - Tags: Add option for a custom page redirection

### DIFF
--- a/classes/class-p4-campaigns.php
+++ b/classes/class-p4-campaigns.php
@@ -84,8 +84,27 @@ if ( ! class_exists( 'P4_Campaigns' ) ) {
 				$happypoint_attachment_url   = $happypoint_image_attributes ? $happypoint_image_attributes[0] : '';
 
 				$happypoint_bg_opacity = get_term_meta( $wp_tag->term_id, 'happypoint_bg_opacity', true );
-				$happypoint_bg_opacity = $happypoint_bg_opacity ?? '30'; ?>
+				$happypoint_bg_opacity = $happypoint_bg_opacity ?? '30';
 
+				$redirect_page = get_term_meta( $wp_tag->term_id, 'redirect_page', true );
+				$dropdown_args = [
+					'show_option_none' => __( 'Select Page', 'planet4-master-theme-backend' ),
+					'hide_empty'       => 0,
+					'hierarchical'     => true,
+					'selected'         => $redirect_page,
+					'name'             => 'redirect_page',
+				];
+				?>
+
+				<tr class="form-field edit-wrap">
+					<th>
+						<label><?php echo __( 'Redirect Page', 'planet4-master-theme-backend' ); ?></label>
+					</th>
+					<td>
+						<?php wp_dropdown_pages( $dropdown_args ); ?>
+						<p class="description"><?php echo __( 'Leave this empty if you want to use the automated Tag page. Otherwise pick a page to redirect this Tag to.', 'planet4-master-theme-backend' ); ?></p>
+					</td>
+				</tr>
 				<tr>
 					<th colspan="2">
 						<?php esc_html_e( 'Column block: Choose which Page Types will populate the content of the Column block. If no box is checked Publications will appear by default.', 'planet4-master-theme-backend' ); ?>
@@ -144,7 +163,20 @@ if ( ! class_exists( 'P4_Campaigns' ) ) {
 						<p class="description"><?php echo __( 'We use an overlay to fade the image back. Use a number between 1 and 100, the higher the number, the more faded the image will look. If you leave this empty, the default of 30 will be used.', 'planet4-master-theme-backend' ); ?></p>
 					</td>
 				</tr>
-			<?php } else { ?>
+				<?php
+			} else {
+				$dropdown_args = [
+					'show_option_none' => __( 'Select Page', 'planet4-master-theme-backend' ),
+					'hide_empty'       => 0,
+					'hierarchical'     => true,
+					'name'             => 'redirect_page',
+				];
+				?>
+				<div class="form-field add-wrap">
+					<label><?php echo __( 'Redirect Page', 'planet4-master-theme-backend' ); ?></label>
+					<?php wp_dropdown_pages( $dropdown_args ); ?>
+					<p class="description"><?php echo __( 'Leave this empty if you want to use the automated Tag page. Otherwise pick a page to redirect this Tag to.', 'planet4-master-theme-backend' ); ?></p>
+				</div>
 				<div class="form-field add-wrap term-image-wrap">
 					<label><?php esc_html_e( 'Image', 'planet4-master-theme-backend' ); ?></label>
 					<input type="hidden" name="tag_attachment_id" id="tag_attachment_id" class="tag_attachment_id field-id" value="" />
@@ -197,6 +229,11 @@ if ( ! class_exists( 'P4_Campaigns' ) ) {
 
 			if ( $this->validate( $happypoint_bg_opacity ) ) {
 				update_term_meta( $term_id, $field_id, $happypoint_bg_opacity );
+			}
+
+			$redirect_page = $_POST['redirect_page'] ?? 0;
+			if ( $this->validate_page_types( $redirect_page ) ) {
+				update_term_meta( $term_id, 'redirect_page', $redirect_page );
 			}
 		}
 

--- a/tag.php
+++ b/tag.php
@@ -16,103 +16,115 @@ use P4BKS\Controllers\Blocks\ContentFourColumn_Controller as ContentFourColumn;
 use P4BKS\Controllers\Blocks\CampaignThumbnail_Controller as CampaignThumbnail;
 use P4BKS\Controllers\Blocks\HappyPoint_Controller as HappyPoint;
 
-$templates = [ 'tag.twig', 'archive.twig', 'index.twig' ];
-
 $context = Timber::get_context();
 
 if ( is_tag() ) {
 	$context['tag']  = get_queried_object();
 	$explore_page_id = planet4_get_option( 'explore_page' );
 
-	$posts = get_posts(
-		[
-			'posts_per_page'   => 1,
-			'offset'           => 0,
-			'post_parent'      => $explore_page_id,
-			'post_type'        => 'page',
-			'post_status'      => 'publish',
-			'suppress_filters' => false,
-			'tag_slug__in'     => [ $context['tag']->slug ],
-		]
-	);
+	$redirect_id = get_term_meta( $context['tag']->term_id, 'redirect_page', true );
+	if ( $redirect_id ) {
 
-	$context['custom_body_classes'] = 'white-bg page-issue-page';
-	$context['category_name']       = $posts[0]->post_title ?? '';
-	$context['category_link']       = isset( $posts[0] ) ? get_permalink( $posts[0] ) : '';
-	$context['tag_name']            = single_tag_title( '', false );
-	$context['tag_description']     = wpautop( $context['tag']->description );
-	$context['tag_image']           = get_term_meta( $context['tag']->term_id, 'tag_attachment', true );
-	$tag_image_id                   = get_term_meta( $context['tag']->term_id, 'tag_attachment_id', true );
+		global $wp_query;
+		$redirect_page               = get_post( $redirect_id );
+		$wp_query->queried_object    = $redirect_page;
+		$wp_query->queried_object_id = $redirect_page->ID;
+		include 'page.php';
 
-	$context['og_description'] = $context['tag_description'];
-	if ( $tag_image_id ) {
-		$context['og_image_data'] = wp_get_attachment_image_src( $tag_image_id, 'full' );
-	}
-
-	$context['page_category'] = $posts[0]->post_title ?? __( 'Unknown Campaign page', 'planet4-master-theme' );
-
-
-	$campaign = new P4_Taxonomy_Campaign( $templates, $context );
-
-	$campaign->add_block(
-		Covers::BLOCK_NAME,
-		[
-			'title'       => __( 'Things you can do', 'planet4-master-theme' ),
-			'description' => __( 'We want you to take action because together we\'re strong.', 'planet4-master-theme' ),
-			'select_tag'  => $context['tag']->term_id,
-			'covers_view' => '0',   // Show 6 covers in Campaign page.
-		]
-	);
-
-	$campaign->add_block(
-		Articles::BLOCK_NAME,
-		[
-			'tags' => $context['tag']->term_id,
-		]
-	);
-
-	$cfc_args = [
-		'select_tag' => $context['tag']->term_id,
-		'posts_view' => '0',   // Show 1 row of posts.
-	];
-
-	// Get the selected page types for this campaign so that we add posts in the CFC block only for those page types.
-	$selected_page_types = get_term_meta( $context['tag']->term_id, 'selected_page_types' );
-	if ( isset( $selected_page_types[0] ) && $selected_page_types[0] ) {
-		foreach ( $selected_page_types[0] as $selected_page_type ) {
-			$cfc_args[ "p4_page_type_$selected_page_type" ] = 'true';
-		}
 	} else {
-		// If none is selected, then display Publications by default (for backwards compatibility).
-		$cfc_args['p4_page_type_publication'] = 'true';
+
+		$templates = [ 'tag.twig', 'archive.twig', 'index.twig' ];
+
+		$posts = get_posts(
+			[
+				'posts_per_page'   => 1,
+				'offset'           => 0,
+				'post_parent'      => $explore_page_id,
+				'post_type'        => 'page',
+				'post_status'      => 'publish',
+				'suppress_filters' => false,
+				'tag_slug__in'     => [ $context['tag']->slug ],
+			]
+		);
+
+		$context['custom_body_classes'] = 'white-bg page-issue-page';
+		$context['category_name']       = $posts[0]->post_title ?? '';
+		$context['category_link']       = isset( $posts[0] ) ? get_permalink( $posts[0] ) : '';
+		$context['tag_name']            = single_tag_title( '', false );
+		$context['tag_description']     = wpautop( $context['tag']->description );
+		$context['tag_image']           = get_term_meta( $context['tag']->term_id, 'tag_attachment', true );
+		$tag_image_id                   = get_term_meta( $context['tag']->term_id, 'tag_attachment_id', true );
+
+		$context['og_description'] = $context['tag_description'];
+		if ( $tag_image_id ) {
+			$context['og_image_data'] = wp_get_attachment_image_src( $tag_image_id, 'full' );
+		}
+
+		$context['page_category'] = $posts[0]->post_title ?? __( 'Unknown Campaign page', 'planet4-master-theme' );
+
+
+		$campaign = new P4_Taxonomy_Campaign( $templates, $context );
+
+		$campaign->add_block(
+			Covers::BLOCK_NAME,
+			[
+				'title'       => __( 'Things you can do', 'planet4-master-theme' ),
+				'description' => __( 'We want you to take action because together we\'re strong.', 'planet4-master-theme' ),
+				'select_tag'  => $context['tag']->term_id,
+				'covers_view' => '0',   // Show 6 covers in Campaign page.
+			]
+		);
+
+		$campaign->add_block(
+			Articles::BLOCK_NAME,
+			[
+				'tags' => $context['tag']->term_id,
+			]
+		);
+
+		$cfc_args = [
+			'select_tag' => $context['tag']->term_id,
+			'posts_view' => '0',   // Show 1 row of posts.
+		];
+
+		// Get the selected page types for this campaign so that we add posts in the CFC block only for those page types.
+		$selected_page_types = get_term_meta( $context['tag']->term_id, 'selected_page_types' );
+		if ( isset( $selected_page_types[0] ) && $selected_page_types[0] ) {
+			foreach ( $selected_page_types[0] as $selected_page_type ) {
+				$cfc_args[ "p4_page_type_$selected_page_type" ] = 'true';
+			}
+		} else {
+			// If none is selected, then display Publications by default (for backwards compatibility).
+			$cfc_args['p4_page_type_publication'] = 'true';
+		}
+
+		$campaign->add_block( ContentFourColumn::BLOCK_NAME, $cfc_args );
+
+		$campaign->add_block(
+			CampaignThumbnail::BLOCK_NAME,
+			[
+				'title'       => __( 'Related Campaigns', 'planet4-master-theme' ),
+				'category_id' => $category->term_id ?? __( 'This Campaign is not assigned to an Issue', 'planet4-master-theme' ),
+			]
+		);
+
+		// Get the image selected as background for the Subscribe section (HappyPoint block) inside the current Tag.
+		$background = get_term_meta( $context['tag']->term_id, 'happypoint_attachment_id', true );
+		$opacity    = get_term_meta( $context['tag']->term_id, 'happypoint_bg_opacity', true );
+		$options    = get_option( 'planet4_options' );
+
+		$campaign->add_block(
+			HappyPoint::BLOCK_NAME,
+			[
+				'background'          => $background,
+				'background_html'     => wp_get_attachment_image( $background ),
+				'background_src'      => wp_get_attachment_image_src( $background, 'full' ),
+				'engaging_network_id' => $options['engaging_network_form_id'] ?? '',
+				'opacity'             => $opacity,
+				'mailing_list_iframe' => 'true',
+			]
+		);
+
+		$campaign->view();
 	}
-
-	$campaign->add_block( ContentFourColumn::BLOCK_NAME, $cfc_args );
-
-	$campaign->add_block(
-		CampaignThumbnail::BLOCK_NAME,
-		[
-			'title'       => __( 'Related Campaigns', 'planet4-master-theme' ),
-			'category_id' => $category->term_id ?? __( 'This Campaign is not assigned to an Issue', 'planet4-master-theme' ),
-		]
-	);
-
-	// Get the image selected as background for the Subscribe section (HappyPoint block) inside the current Tag.
-	$background = get_term_meta( $context['tag']->term_id, 'happypoint_attachment_id', true );
-	$opacity    = get_term_meta( $context['tag']->term_id, 'happypoint_bg_opacity', true );
-	$options    = get_option( 'planet4_options' );
-
-	$campaign->add_block(
-		HappyPoint::BLOCK_NAME,
-		[
-			'background'          => $background,
-			'background_html'     => wp_get_attachment_image( $background ),
-			'background_src'      => wp_get_attachment_image_src( $background, 'full' ),
-			'engaging_network_id' => $options['engaging_network_form_id'] ?? '',
-			'opacity'             => $opacity,
-			'mailing_list_iframe' => 'true',
-		]
-	);
-
-	$campaign->view();
 }


### PR DESCRIPTION
In order to keep the slug unchanged, instead of redirecting the Tag page fetches and renders the custom page content.

Ref: https://jira.greenpeace.org/browse/PLANET-3172

