### PR TITLE
PLANET-3857 search exclude tag pages

### DIFF
--- a/classes/class-p4-campaigns.php
+++ b/classes/class-p4-campaigns.php
@@ -241,14 +241,14 @@ if ( ! class_exists( 'P4_Campaigns' ) ) {
 				$happypoint_bg_opacity = 30;
 			}
 
-			$redirect_page = $_POST['redirect_page'] ?? 0;
-			if ( ! is_null( get_post( $redirect_page ) ) && 0 != $redirect_page ) {
+			$redirect_page = filter_input( INPUT_POST, 'redirect_page', FILTER_VALIDATE_INT ) ?? 0;
+			if ( $redirect_page ) {
 				update_term_meta( $term_id, 'redirect_page', $redirect_page );
 			} else {
 
 				$tag_data = get_term( $term_id );
 
-				if ( WP_Error != $tag_data ) {
+				if ( $tag_data instanceof \WP_Term ) {
 					$post_content = '[shortcake_newcovers cover_type="1" tags="' . $term_id . '" covers_view="0" title="' . __( 'Things you can do', 'planet4-master-theme' ) . '"  description="' . __( 'We want you to take action because together we\'re strong.', 'planet4-master-theme' ) . '" /]
 
 [shortcake_articles tags="' . $term_id . '" ignore_categories="false" /]
@@ -268,6 +268,7 @@ if ( ! class_exists( 'P4_Campaigns' ) ) {
 					$tag_page_id = wp_insert_post( $my_post );
 					if ( is_int( $tag_page_id ) ) {
 						update_post_meta( $tag_page_id, 'p4_description', $tag_data->description );
+						update_post_meta( $tag_page_id, 'p4_do_not_index', true );
 					}
 
 					if ( $tag_attachment_id ) {

--- a/classes/class-p4-search.php
+++ b/classes/class-p4-search.php
@@ -332,6 +332,27 @@ if ( ! class_exists( 'P4_Search' ) ) {
 				$args  = array_merge( $args, $args2 );
 			}
 
+			// TODO - Provide better fix for excluding auto-created Campaign Pages from Search results.
+			// We should exclude them from indexing in the first place (if possible), or at least exclude them via the Elasticsearch curl request.
+			// All the existing auto-created Campaign Pages should get updated in order to get the p4_do_not_index meta.
+			$query = new WP_Query(
+				[
+					'post_type'   => 'page',
+					'post_status' => 'publish',
+					'meta_query'  => [
+						[
+							'key'     => 'p4_do_not_index',
+							'compare' => 'EXISTS',
+						],
+					],
+					'fields'      => 'ids',
+				]
+			);
+
+			if ( 0 !== $query->post_count ) {
+				$args['post__not_in'] = $query->posts;
+			}
+
 			$args['s'] = $this->search_query;
 			// Add sort by date.
 			$selected_sort = filter_input( INPUT_GET, 'orderby', FILTER_SANITIZE_STRING );


### PR DESCRIPTION
Temporary solution for excluding the auto generated tag pages from the search results (not optimal solution).
Note: _- In order for this to work the Tag pages need to get Updated once after this is merged in -_
Note 2: _Added a small change to avoid possible php error_

**Better solution**
I found the direct Elasticsearch curl request that is required for this but I could not translate it correctly into EP query arguments so I opened an [issue/question](https://github.com/10up/ElasticPress/issues/1437) in the EP repo.
If we can make it work this way it will be better because we will not need the extra SQL query that is included in this PR.

**Optimal solution**
Best way is to exclude them from being indexed in the first place but I have not managed to make this work with the latest EP version.
[Here](https://github.com/10up/ElasticPress/issues/253) is a relevant question.