### PR TITLE
PLANET-4132 Disable redirection guessing

### DIFF
--- a/classes/class-p4-master-site.php
+++ b/classes/class-p4-master-site.php
@@ -151,6 +151,8 @@ class P4_Master_Site extends TimberSite {
 		);
 
 		add_action( 'init', [ $this, 'login_redirect' ], 1 );
+
+		add_filter( 'redirect_canonical', [ $this, 'no_guess_redirect' ] );
 	}
 
 	/**
@@ -857,6 +859,22 @@ class P4_Master_Site extends TimberSite {
 		}
 
 		return $cache;
+	}
+
+	/**
+	 * Filter function to disable WordPress redirect guessing.
+	 *
+	 * @see https://core.trac.wordpress.org/ticket/16557
+	 *
+	 * @param string $redirect_url The redirect URL.
+	 *
+	 * @return mixed
+	 */
+	public function no_guess_redirect( $redirect_url ) {
+		if ( is_404() ) {
+			return false;
+		}
+		return $redirect_url;
 	}
 
 }


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-4132

Instead return a 404 page.

Tested it a bit, but may need some further testing to make sure it doesn't affect the Redirection plugin.

On the comment description of the filter function, I added a link to the [upstream ticket](https://core.trac.wordpress.org/ticket/16557).

**Before the change:**

```
curl -I https://k8s.p4.greenpeace.org/nikosdev/the
HTTP/2 301
location: https://k8s.p4.greenpeace.org/nikosdev/story/554/the-oil-companies-knew-all-along/
```

**After the change:**

```
curl -I https://k8s.p4.greenpeace.org/nikosdev/the
HTTP/2 404
```