### PR TITLE
Remove bootstrap styles from admin side for now.

### DIFF
--- a/classes/class-p4-master-site.php
+++ b/classes/class-p4-master-site.php
@@ -472,7 +472,6 @@ class P4_Master_Site extends TimberSite {
 
 		// Register jQuery 3 for use wherever needed by adding wp_enqueue_script( 'jquery-3' );.
 		wp_register_script( 'jquery-3', 'https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js', [], '3.3.1', true );
-		wp_enqueue_style( 'bootstrap', 'https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.1.1/css/bootstrap.min.css', [], '4.1.1' );
 		wp_enqueue_style( 'parent-style', $this->theme_dir . '/style.css', [], $css_creation );
 	}
 


### PR DESCRIPTION
We prematurely added Bootstrap to the admin side to render the Gutenberg blocks correctly, but it breaks some styles on the admin (see screenshot).

We'll remove it for now and probably add a custom Bootstrap build.

![image](https://user-images.githubusercontent.com/340766/63939666-293a9900-ca3e-11e9-9759-0673983eb44d.png)
