### PR TITLE
PLANET-3419 - Enable Timber template caching

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -24,6 +24,13 @@ if ( ! class_exists( 'Timber' ) ) {
 	);
 
 	return;
+} else {
+	# Enable Timber template cache unless this is a debug environment
+	if (defined('WP_DEBUG') && is_bool(WP_DEBUG)) {
+		Timber::$cache=!WP_DEBUG;
+	} else {
+		Timber::$cache=true;
+	}
 }
 
 require_once( __DIR__ . '/classes/class-p4-master-site.php' );

--- a/functions.php
+++ b/functions.php
@@ -25,11 +25,11 @@ if ( ! class_exists( 'Timber' ) ) {
 
 	return;
 } else {
-	# Enable Timber template cache unless this is a debug environment
-	if (defined('WP_DEBUG') && is_bool(WP_DEBUG)) {
-		Timber::$cache=!WP_DEBUG;
+	// Enable Timber template cache unless this is a debug environment
+	if ( defined('WP_DEBUG') && is_bool(WP_DEBUG) ) {
+		Timber::$cache = ! WP_DEBUG;
 	} else {
-		Timber::$cache=true;
+		Timber::$cache = true;
 	}
 }
 

--- a/functions.php
+++ b/functions.php
@@ -25,8 +25,8 @@ if ( ! class_exists( 'Timber' ) ) {
 
 	return;
 } else {
-	// Enable Timber template cache unless this is a debug environment
-	if ( defined('WP_DEBUG') && is_bool(WP_DEBUG) ) {
+	// Enable Timber template cache unless this is a debug environment.
+	if ( defined( 'WP_DEBUG' ) && is_bool( WP_DEBUG ) ) {
 		Timber::$cache = ! WP_DEBUG;
 	} else {
 		Timber::$cache = true;


### PR DESCRIPTION
Sets `Timber::$cache` to the inverse of `WP_DEBUG`

Enables Timber .twig > .php blob template caching for all non-development environments.

See: https://github.com/greenpeace/planet4-docker/blob/master/src/planet-4-151612/wordpress/wp-config.php.tmpl#L60

If APP_ENV matches `develop` then WP_DEBUG is true, therefore template caching is disabled and edits _should_ be immediately visible without cache clear.
