### PR TITLE
PLANET-2402 Use wp api load promise to initiliaze post report js

### DIFF
--- a/assets/js/posts_report.js
+++ b/assets/js/posts_report.js
@@ -1,3 +1,5 @@
+/* global jQuery, wp */
+
 var postCollection,
   pageCollection,
   postsView,
@@ -8,6 +10,10 @@ var p4_data = p4_data || {};
 var wp = window.wp || {};
 
 (function ($) {
+
+  if ('undefined' === wp.api) {
+    return;
+  }
 
   $(document).ready(function () {
     $('#from').datepicker({
@@ -177,7 +183,8 @@ var wp = window.wp || {};
     $('#pages-table').html(pagesView.render().el);
   };
 
-  $(document).ready(function () {
+  // Initialize page when wp api client has finished loading.
+  wp.api.loadPromise.done(function () {
     p4.initialize();
   });
 })(jQuery);


### PR DESCRIPTION
Use wp api load promise to wait for wp backbone js client to load, before initializing post report backbone views/collections.