### PR TITLE
(No ticket yet): Minimal footer copyright fix

### DIFF
--- a/templates/footer_min.twig
+++ b/templates/footer_min.twig
@@ -25,7 +25,7 @@
 
         <p class="gp-year">
             {{ 'creative-commons'|svgicon }}
-            {{ copyright_text_line2|e('wp_kses_post')|raw }} {{"now"|date('Y')}} | {{ __( 'All rights reserved', 'planet4-master-theme' ) }}
+            {{ copyright_text_line2|e('wp_kses_post')|raw }} {{"now"|date('Y')}}
         </p>
     </div>
 </footer>


### PR DESCRIPTION
As noticed by Kelli, we need to remove the "All rights reserved" text from the minimal footer.

(no ticket yet)