### PR TITLE
PLANET-4773 Use single meta value instead of all

### DIFF
--- a/classes/class-p4-campaign-importer.php
+++ b/classes/class-p4-campaign-importer.php
@@ -252,7 +252,7 @@ if ( ! class_exists( 'P4_Campaign_Importer' ) ) {
 			// 1. Exclude style fields the option for that is set or if it's passed in the form data.
 			if (
 				! empty( $p4_options['campaigns_import_exclude_style'] )
-				|| ! empty( $_POST['campaigns_import_exclude_style'] )
+				|| ! empty( $_POST['campaigns_import_exclude_style'] ) //phpcs:ignore WordPress.Security.NonceVerification.Missing
 			) {
 				// Also exclude the old attribute as the code still falls back to it.
 				$excluded_keys = array_merge( P4_Post_Campaign::META_FIELDS, [ '_campaign_page_template' ] );

--- a/classes/class-p4-post-campaign.php
+++ b/classes/class-p4-post-campaign.php
@@ -346,7 +346,7 @@ if ( ! class_exists( 'P4_Post_Campaign' ) ) {
 					'plastic'   => 'Montserrat',
 				];
 				$theme              = $meta['theme'] ?? $meta['_campaign_page_template'] ?? null;
-				$theme              = $theme ?: 'default';
+				$theme              = $theme ? $theme : 'default';
 				$body_font          = $campaigns_font_map[ $theme ];
 			}
 
@@ -417,13 +417,13 @@ if ( ! class_exists( 'P4_Post_Campaign' ) ) {
 			}
 
 			$theme = $meta['theme'] ?? $meta['_campaign_page_template'] ?? null;
-			$theme = $theme ?: 'default';
+			$theme = $theme ? $theme : 'default';
 
 			if ( 'default' !== $theme ) {
 				return 'greenpeace' === $logo ? 'greenpeace' : $theme;
 			}
 
-			return $logo ?: 'greenpeace';
+			return $logo ? $logo : 'greenpeace';
 		}
 	}
 }

--- a/exporter.php
+++ b/exporter.php
@@ -240,22 +240,6 @@ function p4_px_single_post_taxonomy() {
 	}
 }
 
-/**
- * Filter out Edit lock meta key.
- *
- * @param boolean $return_me Edit lock status.
- * @param string  $meta_key Current post meta key.
- */
-function p4_px_single_post_filter_postmeta( $return_me, $meta_key ) {
-	if ( '_edit_lock' === $meta_key ) {
-		$return_me = true;
-	}
-
-	return $return_me;
-}
-
-add_filter( 'p4_px_single_post_export_skip_postmeta', 'p4_px_single_post_filter_postmeta', 10, 2 );
-
 $post_id = explode( ',', $_GET['post'] );
 
 // Add campaign attachements in XML file.
@@ -375,15 +359,15 @@ echo '<?xml version="1.0" encoding="' . get_bloginfo( 'charset' ) . "\" ?>\n";
 						<?php endif; ?>
 						<?php p4_px_single_post_taxonomy(); ?>
 						<?php
-						$postmeta = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM $wpdb->postmeta WHERE post_id = %d", $post->ID ) );
-						foreach ( $postmeta as $meta ) :
-							if ( apply_filters( 'p4_px_single_post_export_skip_postmeta', false, $meta->meta_key, $meta ) ) {
+						$postmeta = get_post_meta( $post->ID );
+						foreach ( $postmeta as $meta_key => $meta_value ) :
+							if ( '_edit_lock' === $meta_key ) {
 								continue;
 							}
 							?>
 							<wp:postmeta>
-								<wp:meta_key><?php echo $meta->meta_key; ?></wp:meta_key>
-								<wp:meta_value><?php echo p4_px_single_post_cdata( $meta->meta_value ); ?></wp:meta_value>
+								<wp:meta_key><?php echo $meta_key; ?></wp:meta_key>
+								<wp:meta_value><?php echo p4_px_single_post_cdata( maybe_serialize($meta_value[0]) ); ?></wp:meta_value>
 							</wp:postmeta>
 						<?php endforeach; ?>
 						<?php


### PR DESCRIPTION
for certain post_meta keys of the attachment post type. Though a single
value is ever used, due to a bug multiple values are stored containing
mostly the same data. In some cases this was adding up to 70MB to the
size of the export XML.

https://jira.greenpeace.org/browse/PLANET-4773