### PR TITLE
PLANET-2364: Search: Don't display 'Show 5 more' button when there are less than 5 results

### DIFF
--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -84,6 +84,8 @@ $(function() {
   $load_more_button.off( 'click' ).on( 'click', function() {
     // If this button has this class then Lazy-loading is enabled.
     if ( $(this).hasClass( 'btn-load-more-async' ) ) {
+      var total_posts = $(this).data('total_posts');
+      var posts_per_load = $(this).data('posts_per_load');
       var next_page = $(this).data( 'current_page' ) + 1;
       $(this).data( 'current_page', next_page );
 
@@ -101,6 +103,9 @@ $(function() {
         // Append the response at the bottom of the results and then show it.
         $( '.multiple-search-result .list-unstyled' ).append( response );
         $( '.row-hidden:last' ).removeClass( 'row-hidden' ).show( 'fast' );
+        if (posts_per_load * next_page > total_posts) {
+          $load_more_button.hide();
+        }
       }).fail(function ( jqXHR, textStatus, errorThrown ) {
         console.log(errorThrown); //eslint-disable-line no-console
       });

--- a/classes/class-p4-search.php
+++ b/classes/class-p4-search.php
@@ -384,7 +384,7 @@ if ( ! class_exists( 'P4_Search' ) ) {
 
 			// This happens when we search for everything or when filtering for attachments, since WP_Query does not support searching within rich text documents.
 			if ( ! $this->search_query || ( isset( $args['post_type'] ) && 'attachment' !== $args['post_type'] ) ) {
-				if ( $posts ) {
+				if ( isset( $posts ) ) {
 					$ids = [];
 					foreach ( $posts as $post ) {
 						$ids[] = $post->ID;

--- a/templates/search.twig
+++ b/templates/search.twig
@@ -300,7 +300,13 @@
 							</ul>
 							{% if ( load_more and posts|length > paged_posts|length ) %}
 								<div class="col-lg-12 mb-5 load-more-button-div">
-									<button class="btn btn-medium btn-small btn-secondary more-btn {{ load_more.async and not search_query ? 'btn-load-more-async' : '' }} btn-load-more-click-scroll" data-current_page="{{ current_page }}">{{ load_more.button_text }}</button>
+									<button
+										class="btn btn-medium btn-small btn-secondary more-btn {{ load_more.async and not search_query ? 'btn-load-more-async' : '' }} btn-load-more-click-scroll"
+										data-current_page="{{ current_page }}"
+										data-total_posts="{{ found_posts }}"
+										data-posts_per_load="{{ load_more.posts_per_load }}">
+											{{ load_more.button_text }}
+										</button>
 								</div>
 							{% endif %}
 							{% if ( pagination ) %}


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-2364

Note: as we don't have lazy loading for all types of search, I consider this to be a temporary solution until we fix the TODO's in the current search code. That said, it works!.