### PR TITLE
PLANET-3324 Move campaign fields (dataLayer) to the P4 page backend

### DIFF
--- a/classes/class-p4-master-site.php
+++ b/classes/class-p4-master-site.php
@@ -792,6 +792,101 @@ class P4_Master_Site extends TimberSite {
 				'preview_size' => 'large',
 			]
 		);
+
+		// P4 Datalayer/Campaign fields.
+		$p4_campaign_fields = new_cmb2_box(
+			[
+				'id'           => $prefix . 'campaign_fields',
+				'title'        => __( 'Campaign information (dataLayer)', 'planet4-master-theme-backend' ),
+				'object_types' => [ 'page' ],
+				'closed'       => true,  // Keep the metabox closed by default.
+			]
+		);
+
+		$campaign_options = [
+			0                                    => __( '- Select Campaign -', 'planet4-master-theme-backend' ),
+			'Local Campaign'                     => 'Local Campaign',
+			'Ocean Sanctuaries'                  => 'Ocean Sanctuaries',
+			'Climate Emergency Response'         => 'Climate Emergency Response',
+			'All Eyes on the Amazon'             => 'All Eyes on the Amazon',
+			'Asia Energy Transition'             => 'Asia Energy Transition',
+			'BrAndino: Hold the Line'            => 'BrAndino: Hold the Line',
+			'Break Free'                         => 'Break Free',
+			'Climate Justice Liability'          => 'Climate Justice Liability',
+			'Congo Basin Forests'                => 'Congo Basin Forests',
+			'Corporate ICE/ Clean Air Now'       => 'Corporate ICE/ Clean Air Now',
+			'European Energy Transition'         => 'European Energy Transition',
+			'Cross-commodities markets campaign' => 'Cross-commodities markets campaign',
+			'The Future of Europe project'       => 'The Future of Europe project',
+			'Greenpeace Fires'                   => 'Greenpeace Fires',
+			'Indonesia Forests'                  => 'Indonesia Forests',
+			'Meat & Dairy'                       => 'Meat & Dairy',
+			'Plastics Free Future'               => 'Plastics Free Future',
+			'Shifting the trillions'             => 'Shifting the trillions',
+			'Stolen Fish'                        => 'Stolen Fish',
+			'Amazon Reef'                        => 'Amazon Reef',
+			'People vs. Oil'                     => 'People vs. Oil',
+			'Pipelines'                          => 'Pipelines',
+			'Ends of the Earth'                  => 'Ends of the Earth',
+			'Patagonia'                          => 'Patagonia',
+			'Urban Revolution'                   => 'Urban Revolution',
+		];
+
+		$p4_campaign_fields->add_field(
+			[
+				'name'    => __( 'Campaign Name', 'planet4-master-theme-backend' ),
+				'desc'    => __( 'The value added in "Campaign Name" field is used in the GTM dataLayer push event', 'planet4-master-theme-backend' ),
+				'id'      => $prefix . 'campaign_name',
+				'type'    => 'select',
+				'options' => $campaign_options,
+			]
+		);
+
+		$basket_options = [
+			0                      => __( '- Select Basket -', 'planet4-master-theme-backend' ),
+			'Forests'              => 'Forests',
+			'Oceans'               => 'Oceans',
+			'Good Life'            => 'Good Life',
+			'Food'                 => 'Food',
+			'Climate & Energy'     => 'Climate & Energy',
+			'Oil'                  => 'Oil',
+			'Political & Business' => 'Political & Business',
+		];
+
+		$p4_campaign_fields->add_field(
+			[
+				'name'    => __( 'Basket Name', 'planet4-master-theme-backend' ),
+				'desc'    => __( 'The value added in "Basket Name" field is used in the GTM dataLayer push event', 'planet4-master-theme-backend' ),
+				'id'      => $prefix . 'basket_name',
+				'type'    => 'select',
+				'options' => $basket_options,
+			]
+		);
+
+		$scope_options = [
+			0          => __( '- Select Scope -', 'planet4-master-theme-backend' ),
+			'Global'   => 'Global',
+			'National' => 'National',
+		];
+
+		$p4_campaign_fields->add_field(
+			[
+				'name'    => __( 'Scope', 'planet4-master-theme-backend' ),
+				'desc'    => __( 'The value added in "Scope" field is used in the GTM dataLayer push event', 'planet4-master-theme-backend' ),
+				'id'      => $prefix . 'scope',
+				'type'    => 'select',
+				'options' => $scope_options,
+			]
+		);
+
+		$p4_campaign_fields->add_field(
+			[
+				'name' => __( 'Department', 'planet4-master-theme-backend' ),
+				'desc' => __( 'The value added in "Department" field is used in the GTM dataLayer push event', 'planet4-master-theme-backend' ),
+				'id'   => $prefix . 'department',
+				'type' => 'text_medium',
+			]
+		);
 	}
 
 	/**

--- a/page.php
+++ b/page.php
@@ -69,4 +69,10 @@ $context['og_description']          = $post->get_og_description();
 $context['og_image_data']           = $post->get_og_image();
 $context['custom_body_classes']     = 'brown-bg';
 
+// P4 Campaign/dataLayer fields.
+$context['cf_campaign_name'] = $page_meta_data['p4_campaign_name'][0] ?? '';
+$context['cf_basket_name']   = $page_meta_data['p4_basket_name'][0] ?? '';
+$context['cf_scope']         = $page_meta_data['p4_scope'][0] ?? '';
+$context['cf_department']    = $page_meta_data['p4_department'][0] ?? '';
+
 Timber::render( [ 'page-' . $post->post_name . '.twig', 'page.twig' ], $context );

--- a/templates/html-header.twig
+++ b/templates/html-header.twig
@@ -56,7 +56,7 @@
           }
 
           if ( google_tag_value ) {
-			window.dataLayer = window.dataLayer || [];
+			var dataLayer = window.dataLayer = window.dataLayer || [];
 			dataLayer.push({
 				'pageType' : '{{ page_category }}',
 				'signedIn' : 'false',
@@ -64,6 +64,20 @@
 				'userID' : '',
 				'post_tags': '{{ post_tags }}'
 			});
+
+			var cf_campaign_name = '{% if cf_campaign_name is defined and cf_campaign_name is not null %}{{ cf_campaign_name }}{% endif %}';
+			var cf_basket_name   = '{% if cf_basket_name is defined and cf_basket_name is not null %}{{ cf_basket_name }}{% endif %}';
+			var cf_scope         = '{% if cf_scope is defined and cf_scope is not null %}{{ cf_scope }}{% endif %}';
+			var cf_department    = '{% if cf_department is defined and cf_department is not null %}{{ cf_department }}{% endif %}';
+
+			if ( cf_campaign_name || cf_basket_name || cf_scope || cf_department ) {
+				dataLayer.push({
+					'gCampaign' : cf_campaign_name,
+					'gBasket' : cf_basket_name,
+					'gScope': cf_scope,
+					'gDepartment': cf_department,
+				});
+			}
           }
         </script>
         <script>


### PR DESCRIPTION
- Added new option(block) on P4 pages backend for campaign fields
- All fields are optional (no mandatory validation)
- The dataLayer push code is added in HTML `<head>` before GTM code
- The old dataLayer push code is removed from EN form block in separate PR
![image](https://user-images.githubusercontent.com/5357471/54996484-729a3e80-4fef-11e9-9cc0-27c27d9096e7.png)
