### PR TITLE
PLANET-2668: Automate testing of new versions of plugins using RIPPs on the cloud

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,8 +12,6 @@ workflows:
       - rips-test:
           context: rips-scans
           filters:
-            branches:
-              ignore: languages
             tags:
               only: /^v\p{Digit}+\.\p{Digit}+\.\p{Digit}+.*/
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,8 @@ workflows:
       - rips-test:
           context: rips-scans
           filters:
+            branches:
+              ignore: /.*/
             tags:
               only: /^v\p{Digit}+\.\p{Digit}+\.\p{Digit}+.*/
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,14 @@ workflows:
           filters:
             branches:
               ignore: languages
+      - rips-test:
+          context: rips-scans
+          filters:
+            branches:
+              ignore: languages
+            tags:
+              only: /^v\p{Digit}+\.\p{Digit}+\.\p{Digit}+.*/
+
 version: 2
 
 job-references:
@@ -136,3 +144,12 @@ jobs:
           name: Build - Notify failure
           when: on_fail
           command: notify-job-failure.sh
+
+  rips-test:
+    docker:
+      - image: rips/rips-cli:circleci
+    environment:
+      RIPS_APPLICATION_ID: 32
+    steps:
+      - checkout
+      - run: rips-cli -vvv rips:scan:start -a $RIPS_APPLICATION_ID -p ~/project/ -t 1


### PR DESCRIPTION
Add a config entry to automate the test of the master theme in RIPS.

Ref: https://jira.greenpeace.org/browse/PLANET-2668

See the related PR on the p4-builder repo: https://github.com/greenpeace/planet4-builder/pull/27
