### PR TITLE
PLANET-4603 Register campaign fields instead of metaboxes

### DIFF
--- a/campaign_themes/antarctic.json
+++ b/campaign_themes/antarctic.json
@@ -1,0 +1,115 @@
+{
+	"id": "antarctic",
+	"name": "Antarctic",
+	"fields": [
+		{
+			"id": "campaign_logo",
+			"options": [
+				{
+					"value": "antarctic",
+					"label": "Antarctic"
+				},
+				{
+					"value": "greenpeace",
+					"label": "Greenpeace"
+				}
+			],
+			"default": "antarctic"
+		},
+		{
+			"id": "campaign_logo_color",
+			"options": [
+				{
+					"value": "light",
+					"label": "Light"
+				},
+				{
+					"value": "dark",
+					"label": "Dark"
+				}
+			],
+			"default": "light"
+		},
+		{
+			"id": "campaign_nav_type",
+			"options": [
+				{
+					"value": "planet4",
+					"label": "Main website navigation"
+				},
+				{
+					"value": "minimal",
+					"label": "Minimal Navigation"
+				}
+			],
+			"default": "minimal"
+		},
+		{
+			"id": "campaign_nav_color",
+			"options": [
+				{ "color":  "#ffffff"},
+				{ "color":  "#000000"},
+				{ "color": "#0A4461"},
+				{ "color": "#52C9F4"}
+			],
+			"default": "#FFFFFF"
+		},
+		{
+			"id": "campaign_header_color",
+			"options": [
+			]
+		},
+		{
+			"id": "campaign_secondary_color",
+			"options": [
+			]
+		},
+		{
+			"id": "campaign_primary_color",
+			"options": [
+			]
+		},
+		{
+			"id": "campaign_header_primary",
+			"options": [
+			]
+		},
+		{
+			"id": "campaign_body_font",
+			"options": [
+				{
+					"value": "lora",
+					"label": "Serif"
+				},
+				{
+					"value": "roboto",
+					"label": "Sans Serif"
+				},
+				{
+					"value": "campaign",
+					"label": "Campaign default"
+				}
+			],
+			"default": "lora"
+		},
+		{
+			"id": "campaign_footer_theme",
+			"options": [
+				{
+					"value": "default",
+					"label": "Default"
+				},
+				{
+					"value": "white",
+					"label": "White"
+				}
+			],
+			"default": "default"
+		},
+		{
+			"id": "footer_links_color",
+			"options": [
+			]
+		}
+	]
+}

--- a/campaign_themes/arctic.json
+++ b/campaign_themes/arctic.json
@@ -1,0 +1,148 @@
+{
+	"id": "arctic",
+	"name": "Arctic",
+	"fields": [
+		{
+			"id": "campaign_logo",
+			"options": [
+				{
+					"value": "arctic",
+					"label": "Arctic"
+				},
+				{
+					"value": "greenpeace",
+					"label": "Greenpeace"
+				}
+			],
+			"default": "arctic"
+		},
+		{
+			"id": "campaign_logo_color",
+			"options": [
+				{
+					"value": "light",
+					"label": "Light"
+				},
+				{
+					"value": "dark",
+					"label": "Dark"
+				}
+			],
+			"default": "light"
+		},
+		{
+			"id": "campaign_nav_type",
+			"options": [
+				{
+					"value": "planet4",
+					"label": "Main website navigation"
+				},
+				{
+					"value": "minimal",
+					"label": "Minimal Navigation"
+				}
+			],
+			"default": "minimal"
+		},
+		{
+			"id": "campaign_nav_color",
+			"options": [
+				{ "color":  "#ffffff"},
+				{ "color":  "#000000"},
+				{ "color": "#035880"},
+				{ "color": "#00B6C2"}
+			],
+			"default": "#FFFFFF"
+		},
+		{
+			"id": "campaign_header_color",
+			"options": [
+			],
+			"default": "#000000"
+		},
+		{
+			"id": "campaign_primary_color",
+			"options": [
+			]
+		},
+		{
+			"id": "campaign_secondary_color",
+			"options": [
+			]
+		},
+		{
+			"id": "campaign_header_primary",
+			"options": [
+				{
+					"value": "",
+					"label": "Campaign default"
+				},
+				{
+					"value": "Anton",
+					"label": "Anton"
+				},
+				{
+					"value": "Jost",
+					"label": "Jost"
+				},
+				{
+					"value": "Montserrat",
+					"label": "Montserrat Bold"
+				},
+				{
+					"value": "Montserrat_Light",
+					"label": "Montserrat Light"
+				},
+				{
+					"value": "Sanctuary",
+					"label": "Sanctuary"
+				},
+				{
+					"value": "Kanit",
+					"label": "Kanit Extra Bold"
+				},
+				{
+					"value": "Save the Arctic",
+					"label": "Save the Arctic"
+				}
+			]
+		},
+		{
+			"id": "campaign_body_font",
+			"options": [
+				{
+					"value": "lora",
+					"label": "Serif"
+				},
+				{
+					"value": "roboto",
+					"label": "Sans Serif"
+				},
+				{
+					"value": "campaign",
+					"label": "Campaign default"
+				}
+			],
+			"default": "lora"
+		},
+		{
+			"id": "campaign_footer_theme",
+			"options": [
+				{
+					"value": "default",
+					"label": "Default"
+				},
+				{
+					"value": "white",
+					"label": "White"
+				}
+			],
+			"default": "default"
+		},
+		{
+			"id": "footer_links_color",
+			"options": [
+			]
+		}
+	]
+}

--- a/campaign_themes/climate.json
+++ b/campaign_themes/climate.json
@@ -1,0 +1,168 @@
+{
+	"id": "climate",
+	"name": "Climate Emergency",
+	"fields": [
+		{
+			"id": "campaign_logo",
+			"options": [
+				{
+					"value": "climate",
+					"label": "Climate Emergency"
+				},
+				{
+					"value": "greenpeace",
+					"label": "Greenpeace"
+				}
+			],
+			"default": "climate"
+		},
+		{
+			"id": "campaign_logo_color",
+			"options": [
+				{
+					"value": "light",
+					"label": "Light"
+				},
+				{
+					"value": "dark",
+					"label": "Dark"
+				}
+			],
+			"default": "light"
+		},
+		{
+			"id": "campaign_nav_type",
+			"options": [
+				{
+					"value": "planet4",
+					"label": "Main website navigation"
+				},
+				{
+					"value": "minimal",
+					"label": "Minimal Navigation"
+				}
+			],
+			"default": "planet4"
+		},
+		{
+			"id": "campaign_nav_color",
+			"options": [
+				{ "color":  "#ffffff"},
+				{ "color":  "#000000"},
+				{ "color":  "#FF513C"},
+				{ "color":  "#007EFF"}
+			]
+		},
+		{
+			"id": "campaign_header_color",
+			"options": [
+			],
+			"default": "#000000"
+		},
+		{
+			"id": "campaign_primary_color",
+			"options": [
+			]
+		},
+		{
+			"id": "campaign_secondary_color",
+			"options": [
+			]
+		},
+		{
+			"id": "campaign_header_primary",
+			"options": [
+				{
+					"value": "",
+					"label": "Campaign default"
+				},
+				{
+					"value": "Anton",
+					"label": "Anton"
+				},
+				{
+					"value": "Jost",
+					"label": "Jost"
+				},
+				{
+					"value": "Montserrat",
+					"label": "Montserrat Bold"
+				},
+				{
+					"value": "Montserrat_Light",
+					"label": "Montserrat Light"
+				},
+				{
+					"value": "Sanctuary",
+					"label": "Sanctuary"
+				},
+				{
+					"value": "Kanit",
+					"label": "Kanit Extra Bold"
+				},
+				{
+					"value": "Save the Arctic",
+					"label": "Save the Arctic"
+				}
+			]
+		},
+		{
+			"id": "campaign_header_secondary",
+			"options": [
+				{
+					"value": "monsterrat_semi",
+					"label": "Montserrat Semi Bold"
+				},
+				{
+					"value": "kanit_semi",
+					"label": "Kanit Semi Bold"
+				},
+				{
+					"value": "open_sans",
+					"label": "Open Sans"
+				},
+				{
+					"value": "open_sans_shadows",
+					"label": "Open Sans Shadows"
+				}
+			]
+		},
+		{
+			"id": "campaign_body_font",
+			"options": [
+				{
+					"value": "lora",
+					"label": "Serif"
+				},
+				{
+					"value": "roboto",
+					"label": "Sans Serif"
+				},
+				{
+					"value": "campaign",
+					"label": "Campaign default"
+				}
+			],
+			"default": "lora"
+		},
+		{
+			"id": "campaign_footer_theme",
+			"options": [
+				{
+					"value": "default",
+					"label": "Default"
+				},
+				{
+					"value": "white",
+					"label": "White"
+				}
+			],
+			"default": "default"
+		},
+		{
+			"id": "footer_links_color",
+			"options": [
+			]
+		}
+	]
+}

--- a/campaign_themes/default.json
+++ b/campaign_themes/default.json
@@ -1,0 +1,186 @@
+{
+	"id": "default",
+	"name": "Default",
+	"fields": [
+		{
+			"id": "campaign_logo",
+			"options": [
+				{
+					"value": "antarctic",
+					"label": "Antarctic"
+				},
+				{
+					"value": "arctic",
+					"label": "Arctic"
+				},
+				{
+					"value": "climate",
+					"label": "Climate Emergency"
+				},
+				{
+					"value": "forest",
+					"label": "Forest"
+				},
+				{
+					"value": "oceans",
+					"label": "Oceans"
+				},
+				{
+					"value": "oil",
+					"label": "Oil"
+				},
+				{
+					"value": "plastic",
+					"label": "Plastics"
+				}
+			],
+			"default": "greenpeace"
+		},
+		{
+			"id": "campaign_logo_color",
+			"options": [
+				{
+					"value": "light",
+					"label": "Light"
+				},
+				{
+					"value": "dark",
+					"label": "Dark"
+				}
+			],
+			"default": "light"
+		},
+		{
+			"id": "campaign_nav_type",
+			"options": [
+				{
+					"value": "planet4",
+					"label": "Main website navigation"
+				},
+				{
+					"value": "minimal",
+					"label": "Minimal Navigation"
+				}
+			],
+			"default": "planet4"
+		},
+		{
+			"id": "campaign_nav_color",
+			"options": [
+				{ "color":  "#ffffff"},
+				{ "color":  "#000000"},
+				{ "color": "#035880"}
+			]
+		},
+		{
+			"id": "campaign_header_color",
+			"options": [
+			]
+		},
+		{
+			"id": "campaign_primary_color",
+			"options": [
+			]
+		},
+		{
+			"id": "campaign_secondary_color",
+			"options": [
+			]
+		},
+		{
+			"id": "campaign_header_primary",
+			"options": [
+				{
+					"value": "",
+					"label": "Campaign default"
+				},
+				{
+					"value": "Anton",
+					"label": "Anton"
+				},
+				{
+					"value": "Jost",
+					"label": "Jost"
+				},
+				{
+					"value": "Montserrat",
+					"label": "Montserrat Bold"
+				},
+				{
+					"value": "Montserrat_Light",
+					"label": "Montserrat Light"
+				},
+				{
+					"value": "Sanctuary",
+					"label": "Sanctuary"
+				},
+				{
+					"value": "Kanit",
+					"label": "Kanit Extra Bold"
+				},
+				{
+					"value": "Save the Arctic",
+					"label": "Save the Arctic"
+				}
+			]
+		},
+		{
+			"id": "campaign_header_secondary",
+			"options": [
+				{
+					"value": "monsterrat_semi",
+					"label": "Montserrat Semi Bold"
+				},
+				{
+					"value": "kanit_semi",
+					"label": "Kanit Semi Bold"
+				},
+				{
+					"value": "open_sans",
+					"label": "Open Sans"
+				},
+				{
+					"value": "open_sans_shadows",
+					"label": "Open Sans Shadows"
+				}
+			]
+		},
+		{
+			"id": "campaign_body_font",
+			"options": [
+				{
+					"value": "lora",
+					"label": "Serif"
+				},
+				{
+					"value": "roboto",
+					"label": "Sans Serif"
+				},
+				{
+					"value": "campaign",
+					"label": "Campaign default"
+				}
+			],
+			"default": "lora"
+		},
+		{
+			"id": "campaign_footer_theme",
+			"options": [
+				{
+					"value": "default",
+					"label": "Default"
+				},
+				{
+					"value": "white",
+					"label": "White"
+				}
+			],
+			"default": "default"
+		},
+		{
+			"id": "footer_links_color",
+			"options": [
+			]
+		}
+	]
+}

--- a/campaign_themes/forest.json
+++ b/campaign_themes/forest.json
@@ -1,0 +1,148 @@
+{
+	"id": "forest",
+	"name": "Forest",
+	"fields": [
+		{
+			"id": "campaign_logo",
+			"options": [
+				{
+					"value": "forest",
+					"label": "Forest"
+				},
+				{
+					"value": "greenpeace",
+					"label": "Greenpeace"
+				}
+			],
+			"default": "forest"
+		},
+		{
+			"id": "campaign_logo_color",
+			"options": [
+				{
+					"value": "light",
+					"label": "Light"
+				},
+				{
+					"value": "dark",
+					"label": "Dark"
+				}
+			],
+			"default": "light"
+		},
+		{
+			"id": "campaign_nav_type",
+			"options": [
+				{
+					"value": "planet4",
+					"label": "Main website navigation"
+				},
+				{
+					"value": "minimal",
+					"label": "Minimal Navigation"
+				}
+			],
+			"default": "minimal"
+		},
+		{
+			"id": "campaign_nav_color",
+			"options": [
+				{ "color":  "#ffffff"},
+				{ "color":  "#000000"},
+				{ "color":  "#2CAF4E"},
+				{ "color":  "#A0D654"}
+			],
+			"default": "#FFFFFF"
+		},
+		{
+			"id": "campaign_header_color",
+			"options": [
+			],
+			"default": "#000000"
+		},
+		{
+			"id": "campaign_primary_color",
+			"options": [
+			]
+		},
+		{
+			"id": "campaign_secondary_color",
+			"options": [
+			]
+		},
+		{
+			"id": "campaign_header_primary",
+			"options": [
+				{
+					"value": "",
+					"label": "Campaign default"
+				},
+				{
+					"value": "Anton",
+					"label": "Anton"
+				},
+				{
+					"value": "Jost",
+					"label": "Jost"
+				},
+				{
+					"value": "Montserrat",
+					"label": "Montserrat Bold"
+				},
+				{
+					"value": "Montserrat_Light",
+					"label": "Montserrat Light"
+				},
+				{
+					"value": "Sanctuary",
+					"label": "Sanctuary"
+				},
+				{
+					"value": "Kanit",
+					"label": "Kanit Extra Bold"
+				},
+				{
+					"value": "Save the Arctic",
+					"label": "Save the Arctic"
+				}
+			]
+		},
+		{
+			"id": "campaign_body_font",
+			"options": [
+				{
+					"value": "lora",
+					"label": "Serif"
+				},
+				{
+					"value": "roboto",
+					"label": "Sans Serif"
+				},
+				{
+					"value": "campaign",
+					"label": "Campaign default"
+				}
+			],
+			"default": "lora"
+		},
+		{
+			"id": "campaign_footer_theme",
+			"options": [
+				{
+					"value": "default",
+					"label": "Default"
+				},
+				{
+					"value": "white",
+					"label": "White"
+				}
+			],
+			"default": "default"
+		},
+		{
+			"id": "footer_links_color",
+			"options": [
+			]
+		}
+	]
+}

--- a/campaign_themes/oceans.json
+++ b/campaign_themes/oceans.json
@@ -1,0 +1,148 @@
+{
+	"id": "oceans",
+	"name": "Oceans",
+	"fields": [
+		{
+			"id": "campaign_logo",
+			"options": [
+				{
+					"value": "oceans",
+					"label": "Oceans"
+				},
+				{
+					"value": "greenpeace",
+					"label": "Greenpeace"
+				}
+			],
+			"default": "oceans"
+		},
+		{
+			"id": "campaign_logo_color",
+			"options": [
+				{
+					"value": "light",
+					"label": "Light"
+				},
+				{
+					"value": "dark",
+					"label": "Dark"
+				}
+			],
+			"default": "light"
+		},
+		{
+			"id": "campaign_nav_type",
+			"options": [
+				{
+					"value": "planet4",
+					"label": "Main website navigation"
+				},
+				{
+					"value": "minimal",
+					"label": "Minimal Navigation"
+				}
+			],
+			"default": "minimal"
+		},
+		{
+			"id": "campaign_nav_color",
+			"options": [
+				{ "color":  "#ffffff"},
+				{ "color":  "#000000"},
+				{ "color":  "#044362"},
+				{ "color":  "#2CABB1"}
+			],
+			"default": "#FFFFFF"
+		},
+		{
+			"id": "campaign_header_color",
+			"options": [
+			],
+			"default": "#000000"
+		},
+		{
+			"id": "campaign_primary_color",
+			"options": [
+			]
+		},
+		{
+			"id": "campaign_secondary_color",
+			"options": [
+			]
+		},
+		{
+			"id": "campaign_header_primary",
+			"options": [
+				{
+					"value": "",
+					"label": "Campaign default"
+				},
+				{
+					"value": "Anton",
+					"label": "Anton"
+				},
+				{
+					"value": "Jost",
+					"label": "Jost"
+				},
+				{
+					"value": "Montserrat",
+					"label": "Montserrat Bold"
+				},
+				{
+					"value": "Montserrat_Light",
+					"label": "Montserrat Light"
+				},
+				{
+					"value": "Sanctuary",
+					"label": "Sanctuary"
+				},
+				{
+					"value": "Kanit",
+					"label": "Kanit Extra Bold"
+				},
+				{
+					"value": "Save the Arctic",
+					"label": "Save the Arctic"
+				}
+			]
+		},
+		{
+			"id": "campaign_body_font",
+			"options": [
+				{
+					"value": "lora",
+					"label": "Serif"
+				},
+				{
+					"value": "roboto",
+					"label": "Sans Serif"
+				},
+				{
+					"value": "campaign",
+					"label": "Campaign default"
+				}
+			],
+			"default": "lora"
+		},
+		{
+			"id": "campaign_footer_theme",
+			"options": [
+				{
+					"value": "default",
+					"label": "Default"
+				},
+				{
+					"value": "white",
+					"label": "White"
+				}
+			],
+			"default": "default"
+		},
+		{
+			"id": "footer_links_color",
+			"options": [
+			]
+		}
+	]
+}

--- a/campaign_themes/oil.json
+++ b/campaign_themes/oil.json
@@ -1,0 +1,148 @@
+{
+	"id": "oil",
+	"name": "Oil",
+	"fields": [
+		{
+			"id": "campaign_logo",
+			"options": [
+				{
+					"value": "oil",
+					"label": "Oil"
+				},
+				{
+					"value": "greenpeace",
+					"label": "Greenpeace"
+				}
+			],
+			"default": "oil"
+		},
+		{
+			"id": "campaign_logo_color",
+			"options": [
+				{
+					"value": "light",
+					"label": "Light"
+				},
+				{
+					"value": "dark",
+					"label": "Dark"
+				}
+			],
+			"default": "light"
+		},
+		{
+			"id": "campaign_nav_type",
+			"options": [
+				{
+					"value": "planet4",
+					"label": "Main website navigation"
+				},
+				{
+					"value": "minimal",
+					"label": "Minimal Navigation"
+				}
+			],
+			"default": "minimal"
+		},
+		{
+			"id": "campaign_nav_color",
+			"options": [
+				{ "color":  "#ffffff"},
+				{ "color":  "#000000"},
+				{ "color":  "#FF513C"},
+				{ "color":  "#007EFF"}
+			],
+			"default": "#FFFFFF"
+		},
+		{
+			"id": "campaign_header_color",
+			"options": [
+			],
+			"default": "#000000"
+		},
+		{
+			"id": "campaign_primary_color",
+			"options": [
+			]
+		},
+		{
+			"id": "campaign_secondary_color",
+			"options": [
+			]
+		},
+		{
+			"id": "campaign_header_primary",
+			"options": [
+				{
+					"value": "",
+					"label": "Campaign default"
+				},
+				{
+					"value": "Anton",
+					"label": "Anton"
+				},
+				{
+					"value": "Jost",
+					"label": "Jost"
+				},
+				{
+					"value": "Montserrat",
+					"label": "Montserrat Bold"
+				},
+				{
+					"value": "Montserrat_Light",
+					"label": "Montserrat Light"
+				},
+				{
+					"value": "Sanctuary",
+					"label": "Sanctuary"
+				},
+				{
+					"value": "Kanit",
+					"label": "Kanit Extra Bold"
+				},
+				{
+					"value": "Save the Arctic",
+					"label": "Save the Arctic"
+				}
+			]
+		},
+		{
+			"id": "campaign_body_font",
+			"options": [
+				{
+					"value": "lora",
+					"label": "Serif"
+				},
+				{
+					"value": "roboto",
+					"label": "Sans Serif"
+				},
+				{
+					"value": "campaign",
+					"label": "Campaign default"
+				}
+			],
+			"default": "lora"
+		},
+		{
+			"id": "campaign_footer_theme",
+			"options": [
+				{
+					"value": "default",
+					"label": "Default"
+				},
+				{
+					"value": "white",
+					"label": "White"
+				}
+			],
+			"default": "default"
+		},
+		{
+			"id": "footer_links_color",
+			"options": [
+			]
+		}
+	]
+}

--- a/campaign_themes/plastic.json
+++ b/campaign_themes/plastic.json
@@ -1,0 +1,150 @@
+{
+	"id": "plastic",
+	"name": "Plastics",
+	"fields": [
+		{
+			"id": "campaign_logo",
+			"options": [
+				{
+					"value": "plastic",
+					"label": "Plastics"
+				},
+				{
+					"value": "greenpeace",
+					"label": "Greenpeace"
+				}
+			],
+			"default": "plastic"
+		},
+		{
+			"id": "campaign_logo_color",
+			"options": [
+				{
+					"value": "light",
+					"label": "Light"
+				},
+				{
+					"value": "dark",
+					"label": "Dark"
+				}
+			],
+			"default": "light"
+		},
+		{
+			"id": "campaign_nav_type",
+			"options": [
+				{
+					"value": "planet4",
+					"label": "Main website navigation"
+				},
+				{
+					"value": "minimal",
+					"label": "Minimal Navigation"
+				}
+			],
+			"default": "minimal"
+		},
+		{
+			"id": "campaign_nav_color",
+			"options": [
+				{ "color":  "#ffffff"},
+				{ "color":  "#000000"},
+				{ "color":  "#044362"},
+				{ "color":  "#2CABB1"},
+				{ "color": "#66CC00" }
+			],
+			"default": "#FFFFFF"
+		},
+		{
+			"id": "campaign_header_color",
+			"options": [
+			],
+			"default": "#000000"
+		},
+		{
+			"id": "campaign_primary_color",
+			"options": [
+			]
+		},
+		{
+			"id": "campaign_secondary_color",
+			"options": [
+			]
+		},
+		{
+			"id": "campaign_header_primary",
+			"options": [
+				{
+					"value": "",
+					"label": "Campaign default"
+				},
+				{
+					"value": "Anton",
+					"label": "Anton"
+				},
+				{
+					"value": "Jost",
+					"label": "Jost"
+				},
+				{
+					"value": "Montserrat",
+					"label": "Montserrat Bold"
+				},
+				{
+					"value": "Montserrat_Light",
+					"label": "Montserrat Light"
+				},
+				{
+					"value": "Sanctuary",
+					"label": "Sanctuary"
+				},
+				{
+					"value": "Kanit",
+					"label": "Kanit Extra Bold"
+				},
+				{
+					"value": "Save the Arctic",
+					"label": "Save the Arctic"
+				}
+			]
+		},
+		{
+			"id": "campaign_body_font",
+			"options": [
+				{
+					"value": "lora",
+					"label": "Serif"
+				},
+				{
+					"value": "roboto",
+					"label": "Sans Serif"
+				},
+				{
+					"value": "campaign",
+					"label": "Campaign default"
+				}
+			],
+			"default": "lora"
+		},
+		{
+			"id": "campaign_footer_theme",
+			"options": [
+				{
+					"value": "default",
+					"label": "Default"
+				},
+				{
+					"value": "white",
+					"label": "White"
+				}
+			],
+			"default": "default"
+		},
+		{
+			"id": "footer_links_color",
+			"options": [
+				{ "color": "#2077bf" }
+			]
+		}
+	]
+}

--- a/classes/class-p4-campaign-importer.php
+++ b/classes/class-p4-campaign-importer.php
@@ -24,6 +24,7 @@ if ( ! class_exists( 'P4_Campaign_Importer' ) ) {
 		public function __construct() {
 			add_action( 'wp_import_insert_post', [ $this, 'update_campaign_attachements' ], 10, 4 );
 			add_filter( 'wp_import_post_terms', [ $this, 'filter_wp_import_post_terms' ], 10, 3 );
+			add_filter( 'wp_import_post_meta', [ $this, 'read_old_campaign_template_attribute' ] );
 			add_filter( 'wp_import_post_data_processed', [ $this, 'set_imported_campaigns_as_drafts' ], 10, 2 );
 			add_action( 'import_end', [ $this, 'action_import_end' ], 10, 0 );
 		}
@@ -235,6 +236,28 @@ if ( ! class_exists( 'P4_Campaign_Importer' ) ) {
 			}
 
 			return $postdata;
+		}
+
+		/**
+		 * Needed to remove the underscore to expose the field in the API.
+		 * Use the value with underscore for old exports if the new field isn't present.
+		 *
+		 * @param array $post_meta The to be imported post meta fields.
+		 *
+		 * @return array The normalized post meta fields.
+		 */
+		public function read_old_campaign_template_attribute( $post_meta ) {
+			foreach ( $post_meta as $index => $meta ) {
+				if ( '_campaign_page_template' === $meta['key'] ) {
+					$post_meta[] = [
+						'key'   => 'theme',
+						'value' => $meta['value'],
+					];
+					unset( $post_meta[ $index ] );
+				}
+			}
+
+			return $post_meta;
 		}
 	}
 }

--- a/classes/class-p4-post-campaign.php
+++ b/classes/class-p4-post-campaign.php
@@ -30,26 +30,9 @@ if ( ! class_exists( 'P4_Post_Campaign' ) ) {
 		private function hooks() {
 			add_action( 'init', [ $this, 'register_campaigns_cpt' ] );
 			add_action( 'cmb2_admin_init', [ $this, 'register_campaigns_metaboxes' ] );
-			add_action( 'add_meta_boxes', [ $this, 'campaign_page_templates_meta_box' ] );
 			add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_admin_assets' ] );
-			add_action( 'save_post_campaign', [ $this, 'save_campaign_page_templates_meta_box_data' ] );
+			add_action( 'cmb2_render_sidebar_link', [ $this, 'cmb2_render_sidebar_link_field_callback' ], 10, 5 );
 			add_action( 'cmb2_render_footer_icon_link', [ $this, 'cmb2_render_footer_icon_link_field_callback' ], 10, 5 );
-		}
-
-		/**
-		 * Return a list of the available campaign themes
-		 */
-		public function campaign_themes() {
-			$campaign_theme = [
-				'antarctic' => __( 'Antarctic', 'planet4-master-theme-backend' ),
-				'arctic'    => __( 'Arctic', 'planet4-master-theme-backend' ),
-				'climate'   => __( 'Climate Emergency', 'planet4-master-theme-backend' ),
-				'forest'    => __( 'Forest', 'planet4-master-theme-backend' ),
-				'oceans'    => __( 'Oceans', 'planet4-master-theme-backend' ),
-				'oil'       => __( 'Oil', 'planet4-master-theme-backend' ),
-				'plastic'   => __( 'Plastics', 'planet4-master-theme-backend' ),
-			];
-			return $campaign_theme;
 		}
 
 		/**
@@ -90,151 +73,74 @@ if ( ! class_exists( 'P4_Post_Campaign' ) ) {
 				'menu_position'      => null,
 				'menu_icon'          => 'dashicons-megaphone',
 				'show_in_rest'       => true,
-				'supports'           => [ 'title', 'editor', 'author', 'thumbnail', 'excerpt', 'revisions' ],
+				'supports'           => [
+					'title',
+					'editor',
+					'author',
+					'thumbnail',
+					'excerpt',
+					'revisions',
+					// Required to expose meta fields in the REST API.
+					'custom-fields',
+				],
 			);
 
 			register_post_type( self::POST_TYPE, $args );
-		}
 
-		/**
-		 * Add metabox for campaign page template selection on campaigns cpt
-		 */
-		public function campaign_page_templates_meta_box() {
-			add_meta_box(
-				'campaigns-page-templates',
-				__( 'Campaign Templates', 'planet4-master-theme-backend' ),
-				array( $this, 'campaign_page_templates_meta_box_callback' ),
-				'campaign',
-				'side'
+			self::campaign_field(
+				'theme',
+				[ 'default' => '' ]
 			);
-		}
-
-		/**
-		 * Callback function for campaign page template selection
-		 *
-		 * @param object $post The post object.
-		 */
-		public function campaign_page_templates_meta_box_callback( $post ) {
-
-			// Add a nonce field so we can check for it later.
-			wp_nonce_field( 'campaign_page_template_nonce_' . $post->ID, 'campaign_page_template_nonce' );
-
-			$value = get_post_meta( $post->ID, '_campaign_page_template', true );
-
-			$campaign_templates = $this->campaign_themes();
-			?>
-			<select id="campaign_page_template" name="campaign_page_template">
-				<option value=""><?php _e( 'Default Template', 'planet4-master-theme-backend' ); ?>
-				</option>
-				<?php
-				foreach ( $campaign_templates as $campaign => $campaign_template ) {
-					?>
-					<option value="<?php echo $campaign; ?>" <?php selected( $value, $campaign ); ?>>
-					<?php echo $campaign_template; ?>
-					</option>
-					<?php
-				}
-				?>
-			</select>
-			<?php
-		}
-
-		/**
-		 * Save campaigns page template data
-		 *
-		 * @param number $post_id The post id.
-		 */
-		public function save_campaign_page_templates_meta_box_data( $post_id ) {
-
-			// Check if our nonce is set.
-			if ( ! isset( $_POST['campaign_page_template_nonce'] ) ) {
-				return;
-			}
-
-			// Verify that the nonce is valid.
-			if ( ! wp_verify_nonce( $_POST['campaign_page_template_nonce'], 'campaign_page_template_nonce_' . $post_id ) ) {
-				return;
-			}
-
-			// If this is an autosave, our form has not been submitted, so we don't want to do anything.
-			if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
-				return;
-			}
-
-			// Check the user's permissions.
-			if ( ! current_user_can( 'edit_post', $post_id ) ) {
-				return;
-			}
-
-			/* OK, it's safe for us to save the data now. */
-
-			// Make sure that it is set.
-			if ( ! isset( $_POST['campaign_page_template'] ) ) {
-				return;
-			}
-
-			// Validate user input.
-			if ( in_array( $_POST['campaign_page_template'], array_keys( $this->campaign_themes() ) ) ) {
-				$campaign_page_template = $_POST['campaign_page_template'];
-			}
-
-			// Update the meta field in the database.
-			update_post_meta( $post_id, '_campaign_page_template', $campaign_page_template );
+			self::campaign_field(
+				'campaign_logo',
+				[ 'default' => 'campaign' ]
+			);
+			self::campaign_field(
+				'campaign_logo_color',
+				[ 'default' => 'light' ]
+			);
+			self::campaign_field(
+				'campaign_nav_type',
+				[ 'default' => 'planet4' ]
+			);
+			self::campaign_field(
+				'campaign_nav_color',
+				[ 'default' => '#FFFFFF' ]
+			);
+			self::campaign_field(
+				'campaign_nav_border',
+				[ 'default' => 'none' ]
+			);
+			self::campaign_field(
+				'campaign_header_color',
+				[ 'default' => '#000000' ]
+			);
+			self::campaign_field(
+				'campaign_primary_color'
+			);
+			self::campaign_field(
+				'campaign_secondary_color'
+			);
+			self::campaign_field(
+				'campaign_header_primary'
+			);
+			self::campaign_field(
+				'campaign_body_font',
+				[ 'default' => 'lora' ]
+			);
+			self::campaign_field(
+				'campaign_footer_theme',
+				[ 'default' => 'default' ]
+			);
+			self::campaign_field(
+				'footer_links_color'
+			);
 		}
 
 		/**
 		 * Register Color Picker Metabox for navigation
 		 */
 		public function register_campaigns_metaboxes() {
-			$prefix = 'sc_ch_';
-			$themes = $this->campaign_themes();
-			// Add default Greenpeace logo to array.
-			$themes['greenpeace'] = __( 'Greenpeace', 'planet4-master-theme-backend' );
-
-			$header_palette = [
-				'#E5E5E5',
-				'#32CA89',
-				'#1BB6D6',
-				'#22938D',
-				'#186A70',
-				'#043029',
-				'#093944',
-				'#042233',
-				'#1A1A1A',
-			];
-
-			$nav_palette = [
-				'#FFFFFF',
-				'#E5E5E5',
-				'#66CC00',
-				'#32CA89',
-				'#1BB6D6',
-				'#22938D',
-				'#186A70',
-				'#043029',
-				'#093944',
-				'#042233',
-				'#1A1A1A',
-				'#1B4A1B',
-			];
-
-			$primary_palette = [
-				'#ffd204',
-				'#66cc00',
-				'#6ed961',
-				'#21cbca',
-				'#ee562d',
-				'#7a1805',
-				'#2077bf',
-				'#1B4A1B',
-			];
-
-			$secondary_palette = [
-				'#042233',
-				'#093944',
-				'#074365',
-			];
-
 			$cmb = new_cmb2_box(
 				[
 					'id'           => 'campaign_nav_settings_mb',
@@ -250,194 +156,8 @@ if ( ! class_exists( 'P4_Post_Campaign' ) ) {
 
 			$cmb->add_field(
 				[
-					'name'    => 'Logo',
-					'desc'    => 'Change the campaign logo',
-					'id'      => 'campaign_logo',
-					'type'    => 'select',
-					'default' => 'greenpeace',
-					'options' => $themes,
-				]
-			);
-
-			$cmb->add_field(
-				[
-					'name'    => 'Logo Color',
-					'desc'    => 'Change the campaign logo color (if not default)',
-					'id'      => 'campaign_logo_color',
-					'type'    => 'radio_inline',
-					'default' => 'light',
-					'options' => [
-						'light' => __( 'Light', 'planet4-master-theme-backend' ),
-						'dark'  => __( 'Dark', 'planet4-master-theme-backend' ),
-					],
-				]
-			);
-
-			$cmb->add_field(
-				[
-					'name'    => __( 'Navigation', 'planet4-master-theme-backend' ),
-					'id'      => 'campaign_nav_type',
-					'type'    => 'radio_inline',
-					'options' => [
-						'planet4' => __( 'Planet 4 Navigation', 'planet4-master-theme-backend' ),
-						'minimal' => __( 'Minimal Navigation', 'planet4-master-theme-backend' ),
-					],
-					'default' => 'planet4',
-				]
-			);
-
-			$cmb->add_field(
-				[
-					'name'       => __( 'Navigation Background Color', 'planet4-master-theme-backend' ),
-					'id'         => 'campaign_nav_color',
-					'type'       => 'colorpicker',
-					'classes'    => 'palette-only',
-					'attributes' => [
-						'data-colorpicker' => wp_json_encode(
-							[
-								'palettes' => $nav_palette,
-							]
-						),
-					],
-				]
-			);
-
-			$cmb->add_field(
-				[
-					'name'    => __( 'Navigation bottom border', 'planet4-master-theme-backend' ),
-					'id'      => 'campaign_nav_border',
-					'type'    => 'radio_inline',
-					'options' => [
-						'none'   => __( 'No border', 'planet4-master-theme-backend' ),
-						'border' => __( 'White bottom border', 'planet4-master-theme-backend' ),
-					],
-					'default' => 'none',
-				]
-			);
-
-			$cmb->add_field(
-				[
-					'name'       => __( 'Header Text Color', 'planet4-master-theme-backend' ),
-					'id'         => 'campaign_header_color',
-					'type'       => 'colorpicker',
-					'classes'    => 'palette-only',
-					'attributes' => [
-						'data-colorpicker' => wp_json_encode(
-							[
-								'palettes' => $header_palette,
-							]
-						),
-					],
-				]
-			);
-
-			$cmb->add_field(
-				[
-					'name'       => __( 'Primary Button Color', 'planet4-master-theme-backend' ),
-					'id'         => 'campaign_primary_color',
-					'type'       => 'colorpicker',
-					'classes'    => 'palette-only',
-					'attributes' => [
-						'data-colorpicker' => json_encode(
-							[
-								'palettes' => $primary_palette,
-							]
-						),
-					],
-				]
-			);
-
-			$cmb->add_field(
-				[
-					'name'       => __( 'Secondary Button Color and Link Text Color', 'planet4-master-theme-backend' ),
-					'id'         => 'campaign_secondary_color',
-					'type'       => 'colorpicker',
-					'classes'    => 'palette-only',
-					'attributes' => [
-						'data-colorpicker' => json_encode(
-							[
-								'palettes' => $secondary_palette,
-							]
-						),
-					],
-				]
-			);
-
-			$cmb->add_field(
-				[
-					'name'             => 'Header Primary Font',
-					'desc'             => 'Select an option',
-					'id'               => 'campaign_header_primary',
-					'type'             => 'select',
-					'show_option_none' => '-----',
-					'options'          => [
-						'Anton'            => __( 'Anton', 'planet4-master-theme-backend' ),
-						'Jost'             => __( 'Jost', 'planet4-master-theme-backend' ),
-						'Montserrat'       => __( 'Montserrat Bold', 'planet4-master-theme-backend' ),
-						'Montserrat_Light' => __( 'Montserrat Light', 'planet4-master-theme-backend' ),
-						'Sanctuary'        => __( 'Sanctuary', 'planet4-master-theme-backend' ),
-						'Kanit'            => __( 'Kanit Extra Bold', 'planet4-master-theme-backend' ),
-						'Save the Arctic'  => __( 'Save the Arctic', 'planet4-master-theme-backend' ),
-					],
-				]
-			);
-
-			$cmb->add_field(
-				[
-					'name'             => 'Header Secondary Font',
-					'desc'             => 'Select an option',
-					'id'               => 'campaign_header_secondary',
-					'type'             => 'select',
-					'show_option_none' => '-----',
-					'options'          => [
-						'monsterrat_semi'   => __( 'Montserrat Semi Bold', 'planet4-master-theme-backend' ),
-						'kanit_semi'        => __( 'Kanit Semi Bold', 'planet4-master-theme-backend' ),
-						'open_sans'         => __( 'Open Sans', 'planet4-master-theme-backend' ),
-						'open_sans_shadows' => __( 'Open Sans Shadows', 'planet4-master-theme-backend' ),
-					],
-				]
-			);
-
-			$cmb->add_field(
-				[
-					'name'    => __( 'Body Font', 'planet4-master-theme-backend' ),
-					'id'      => 'campaign_body_font',
-					'type'    => 'radio_inline',
-					'options' => [
-						'lora'     => __( 'Serif', 'planet4-master-theme-backend' ),
-						'roboto'   => __( 'Sans Serif', 'planet4-master-theme-backend' ),
-						'campaign' => __( 'Campaign default', 'planet4-master-theme-backend' ),
-					],
-					'default' => 'lora',
-				]
-			);
-
-			$cmb->add_field(
-				[
-					'name'    => __( 'Footer Theme', 'planet4-master-theme-backend' ),
-					'id'      => 'campaign_footer_theme',
-					'type'    => 'radio_inline',
-					'options' => [
-						'default' => __( 'Default', 'planet4-master-theme-backend' ),
-						'white'   => __( 'White', 'planet4-master-theme-backend' ),
-					],
-					'default' => 'default',
-				]
-			);
-
-			$cmb->add_field(
-				[
-					'name'       => __( 'Footer links color', 'planet4-master-theme-backend' ),
-					'id'         => 'footer_links_color',
-					'type'       => 'colorpicker',
-					'classes'    => 'palette-only',
-					'attributes' => [
-						'data-colorpicker' => json_encode(
-							[
-								'palettes' => $primary_palette,
-							]
-						),
-					],
+					'id'   => 'new_sidebar_link',
+					'type' => 'sidebar_link',
 				]
 			);
 
@@ -488,6 +208,41 @@ if ( ! class_exists( 'P4_Post_Campaign' ) ) {
 		public function enqueue_admin_assets() {
 			wp_register_style( 'cmb-style', get_template_directory_uri() . '/admin/css/campaign.css' );
 			wp_enqueue_style( 'cmb-style' );
+		}
+
+		/**
+		 * CMB2 custom field(sidebar_link) callback function.
+		 *
+		 * @param array $field The CMB2 field array.
+		 * @param array $value The CMB2 field Value.
+		 * @param array $object_id The id of the object.
+		 * @param array $object_type The type of object.
+		 * @param array $field_type Instance of the `cmb2_Meta_Box_types` object.
+		 */
+		public function cmb2_render_sidebar_link_field_callback(
+			$field,
+			$value,
+			$object_id,
+			$object_type,
+			$field_type
+		) {
+			?>
+			<a
+				href="#" onclick="openSidebar()"
+				id="new_sidebar_link">
+				<?php
+					echo __( 'Design settings moved to a new sidebar.', 'planet4-master-theme-backend' )
+				?>
+			</a>
+			<script>
+				function openSidebar() {
+					let sidebarButton = document.querySelector( '.edit-post-pinned-plugins button[aria-expanded=false]' );
+					if ( sidebarButton ) {
+						sidebarButton.click();
+					}
+				}
+			</script>
+			<?php
 		}
 
 		/**
@@ -562,8 +317,108 @@ if ( ! class_exists( 'P4_Post_Campaign' ) ) {
 				);
 			?>
 			</div>
-			<div class="alignleft"> <?php esc_html_e( 'In the “Footer icon name” field add the name of the icon you want from the', 'planet4-master-theme-backend' ); ?> <a target="_blank" href="https://github.com/greenpeace/planet4-styleguide/tree/master/src/icons"><?php esc_html_e( 'list of icons in the CSS styleguide', 'planet4-master-theme-backend' ); ?></a>. e.g. twitter-square</div>
+			<div class="alignleft"> <?php esc_html_e( 'In the “Footer icon name” field add the name of the icon you want from the', 'planet4-master-theme-backend' ); ?> <a target="_blank" href="https://github.com/greenpeace/planet4-styleguide/tree/master/src/icons"><?php esc_html_e( 'list of icons in the CSS styleguide', 'planet4-master-theme-backend' ); ?></a>. e.g. twitter-square</div>
 			<?php
+		}
+
+		/**
+		 * Register a key as a post_meta with the argument `show_in_rest` that is needed on all fields so they can be
+		 * used through the REST api. Also set `type` and `single` as both are the same for all attributes.
+		 *
+		 * @param string $meta_key Identifier the post_meta field will be registered with.
+		 * @param array  $args Arguments which are passed on to register_post_meta.
+		 *
+		 * @return void A description of the field.
+		 */
+		private static function campaign_field(
+			string $meta_key,
+			array $args = []
+		): void {
+			$args = array_merge(
+				[
+					'show_in_rest' => true,
+					'type'         => 'string',
+					'single'       => true,
+				],
+				$args
+			);
+			register_post_meta( self::POST_TYPE, $meta_key, $args );
+		}
+
+		/**
+		 * Determine the css variables for a certain post.
+		 *
+		 * @param array $meta The meta containing the variable values.
+		 * @return array The values that will be used for the css variables.
+		 */
+		public static function css_vars( array $meta ): array {
+			$theme = $meta['theme'] ?? $meta['_campaign_page_template'];
+
+			// Set specific CSS for Montserrat.
+			$special_weight_fonts = [
+				'Montserrat'       => '900',
+				'Montserrat_Light' => '500',
+			];
+
+			$header_primary_font =
+				'Montserrat_Light' === $meta['campaign_header_primary'] ?? null
+					? 'Montserrat'
+					: $meta['campaign_header_primary'] ?? null;
+
+			$campaigns_font_map = [
+				'default'   => 'lora',
+				'antarctic' => 'sanctuary',
+				'arctic'    => 'Save the Arctic',
+				'climate'   => 'Jost',
+				'forest'    => 'Kanit',
+				'oceans'    => 'Montserrat',
+				'oil'       => 'Anton',
+				'plastic'   => 'Montserrat',
+			];
+
+			$campaign_font = $campaigns_font_map[ $theme ?: 'default' ];
+
+			if ( 'campaign' === $meta['campaign_body_font'] ) {
+				$body_font = $campaign_font;
+			} else {
+				$body_font = $meta['campaign_body_font'];
+			}
+			$footer_theme = $meta['campaign_footer_theme'] ?? null;
+
+			if ( 'white' === $footer_theme ) {
+				$default_footer_links_color = $meta['campaign_nav_color'] ?: '#1A1A1A';
+				$footer_links_color         = $meta['footer_links_color'] ?: $default_footer_links_color;
+				$footer_color               = '#FFFFFF';
+			} else {
+				$footer_links_color = 'light' === $meta['campaign_logo_color'] ? '#FFFFFF' : '#1A1A1A';
+				$footer_color       = $meta['campaign_nav_color'] ?? null;
+			}
+
+			$passive_button_colors_map = [
+				'#ffd204' => '#ffe467',
+				'#66cc00' => '#66cc00',
+				'#6ed961' => '#a7e021',
+				'#21cbca' => '#77ebe0',
+				'#ee562d' => '#f36d3a',
+				'#7a1805' => '#a01604',
+				'#2077bf' => '#2077bf',
+				'#1b4a1b' => '#1b4a1b',
+			];
+
+			return [
+				'nav-color'            => $meta['campaign_nav_color'] ?? null,
+				'footer-color'         => $footer_color,
+				'footer-links-color'   => $footer_links_color,
+				'header-color'         => $meta['campaign_header_color'] ?? null,
+				'header-primary-font'  => $header_primary_font,
+				'header-font-weight'   => $special_weight_fonts[ $meta['campaign_header_primary'] ] ?? null,
+				'body-font'            => $body_font,
+				'passive-button-color' => isset( $meta['campaign_primary_color'] ) && $meta['campaign_primary_color']
+					? $passive_button_colors_map[ strtolower( $meta['campaign_primary_color'] ) ]
+					: null,
+				'primary-color'        => $meta['campaign_primary_color'] ?? null,
+				'secondary-color'      => $meta['campaign_secondary_color'] ?? null,
+			];
 		}
 	}
 }

--- a/single-campaign.php
+++ b/single-campaign.php
@@ -19,125 +19,37 @@ $post            = Timber::query_post( false, 'P4_Post' );
 $context['post'] = $post;
 
 // Get the cmb2 custom fields data.
-$page_meta_data    = get_post_meta( $post->ID );
-$campaign_template = ! empty( $page_meta_data['_campaign_page_template'][0] ) ? $page_meta_data['_campaign_page_template'][0] : false;
+$meta = $post->custom;
+// This will later become something else than the meta of the post, but using this already so we only have to change
+// this line later.
+$campaign_meta = $meta;
+$theme         = $campaign_meta['theme'] ?? $campaign_meta['_campaign_page_template'] ?? null;
 
-if ( $campaign_template ) {
-	$context['custom_body_classes'] = 'brown-bg theme-' . $campaign_template;
+if ( $theme ) {
+	$context['custom_body_classes'] = 'brown-bg theme-' . $theme;
 }
 
 // Save custom style settings.
 $custom_styles = [];
 
-// Set specific CSS for Montserrat.
-$pf = $post->campaign_header_primary;
-
-$header_font_style = [
-	'Montserrat'       => "font-family: 'Montserrat' !important; font-weight: 900 !important;",
-	'Montserrat_Light' => "font-family: 'Montserrat' !important; font-weight: 500 !important;",
-];
-
-if ( $pf && array_key_exists( $pf, $header_font_style ) ) {
-	$header_font = $header_font_style[ $pf ];
-} else {
-	$header_font = "font-family: {$pf} !important;";
-}
-
-$footer_links_color = 'light' === $post->campaign_logo_color ? '#FFFFFF' : '#1A1A1A';
-
-$footer_theme = $post->campaign_footer_theme ?? null;
-
-if ( 'white' == $footer_theme ) {
-	$default_footer_links_color = $post->campaign_nav_color ?? '#1A1A1A';
-	$footer_links_color         = $post->footer_links_color ?? $default_footer_links_color;
-	$footer_color               = '#FFFFFF';
-} else {
-	$footer_color = $post->campaign_nav_color ?? null;
-}
-
-$passive_button_colors_map = [
-	'#ffd204' => '#ffe467',
-	'#66cc00' => '#66cc00',
-	'#6ed961' => '#a7e021',
-	'#21cbca' => '#77ebe0',
-	'#ee562d' => '#f36d3a',
-	'#7a1805' => '#a01604',
-	'#2077bf' => '#2077bf',
-	'#1b4a1b' => '#1b4a1b',
-];
-
-$campaigns_font_map = [
-	'default'   => 'lora',
-	'antarctic' => 'sanctuary',
-	'arctic'    => 'Save the Arctic',
-	'climate'   => 'Jost',
-	'forest'    => 'Kanit',
-	'oceans'    => 'Montserrat',
-	'oil'       => 'Anton',
-	'plastic'   => 'Montserrat',
-];
-
-if ( $campaign_template ) {
-	$context['custom_body_classes'] = 'brown-bg theme-' . $campaign_template;
-	$campaign_font                  = $campaigns_font_map[ $campaign_template ];
-} else {
-	$campaign_font = $campaigns_font_map['default'];
-}
-
-if ( 'campaign' == $post->campaign_body_font ) {
-	$body_font = $campaign_font;
-} else {
-	$body_font = $post->campaign_body_font ?? null;
-}
-
-$custom_styles['css']['nav_color']               = $post->campaign_nav_color ? ".navbar { background-color: {$post->campaign_nav_color} !important;}" : null;
-$custom_styles['nav_type']                       = $post->campaign_nav_type;
-$custom_styles['nav_border']                     = $post->campaign_nav_border;
-$custom_styles['campaign_logo_color']            = $post->campaign_logo_color ?? 'light';
-$custom_styles['css']['footer_color']            = $footer_color ? ".site-footer { background-color: {$footer_color} !important;}" : null;
-$custom_styles['css']['footer_svg_icons_color']  = ".site-footer_min .icon { fill: {$footer_links_color} !important }";
-$custom_styles['css']['footer_elements_color']   = ".site-footer a { color: {$footer_links_color} !important }";
-$custom_styles['css']['footer_separatos_color']  = ".site-footer li { color: {$footer_links_color} !important }";
-$custom_styles['css']['footer_year_color']       = ".site-footer .gp-year { color: {$footer_links_color} !important; font-family: Roboto !important }";
-$custom_styles['css']['footer_copyright_color']  = ".site-footer .copyright-text { color: {$footer_links_color} !important }";
-$custom_styles['css']['header_color']            = $post->campaign_header_color ? " h1, h2, h3, h4, h5 { color: {$post->campaign_header_color} !important;}" : null;
-$custom_styles['css']['campaign_header_primary'] = $post->campaign_header_primary ? " h1, h2, h3, h4, h5 { {$header_font} }" : null;
-$custom_styles['css']['header_serif']            = $post->campaign_header_serif ? " .page-header { font-family: {$post->campaign_header_serif}!important;}" : null;
-$custom_styles['css']['header_sans']             = $post->campaign_header_sans ? " .page-header { font-family: {$post->campaign_header_sans} !important;}" : null;
-$custom_styles['css']['body_font']               = $body_font ? " body, p { font-family: '{$body_font}' !important;}" : null;
-$custom_styles['css']['btn_primary']             = $post->campaign_primary_color ? " .btn-primary { background: {$passive_button_colors_map[strtolower($post->campaign_primary_color)]} !important; border-color: {$passive_button_colors_map[$post->campaign_primary_color]} !important;}" : null;
-$custom_styles['css']['btn_primary_hover']       = $post->campaign_primary_color ? " .btn-primary:hover { background: {$post->campaign_primary_color} !important; border-color: {$post->campaign_primary_color} !important;}" : null;
-$custom_styles['css']['btn_secondary']           = $post->campaign_secondary_color
-	? " .btn-secondary, .btn-action.cover-card-btn {
-			background: rgba(255, 255, 255, .75) !important;
-			border: 1px solid {$post->campaign_secondary_color} !important;
-			color: {$post->campaign_secondary_color} !important;
-		}"
-	: null;
-$custom_styles['css']['btn_secondary_hover']     = $post->campaign_secondary_color
-	? " .btn-secondary:hover {
-			background: {$post->campaign_secondary_color} !important;
-			border: 1px solid {$post->campaign_secondary_color} !important;
-			color: white !important;
-		}"
-	: null;
-
-$custom_styles['css']['anchor']         = $post->campaign_secondary_color ? " a { color: {$post->campaign_secondary_color } !important; }" : null;
-$custom_styles['css']['cover-card-btn'] = $post->campaign_primary_color ? " .cover-card:hover .cover-card-btn { background-color: {$post->campaign_primary_color} !important; border-color: {$post->campaign_primary_color} !important;}" : null;
-$custom_styles['campaign_logo']         = $post->campaign_logo ?? null;
+$custom_styles['nav_type']            = $campaign_meta['campaign_nav_type'];
+$custom_styles['nav_border']          = $campaign_meta['campaign_nav_border'];
+$custom_styles['campaign_logo_color'] = $campaign_meta['campaign_logo_color'] ?? 'light';
+$custom_styles['campaign_logo']       = $campaign_meta['campaign_logo'] ?? null;
 
 // Set GTM Data Layer values.
 $post->set_data_layer();
 $data_layer = $post->get_data_layer();
 
+$context['theme']                       = $theme;
 $context['post']                        = $post;
-$context['header_title']                = is_front_page() ? ( $page_meta_data['p4_title'][0] ?? '' ) : ( $page_meta_data['p4_title'][0] ?? $post->title );
-$context['header_subtitle']             = $page_meta_data['p4_subtitle'][0] ?? '';
-$context['header_description']          = wpautop( $page_meta_data['p4_description'][0] ?? '' );
-$context['header_button_title']         = $page_meta_data['p4_button_title'][0] ?? '';
-$context['header_button_link']          = $page_meta_data['p4_button_link'][0] ?? '';
-$context['header_button_link_checkbox'] = $page_meta_data['p4_button_link_checkbox'][0] ?? '';
-$context['hide_page_title_checkbox']    = $page_meta_data['p4_hide_page_title_checkbox'][0] ?? '';
+$context['header_title']                = is_front_page() ? ( $meta['p4_title'] ?? '' ) : ( $meta['p4_title'] ?? $post->title );
+$context['header_subtitle']             = $meta['p4_subtitle'] ?? '';
+$context['header_description']          = wpautop( $meta['p4_description'] ?? '' );
+$context['header_button_title']         = $meta['p4_button_title'] ?? '';
+$context['header_button_link']          = $meta['p4_button_link'] ?? '';
+$context['header_button_link_checkbox'] = $meta['p4_button_link_checkbox'] ?? '';
+$context['hide_page_title_checkbox']    = $meta['p4_hide_page_title_checkbox'] ?? '';
 $context['social_accounts']             = $post->get_social_accounts( $context['footer_social_menu'] );
 $context['page_category']               = $data_layer['page_category'];
 $context['post_tags']                   = implode( ', ', $post->tags() );
@@ -149,19 +61,22 @@ $context['og_title']                = $post->get_og_title();
 $context['og_description']          = $post->get_og_description();
 $context['og_image_data']           = $post->get_og_image();
 $context['custom_styles']           = $custom_styles;
+$context['css_vars']                = P4_Post_Campaign::css_vars( $campaign_meta );
 
 // P4 Campaign/dataLayer fields.
-$context['cf_campaign_name'] = $page_meta_data['p4_campaign_name'][0] ?? '';
-$context['cf_basket_name']   = $page_meta_data['p4_basket_name'][0] ?? '';
-$context['cf_scope']         = $page_meta_data['p4_scope'][0] ?? '';
-$context['cf_department']    = $page_meta_data['p4_department'][0] ?? '';
+$context['cf_campaign_name'] = $campaign_meta['p4_campaign_name'] ?? '';
+$context['cf_basket_name']   = $campaign_meta['p4_basket_name'] ?? '';
+$context['cf_scope']         = $campaign_meta['p4_scope'] ?? '';
+$context['cf_department']    = $campaign_meta['p4_department'] ?? '';
 
 // Social footer link overrides.
 $context['social_overrides'] = [];
 
-for ( $i = 1; $i <= 5; $i++ ) {
-	if ( isset( $page_meta_data[ 'campaign_footer_item' . $i ] ) ) {
-		$campaign_footer_item = maybe_unserialize( $page_meta_data[ 'campaign_footer_item' . $i ][0] );
+foreach ( range( 1, 5 ) as $i ) {
+	$footer_item_key = 'campaign_footer_item' . $i;
+
+	if ( isset( $campaign_meta[ $footer_item_key ] ) ) {
+		$campaign_footer_item = maybe_unserialize( $campaign_meta[ $footer_item_key ] );
 		if ( $campaign_footer_item['url'] && $campaign_footer_item['icon'] ) {
 			$context['social_overrides'][ $i ]['url']  = $campaign_footer_item['url'];
 			$context['social_overrides'][ $i ]['icon'] = $campaign_footer_item['icon'];

--- a/templates/css-variables.twig
+++ b/templates/css-variables.twig
@@ -1,0 +1,92 @@
+{# As a first step use a twig template to set css variables instead of in PHP so that IDEs can have syntax color.
+Later we will use these variables in our source scss files (with a fallback to the default value)
+ to expose variables to theme configuration files, thereby removing the need of separate selectors.
+ #}
+<style>
+	{% if css_vars['nav-color'] %}
+		.navbar {
+			background-color: {{ css_vars['nav-color'] }} !important;
+		}
+	{% endif %}
+
+	{% if css_vars['footer-color'] %}
+		.site-footer {
+			background-color: {{ css_vars['footer-color'] }} !important;
+		}
+	{% endif %}
+
+	{# footer-links-color is always set. #}
+	.site-footer a,
+	.site-footer li,
+	.site-footer .gp-year,
+	.site-footer .copyright-text {
+		color: {{ css_vars['footer-links-color'] }} !important;
+	}
+
+	.site-footer .gp-year {
+		font-family: Roboto !important;
+	}
+
+	.site-footer_min .icon {
+		fill: {{ css_vars['footer-links-color'] }} !important;
+	}
+
+	{% if css_vars['header-color'] %}
+		h1, h2, h3, h4, h5 {
+			color: {{ css_vars['header-color'] }} !important;
+		}
+	{% endif %}
+
+	{% if css_vars['header-primary-font'] %}
+		h1, h2, h3, h4, h5 {
+			font-family: {{ css_vars['header-primary-font'] }} !important;
+		}
+	{% endif %}
+
+	{% if css_vars['header-font-weight'] %}
+		h1, h2, h3, h4, h5 {
+			font-weight: {{ css_vars['header-font-weight'] }} !important;
+		}
+	{% endif %}
+
+	{% if css_vars['body-font'] %}
+		body, p {
+			font-family: {{ css_vars['body-font'] }} !important;
+		}
+	{% endif %}
+
+	{% if css_vars['primary-color'] %}
+		.btn-primary {
+			background: {{ css_vars['passive-button-color'] }} !important;
+			border-color: {{ css_vars['passive-button-color'] }} !important;
+		}
+
+		.btn-primary:hover {
+			background: {{ css_vars['primary-color'] }} !important;
+			border-color: {{ css_vars['primary-color'] }} !important;
+		}
+
+		.cover-card:hover .cover-card-btn {
+			background: {{ css_vars['primary-color'] }} !important;
+			border-color: {{ css_vars['primary-color'] }} !important;
+		}
+	{% endif %}
+
+	{% if css_vars['secondary-color'] %}
+		a {
+			color: {{ css_vars['secondary-color'] }} !important;
+		}
+
+		.btn-secondary, .btn-action.cover-card-btn {
+			background: rgba(255, 255, 255, .75) !important;
+			border: 1px solid {{ css_vars['secondary-color'] }} !important;
+			color: {{ css_vars['secondary-color'] }} !important;
+		}
+
+		.btn-secondary:hover, .btn-action.cover-card-btn:hover {
+			background: {{ css_vars['secondary-color'] }} !important;
+			border: 1px solid {{ css_vars['secondary-color'] }} !important;
+			color: white !important;
+		}
+	{% endif %}
+</style>

--- a/templates/html-header.twig
+++ b/templates/html-header.twig
@@ -82,6 +82,9 @@
 		{% endfor %}
 	{% endif %}
 
+	{% if css_vars %}
+		{% include 'css-variables.twig' %}
+	{% endif %}
 	{% if custom_styles %}
 		<style type="text/css">
 			{% for style in custom_styles.css %}{{ style|raw }}{% endfor %}


### PR DESCRIPTION
* Use `register_post_meta` to add campaign fields instead of cmb2. The
editor interface for these fields will be added to
planet4-plugin-gutenberg-blocks in https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/190
* Move allowed values to json files. These are fetched by the frontend
to populate the values of the editor. Initially all files contain the
same values as were available for all templates in the code.
* Use a wrapper function `P4_Post_Campaign::campaign_field()` to add
these fields for convenience, as they all share some args.
* Create a list of CSS variables. Ultimately these should be used as
actual css variables, however as a first step use these in a twig
template that only adds the rule if a variable is set. This intermediary
step is because a bigger change is needed to handle fallbacks when a
value is not set: the fallback would be dependant on which campaign
template is chosen.