### PR TITLE
PLANET-4039 Adjust campaign roles for editors and authors

### DIFF
--- a/classes/class-p4-post-campaign.php
+++ b/classes/class-p4-post-campaign.php
@@ -30,6 +30,9 @@ if ( ! class_exists( 'P4_Post_Campaign' ) ) {
 		private function hooks() {
 			add_action( 'init', [ $this, 'register_campaigns_cpt' ] );
 			add_action( 'init', [ $this, 'add_campaign_caps_admin' ] );
+			add_action( 'init', [ $this, 'add_campaign_caps_editor' ] );
+			add_action( 'init', [ $this, 'add_campaign_caps_author' ] );
+			add_action( 'init', [ $this, 'add_campaign_caps_contributor' ] );
 			add_action( 'init', [ $this, 'add_campaigner_role' ] );
 			add_action( 'cmb2_admin_init', [ $this, 'register_campaigns_metaboxes' ] );
 			add_action( 'add_meta_boxes', [ $this, 'campaign_page_templates_meta_box' ] );
@@ -116,6 +119,51 @@ if ( ! class_exists( 'P4_Post_Campaign' ) ) {
 			$role->add_cap( 'delete_published_campaigns' );
 			$role->add_cap( 'delete_others_campaigns' );
 			$role->add_cap( 'edit_private_campaigns' );
+			$role->add_cap( 'edit_published_campaigns' );
+		}
+
+		/**
+		 * Add Campaign capabilities to Editor User.
+		 */
+		public function add_campaign_caps_editor() {
+			$role = get_role( 'editor' );
+
+			$role->add_cap( 'edit_campaign' );
+			$role->add_cap( 'read_campaign' );
+			$role->add_cap( 'delete_campaign' );
+			$role->add_cap( 'edit_campaigns' );
+			$role->add_cap( 'edit_others_campaigns' );
+			$role->add_cap( 'publish_campaigns' );
+			$role->add_cap( 'delete_campaigns' );
+			$role->add_cap( 'delete_published_campaigns' );
+			$role->add_cap( 'delete_others_campaigns' );
+			$role->add_cap( 'edit_published_campaigns' );
+		}
+
+		/**
+		 * Add Campaign capabilities to Author User.
+		 */
+		public function add_campaign_caps_author() {
+			$role = get_role( 'author' );
+
+			$role->add_cap( 'edit_campaign' );
+			$role->add_cap( 'read_campaign' );
+			$role->add_cap( 'delete_campaign' );
+			$role->add_cap( 'edit_campaigns' );
+			$role->add_cap( 'publish_campaigns' );
+			$role->add_cap( 'delete_published_campaigns' );
+			$role->add_cap( 'edit_published_campaigns' );
+		}
+
+		/**
+		 * Add Campaign capabilities to Author User.
+		 */
+		public function add_campaign_caps_contributor() {
+			$role = get_role( 'contributor' );
+
+			$role->add_cap( 'edit_campaign' );
+			$role->add_cap( 'read_campaign' );
+			$role->add_cap( 'edit_campaigns' );
 			$role->add_cap( 'edit_published_campaigns' );
 		}
 


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-4039

- Editors to be able to create/edit/delete all campaign pages
- Authors to be able to create/edit/delete only my own campaign pages
- Contributors simliar to Authors, but not able to publish