### PR TITLE
PLANET-4456 Fix special chars in campaign import

### DIFF
--- a/classes/class-p4-campaign-importer.php
+++ b/classes/class-p4-campaign-importer.php
@@ -131,7 +131,7 @@ if ( ! class_exists( 'P4_Campaign_Importer' ) ) {
 					'post_content' => $post_content,
 					'postmeta'     => $campaign_postmeta,
 				];
-				wp_update_post( $updated_post );
+				wp_update_post( wp_slash( $updated_post ) );
 			}
 		}
 

--- a/exporter-helper.php
+++ b/exporter-helper.php
@@ -85,7 +85,7 @@ function get_campaign_attachments( $post_ids ) {
 		}
 
 		// Filter attachment ids from shortcake code(shortcake_gallery, shortcake_happy_point, shortcake_media_video).
-		preg_match_all( '#wp\:planet4\-blocks\/[a-zA-Z0-9\_\"\'\-\s\:\/\/\=\.\?\&\,\_\{\%]*(multiple_image|background|id|video_poster_img)[\"|\'][\:][\"|\']?([\d\s\,]*)[\"|\']?#', $text, $matches, PREG_SET_ORDER );
+		preg_match_all( '#wp\:planet4\-blocks\/[a-zA-Z0-9\_\"\'\-\s\:\/\/\=\.\?\&\,\_\{\%]*[\"|\'](multiple_image|background|id|video_poster_img)[\"|\'][\:][\"|\']?([\d\s\,]*)[\"|\']?#', $text, $matches, PREG_SET_ORDER );
 		foreach ( $matches as $match ) {
 			if ( 'multiple_image' === $match[1] ) {
 				$multiple_images = explode( ',', $match[2] );


### PR DESCRIPTION
- Fix special char issue in campaign export/import functionality.
- The EN form background image not exported properly, added small fix in regular exp. to fix this issue.

Example :
Campaign exported from `staging` -
https://release.k8s.p4.greenpeace.org/international/campaign/campaign-page-demo-plastics/
Campaign imported on `sagardev` instance (current PR branch is pinned on sagardev instance) -
https://k8s.p4.greenpeace.org/sagardev/?post_type=campaign&p=27747&preview=true

The EN form bg image issue tested by exporting from sagardev instance and imported on staging.
https://k8s.p4.greenpeace.org/sagardev/campaign/test-en-form/
https://release.k8s.p4.greenpeace.org/international/?post_type=campaign&p=27806&preview=true 