### PR TITLE
PLANET-3190 - Posts: Add clearfix hack for clearing floating items

### DIFF
--- a/templates/single.twig
+++ b/templates/single.twig
@@ -69,7 +69,7 @@
 					{{ post.take_action_boxout|shortcodes|raw }}
 				{% endif %}
 				<div class="post-content-lead">
-					<article class="post-details">
+					<article class="post-details clearfix">
 						{{ post.content|e('wp_kses_post')|raw }}
 					</article>
 				</div>


### PR DESCRIPTION
`.cleafix` comes from [Bootstrap](https://getbootstrap.com/docs/4.2/utilities/clearfix/) and adds an `::after` element to make prevent problems with floating items at the end of post content.

Ref: https://jira.greenpeace.org/browse/PLANET-3190