### PR TITLE
PLANET-4454: Posts: Anchor link extends beyond the body column

### DIFF
--- a/assets/src/scss/base/_body.scss
+++ b/assets/src/scss/base/_body.scss
@@ -39,8 +39,6 @@ a {
   color: $blue;
 
   &.external-link {
-    white-space: nowrap;
-
     .external-icon {
       height: .55rem;
       width: .55rem;


### PR DESCRIPTION
Removing this generic rule as it is too broad, if something comes up we'll deal with that case with something more specific.

Ref: https://jira.greenpeace.org/browse/PLANET-4454
