### PR TITLE
PLANET-3498 Show dev report of what repos/tags/branches are used

### DIFF
--- a/classes/class-p4-dev-report.php
+++ b/classes/class-p4-dev-report.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Settings Class
+ *
+ * @package P4MT
+ */
+
+if ( ! class_exists( 'P4_Dev_Report' ) ) {
+	/**
+	 * Class P4_Dev_Report
+	 */
+	class P4_Dev_Report {
+		/**
+		 * Option key, and option page slug
+		 *
+		 * @var string
+		 */
+		private $key = 'planet4_dev_report';
+
+		/**
+		 * Constructor
+		 */
+		public function __construct() {
+
+			// Set our title.
+			$this->title = 'Planet4 Dev Report';
+			$this->hooks();
+		}
+
+		/**
+		 * Register our setting to WP.
+		 */
+		public function init() {
+			register_setting( $this->key, $this->key );
+		}
+
+		/**
+		 * Initiate our hooks
+		 */
+		public function hooks() {
+			add_action( 'admin_init', [ $this, 'init' ] );
+			add_action( 'admin_menu', [ $this, 'add_options_page' ] );
+		}
+
+		/**
+		 * Add menu options page.
+		 */
+		public function add_options_page() {
+			$this->options_page = add_options_page( $this->title, $this->title, 'manage_options', $this->key, [ $this, 'admin_page_display' ] );
+		}
+
+		/**
+		 * Admin page markup. Mostly handled by CMB2.
+		 */
+		public function admin_page_display() {
+			echo '<h1>P4 Dev report</h1>' . "\n";
+			$gp_packages = get_option( 'greenpeace_packages' );
+
+			if ( $gp_packages ) {
+				foreach ( $gp_packages as $gp_package ) {
+					$url = $gp_package[2]['url'];
+					if ( '.git' === substr( $url, -4 ) ) {
+						$url = substr( $url, 0, -4 );
+					}
+					$url .= '/commit/' . $gp_package[2]['reference'];
+					echo '<h3>' . esc_html( $gp_package[0] ) . "</h3>\n";
+					echo '<p>Version (tag/branch): ' . esc_html( $gp_package[1] ) . "</p>\n";
+					echo "<p>Source repo: <a href='" . esc_url( $gp_package[2]['url'] ) . "'>" . esc_html( $gp_package[2]['url'] ) . "</a></p>\n";
+					echo "<p>Source hash: <a href='" . esc_url( $url ) . "'>" . esc_html( $gp_package[2]['reference'] ) . "</a></p>\n";
+
+				}
+			}
+		}
+	}
+}

--- a/functions.php
+++ b/functions.php
@@ -45,5 +45,6 @@ new P4_Master_Site(
 		'P4_Control_Panel',
 		'P4_Post_Report_Controller',
 		'P4_Cookies',
+		'P4_Dev_Report',
 	]
 );


### PR DESCRIPTION
This creates a new settings page, that only shows the p4 dev releated data if the relevant wp option exists (needs the [PR in base-fork](https://github.com/greenpeace/planet4-base-fork/pull/29) to have been merged, and run on deploys for the report to show)

The report can be seen at the [koyansync](https://k8s.p4.greenpeace.org/koyansync/wp-admin/options-general.php?page=planet4_dev_report) site