### PR TITLE
PLANET-4595: Archive - Implement command to include archived content in search results (incl. mobile)

### DIFF
--- a/assets/src/scss/pages/search/_search.scss
+++ b/assets/src/scss/pages/search/_search.scss
@@ -3,7 +3,11 @@
 
   .multiple-search-result .more-btn {
     width: auto;
-    margin-bottom: $space-xxl;
+    margin-bottom: $space-md;
+
+    @include large-and-up {
+      margin-bottom: $space-xxl;
+    }
   }
 
   .more-btn[disabled]:hover {
@@ -84,7 +88,7 @@
 
 .toggle-wrapper {
   display: inline-block;
-  margin-left: 48px;
+  margin-bottom: $space-xl;
 
   .toggle-button {
     display: inline-block;
@@ -92,6 +96,11 @@
     label {
       margin-bottom: -0.6rem;
     }
+  }
+
+  @include large-and-up {
+    margin-left: 48px;
+    margin-top: 42px;
   }
 
   span {

--- a/templates/search.twig
+++ b/templates/search.twig
@@ -297,26 +297,31 @@
 							</ul>
 							{% if ( load_more ) %}
 								<div class="col-lg-12 mb-5 load-more-button-div">
-									<button
-										class="btn btn-medium btn-small btn-secondary more-btn {{ load_more.async ? 'btn-load-more-async' : '' }} btn-load-more-click-scroll"
-										data-current_page="{{ current_page }}"
-										data-total_posts="{{ found_posts }}"
-										data-posts_per_load="{{ load_more.posts_per_load }}"
-										data-archives_per_load="{{ load_more.archives_per_load }}"
-										data-page_archive_available_after = "{{ load_more.page_archive_available_after }}">
-											{{ load_more.button_text }}
-									</button>
-
-									{% if settings.include_archive_content %}
-										<div class="toggle-wrapper">
-											<div class="toggle-button">
-												<input type="checkbox" id="show-archive-toggle" class="toggle show-archive-toggle"/>
-												<label class="toggle-label" for="show-archive-toggle"></label>
-											</div>
-											<span class="toggle-label-include">{{ load_more.include_archive_content_text }}</span>
-											<span class="toggle-label-exclude">{{ load_more.exclude_archive_content_text }}</span>
+									<div class="row">
+										<div class="col-lg-5 col-sm-12">
+											<button
+												class="btn btn-medium btn-small btn-secondary more-btn {{ load_more.async ? 'btn-load-more-async' : '' }} btn-load-more-click-scroll"
+												data-current_page="{{ current_page }}"
+												data-total_posts="{{ found_posts }}"
+												data-posts_per_load="{{ load_more.posts_per_load }}"
+												data-archives_per_load="{{ load_more.archives_per_load }}"
+												data-page_archive_available_after = "{{ load_more.page_archive_available_after }}">
+													{{ load_more.button_text }}
+											</button>
 										</div>
-									{% endif %}
+										<div class="col-lg-7 col-sm-12">
+											{% if settings.include_archive_content %}
+												<div class="toggle-wrapper">
+													<div class="toggle-button">
+														<input type="checkbox" id="show-archive-toggle" class="toggle show-archive-toggle"/>
+														<label class="toggle-label" for="show-archive-toggle"></label>
+													</div>
+													<span class="toggle-label-include">{{ load_more.include_archive_content_text }}</span>
+													<span class="toggle-label-exclude">{{ load_more.exclude_archive_content_text }}</span>
+												</div>
+											{% endif %}
+										</div>
+									</div>
 								</div>
 							{% endif %}
 							{% if ( pagination ) %}


### PR DESCRIPTION
This branch is based on: https://github.com/greenpeace/planet4-master-theme/pull/972

The task was to move the "Include Archive" switch below the button in mobile. 

Ref: https://jira.greenpeace.org/browse/PLANET-4595