### PR TITLE
PLANET-4429 Give `list_users` capability to editors

### DIFF
--- a/classes/class-p4-activator.php
+++ b/classes/class-p4-activator.php
@@ -39,5 +39,11 @@ class P4_Activator {
 
 		$campaigner = new P4_Campaigner();
 		$campaigner->register_role_and_add_capabilities();
+
+		// Needed to allow the editor rule to change the author of a post in the document sidebar. The users data for that
+		// control is fetched using the REST API, where WordPress by default doesn't perform a permissions check, however
+		// the Wordfence plugin adds this check in `\wordfence::jsonAPIAuthorFilter`.
+		$roles = wp_roles();
+		$roles->add_cap( 'editor', 'list_users' );
 	}
 }


### PR DESCRIPTION
This enables them to change the author from the document sidebar. By
default wordpress doesn't require this permission, however the Wordfence
plugin adds a check on this.

This does mean that editors are able to access the `users` menu item and see (but not edit) users of all roles. I asked Gabor in the ticket if this is an issue for us.