### PR TITLE
PLANET-4740: CSS: Remove :not(#hidecookie) rule

### DIFF
--- a/assets/src/js/cookies.js
+++ b/assets/src/js/cookies.js
@@ -27,15 +27,11 @@ export const setupCookies = function($) {
 
   if (cookie == null) {
     $('.cookie-notice').css('display', 'flex');
-    const height = $('.cookie-notice').height();
-    $('footer').css('margin-bottom', height + 'px');
   } else {
     window.createCookie('gp_nro', nro, 365);
   }
 
   $('#hidecookie').click(function () {
-    $('.cookie-notice').slideUp('slow');
-    $('footer').css('margin-bottom', '0');
     window.createCookie('greenpeace', '2', 365);
 
     // Remove the 'no_track' cookie, if user accept the cookies consent.
@@ -49,5 +45,7 @@ export const setupCookies = function($) {
     dataLayer.push({
       'event' : 'cookiesConsent'
     });
+
+    $('.cookie-notice').fadeOut('slow');
   });
 };

--- a/templates/cookies.twig
+++ b/templates/cookies.twig
@@ -3,6 +3,6 @@
 		<div>
 			{{ cookies.text|e('wp_kses_post')|raw }}
 		</div>
-		<button class="btn btn-secondary p-0" id="hidecookie">{{ __( 'GOT IT!', 'planet4-master-theme' ) }}</button>
+		<button class="btn p-0" id="hidecookie">{{ __( 'GOT IT!', 'planet4-master-theme' ) }}</button>
 	</div>
 {% endif %}


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-4740

Styleguide PR: https://github.com/greenpeace/planet4-styleguide/pull/37
Blocks Plugin PR: https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/215

Note: this also removes a vestigial animation, which made sense when the cookie bar was not fixed but not anymore.

![cookie-animation](https://user-images.githubusercontent.com/340766/74426010-57b50080-4e33-11ea-8eb0-e78d4d73f803.gif)
