### PR TITLE
PLANET-4845: JS Error: Unable to edit background image in pages

### DIFF
--- a/classes/class-p4-master-site.php
+++ b/classes/class-p4-master-site.php
@@ -522,6 +522,7 @@ class P4_Master_Site extends TimberSite {
 	public function enqueue_admin_assets( $hook ) {
 		// Register jQuery 3 for use wherever needed by adding wp_enqueue_script( 'jquery-3' );.
 		wp_register_script( 'jquery-3', 'https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js', [], '3.3.1', true );
+		wp_enqueue_script( 'lazyload', 'https://cdnjs.cloudflare.com/ajax/libs/vanilla-lazyload/12.3.0/lazyload.min.js', [], '12.3.0', true );
 	}
 
 	/**


### PR DESCRIPTION
The LazyLoading script was not loaded on the editor side so some calls to it were triggering a JS error.

Ref: https://jira.greenpeace.org/browse/PLANET-4845