### PR TITLE
[No ticket number] Missing class rename fix

### DIFF
--- a/templates/single.twig
+++ b/templates/single.twig
@@ -81,7 +81,7 @@
 			{% include "blocks/author_profile.twig" with {post:post} %}
 		{% endif %}
 
-		<section class="article-listing">
+		<section class="articles-block">
 			{% if ( post.articles ) %}
 				{{ fn('do_blocks', post.articles )|raw }}
 			{% endif %}


### PR DESCRIPTION
The class `.article-listing` was renamed in this PR: https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/commit/89c21883121fa4044cdf22f70f72760aa681792f#diff-7e3188835fafb9e447ab7a0fe44be0a0R122

This renames an occurrence of it in the `master-theme`.