### PR TITLE
PLANET-4742 Provide option to exclude campaign style on import

### DIFF
--- a/classes/class-p4-post-campaign.php
+++ b/classes/class-p4-post-campaign.php
@@ -16,6 +16,21 @@ if ( ! class_exists( 'P4_Post_Campaign' ) ) {
 		 */
 		const POST_TYPE = 'campaign';
 
+		public const META_FIELDS = [
+			'theme',
+			'campaign_logo',
+			'campaign_logo_color',
+			'campaign_nav_type',
+			'campaign_nav_color',
+			'campaign_nav_border',
+			'campaign_header_color',
+			'campaign_primary_color',
+			'campaign_secondary_color',
+			'campaign_header_primary',
+			'campaign_body_font',
+			'campaign_footer_theme',
+			'footer_links_color',
+		];
 
 		/**
 		 * Taxonomy_Image constructor.
@@ -87,19 +102,9 @@ if ( ! class_exists( 'P4_Post_Campaign' ) ) {
 
 			register_post_type( self::POST_TYPE, $args );
 
-			self::campaign_field( 'theme' );
-			self::campaign_field( 'campaign_logo' );
-			self::campaign_field( 'campaign_logo_color' );
-			self::campaign_field( 'campaign_nav_type' );
-			self::campaign_field( 'campaign_nav_color' );
-			self::campaign_field( 'campaign_nav_border' );
-			self::campaign_field( 'campaign_header_color' );
-			self::campaign_field( 'campaign_primary_color' );
-			self::campaign_field( 'campaign_secondary_color' );
-			self::campaign_field( 'campaign_header_primary' );
-			self::campaign_field( 'campaign_body_font' );
-			self::campaign_field( 'campaign_footer_theme' );
-			self::campaign_field( 'footer_links_color' );
+			foreach ( self::META_FIELDS as $field ) {
+				self::campaign_field( $field );
+			}
 		}
 
 		/**

--- a/classes/class-p4-settings.php
+++ b/classes/class-p4-settings.php
@@ -247,6 +247,15 @@ if ( ! class_exists( 'P4_Settings' ) ) {
 						'type' => 'text',
 					],
 				],
+				[
+					'name' => __( 'Exclude campaign styles when importing', 'planet4-master-theme-backend' ),
+					'desc' => __(
+						'Whether to exclude campaign theme and style settings when importing a campaign.',
+						'planet4-master-theme-backend'
+					),
+					'id'   => 'campaigns_import_exclude_style',
+					'type' => 'checkbox',
+				],
 			];
 			$this->hooks();
 		}


### PR DESCRIPTION
* Add configuration toggle for whether campaign styles should be
excluded on import.
* Move campaign fields to a constant so that it can be used in the
filter on import.
* Make sure that old `_campaign_page_template` is only used if the new
one isn't set.

ref. https://jira.greenpeace.org/browse/PLANET-4742