### PR TITLE
Allow p4 custom taxonomy to be queried by rest api requests

### DIFF
--- a/classes/class-p4-custom-taxonomy.php
+++ b/classes/class-p4-custom-taxonomy.php
@@ -226,6 +226,7 @@ if ( ! class_exists( 'P4_Custom_Taxonomy' ) ) {
 				'rewrite'           => [
 					'slug' => self::TAXONOMY_SLUG,
 				],
+				'show_in_rest'      => true,
 				'show_ui'           => true,
 				'show_admin_column' => true,
 				'query_var'         => true,


### PR DESCRIPTION
It is needed for gutenberg blocks to be able to query the taxonomy's terms.