### PR TITLE
PLANET-4241 - CPP: Use same page header options as regular pages

### DIFF
--- a/classes/class-p4-metabox-register.php
+++ b/classes/class-p4-metabox-register.php
@@ -145,11 +145,10 @@ class P4_Metabox_Register {
 
 		$p4_header->add_field(
 			[
-				'name'       => __( 'Hide page title', 'planet4-master-theme-backend' ),
-				'desc'       => __( 'Hide page title on frontend page.', 'planet4-master-theme-backend' ),
-				'id'         => $this->prefix . 'hide_page_title_checkbox',
-				'type'       => 'checkbox',
-				'show_on_cb' => [ $this, 'is_not_campaign_post' ],
+				'name' => __( 'Hide page title', 'planet4-master-theme-backend' ),
+				'desc' => __( 'Hide page title on frontend page.', 'planet4-master-theme-backend' ),
+				'id'   => $this->prefix . 'hide_page_title_checkbox',
+				'type' => 'checkbox',
 			]
 		);
 	}

--- a/single-campaign.php
+++ b/single-campaign.php
@@ -137,6 +137,7 @@ $context['header_description']          = wpautop( $page_meta_data['p4_descripti
 $context['header_button_title']         = $page_meta_data['p4_button_title'][0] ?? '';
 $context['header_button_link']          = $page_meta_data['p4_button_link'][0] ?? '';
 $context['header_button_link_checkbox'] = $page_meta_data['p4_button_link_checkbox'][0] ?? '';
+$context['hide_page_title_checkbox']    = $page_meta_data['p4_hide_page_title_checkbox'][0] ?? '';
 $context['social_accounts']             = $post->get_social_accounts( $context['footer_social_menu'] );
 $context['page_category']               = $data_layer['page_category'];
 $context['post_tags']                   = implode( ', ', $post->tags() );

--- a/templates/base.twig
+++ b/templates/base.twig
@@ -26,9 +26,7 @@
 		{% include 'navigation-bar.twig' with data_nav_bar %}
 	{% endif %}
 	{% include 'sidebar.twig' with data_nav_bar %}
-	{% if post.post_type != 'campaign'  %}
-		{% include 'blocks/header.twig' %}
-	{% endif %}
+	{% include 'blocks/header.twig' %}
 
 	{% block content %}
 		Sorry, no content


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-4241

Add the option to hide page title for editors, same as regular pages.
This fixes the current bug, that we completely hide the header.