### PR TITLE
Fix stylelint and eslint paths

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,11 +59,11 @@ job-references:
       - run:
           name: "stylelint"
           when: always
-          command: stylelint $HOME/project/assets/scss/**/*.scss $HOME/project/assets/css/*.css
+          command: stylelint "$HOME/project/assets/scss/**/*.scss" "$HOME/project/admin/css/*.css"
       - run:
           name: "eslint"
           when: always
-          command: eslint $HOME/project/assets/js/**/*.js
+          command: eslint "$HOME/project/assets/js/**/*.js" "$HOME/project/admin/js/**/*.js"
       - store_test_results:
           path: /tmp/test-results
       - store_artifacts:

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -23,6 +23,7 @@ const path_js = 'assets/js/*.js';
 const path_exclude_js = '!assets/js/search.js';
 const path_js_admin = 'admin/js/*.js';
 const path_scss = 'assets/scss/**/*.scss';
+const path_admin_css = 'admin/css/**/*.css';
 const path_style = 'assets/scss/style.scss';
 
 let error_handler = {
@@ -50,7 +51,7 @@ const icons_config = {
 };
 
 function lint_css() {
-  return gulp.src(path_scss)
+  return gulp.src([path_scss, path_admin_css])
     .pipe(plumber(error_handler))
     .pipe(stylelint({
       reporters: [{ formatter: 'string', console: true}]


### PR DESCRIPTION
Double asterisk patterns need double quotes to work properly.