### PR TITLE
PLANET-3812: Fixed login URL for password protected pages

### DIFF
--- a/page.php
+++ b/page.php
@@ -80,6 +80,8 @@ $context['cf_scope']         = $page_meta_data['p4_scope'][0] ?? '';
 $context['cf_department']    = $page_meta_data['p4_department'][0] ?? '';
 
 if ( post_password_required( $post->ID ) ) {
+	$context['login_url'] = wp_login_url();
+
 	Timber::render( 'single-page.twig', $context );
 } else {
 	Timber::render( [ 'page-' . $post->post_name . '.twig', 'page.twig' ], $context );

--- a/single.php
+++ b/single.php
@@ -94,6 +94,8 @@ $context['post_comments_count'] = get_comments(
 $context['post_tags'] = implode( ', ', $post->tags() );
 
 if ( post_password_required( $post->ID ) ) {
+	$context['login_url'] = wp_login_url();
+
 	Timber::render( 'single-password.twig', $context );
 } else {
 	Timber::render( [ 'single-' . $post->ID . '.twig', 'single-' . $post->post_type . '.twig', 'single.twig' ], $context );

--- a/templates/single-page.twig
+++ b/templates/single-page.twig
@@ -3,7 +3,7 @@
 {% block content %}
 	<div class="page-template">
 
-		<form id="password-form" class="mb-5" action="{{site.link}}/wp-login.php?action=postpass" method="post">
+		<form id="password-form" class="mb-5" action="{{login_url}}?action=postpass" method="post">
 			<div class="form-group">
 				<label for="pwbox-{{post.ID}}">{{ __( 'Password', 'planet4-master-theme' ) }}:</label>
 				<input class="form-control" name="post_password" id="pwbox-{{post.ID}}" type="password" size="20" maxlength="20">

--- a/templates/single-password.twig
+++ b/templates/single-password.twig
@@ -16,7 +16,7 @@
 			<div class="post-content">
 				<div class="post-content-lead">
 
-					<form id="password-form" class="mb-5" action="{{site.link}}/wp-login.php?action=postpass" method="post">
+					<form id="password-form" class="mb-5" action="{{login_url}}?action=postpass" method="post">
 						<div class="form-group">
 							<label for="pwbox-{{post.ID}}">{{ __( 'Password', 'planet4-master-theme' ) }}:</label>
 							<input class="form-control" name="post_password" id="pwbox-{{post.ID}}" type="password" size="20" maxlength="20">


### PR DESCRIPTION
Changed the login URL for password protected posts and pages to use wp_login_url() instead of Timber's site.link.

[site.link](https://timber.github.io/docs/reference/timber-site/#link) points to the home page and with WPML installed, that includes for example /en/ for the language. Using it to generate the login URL won't work in those cases and leads to a 404 error.

[wp_login_url()](https://codex.wordpress.org/Function_Reference/wp_login_url) returns the URL of the login page and is more reliable in special cases like this one. 