### PR TITLE
PLANET-3293 show correct author for replied reatributed comments

### DIFF
--- a/templates/child_comments.twig
+++ b/templates/child_comments.twig
@@ -1,7 +1,7 @@
 <article class="single-comment {{ comment.comment_type }} comment-level-{{ comment.depth }}" id="comment-{{ comment.ID }}" >
 	<p itemprop="commentText" class="single-comment-text">{{ comment.comment_content|wpautop|striptags( '<br>,<p>' )|raw }}</p>
 	<footer class="single-comment-meta">
-		<span class="author-info" itemprop="author">{{ comment.author.name }}</span>
+		<span class="author-info" itemprop="author">{{ comment.comment_author }}</span>
 		<time datetime="" class="comment-date" itemprop="commentTime">{{ comment.date }}</time>
 		{# Add custom css classes to reply button #}
 		{% if ( comment.depth < p4_comments_depth ) %}


### PR DESCRIPTION
As in https://github.com/greenpeace/planet4-master-theme/pull/805 , show the correct author for comments that have been reattributed. Previous fix was doing only first level comments. This one does all the other levels (that use a different twig template) 