### PR TITLE
Remove obsolete admin action

### DIFF
--- a/classes/class-p4-master-site.php
+++ b/classes/class-p4-master-site.php
@@ -112,7 +112,6 @@ class P4_Master_Site extends TimberSite {
 			}
 		);
 		add_action( 'after_setup_theme', [ $this, 'add_image_sizes' ] );
-		add_action( 'admin_head', [ $this, 'remove_add_post_element' ] );
 		add_filter( 'post_gallery', [ $this, 'carousel_post_gallery' ], 10, 2 );
 		add_action( 'save_post', [ $this, 'p4_auto_generate_excerpt' ], 10, 2 );
 		add_filter( 'img_caption_shortcode', [ $this, 'override_img_caption_shortcode' ], 10, 3 );
@@ -635,16 +634,6 @@ class P4_Master_Site extends TimberSite {
 			[ 'post', 'page' ],
 			'side'
 		);
-	}
-
-	/**
-	 * Remove "Add Post Element" button for POST & rename on page as "Add Page Element".
-	 */
-	function remove_add_post_element() {
-		if ( 'page' === get_post_type() ) {
-			remove_action( 'media_buttons', [ Shortcode_UI::get_instance(), 'action_media_buttons' ] );
-			add_action( 'media_buttons', [ $this, 'action_page_media_buttons' ] );
-		}
 	}
 
 	/**


### PR DESCRIPTION
We don't seem to need that after the Gutenberg switch, and it also raises some exceptions.

```
Uncaught exception 'Error' with message 'Class 'Shortcode_UI' not found' in /app/source/public/wp-content/themes/planet4-master-theme/classes/class-p4-master-site.php:645
```