### PR TITLE
PLANET-3268 object cache issue

### DIFF
--- a/classes/class-p4-taxonomy-campaign.php
+++ b/classes/class-p4-taxonomy-campaign.php
@@ -6,7 +6,6 @@
  */
 
 use Timber\Timber;
-use Timber\Loader as TimberLoader;
 
 if ( ! class_exists( 'P4_Taxonomy_Campaign' ) ) {
 
@@ -66,7 +65,6 @@ if ( ! class_exists( 'P4_Taxonomy_Campaign' ) ) {
 		 * View the Campaign template.
 		 */
 		public function view() {
-			( new TimberLoader() )->clear_cache_timber();
 			Timber::render( $this->templates, $this->context );
 		}
 	}


### PR DESCRIPTION
Flush object cache after every page/post update (due to Nginx-Helper plugin 4-hour-caching not allowing editors to view their changes when not logged in).
Also, revert previous changes that did not help.

*Note*
Tried to delete only the nginx keys from cache but did not find a way to get multiple keys based on a phrase or wild card, and also the wp_cache_delete_group function works only if the group is empty... so...