### PR TITLE
Planet 2658 Campaign Export and Import with attachments

### DIFF
--- a/classes/class-p4-campaign-importer.php
+++ b/classes/class-p4-campaign-importer.php
@@ -112,10 +112,24 @@ if ( ! class_exists( 'P4_Campaign_Importer' ) ) {
 					$post_content = str_replace( $filter_data[0], $filter_data[1], $post_content );
 				}
 
+				// Update Page header fields background image in postmeta.
+				$campaign_postmeta = [];
+				if ( isset( $post['postmeta'] ) ) {
+					foreach ( $post['postmeta'] as $metakey => $metadata ) {
+						if ( 'background_image_id' === $metadata['key'] ) {
+							if ( isset( $attachment_mapping[ $metadata['value'] ] ) ) {
+								$post['postmeta'][ $metakey ]['value'] = $attachment_mapping[ $metadata['value'] ];
+							}
+						}
+					}
+					$campaign_postmeta = $post['postmeta'];
+				}
+
 				$updated_post = [
 					'ID'           => $post_id,
 					'post_title'   => $post['post_title'],
 					'post_content' => $post_content,
+					'postmeta'     => $campaign_postmeta,
 				];
 				wp_update_post( $updated_post );
 			}

--- a/classes/class-p4-campaign-importer.php
+++ b/classes/class-p4-campaign-importer.php
@@ -1,0 +1,153 @@
+<?php
+/**
+ * Campaign Data(Attachment) Importer
+ *
+ * @package P4MT
+ */
+
+if ( ! class_exists( 'P4_Campaign_Importer' ) ) {
+	/**
+	 * Class P4_Campaign_Importer.
+	 */
+	class P4_Campaign_Importer {
+		/**
+		 * AutoLoad Hooks
+		 * */
+		public function __construct() {
+			add_action( 'wp_import_insert_post', [ $this, 'update_campaign_attachements' ], 10, 4 );
+			add_filter( 'wp_import_post_terms', [ $this, 'filter_wp_import_post_terms' ], 10, 3 );
+			add_action( 'import_end', [ $this, 'action_import_end' ], 10, 0 );
+		}
+
+		/**
+		 * Filter the old attachement IDs from Campaign and replace them with the newly imported attachment Ids.
+		 *
+		 * @param integer $post_id Post ID.
+		 * @param integer $original_post_id Original Post ID.
+		 * @param array   $postdata Post data array.
+		 * @param array   $post Post array.
+		 */
+		public function update_campaign_attachements( $post_id, $original_post_id, $postdata, $post ) {
+			if ( 'campaign' === $post['post_type'] ) {
+				$post_content = $post['post_content'];
+				$old_ids      = [];
+				$filter_term  = [];
+
+				// wp-x-ID tags content.
+				preg_match_all( '#((wp-image-|wp-att-|attachment\_)(\d+))#', $post_content, $matches, PREG_SET_ORDER );
+				foreach ( $matches as $match ) {
+					$old_ids[]     = $match[3];
+					$filter_term[] = $match[1];
+				}
+
+				// shortcake image ID filter.
+				preg_match_all( '#\[shortcake\_[a-zA-Z0-9\_\"\'\-\s\:\/\/\=\.]*\s((multiple_image|background|video_poster_img)[=][\"|\']([\d\s\,]*)[\"|\'])#', $post_content, $matches, PREG_SET_ORDER );
+				foreach ( $matches as $match ) {
+					if ( 'multiple_image' === $match[2] ) {
+						$multiple_images = explode( ',', $match[3] );
+						$old_ids         = array_merge( $old_ids, $multiple_images );
+					} else {
+						$old_ids[] = $match[3];
+					}
+					$filter_term[] = $match[1];
+				}
+
+				// filter shortcake_carousel_header, shortcake_split_two_columns.
+				preg_match_all( '#\s((image_[0-9]*|issue_image|tag_image)[=][\"|\']([\d\s\,]*)[\"|\'])#', $post_content, $matches, PREG_SET_ORDER );
+				foreach ( $matches as $match ) {
+					$old_ids[]     = $match[3];
+					$filter_term[] = $match[1];
+				}
+
+				// [gallery] shortcode
+				preg_match_all( '#\[gallery\s+([ids=\"\']+([\d\s,]*)[\"\']).#', $post_content, $matches, PREG_SET_ORDER );
+				foreach ( $matches as $match ) {
+					foreach ( explode( ',', $match[2] ) as $id ) {
+						$old_ids[] = (int) $id;
+					}
+					$filter_term[] = $match[1];
+				}
+
+				$old_ids = array_unique( $old_ids );
+				sort( $old_ids );
+
+				global $wpdb;
+				$result = $wpdb->get_results( "SELECT post_id, meta_value FROM {$wpdb->postmeta} WHERE meta_key = '_wp_attachment_metadata' AND meta_value LIKE '%imported_attachment_id%'" );
+
+				$attachment_mapping = [];
+
+				foreach ( $result as $attachment_metadata ) {
+					$new_attachment_id                        = $attachment_metadata->post_id;
+					$attachment_data                          = maybe_unserialize( $attachment_metadata->meta_value );
+					$old_attachment_id                        = $attachment_data['image_meta']['imported_attachment_id'];
+					$attachment_mapping[ $old_attachment_id ] = $new_attachment_id;
+				}
+
+				$filter_data_array = [];
+				foreach ( $filter_term as $filter_str ) {
+					if ( strpos( $filter_str, 'multiple_image' ) !== false || strpos( $filter_str, 'ids' ) !== false ) {
+						$multiple_images_ids = $filter_str;
+						preg_match_all( '#(\d+)#', $multiple_images_ids, $matches, PREG_SET_ORDER );
+
+						foreach ( $matches as $old_id ) {
+							if ( isset( $attachment_mapping[ $old_id[0] ] ) ) {
+								$multiple_images_ids = str_replace( $old_id, $attachment_mapping[ $old_id[0] ], $multiple_images_ids );
+							}
+						}
+						$filter_data_array[] = [ $filter_str, $multiple_images_ids ];
+					} else {
+						foreach ( $attachment_mapping as $old_id => $new_id ) {
+							$updated_str = str_replace( $old_id, $new_id, $filter_str );
+							if ( $updated_str !== $filter_str ) {
+								$filter_data_array[] = [ $filter_str, $updated_str ];
+							}
+						}
+					}
+				}
+
+				foreach ( $filter_data_array as $filter_data ) {
+					$post_content = str_replace( $filter_data[0], $filter_data[1], $post_content );
+				}
+
+				$updated_post = [
+					'ID'           => $post_id,
+					'post_title'   => $post['post_title'],
+					'post_content' => $post_content,
+				];
+				wp_update_post( $updated_post );
+			}
+		}
+
+		/**
+		 * Update campaign attachement source ID in attachment metadata for future data mapping purpose.
+		 *
+		 * @param array   $post_terms Post term array.
+		 * @param integer $post_id Post ID.
+		 * @param object  $post Post object.
+		 * @return array  $post_terms Post term array.
+		 */
+		public function filter_wp_import_post_terms( $post_terms, $post_id, $post ) {
+			if ( 'attachment' === $post['post_type'] ) {
+				$attachment_metadata = wp_get_attachment_metadata( $post_id );
+				$attachment_metadata['image_meta']['imported_attachment_id'] = $post['post_id'];
+				wp_update_attachment_metadata( $post_id, $attachment_metadata );
+			}
+
+			return $post_terms;
+		}
+
+		/**
+		 * Clean the campaign attachment metadata.
+		 */
+		public function action_import_end() {
+			global $wpdb;
+			$result = $wpdb->get_results( "SELECT post_id, meta_value FROM {$wpdb->postmeta} WHERE meta_key = '_wp_attachment_metadata' AND meta_value LIKE '%imported_attachment_id%'" );
+
+			foreach ( $result as $attachment_metadata ) {
+				$attachment_data = maybe_unserialize( $attachment_metadata->meta_value );
+				unset( $attachment_data['image_meta']['imported_attachment_id'] );
+				wp_update_attachment_metadata( $attachment_metadata->post_id, $attachment_data );
+			}
+		}
+	}
+}

--- a/classes/class-p4-campaign-importer.php
+++ b/classes/class-p4-campaign-importer.php
@@ -10,6 +10,14 @@ if ( ! class_exists( 'P4_Campaign_Importer' ) ) {
 	 * Class P4_Campaign_Importer.
 	 */
 	class P4_Campaign_Importer {
+
+		/**
+		 * Old and new attachment ids mapping var
+		 *
+		 * @var array $attachment_mapping
+		 */
+		private $attachment_mapping = [];
+
 		/**
 		 * AutoLoad Hooks
 		 * */
@@ -30,85 +38,74 @@ if ( ! class_exists( 'P4_Campaign_Importer' ) ) {
 		public function update_campaign_attachements( $post_id, $original_post_id, $postdata, $post ) {
 			if ( 'campaign' === $post['post_type'] ) {
 				$post_content = $post['post_content'];
-				$old_ids      = [];
-				$filter_term  = [];
+				$filter_data  = [];
 
 				// Filter attachment ids from caption.
 				preg_match_all( '#((wp-image-|wp-att-|attachment\_)(\d+))#', $post_content, $matches, PREG_SET_ORDER );
 				foreach ( $matches as $match ) {
-					$old_ids[]     = $match[3];
-					$filter_term[] = $match[1];
+					$filter_data[] = $match[1];
 				}
 
 				// Filter attachment ids from shortcake code(shortcake_gallery, shortcake_happy_point, shortcake_media_video).
 				preg_match_all( '#\[shortcake\_[a-zA-Z0-9\_\"\'\-\s\:\/\/\=\.\?\&]*\s((multiple_image|background|video_poster_img)[=][\"|\']([\d\s\,]*)[\"|\'])#', $post_content, $matches, PREG_SET_ORDER );
 				foreach ( $matches as $match ) {
-					if ( 'multiple_image' === $match[2] ) {
-						$multiple_images = explode( ',', $match[3] );
-						$old_ids         = array_merge( $old_ids, $multiple_images );
-					} else {
-						$old_ids[] = $match[3];
-					}
-					$filter_term[] = $match[1];
+					$filter_data[] = $match[1];
 				}
 
 				// Filter attachment ids from shortcake code(shortcake_carousel_header, shortcake_split_two_columns, shortcake_columns).
 				preg_match_all( '#\s((image_[0-9]*|attachment_[0-9]*|issue_image|tag_image)[=][\"|\']([\d\s\,]*)[\"|\'])#', $post_content, $matches, PREG_SET_ORDER );
 				foreach ( $matches as $match ) {
-					$old_ids[]     = $match[3];
-					$filter_term[] = $match[1];
+					$filter_data[] = $match[1];
 				}
 
 				// Filter attachment ids from [gallery] shortcode.
 				preg_match_all( '#\[gallery\s+([ids=\"\']+([\d\s,]*)[\"\']).#', $post_content, $matches, PREG_SET_ORDER );
 				foreach ( $matches as $match ) {
-					foreach ( explode( ',', $match[2] ) as $id ) {
-						$old_ids[] = (int) $id;
+					$filter_data[] = $match[1];
+				}
+
+				// Check if attachement mapping var is empty and update it.
+				if ( empty( $this->attachment_mapping ) ) {
+
+					global $wpdb;
+
+					// phpcs:disable
+					$result = $wpdb->get_results( "SELECT post_id, meta_value FROM {$wpdb->postmeta} WHERE meta_key = '_wp_attachment_metadata' AND meta_value LIKE '%imported_attachment_id%'" );
+					// phpcs:enable
+
+					foreach ( $result as $attachment_metadata ) {
+						$new_attachment_id                              = $attachment_metadata->post_id;
+						$attachment_data                                = maybe_unserialize( $attachment_metadata->meta_value );
+						$old_attachment_id                              = $attachment_data['image_meta']['imported_attachment_id'];
+						$this->attachment_mapping[ $old_attachment_id ] = $new_attachment_id;
 					}
-					$filter_term[] = $match[1];
 				}
 
-				$old_ids = array_unique( $old_ids );
-				sort( $old_ids );
-
-				global $wpdb;
-
-				// phpcs:disable
-				$result = $wpdb->get_results( "SELECT post_id, meta_value FROM {$wpdb->postmeta} WHERE meta_key = '_wp_attachment_metadata' AND meta_value LIKE '%imported_attachment_id%'" );
-				// phpcs:enable
-
-				$attachment_mapping = [];
-
-				foreach ( $result as $attachment_metadata ) {
-					$new_attachment_id                        = $attachment_metadata->post_id;
-					$attachment_data                          = maybe_unserialize( $attachment_metadata->meta_value );
-					$old_attachment_id                        = $attachment_data['image_meta']['imported_attachment_id'];
-					$attachment_mapping[ $old_attachment_id ] = $new_attachment_id;
-				}
-
-				$filter_data_array = [];
-				foreach ( $filter_term as $filter_str ) {
+				// Old ids and new ids(attachment ids) string data mapping.
+				$filter_data_mapping = [];
+				foreach ( $filter_data as $filter_str ) {
 					if ( strpos( $filter_str, 'multiple_image' ) !== false || strpos( $filter_str, 'ids' ) !== false ) {
-						$multiple_images_ids = $filter_str;
-						preg_match_all( '#(\d+)#', $multiple_images_ids, $matches, PREG_SET_ORDER );
+						$new_filter_str = $filter_str;
+						preg_match_all( '#(\d+)#', $new_filter_str, $matches, PREG_SET_ORDER );
 
 						foreach ( $matches as $old_id ) {
-							if ( isset( $attachment_mapping[ $old_id[0] ] ) ) {
-								$multiple_images_ids = str_replace( $old_id, $attachment_mapping[ $old_id[0] ], $multiple_images_ids );
+							if ( isset( $this->attachment_mapping[ $old_id[0] ] ) ) {
+								$new_filter_str = str_replace( $old_id[0], $this->attachment_mapping[ $old_id[0] ], $new_filter_str );
 							}
 						}
-						$filter_data_array[] = [ $filter_str, $multiple_images_ids ];
+						$filter_data_mapping[] = [ $filter_str, $new_filter_str ];
 					} else {
-						foreach ( $attachment_mapping as $old_id => $new_id ) {
+						foreach ( $this->attachment_mapping as $old_id => $new_id ) {
 							$updated_str = str_replace( $old_id, $new_id, $filter_str );
 							if ( $updated_str !== $filter_str ) {
-								$filter_data_array[] = [ $filter_str, $updated_str ];
+								$filter_data_mapping[] = [ $filter_str, $updated_str ];
 							}
 						}
 					}
 				}
 
-				foreach ( $filter_data_array as $filter_data ) {
+				// Search replace filter data string(with old attachement ids) with updated attachment ids string.
+				foreach ( $filter_data_mapping as $filter_data ) {
 					$post_content = str_replace( $filter_data[0], $filter_data[1], $post_content );
 				}
 
@@ -117,8 +114,8 @@ if ( ! class_exists( 'P4_Campaign_Importer' ) ) {
 				if ( isset( $post['postmeta'] ) ) {
 					foreach ( $post['postmeta'] as $metakey => $metadata ) {
 						if ( 'background_image_id' === $metadata['key'] ) {
-							if ( isset( $attachment_mapping[ $metadata['value'] ] ) ) {
-								$post['postmeta'][ $metakey ]['value'] = $attachment_mapping[ $metadata['value'] ];
+							if ( isset( $this->attachment_mapping[ $metadata['value'] ] ) ) {
+								$post['postmeta'][ $metakey ]['value'] = $this->attachment_mapping[ $metadata['value'] ];
 							}
 						}
 					}
@@ -148,6 +145,10 @@ if ( ! class_exists( 'P4_Campaign_Importer' ) ) {
 				$attachment_metadata = wp_get_attachment_metadata( $post_id );
 				$attachment_metadata['image_meta']['imported_attachment_id'] = $post['post_id'];
 				wp_update_attachment_metadata( $post_id, $attachment_metadata );
+
+				if ( ! empty( $this->attachment_mapping ) ) {
+					$this->attachment_mapping = [];
+				}
 			}
 
 			return $post_terms;

--- a/exporter-helper.php
+++ b/exporter-helper.php
@@ -30,7 +30,7 @@ function get_campaign_attachments( $post_ids ) {
 	 */
 	if ( $post_ids ) {
 		// phpcs:disable
-		$ids = $wpdb->get_col( sprintf( "SELECT meta_value FROM {$wpdb->postmeta} WHERE meta_key = '_thumbnail_id' AND post_id IN(%s)", implode( ',', $post_ids ) ) );
+		$ids = $wpdb->get_col( sprintf( "SELECT meta_value FROM {$wpdb->postmeta} WHERE ( meta_key = '_thumbnail_id' or meta_key = 'background_image_id' ) AND post_id IN(%s)", implode( ',', $post_ids ) ) );
 		// phpcs:enable
 	}
 

--- a/exporter-helper.php
+++ b/exporter-helper.php
@@ -23,14 +23,14 @@ function get_campaign_attachments( $post_ids ) {
 		return $post_ids;
 	}
 
-	$ids = [];
+	$attachment_ids = [];
 
 	/**
 	 * Post thumbnails
 	 */
 	if ( $post_ids ) {
 		// phpcs:disable
-		$ids = $wpdb->get_col( sprintf( "SELECT meta_value FROM {$wpdb->postmeta} WHERE ( meta_key = '_thumbnail_id' or meta_key = 'background_image_id' ) AND post_id IN(%s)", implode( ',', $post_ids ) ) );
+		$attachment_ids = $wpdb->get_col( sprintf( "SELECT meta_value FROM {$wpdb->postmeta} WHERE ( meta_key = '_thumbnail_id' or meta_key = 'background_image_id' ) AND post_id IN(%s)", implode( ',', $post_ids ) ) );
 		// phpcs:enable
 	}
 
@@ -39,7 +39,7 @@ function get_campaign_attachments( $post_ids ) {
 	 */
 	foreach ( $attachments as $id => $att ) {
 		if ( in_array( $att->post_parent, $post_ids, true ) ) {
-			$ids[] = $id;
+			$attachment_ids[] = $id;
 		}
 	}
 
@@ -50,7 +50,7 @@ function get_campaign_attachments( $post_ids ) {
 		// Filter attachment ids from caption.
 		preg_match_all( '#(wp-image-|wp-att-|attachment\_)(\d+)#', $text, $matches, PREG_SET_ORDER );
 		foreach ( $matches as $match ) {
-			$ids[] = $match[2];
+			$attachment_ids[] = $match[2];
 		}
 
 		// Filter attachment ids from shortcake code(shortcake_gallery, shortcake_happy_point, shortcake_media_video).
@@ -58,33 +58,33 @@ function get_campaign_attachments( $post_ids ) {
 		foreach ( $matches as $match ) {
 			if ( 'multiple_image' === $match[1] ) {
 				$multiple_images = explode( ',', $match[2] );
-				$ids             = array_merge( $ids, $multiple_images );
+				$attachment_ids  = array_merge( $attachment_ids, $multiple_images );
 			} else {
-				$ids[] = $match[2];
+				$attachment_ids[] = $match[2];
 			}
 		}
 
 		// Filter attachment ids from shortcake code(shortcake_carousel_header, shortcake_split_two_columns, shortcake_columns).
 		preg_match_all( '#\s(image_[0-9]*|attachment_[0-9]*|issue_image|tag_image)[=][\"|\']([\d\s\,]*)[\"|\']#', $text, $matches, PREG_SET_ORDER );
 		foreach ( $matches as $match ) {
-			$ids[] = $match[2];
+			$attachment_ids[] = $match[2];
 		}
 
 		// Filter attachment ids from [gallery] shortcode.
 		preg_match_all( '#\[gallery\s+[ids=\"\']+([\d\s,]*)[\"\'].#', $text, $matches, PREG_SET_ORDER );
 		foreach ( $matches as $match ) {
 			foreach ( explode( ',', $match[1] ) as $id ) {
-				$ids[] = (int) $id;
+				$attachment_ids[] = (int) $id;
 			}
 		}
 	}
 
-	$ids = array_unique( $ids );
-	sort( $ids );
+	$attachment_ids = array_unique( $attachment_ids );
+	sort( $attachment_ids );
 
 	// The post ids are reorderd as sort all attachment ids first and then append the post id to array.(Added for simplification of import process).
-	$ids      = array_diff( $ids, $post_ids );
-	$post_ids = array_merge( $ids, $post_ids );
+	$attachment_ids = array_diff( $attachment_ids, $post_ids );
+	$post_ids       = array_merge( $attachment_ids, $post_ids );
 
 	return $post_ids;
 }

--- a/exporter-helper.php
+++ b/exporter-helper.php
@@ -8,8 +8,8 @@
 /**
  * Returns all attachment ids from campaign post content.
  *
- * @param string $post_ids Post IDs.
- * @return string  $post_ids Post IDs.
+ * @param array $post_ids Post IDs.
+ * @return array  $post_ids Post IDs.
  */
 function get_campaign_attachments( $post_ids ) {
 

--- a/exporter.php
+++ b/exporter.php
@@ -276,8 +276,8 @@ add_filter( 'p4_px_single_post_export_skip_postmeta', 'p4_px_single_post_filter_
 
 $post_id = explode( ',', $_GET['post'] );
 
-// Add campaign related attachements in XML file.
-require_once 'exporter_helper.php';
+// Add campaign attachements in XML file.
+require_once 'exporter-helper.php';
 $post_id = get_campaign_attachments( $post_id );
 
 echo '<?xml version="1.0" encoding="' . get_bloginfo( 'charset' ) . "\" ?>\n";

--- a/exporter.php
+++ b/exporter.php
@@ -276,6 +276,10 @@ add_filter( 'p4_px_single_post_export_skip_postmeta', 'p4_px_single_post_filter_
 
 $post_id = explode( ',', $_GET['post'] );
 
+// Add campaign related attachements in XML file.
+require_once 'exporter_helper.php';
+$post_id = get_campaign_attachments( $post_id );
+
 echo '<?xml version="1.0" encoding="' . get_bloginfo( 'charset' ) . "\" ?>\n";
 
 ?>

--- a/exporter_helper.php
+++ b/exporter_helper.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Post Exporter Helper Function
+ *
+ * @package P4MT
+ */
+
+/**
+ * Returns all attachment ids from campaign post content.
+ *
+ * @param integer $post_ids Post ID.
+ */
+function get_campaign_attachments( $post_ids ) {
+
+	global $wpdb;
+
+	$attachments = $wpdb->get_results( "SELECT ID, guid, post_parent FROM {$wpdb->posts} WHERE post_type = 'attachment'", OBJECT_K );
+	if ( empty( $attachments ) ) {
+		return $post_ids;
+	}
+
+	$ids = array();
+
+	/**
+	 * Post thumbnails
+	 */
+	if ( $post_ids ) {
+		$ids = $wpdb->get_col( sprintf( "SELECT meta_value FROM {$wpdb->postmeta} WHERE meta_key = '_thumbnail_id' AND post_id IN(%s)", implode( ',', $post_ids ) ) );
+	}
+
+	/**
+	 * Uploaded to (post_parent)
+	 */
+	foreach ( $attachments as $id => $att ) {
+		if ( in_array( $att->post_parent, $post_ids ) ) {
+			$ids[] = $id;
+		}
+	}
+
+	foreach ( $wpdb->get_col( "SELECT post_content FROM {$wpdb->posts} WHERE ID IN( " . implode( ',', $post_ids ) . " ) AND post_content REGEXP '((wp-image-|wp-att-)[0-9][0-9]*)|\\\[gallery |href=|src='" ) as $text ) {
+
+		// wp-x-ID tags content.
+		preg_match_all( '#(wp-image-|wp-att-)(\d+)#', $text, $matches, PREG_SET_ORDER );
+		foreach ( $matches as $match ) {
+			$ids[] = $match[2];
+		}
+
+		// shortcake image ID filter.
+		preg_match_all( '#\[shortcake\_[a-zA-Z0-9\_\"\'\-\s\:\/\/\=\.]*\s(multiple_image|background|video_poster_img)[=][\"|\']([\d\s\,]*)[\"|\']#', $text, $matches, PREG_SET_ORDER );
+		foreach ( $matches as $match ) {
+			if ( 'multiple_image' === $match[1] ) {
+				$multiple_images = explode( ',', $match[2] );
+				$ids             = array_merge( $ids, $multiple_images );
+			} else {
+				$ids[] = $match[2];
+			}
+		}
+
+		// filter shortcake_carousel_header, shortcake_split_two_columns.
+		preg_match_all( '#\s(image_[0-9]*|issue_image|tag_image)[=][\"|\']([\d\s\,]*)[\"|\']#', $text, $matches, PREG_SET_ORDER );
+		foreach ( $matches as $match ) {
+			$ids[] = $match[2];
+		}
+
+		// [gallery] shortcode.
+		preg_match_all( '#\[gallery\s+[ids=\"\']+([\d\s,]*)[\"\'].#', $text, $matches, PREG_SET_ORDER );
+		foreach ( $matches as $match ) {
+			foreach ( explode( ',', $match[1] ) as $id ) {
+				$ids[] = (int) $id;
+			}
+		}
+	}
+
+	$ids = array_unique( $ids );
+	sort( $ids );
+
+	// The post ids are reorderd as sort all attachment ids first and then append the post id to array.(Added for simplification of import process).
+	$ids      = array_diff( $ids, $post_ids );
+	$post_ids = array_merge( $ids, $post_ids );
+
+	return $post_ids;
+}

--- a/functions.php
+++ b/functions.php
@@ -42,6 +42,7 @@ new P4_Master_Site(
 		'P4_Campaigns',
 		'P4_Post_Campaign',
 		'P4_Campaign_Exporter',
+		'P4_Campaign_Importer',
 		'P4_Settings',
 		'P4_Control_Panel',
 		'P4_Post_Report_Controller',

--- a/functions.php
+++ b/functions.php
@@ -35,18 +35,32 @@ if ( ! class_exists( 'Timber' ) ) {
 
 require_once( __DIR__ . '/classes/class-p4-master-site.php' );
 
+$services = [
+	'P4_Metabox_Register',
+	'P4_Custom_Taxonomy',
+	'P4_Campaigns',
+	'P4_Post_Campaign',
+	'P4_Settings',
+	'P4_Control_Panel',
+	'P4_Post_Report_Controller',
+	'P4_Cookies',
+	'P4_Dev_Report',
+];
+
+if ( is_admin() ) {
+	// Load `P4_Campaign_Exporter` class on admin campaign listing page and campaign export only.
+	if ( 'campaign' === filter_input( INPUT_GET, 'post_type', FILTER_SANITIZE_STRING ) || 'export_data' === filter_input( INPUT_GET, 'action', FILTER_SANITIZE_STRING ) ) {
+		$services[] = 'P4_Campaign_Exporter';
+	}
+
+	// Load `P4_Campaign_Importer` class on admin campaign import only.
+	// phpcs:disable
+	if ( 'wordpress' === filter_input( INPUT_GET, 'import', FILTER_SANITIZE_STRING ) ) {
+	// phpcs:enable
+		$services[] = 'P4_Campaign_Importer';
+	}
+}
+
 new P4_Master_Site(
-	[
-		'P4_Metabox_Register',
-		'P4_Custom_Taxonomy',
-		'P4_Campaigns',
-		'P4_Post_Campaign',
-		'P4_Campaign_Exporter',
-		'P4_Campaign_Importer',
-		'P4_Settings',
-		'P4_Control_Panel',
-		'P4_Post_Report_Controller',
-		'P4_Cookies',
-		'P4_Dev_Report',
-	]
+	$services
 );


### PR DESCRIPTION
[JIRA 2658](https://jira.greenpeace.org/browse/PLANET-2658)

On export of campaign, export all attachment data in XML file.

On campaign import, import attachments and update all source image ids with newly imported attachment ids in post content.

The `planet-2658` branch is pinned to `koyansync` and `campaign` instances.

Example -
Exported campaign from `campaigns` instance :
https://k8s.p4.greenpeace.org/campaigns/campaign/test-campaign-export/
Imported campaign on `koyansync` instance:
https://k8s.p4.greenpeace.org/koyansync/campaign/test-campaign-export/