### PR TITLE
PLANET-4750: Campaigns customiser - Adjust Header primary font options

### DIFF
--- a/campaign_themes/antarctic.json
+++ b/campaign_themes/antarctic.json
@@ -103,7 +103,40 @@
 		{
 			"id": "campaign_header_primary",
 			"options": [
-			]
+				{
+					"value": "Anton",
+					"label": "Anton"
+				},
+				{
+					"value": "Jost",
+					"label": "Jost"
+				},
+				{
+					"value": "Montserrat",
+					"label": "Montserrat Bold"
+				},
+				{
+					"value": "Montserrat_Light",
+					"label": "Montserrat Light"
+				},
+				{
+					"value": "Roboto",
+					"label": "Roboto"
+				},
+				{
+					"value": "Sanctuary",
+					"label": "Sanctuary"
+				},
+				{
+					"value": "Kanit",
+					"label": "Kanit Extra Bold"
+				},
+				{
+					"value": "Save the Arctic",
+					"label": "Save the Arctic"
+				}
+			],
+			"default": "Sanctuary"
 		},
 		{
 			"id": "campaign_body_font",

--- a/campaign_themes/arctic.json
+++ b/campaign_themes/arctic.json
@@ -104,10 +104,6 @@
 			"id": "campaign_header_primary",
 			"options": [
 				{
-					"value": "",
-					"label": "Campaign default"
-				},
-				{
 					"value": "Anton",
 					"label": "Anton"
 				},
@@ -128,6 +124,10 @@
 					"label": "Sanctuary"
 				},
 				{
+					"value": "Roboto",
+					"label": "Roboto"
+				},
+				{
 					"value": "Kanit",
 					"label": "Kanit Extra Bold"
 				},
@@ -135,7 +135,8 @@
 					"value": "Save the Arctic",
 					"label": "Save the Arctic"
 				}
-			]
+			],
+			"default": "Save the Arctic"
 		},
 		{
 			"id": "campaign_body_font",

--- a/campaign_themes/climate.json
+++ b/campaign_themes/climate.json
@@ -105,10 +105,6 @@
 			"id": "campaign_header_primary",
 			"options": [
 				{
-					"value": "",
-					"label": "Campaign default"
-				},
-				{
 					"value": "Anton",
 					"label": "Anton"
 				},
@@ -125,6 +121,10 @@
 					"label": "Montserrat Light"
 				},
 				{
+					"value": "Roboto",
+					"label": "Roboto"
+				},
+				{
 					"value": "Sanctuary",
 					"label": "Sanctuary"
 				},
@@ -136,7 +136,8 @@
 					"value": "Save the Arctic",
 					"label": "Save the Arctic"
 				}
-			]
+			],
+			"default": "Jost"
 		},
 		{
 			"id": "campaign_header_secondary",

--- a/campaign_themes/default.json
+++ b/campaign_themes/default.json
@@ -205,10 +205,6 @@
 			"id": "campaign_header_primary",
 			"options": [
 				{
-					"value": "",
-					"label": "Campaign default"
-				},
-				{
 					"value": "Anton",
 					"label": "Anton"
 				},
@@ -225,6 +221,10 @@
 					"label": "Montserrat Light"
 				},
 				{
+					"value": "Roboto",
+					"label": "Roboto"
+				},
+				{
 					"value": "Sanctuary",
 					"label": "Sanctuary"
 				},
@@ -236,7 +236,8 @@
 					"value": "Save the Arctic",
 					"label": "Save the Arctic"
 				}
-			]
+			],
+			"default": "Roboto"
 		},
 		{
 			"id": "campaign_header_secondary",

--- a/campaign_themes/forest.json
+++ b/campaign_themes/forest.json
@@ -104,10 +104,6 @@
 			"id": "campaign_header_primary",
 			"options": [
 				{
-					"value": "",
-					"label": "Campaign default"
-				},
-				{
 					"value": "Anton",
 					"label": "Anton"
 				},
@@ -124,6 +120,10 @@
 					"label": "Montserrat Light"
 				},
 				{
+					"value": "Roboto",
+					"label": "Roboto"
+				},
+				{
 					"value": "Sanctuary",
 					"label": "Sanctuary"
 				},
@@ -135,7 +135,8 @@
 					"value": "Save the Arctic",
 					"label": "Save the Arctic"
 				}
-			]
+			],
+			"default": "Kanit"
 		},
 		{
 			"id": "campaign_body_font",

--- a/campaign_themes/oceans.json
+++ b/campaign_themes/oceans.json
@@ -107,10 +107,6 @@
 			"id": "campaign_header_primary",
 			"options": [
 				{
-					"value": "",
-					"label": "Campaign default"
-				},
-				{
 					"value": "Anton",
 					"label": "Anton"
 				},
@@ -127,6 +123,10 @@
 					"label": "Montserrat Light"
 				},
 				{
+					"value": "Roboto",
+					"label": "Roboto"
+				},
+				{
 					"value": "Sanctuary",
 					"label": "Sanctuary"
 				},
@@ -138,7 +138,8 @@
 					"value": "Save the Arctic",
 					"label": "Save the Arctic"
 				}
-			]
+			],
+			"default": "Montserrat"
 		},
 		{
 			"id": "campaign_body_font",

--- a/campaign_themes/oil.json
+++ b/campaign_themes/oil.json
@@ -105,10 +105,6 @@
 			"id": "campaign_header_primary",
 			"options": [
 				{
-					"value": "",
-					"label": "Campaign default"
-				},
-				{
 					"value": "Anton",
 					"label": "Anton"
 				},
@@ -125,6 +121,10 @@
 					"label": "Montserrat Light"
 				},
 				{
+					"value": "Roboto",
+					"label": "Roboto"
+				},
+				{
 					"value": "Sanctuary",
 					"label": "Sanctuary"
 				},
@@ -136,7 +136,8 @@
 					"value": "Save the Arctic",
 					"label": "Save the Arctic"
 				}
-			]
+			],
+			"default": "Anton"
 		},
 		{
 			"id": "campaign_body_font",

--- a/campaign_themes/plastic.json
+++ b/campaign_themes/plastic.json
@@ -105,10 +105,6 @@
 			"id": "campaign_header_primary",
 			"options": [
 				{
-					"value": "",
-					"label": "Campaign default"
-				},
-				{
 					"value": "Anton",
 					"label": "Anton"
 				},
@@ -125,6 +121,10 @@
 					"label": "Montserrat Light"
 				},
 				{
+					"value": "Roboto",
+					"label": "Roboto"
+				},
+				{
 					"value": "Sanctuary",
 					"label": "Sanctuary"
 				},
@@ -136,7 +136,8 @@
 					"value": "Save the Arctic",
 					"label": "Save the Arctic"
 				}
-			]
+			],
+			"default": "Montserrat"
 		},
 		{
 			"id": "campaign_body_font",


### PR DESCRIPTION
UAT Passed.

This is just for setting the default font on the JSON files.

Ref: https://jira.greenpeace.org/browse/PLANET-4750

Blocks counterpart: https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/230