### PR TITLE
PLANET-4311 Take action boxout: added by TA page selector in posts showing wrong content

### DIFF
--- a/single.php
+++ b/single.php
@@ -80,7 +80,7 @@ if ( isset( $take_action_boxout_block ) ) {
 	$post->take_action_page = $take_action_page;
 
 	$block_attributes = [
-		'take_action_page' => $post->ID,
+		'take_action_page' => $take_action_page,
 	];
 
 	$post->take_action_boxout = '<!-- wp:planet4-blocks/take-action-boxout ' . wp_json_encode( $block_attributes, JSON_UNESCAPED_SLASHES ) . ' /-->';


### PR DESCRIPTION
- Auto generated code was using post id of post page rather than selected id of take action page.
- Changed to use selected take action page id.