### PR TITLE
PLANET-3320: Add a new dataLayer field (Goal) on Form Block backend

### DIFF
--- a/classes/class-p4-metabox-register.php
+++ b/classes/class-p4-metabox-register.php
@@ -359,26 +359,6 @@ class P4_Metabox_Register {
 			]
 		);
 
-		$goal_options = [
-			'not set'         => __( '- Select Goal -', 'planet4-master-theme-backend' ),
-			'Petition Signup' => 'Petition Signup',
-			'Action Alert'    => 'Action Alert',
-			'Contact Form'    => 'Contact Form',
-			'Other'           => 'Other',
-		];
-
-		$p4_campaign_fields->add_field(
-			[
-				'name'       => __( 'Goal', 'planet4-master-theme-backend' ),
-				'id'         => $this->prefix . 'goal',
-				'type'       => 'select',
-				'options'    => $goal_options,
-				'attributes' => [
-					'data-validation' => 'required',
-				],
-			]
-		);
-
 		$p4_campaign_fields->add_field(
 			[
 				'name'       => __( 'Department', 'planet4-master-theme-backend' ),


### PR DESCRIPTION
This removes all references to the Goal field on the master theme as it needs to live on the EN form. I got the requirements wrong the first time.

Ref: https://jira.greenpeace.org/browse/PLANET-3320