### PR TITLE
Move conditional into author_profile

### DIFF
--- a/templates/blocks/author_profile.twig
+++ b/templates/blocks/author_profile.twig
@@ -1,20 +1,22 @@
-<div class="container clearfix">
-	<footer class="author-block" itemtype="http://schema.org/Person">
-		<div class="author-block-info">
-			<h2 class="author-block-info-title">{{ __( 'about the author', 'planet4-master-theme' ) }}</h2>
-			<h5 rel="author" class="author-block-info-name">
-				<a href="{{ post.author.link }}" itemprop="name">{{ post.author.name }}</a>
-			</h5>
-			<p class="author-block-info-bio" itemprop="description">
-				{{ fn('wpautop', fn('the_author_meta', 'description', author.id))|e('wp_kses_post')|raw }}
-			</p>
-		</div>
-		<figure class="author-block-image">
-			{% if ( post.author.avatar ) %}
-				<img itemprop="image" class="author-pic"
-				     src="{{ fn('get_avatar_url', post.author.id, {'size' : 294}) }}"
-				     alt="{{ post.author.name }}">
-			{% endif %}
-		</figure>
-	</footer>
+{% if ( post.author.name and post.author.description ) %}
+	<div class="container clearfix">
+		<footer class="author-block" itemtype="http://schema.org/Person">
+			<div class="author-block-info">
+				<h2 class="author-block-info-title">{{ __( 'about the author', 'planet4-master-theme' ) }}</h2>
+				<h5 rel="author" class="author-block-info-name">
+					<a href="{{ post.author.link }}" itemprop="name">{{ post.author.name }}</a>
+				</h5>
+				<p class="author-block-info-bio" itemprop="description">
+					{{ fn('wpautop', fn('the_author_meta', 'description', author.id))|e('wp_kses_post')|raw }}
+				</p>
+			</div>
+			<figure class="author-block-image">
+				{% if ( post.author.avatar ) %}
+					<img itemprop="image" class="author-pic"
+						 src="{{ fn('get_avatar_url', post.author.id, {'size' : 294}) }}"
+						 alt="{{ post.author.name }}">
+				{% endif %}
+			</figure>
+		</footer>
 </div>
+{% endif %}

--- a/templates/single.twig
+++ b/templates/single.twig
@@ -77,9 +77,8 @@
 		</div>
 		<!-- Post Page Block End -->
 
-		{% if ( post.author.name and post.author.description ) %}
-			{% include "blocks/author_profile.twig" with {post:post} %}
-		{% endif %}
+		{% include "blocks/author_profile.twig" with {post:post} %}
+
 
 		<section class="article-listing">
 			{% if ( post.articles ) %}


### PR DESCRIPTION
# What?
This PR moves the conditional check if a author is set to the author_profile.
This way child-themes are able to easily override the author_profile and set their own logic.

# Why?
GPNL wants to be able to set a default author block in some cases.
Moving the logic to the block itself instead of the single.twig makes sure we don't override too much unnecessarily.