### PR TITLE
PLANET-3172 - Tag redirection: Fix validation to allow zero value selection

### DIFF
--- a/classes/class-p4-campaigns.php
+++ b/classes/class-p4-campaigns.php
@@ -232,7 +232,7 @@ if ( ! class_exists( 'P4_Campaigns' ) ) {
 			}
 
 			$redirect_page = $_POST['redirect_page'] ?? 0;
-			if ( ! is_null( get_post( $redirect_page ) ) ) {
+			if ( ! is_null( get_post( $redirect_page ) ) || ! $redirect_page ) {
 				update_term_meta( $term_id, 'redirect_page', $redirect_page );
 			}
 		}


### PR DESCRIPTION
A minor fix to allow validation to allow zero value selection. This means that by selecting "Select Page" (`value=0`) you can disable the redirection.