### PR TITLE
Planet-3256-fix: Removed test code in header.twig for planet-3256

### DIFF
--- a/templates/blocks/header.twig
+++ b/templates/blocks/header.twig
@@ -43,7 +43,6 @@
 			{% if ( header_button_title and header_button_link ) %}
 				<div class="row">
 					<div class="col-md-4">
-						<p>{{ header_button_link_checkbox }}</p>
 						<a href="{{ header_button_link }}"
 								{% if ( header_button_link_checkbox ) %}
 									target="_blank"


### PR DESCRIPTION
Original Ticket(planet-3256) Comment:

Checkbox added to header to choose whether to open header link in new tab or not.

Ticket requested to add checkbox alongside Header Button Title but that wasn't feasible so it was added below.

Ref: https://jira.greenpeace.org/browse/PLANET-3256