### PR TITLE
Planet-3256-fix: Add "Open in a new tab" for Page Header Link fields (Planet-3256)

### DIFF
--- a/classes/class-p4-master-site.php
+++ b/classes/class-p4-master-site.php
@@ -669,6 +669,15 @@ class P4_Master_Site extends TimberSite {
 
 		$p4_header->add_field(
 			[
+				'name' => __( 'New Tab', 'planet4-master-theme-backend' ),
+				'desc' => __( 'Open header button link in new tab', 'planet4-master-theme-backend' ),
+				'id'   => $prefix . 'button_link_checkbox',
+				'type' => 'checkbox',
+			]
+		);
+
+		$p4_header->add_field(
+			[
 				'name'         => __( 'Background overide', 'planet4-master-theme-backend' ),
 				'desc'         => __( 'Upload an image', 'planet4-master-theme-backend' ),
 				'id'           => 'background_image',

--- a/languages/planet4-master-theme-backend.pot
+++ b/languages/planet4-master-theme-backend.pot
@@ -66,6 +66,14 @@ msgstr ""
 msgid "Header button link comes here"
 msgstr ""
 
+#: functions.php:682
+msgid "New Tab"
+msgstr ""
+
+#: functions.php:683
+msgid "Open header button link in new tab"
+msgstr ""
+
 #: functions.php:689
 msgid "Background overide"
 msgstr ""

--- a/package-lock.json
+++ b/package-lock.json
@@ -3200,8 +3200,7 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -3616,8 +3615,7 @@
 				"safe-buffer": {
 					"version": "5.1.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -3673,7 +3671,6 @@
 					"version": "3.0.1",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -3717,14 +3714,12 @@
 				"wrappy": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"yallist": {
 					"version": "3.0.2",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				}
 			}
 		},

--- a/package-lock.json
+++ b/package-lock.json
@@ -3200,7 +3200,8 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -3615,7 +3616,8 @@
 				"safe-buffer": {
 					"version": "5.1.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -3671,6 +3673,7 @@
 					"version": "3.0.1",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -3714,12 +3717,14 @@
 				"wrappy": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"yallist": {
 					"version": "3.0.2",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				}
 			}
 		},

--- a/page-templates/evergreen.php
+++ b/page-templates/evergreen.php
@@ -40,14 +40,14 @@ if ( is_array( $page_tags ) && $page_tags ) {
 	$context['campaigns'] = $tags;
 }
 
-$context['post']                         = $post;
-$context['header_title']                 = is_front_page() ? '' : ( $page_meta_data['p4_title'][0] ?? $post->title );
-$context['header_subtitle']              = $page_meta_data['p4_subtitle'][0] ?? '';
-$context['header_description']           = wpautop( $page_meta_data['p4_description'][0] ) ?? '';
-$context['header_button_title']          = $page_meta_data['p4_button_title'][0] ?? '';
-$context['header_button_link']           = $page_meta_data['p4_button_link'][0] ?? '';
-$context['header_button_link_checkbox']  = $page_meta_data['p4_button_link_checkbox'];
-$context['background_image']             = wp_get_attachment_url( get_post_meta( get_the_ID(), 'background_image_id', 1 ) );
-$context['custom_body_classes']          = 'white-bg';
+$context['post']                        = $post;
+$context['header_title']                = is_front_page() ? '' : ( $page_meta_data['p4_title'][0] ?? $post->title );
+$context['header_subtitle']             = $page_meta_data['p4_subtitle'][0] ?? '';
+$context['header_description']          = wpautop( $page_meta_data['p4_description'][0] ) ?? '';
+$context['header_button_title']         = $page_meta_data['p4_button_title'][0] ?? '';
+$context['header_button_link']          = $page_meta_data['p4_button_link'][0] ?? '';
+$context['header_button_link_checkbox'] = $page_meta_data['p4_button_link_checkbox'];
+$context['background_image']            = wp_get_attachment_url( get_post_meta( get_the_ID(), 'background_image_id', 1 ) );
+$context['custom_body_classes']         = 'white-bg';
 
 Timber::render( [ 'evergreen.twig' ], $context );

--- a/page-templates/evergreen.php
+++ b/page-templates/evergreen.php
@@ -40,13 +40,14 @@ if ( is_array( $page_tags ) && $page_tags ) {
 	$context['campaigns'] = $tags;
 }
 
-$context['post']                = $post;
-$context['header_title']        = is_front_page() ? '' : ( $page_meta_data['p4_title'][0] ?? $post->title );
-$context['header_subtitle']     = $page_meta_data['p4_subtitle'][0] ?? '';
-$context['header_description']  = wpautop( $page_meta_data['p4_description'][0] ) ?? '';
-$context['header_button_title'] = $page_meta_data['p4_button_title'][0] ?? '';
-$context['header_button_link']  = $page_meta_data['p4_button_link'][0] ?? '';
-$context['background_image']    = wp_get_attachment_url( get_post_meta( get_the_ID(), 'background_image_id', 1 ) );
-$context['custom_body_classes'] = 'white-bg';
+$context['post']                         = $post;
+$context['header_title']                 = is_front_page() ? '' : ( $page_meta_data['p4_title'][0] ?? $post->title );
+$context['header_subtitle']              = $page_meta_data['p4_subtitle'][0] ?? '';
+$context['header_description']           = wpautop( $page_meta_data['p4_description'][0] ) ?? '';
+$context['header_button_title']          = $page_meta_data['p4_button_title'][0] ?? '';
+$context['header_button_link']           = $page_meta_data['p4_button_link'][0] ?? '';
+$context['header_button_link_checkbox']  = $page_meta_data['p4_button_link_checkbox'];
+$context['background_image']             = wp_get_attachment_url( get_post_meta( get_the_ID(), 'background_image_id', 1 ) );
+$context['custom_body_classes']          = 'white-bg';
 
 Timber::render( [ 'evergreen.twig' ], $context );

--- a/page.php
+++ b/page.php
@@ -51,16 +51,16 @@ if ( is_array( $page_tags ) && $page_tags ) {
 }
 
 
-$context['post']                         = $post;
-$context['header_title']                 = is_front_page() ? ( $page_meta_data['p4_title'][0] ?? '' ) : ( $page_meta_data['p4_title'][0] ?? $post->title );
-$context['header_subtitle']              = $page_meta_data['p4_subtitle'][0] ?? '';
-$context['header_description']           = wpautop( $page_meta_data['p4_description'][0] ?? '' );
-$context['header_button_title']          = $page_meta_data['p4_button_title'][0] ?? '';
-$context['header_button_link']           = $page_meta_data['p4_button_link'][0] ?? '';
-$context['header_button_link_checkbox']  = $page_meta_data['p4_button_link_checkbox'][0] ?? '';
-$context['page_category']                = is_front_page() ? 'Front Page' : ( $category->name ?? 'Unknown page' );
-$context['social_accounts']              = $post->get_social_accounts( $context['footer_social_menu'] );
-$context['post_tags']                    = implode( ', ', $post->tags() );
+$context['post']                        = $post;
+$context['header_title']                = is_front_page() ? ( $page_meta_data['p4_title'][0] ?? '' ) : ( $page_meta_data['p4_title'][0] ?? $post->title );
+$context['header_subtitle']             = $page_meta_data['p4_subtitle'][0] ?? '';
+$context['header_description']          = wpautop( $page_meta_data['p4_description'][0] ?? '' );
+$context['header_button_title']         = $page_meta_data['p4_button_title'][0] ?? '';
+$context['header_button_link']          = $page_meta_data['p4_button_link'][0] ?? '';
+$context['header_button_link_checkbox'] = $page_meta_data['p4_button_link_checkbox'][0] ?? '';
+$context['page_category']               = is_front_page() ? 'Front Page' : ( $category->name ?? 'Unknown page' );
+$context['social_accounts']             = $post->get_social_accounts( $context['footer_social_menu'] );
+$context['post_tags']                   = implode( ', ', $post->tags() );
 
 $background_image_id                = get_post_meta( get_the_ID(), 'background_image_id', 1 );
 $context['background_image']        = wp_get_attachment_url( $background_image_id );

--- a/page.php
+++ b/page.php
@@ -51,15 +51,16 @@ if ( is_array( $page_tags ) && $page_tags ) {
 }
 
 
-$context['post']                = $post;
-$context['header_title']        = is_front_page() ? ( $page_meta_data['p4_title'][0] ?? '' ) : ( $page_meta_data['p4_title'][0] ?? $post->title );
-$context['header_subtitle']     = $page_meta_data['p4_subtitle'][0] ?? '';
-$context['header_description']  = wpautop( $page_meta_data['p4_description'][0] ?? '' );
-$context['header_button_title'] = $page_meta_data['p4_button_title'][0] ?? '';
-$context['header_button_link']  = $page_meta_data['p4_button_link'][0] ?? '';
-$context['page_category']       = is_front_page() ? 'Front Page' : ( $category->name ?? 'Unknown page' );
-$context['social_accounts']     = $post->get_social_accounts( $context['footer_social_menu'] );
-$context['post_tags']           = implode( ', ', $post->tags() );
+$context['post']                         = $post;
+$context['header_title']                 = is_front_page() ? ( $page_meta_data['p4_title'][0] ?? '' ) : ( $page_meta_data['p4_title'][0] ?? $post->title );
+$context['header_subtitle']              = $page_meta_data['p4_subtitle'][0] ?? '';
+$context['header_description']           = wpautop( $page_meta_data['p4_description'][0] ?? '' );
+$context['header_button_title']          = $page_meta_data['p4_button_title'][0] ?? '';
+$context['header_button_link']           = $page_meta_data['p4_button_link'][0] ?? '';
+$context['header_button_link_checkbox']  = $page_meta_data['p4_button_link_checkbox'][0] ?? '';
+$context['page_category']                = is_front_page() ? 'Front Page' : ( $category->name ?? 'Unknown page' );
+$context['social_accounts']              = $post->get_social_accounts( $context['footer_social_menu'] );
+$context['post_tags']                    = implode( ', ', $post->tags() );
 
 $background_image_id                = get_post_meta( get_the_ID(), 'background_image_id', 1 );
 $context['background_image']        = wp_get_attachment_url( $background_image_id );

--- a/templates/blocks/header.twig
+++ b/templates/blocks/header.twig
@@ -43,7 +43,12 @@
 			{% if ( header_button_title and header_button_link ) %}
 				<div class="row">
 					<div class="col-md-4">
-						<a href="{{ header_button_link }}" class="btn btn-primary btn-medium page-header-btn">{{ header_button_title }}</a>
+						<p>{{ header_button_link_checkbox }}</p>
+						<a href="{{ header_button_link }}"
+						    {% if ( header_button_link_checkbox ) %}
+								target="_blank"
+							{% endif %}
+						   class="btn btn-primary btn-medium page-header-btn">{{ header_button_title }}</a>
 					</div>
 				</div>
 			{% endif %}

--- a/templates/blocks/header.twig
+++ b/templates/blocks/header.twig
@@ -45,10 +45,10 @@
 					<div class="col-md-4">
 						<p>{{ header_button_link_checkbox }}</p>
 						<a href="{{ header_button_link }}"
-						    {% if ( header_button_link_checkbox ) %}
-								target="_blank"
-							{% endif %}
-						   class="btn btn-primary btn-medium page-header-btn">{{ header_button_title }}</a>
+								{% if ( header_button_link_checkbox ) %}
+									target="_blank"
+								{% endif %}
+						class="btn btn-primary btn-medium page-header-btn">{{ header_button_title }}</a>
 					</div>
 				</div>
 			{% endif %}

--- a/templates/blocks/header.twig
+++ b/templates/blocks/header.twig
@@ -43,7 +43,6 @@
 			{% if ( header_button_title and header_button_link ) %}
 				<div class="row">
 					<div class="col-md-4">
-						<p>{{ header_button_link_checkbox }}</p>
 						<a href="{{ header_button_link }}"
 								{% if ( header_button_link_checkbox ) %}
 									target="_blank"


### PR DESCRIPTION
Removed test code still left in Planet-3256

Original Comment:

Checkbox added to header to choose whether to open header link in new tab or not.

Ticket requested to add checkbox alongside Header Button Title but that wasn't feasible so it was added below.

Ref: https://jira.greenpeace.org/browse/PLANET-3256