### PR TITLE
PLANET-3583 - Added show_admin_column argument to page-type taxonomy

### DIFF
--- a/classes/class-p4-custom-taxonomy.php
+++ b/classes/class-p4-custom-taxonomy.php
@@ -218,14 +218,15 @@ if ( ! class_exists( 'P4_Custom_Taxonomy' ) ) {
 			];
 
 			$args = [
-				'hierarchical' => false,
-				'labels'       => $p4_page_type,
-				'rewrite'      => [
+				'hierarchical'      => false,
+				'labels'            => $p4_page_type,
+				'rewrite'           => [
 					'slug' => self::TAXONOMY_SLUG,
 				],
-				'show_ui'      => true,
-				'query_var'    => true,
-				'meta_box_cb'  => [ $this, 'create_taxonomy_metabox_markup' ],
+				'show_ui'           => true,
+				'show_admin_column' => true,
+				'query_var'         => true,
+				'meta_box_cb'       => [ $this, 'create_taxonomy_metabox_markup' ],
 			];
 
 			register_taxonomy( self::TAXONOMY, [ self::TAXONOMY_PARAMETER, 'post' ], $args );


### PR DESCRIPTION
This will add an additional column to the posts list that contains the post type, like the second last column in the screenshot:

![additional-column](https://user-images.githubusercontent.com/46678842/58539355-7a48b000-81f7-11e9-8519-93722a29602d.png)

Clicking the post type will filter the list. 

Related Wordpress documentation is here:
https://codex.wordpress.org/Function_Reference/register_taxonomy#Arguments