### PR TITLE
PLANET-2981 cache page issue

### DIFF
--- a/classes/class-p4-master-site.php
+++ b/classes/class-p4-master-site.php
@@ -132,6 +132,7 @@ class P4_Master_Site extends TimberSite {
 		add_action( 'add_meta_boxes', [ $this, 'add_meta_box_search' ] );
 		add_action( 'save_post', [ $this, 'save_meta_box_search' ], 10, 2 );
 		add_action( 'save_post', [ $this, 'set_featured_image' ], 10, 3 );
+		add_action( 'post_updated', [ $this, 'clean_post_cache' ], 10, 3 );
 		add_action( 'after_setup_theme', [ $this, 'p4_master_theme_setup' ] );
 		add_action( 'admin_menu', [ $this, 'add_restricted_tags_box' ] );
 		add_action( 'do_meta_boxes', [ $this, 'remove_default_tags_box' ] );
@@ -191,6 +192,22 @@ class P4_Master_Site extends TimberSite {
 				set_post_thumbnail( $post_id, $matches[1][0] );
 			}
 		}
+	}
+
+	/**
+	 * Sets as featured image of the post the first image found attached in the post's content (if any).
+	 *
+	 * @param int     $post_id The ID of the current Post.
+	 * @param WP_Post $post_after The current Post.
+	 * @param WP_Post $post_before Whether this is an existing post being updated or not.
+	 */
+	public function clean_post_cache( $post_id, $post_after, $post_before ) {
+
+		// Ignore autosave.
+		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+			return;
+		}
+		clean_post_cache( $post_id );
 	}
 
 	/**

--- a/classes/class-p4-taxonomy-campaign.php
+++ b/classes/class-p4-taxonomy-campaign.php
@@ -6,6 +6,7 @@
  */
 
 use Timber\Timber;
+use Timber\Loader as TimberLoader;
 
 if ( ! class_exists( 'P4_Taxonomy_Campaign' ) ) {
 
@@ -65,6 +66,7 @@ if ( ! class_exists( 'P4_Taxonomy_Campaign' ) ) {
 		 * View the Campaign template.
 		 */
 		public function view() {
+			( new TimberLoader() )->clear_cache_timber();
 			Timber::render( $this->templates, $this->context );
 		}
 	}


### PR DESCRIPTION
Make sure post cache is cleared after each update. Clear Timber's cache as well to avoid cache issue with rendering block changes.

The cache issue appeared in WP Pages and within blocks (for example, in an auto-generated campaign page https://release.k8s.p4.greenpeace.org/greece/tag/theseis-ergasias/).

Not sure if this will fix the issue (since I can not reproduce it locally) but it seems that there is a correlation with Timber caching since Timber caching uses different expiration time for anonymous and logged in users (which is something that was reported).