### PR TITLE
PLANET-4166 Strip html markup from Open Graph description field

### DIFF
--- a/templates/html-header.twig
+++ b/templates/html-header.twig
@@ -23,7 +23,7 @@
 		<meta property="og:type" content="article" />
 		<meta property="og:url" content="{{ current_url }}" />
 		{% if (og_description) %}
-			<meta property="og:description" content="{{ og_description|e('html_attr')|raw }}" />
+			<meta property="og:description" content="{{ og_description|striptags }}" />
 		{% endif %}
 		{% if (og_image_data) %}
 			<meta property="og:image" content="{{ og_image_data[0] }}" />


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-4166

Markup on this field is useless and it creates problem since it's escaped to html entities.