### PR TITLE
PLANET-4741 Do not show tags/share buttons if title is hidden

### DIFF
--- a/templates/blocks/header.twig
+++ b/templates/blocks/header.twig
@@ -12,7 +12,7 @@
 			</div>
 		{% endif %}
 		<div class="container">
-			{% if ( post.issues_nav_data or campaigns ) %}
+			{% if hide_page_title_checkbox != 'on' and ( post.issues_nav_data or campaigns ) %}
 				<div class="top-page-tags">
 					{% if ( post.issues_nav_data ) %}
 						<div class="tag-wrap issues">
@@ -35,7 +35,7 @@
 				<h1 class="page-header-title">{{ header_title|e('wp_kses_post')|raw }}</h1>
 			{% endif %}
 			{% if not post.password_required %}
-				{% if ( post.is_take_action_page ) %}
+				{% if hide_page_title_checkbox != 'on' and ( post.is_take_action_page ) %}
 					{% include "blocks/share_buttons.twig" with {social:post.share_meta} %}
 				{% endif %}
 				{% if ( header_subtitle ) %}


### PR DESCRIPTION
The tags and share buttons were being shown under the top nav bar,
making them hardly visible and impossible to click.
Don't include these elements if the page title is hidden.
This is a temporary fix while we await the design of where the share
buttons should be if the page title is hidden.