### PR TITLE
PLANET-3932 Search: Media Results not accommodating special characters

### DIFF
--- a/templates/tease-search.twig
+++ b/templates/tease-search.twig
@@ -40,8 +40,8 @@
 					</div>
 
 					{% if ( is_document ) %}
-						{% set title = post.title|e('wp_kses_post')|raw %}
-						<a href="{{ fn('wp_get_attachment_url', post.id) }}" class="search-result-item-headline">{{ title|length > 30 ? title|striptags|slice(0, 30) ~ '...' : title }}</a>
+						{% set title = post.title|e('wp_kses_post') %}
+						<a href="{{ fn('wp_get_attachment_url', post.id) }}" class="search-result-item-headline">{{ title|raw|length > 30 ? ( title|striptags|slice(0, 30) ~ '...' )|raw  : title|raw }}</a>
 					{% else %}
 						<a href="{{ post.link() }}" class="search-result-item-headline">{{ post.title|e('wp_kses_post')|raw }}</a>
 					{% endif %}


### PR DESCRIPTION
- Changed header length check and concatenation to still allow rendering of normal characters 