### PR TITLE
PLANET-4603 Dealing with how WP deals with default values

### DIFF
--- a/classes/class-p4-post-campaign.php
+++ b/classes/class-p4-post-campaign.php
@@ -87,54 +87,19 @@ if ( ! class_exists( 'P4_Post_Campaign' ) ) {
 
 			register_post_type( self::POST_TYPE, $args );
 
-			self::campaign_field(
-				'theme',
-				[ 'default' => '' ]
-			);
-			self::campaign_field(
-				'campaign_logo',
-				[ 'default' => 'greenpeace' ]
-			);
-			self::campaign_field(
-				'campaign_logo_color',
-				[ 'default' => 'light' ]
-			);
-			self::campaign_field(
-				'campaign_nav_type',
-				[ 'default' => 'planet4' ]
-			);
-			self::campaign_field(
-				'campaign_nav_color',
-				[ 'default' => '#ffffff' ]
-			);
-			self::campaign_field(
-				'campaign_nav_border',
-				[ 'default' => 'none' ]
-			);
-			self::campaign_field(
-				'campaign_header_color',
-				[ 'default' => '#000000' ]
-			);
-			self::campaign_field(
-				'campaign_primary_color'
-			);
-			self::campaign_field(
-				'campaign_secondary_color'
-			);
-			self::campaign_field(
-				'campaign_header_primary'
-			);
-			self::campaign_field(
-				'campaign_body_font',
-				[ 'default' => 'campaign' ]
-			);
-			self::campaign_field(
-				'campaign_footer_theme',
-				[ 'default' => 'default' ]
-			);
-			self::campaign_field(
-				'footer_links_color'
-			);
+			self::campaign_field( 'theme' );
+			self::campaign_field( 'campaign_logo' );
+			self::campaign_field( 'campaign_logo_color' );
+			self::campaign_field( 'campaign_nav_type' );
+			self::campaign_field( 'campaign_nav_color' );
+			self::campaign_field( 'campaign_nav_border' );
+			self::campaign_field( 'campaign_header_color' );
+			self::campaign_field( 'campaign_primary_color' );
+			self::campaign_field( 'campaign_secondary_color' );
+			self::campaign_field( 'campaign_header_primary' );
+			self::campaign_field( 'campaign_body_font' );
+			self::campaign_field( 'campaign_footer_theme' );
+			self::campaign_field( 'footer_links_color' );
 		}
 
 		/**
@@ -352,34 +317,22 @@ if ( ! class_exists( 'P4_Post_Campaign' ) ) {
 		 * @return array The values that will be used for the css variables.
 		 */
 		public static function css_vars( array $meta ): array {
-			$theme = $meta['theme'] ?? $meta['_campaign_page_template'];
-
 			// Set specific CSS for Montserrat.
 			$special_weight_fonts = [
 				'Montserrat'       => '900',
 				'Montserrat_Light' => '500',
 			];
 
-			$header_primary_font =
-				'Montserrat_Light' === $meta['campaign_header_primary'] ?? null
+			$header_primary_font = 'Montserrat_Light' === ( $meta['campaign_header_primary'] ?? null )
 					? 'Montserrat'
 					: $meta['campaign_header_primary'] ?? null;
 
-			$campaigns_font_map = [
-				'default'   => 'lora',
-				'antarctic' => 'sanctuary',
-				'arctic'    => 'Save the Arctic',
-				'climate'   => 'Jost',
-				'forest'    => 'Kanit',
-				'oceans'    => 'Montserrat',
-				'oil'       => 'Anton',
-				'plastic'   => 'Montserrat',
-			];
-
-			$campaign_font = $campaigns_font_map[ $theme ?: 'default' ];
-
-			if ( 'campaign' === $meta['campaign_body_font'] ) {
-				$body_font = $campaign_font;
+			if (
+				! isset( $meta['campaign_body_font'] )
+				|| empty( $meta['campaign_body_font'] )
+				|| 'campaign' === $meta['campaign_body_font']
+			) {
+				$body_font = null;
 			} else {
 				$body_font = $meta['campaign_body_font'];
 			}
@@ -411,7 +364,7 @@ if ( ! class_exists( 'P4_Post_Campaign' ) ) {
 				'footer-links-color'   => $footer_links_color,
 				'header-color'         => $meta['campaign_header_color'] ?? null,
 				'header-primary-font'  => $header_primary_font,
-				'header-font-weight'   => $special_weight_fonts[ $meta['campaign_header_primary'] ] ?? null,
+				'header-font-weight'   => $special_weight_fonts[ $meta['campaign_header_primary'] ?? null ] ?? null,
 				'body-font'            => $body_font,
 				'passive-button-color' => isset( $meta['campaign_primary_color'] ) && $meta['campaign_primary_color']
 					? $passive_button_colors_map[ strtolower( $meta['campaign_primary_color'] ) ]

--- a/single-campaign.php
+++ b/single-campaign.php
@@ -32,10 +32,10 @@ if ( $theme ) {
 // Save custom style settings.
 $custom_styles = [];
 
-$custom_styles['nav_type']            = $campaign_meta['campaign_nav_type'];
-$custom_styles['nav_border']          = $campaign_meta['campaign_nav_border'];
-$custom_styles['campaign_logo_color'] = $campaign_meta['campaign_logo_color'] ?? 'light';
-$custom_styles['campaign_logo']       = $campaign_meta['campaign_logo'] ?? null;
+$custom_styles['nav_type']            = $campaign_meta['campaign_nav_type'] ?? null;
+$custom_styles['nav_border']          = $campaign_meta['campaign_nav_border'] ?? null;
+$custom_styles['campaign_logo_color'] = isset( $campaign_meta['campaign_logo_color'] ) && ! empty( $campaign_meta['campaign_logo_color'] ) ? $campaign_meta['campaign_logo_color'] : 'light';
+$custom_styles['campaign_logo']       = isset( $campaign_meta['campaign_logo'] ) && ! empty( $campaign_meta['campaign_logo'] ) ? $campaign_meta['campaign_logo'] : 'greenpeace';
 
 // Set GTM Data Layer values.
 $post->set_data_layer();


### PR DESCRIPTION
... of post meta fields, which is not very well. This can definitely be
cleaned up later.

Context:
- When you create a new post there will be no entries in the db for the meta fields, until they are set.
- However when in the editor you use the API `dispatch( 'core/editor' ).editPost( { meta: { [ metaKey ]: value } } )`, wordpress will actually create a key for all registered meta fields, however it doesn't use the default value specified in `register_post_meta`. Instead the entries will have an empty value.
- So I moved all the defaults into the code where they are used, which is manageable as they're mostly used in a single place, but does involve a lot of checks.