### PR TITLE
search exclude tag pages improved

### DIFF
--- a/classes/class-p4-campaigns.php
+++ b/classes/class-p4-campaigns.php
@@ -269,7 +269,7 @@ if ( ! class_exists( 'P4_Campaigns' ) ) {
 					$tag_page_id = wp_insert_post( $my_post );
 					if ( is_int( $tag_page_id ) ) {
 						update_post_meta( $tag_page_id, 'p4_description', $tag_data->description );
-						update_post_meta( $tag_page_id, 'p4_do_not_index', true );
+						update_post_meta( $tag_page_id, P4_Search::EXCLUDE_FROM_SEARCH, true );
 					}
 
 					if ( $tag_attachment_id ) {


### PR DESCRIPTION
Hello all,
this is my first PR as a contributor :)

I received a [response](https://github.com/10up/ElasticPress/issues/1437#issuecomment-523669618) from the EP guys and this is a better way to exclude the auto-generated tag pages (without the need of an extra db query).

_Note 1: Tried also the non-indexing solution that was proposed in the response but it did not work for me.
Note 2: (I am not sure of the contributing process, so let me know if I should change something)._