### PR TITLE
PLANET-4157 Fix author bio block readmore link

### DIFF
--- a/assets/src/scss/pages/post/_author-block.scss
+++ b/assets/src/scss/pages/post/_author-block.scss
@@ -55,7 +55,6 @@
 
   @supports (display: -webkit-box) {
     display: -webkit-box;
-    -webkit-line-clamp: 5;
     -webkit-box-orient: vertical;
     max-height: none;
   }

--- a/templates/blocks/author_profile.twig
+++ b/templates/blocks/author_profile.twig
@@ -6,9 +6,24 @@
 				<h5 rel="author" class="author-block-info-name">
 					<a href="{{ post.author.link }}" itemprop="name">{{ post.author.name }}</a>
 				</h5>
+
+				{% set author_bio_readmore %}
+					...  &nbsp;<a href="{{ post.author.link }}">{{ __( 'Read More', 'planet4-master-theme' ) }}</a>
+				{% endset %}
+
+				{% if ( fn('wp_is_mobile') ) %}
+					{% set author_bio_char_limit = 180 %}
+				{% else %}
+					{% set author_bio_char_limit = 300 %}
+				{% endif %}
+
+				{% set author_bio = fn('substr', post.author.description, 0, fn('strpos', post.author.description ,' ', author_bio_char_limit)) %}
+				{% set author_bio = post.author.description|length > author_bio_char_limit ? author_bio ~ author_bio_readmore : author_bio %}
+
 				<p class="author-block-info-bio" itemprop="description">
-					{{ fn('wpautop', fn('the_author_meta', 'description', author.id))|e('wp_kses_post')|raw }}
+					{{ fn('wpautop', author_bio)|e('wp_kses_post')|raw }}
 				</p>
+
 			</div>
 			<figure class="author-block-image">
 				{% if ( post.author.avatar ) %}


### PR DESCRIPTION
[JIRA 4157](https://jira.greenpeace.org/browse/PLANET-4157)

- The `wp_trim_words()` function is localized. For languages that count ‘words’ by the individual character (such as East Asian languages), the `num_words` argument will apply to the number of individual characters
- The `wp_is_mobile()` function is used to apply `author_bio_word_limit` as per device size