### PR TITLE
PLANET-3425 Hide the campaigns menu item until it is ready to be shown

### DIFF
--- a/classes/class-p4-post-campaign.php
+++ b/classes/class-p4-post-campaign.php
@@ -79,7 +79,7 @@ if ( ! class_exists( 'P4_Post_Campaign' ) ) {
 				'public'             => true,
 				'publicly_queryable' => true,
 				'show_ui'            => true,
-				'show_in_menu'       => true,
+				'show_in_menu'       => false,
 				'query_var'          => true,
 				'rewrite'            => [ 'slug' => 'campaign' ],
 				'capability_type'    => 'post',


### PR DESCRIPTION
As per product owners requirements, the campaigns functionality should be hidden until it is ready to be delivered. 