### PR TITLE
PLANET-3180 es search update

### DIFF
--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -43,6 +43,7 @@ $(function() {
       } else {
         $search_form.append('<input type="hidden" name="es" value="true" />');
       }
+      $( '#orderby', $( this ) ).val( '_score' );
     }
 
     if ( 0 === $('.filter-modal.show').length ) {

--- a/classes/class-p4-master-site.php
+++ b/classes/class-p4-master-site.php
@@ -606,7 +606,7 @@ class P4_Master_Site extends TimberSite {
 		$selected_sort = filter_input( INPUT_GET, 'orderby', FILTER_SANITIZE_STRING );
 		$selected_sort = sanitize_sql_orderby( $selected_sort );
 
-		if ( $selected_sort && P4_Search::DEFAULT_SORT !== $selected_sort ) {
+		if ( $selected_sort && 'relevant' !== $selected_sort && '_score' !== $selected_sort ) {
 			// First orderby 'weight' meta_key.
 			$primary_sort  = 'meta_value';
 			$primary_order = 'DESC';

--- a/classes/class-p4-search.php
+++ b/classes/class-p4-search.php
@@ -21,8 +21,8 @@ if ( ! class_exists( 'P4_Search' ) ) {
 		const SHOW_SCROLL_TIMES     = 2;
 		const DEFAULT_SORT          = '_score';
 		const DEFAULT_MIN_WEIGHT    = 1;
-		const DEFAULT_PAGE_WEIGHT   = 20;
-		const DEFAULT_ACTION_WEIGHT = 25;
+		const DEFAULT_PAGE_WEIGHT   = 100;
+		const DEFAULT_ACTION_WEIGHT = 2000;
 		const DEFAULT_MAX_WEIGHT    = 30;
 		const DEFAULT_CACHE_TTL     = 600;
 		const DUMMY_THUMBNAIL       = '/images/dummy-thumbnail.png';
@@ -967,7 +967,7 @@ if ( ! class_exists( 'P4_Search' ) ) {
 		 */
 		public function enqueue_public_assets() {
 			if ( is_search() ) {
-				wp_register_script( 'search', get_template_directory_uri() . '/assets/js/search.js', [ 'jquery' ], '0.2.4', true );
+				wp_register_script( 'search', get_template_directory_uri() . '/assets/js/search.js', [ 'jquery' ], '0.2.5', true );
 				wp_localize_script( 'search', 'localizations', $this->localizations );
 				wp_enqueue_script( 'search' );
 			}

--- a/templates/search.twig
+++ b/templates/search.twig
@@ -275,7 +275,7 @@
 								<label class="mr-sm-2" for="select_order">{{ __('Sort by', 'planet4-master-theme' ) }}</label>
 								<select id="select_order" name="select_order" class="">
 									{% for key, sort_option in sort_options %}
-										{% if ( not search_query and key == '_score' ) %}
+										{% if ( not search_query and ( key == '_score' or key == 'relevant' ) ) %}
 											<option value="{{ key }}" disabled>{{ __( sort_option.name, 'planet4-master-theme' ) }}</option>
 										{% elseif key == selected_sort %}
 											<option value="{{ key }}" selected>{{ __( sort_option.name, 'planet4-master-theme' ) }}</option>


### PR DESCRIPTION
* Change default weight for Action Pages and simple Pages so that they always rank higher than other search results.
* Fix issue so that both ways (SearchWP/ES) function properly (left/right click), so that we can compare results more easily.

Note: As it is currently, default search (left click) still works with SearchWP