### PR TITLE
PLANET-4305: Enable wpautop as Wordpress did before Gutenberg.

### DIFF
--- a/classes/class-p4-master-site.php
+++ b/classes/class-p4-master-site.php
@@ -150,6 +150,9 @@ class P4_Master_Site extends TimberSite {
 			}
 		);
 
+		// wpautop is already added, this just changes its priority.
+		add_filter( 'the_content', 'wpautop', 9 );
+
 		add_action( 'init', [ $this, 'login_redirect' ], 1 );
 	}
 

--- a/classes/class-p4-master-site.php
+++ b/classes/class-p4-master-site.php
@@ -150,8 +150,25 @@ class P4_Master_Site extends TimberSite {
 			}
 		);
 
-		// wpautop is already added, this just changes its priority.
-		add_filter( 'the_content', 'wpautop', 9 );
+		/**
+		 * Apply wpautop to non-block content.
+		 *
+		 * @link https://wordpress.stackexchange.com/q/321662/26317
+		 *
+		 * @param string $block_content The HTML generated for the block.
+		 * @param array  $block         The block.
+		 */
+		add_filter(
+			'render_block',
+			function ( $block_content, $block ) {
+				if ( is_null( $block['blockName'] ) ) {
+					return wpautop( $block_content );
+				}
+				return $block_content;
+			},
+			10,
+			2
+		);
 
 		add_action( 'init', [ $this, 'login_redirect' ], 1 );
 	}


### PR DESCRIPTION
Test with more content if this solves the issue.

Ref: https://jira.greenpeace.org/browse/PLANET-4305

I think WP by default also adds `wpautop` to excerpts, we could mimic this by adding the same filter to the `the_excerpt` hook, but we are using the `excerpt` filter from Timber which is an alias of `wp_trim_words`, it trims words, strips tags, and removes line-breaks internally, so it makes no difference.

Some notes:
https://wpquark.com/kb/misc/wordpress/fixing-themes-custom-wpautop-priority/

