### PR TITLE
Remove wp-admin exclusion from body css

### DIFF
--- a/assets/src/scss/base/_body.scss
+++ b/assets/src/scss/base/_body.scss
@@ -4,36 +4,34 @@ body {
 }
 
 body {
-  &:not(.wp-admin) {
-    color: $dark-shade-black;
-    font-family: $lora;
+  color: $dark-shade-black;
+  font-family: $lora;
+  position: relative;
+  overflow-y: hidden;
+
+  &.white-bg {
+    background-color: $white;
+  }
+
+  &.brown-bg {
+    background: $brown-bg;
+  }
+
+  &.home {
+    background-color: #ecf1f3;
+  }
+
+  &.search {
+    font-family: $roboto;
+  }
+
+  .mejs-container {
+    clear: initial;
+  }
+
+  .container > * {
     position: relative;
-    overflow-y: hidden;
-
-    &.white-bg {
-      background-color: $white;
-    }
-
-    &.brown-bg {
-      background: $brown-bg;
-    }
-
-    &.home {
-      background-color: #ecf1f3;
-    }
-
-    &.search {
-      font-family: $roboto;
-    }
-
-    .mejs-container {
-      clear: initial;
-    }
-
-    .container > * {
-      position: relative;
-      z-index: 2;
-    }
+    z-index: 2;
   }
 }
 


### PR DESCRIPTION
We no longer need this, since we are creating separate builds for editor and frontend. This is making these styles less explicit and easier to override on child themes.