### PR TITLE
PLANET-4827 Archive as a post type

### DIFF
--- a/assets/src/js/search.js
+++ b/assets/src/js/search.js
@@ -103,6 +103,7 @@ export const setupSearch = function($) {
           'search-action': 'get_paged_posts',
           'search_query':  $( '#search_input' ).val().trim(),
           'paged':         next_page,
+          'orderby': $( '#orderby', $search_form ).val(),
           'query-string':  decodeURIComponent( location.search ).substr( 1 ) // Ignore the ? in the search url (first char).
         },
         dataType: 'html'

--- a/classes/class-p4-loader.php
+++ b/classes/class-p4-loader.php
@@ -82,13 +82,14 @@ final class P4_Loader {
 	private function load_services( $services ) {
 
 		$this->default_services = [
-			'P4_Custom_Taxonomy',
-			'P4_Post_Campaign',
-			'P4_Settings',
-			'P4_Post_Report_Controller',
-			'P4_Cookies',
-			'P4_Dev_Report',
-			'P4_Master_Site',
+			P4_Custom_Taxonomy::class,
+			P4_Post_Campaign::class,
+			P4_Post_Archive::class,
+			P4_Settings::class,
+			P4_Post_Report_Controller::class,
+			P4_Cookies::class,
+			P4_Dev_Report::class,
+			P4_Master_Site::class,
 		];
 
 		if ( is_admin() ) {

--- a/classes/class-p4-master-site.php
+++ b/classes/class-p4-master-site.php
@@ -85,7 +85,6 @@ class P4_Master_Site extends TimberSite {
 		add_filter( 'get_twig', [ $this, 'add_to_twig' ] );
 		add_action( 'init', [ $this, 'register_taxonomies' ], 2 );
 		add_action( 'init', [ $this, 'register_oembed_provider' ] );
-		add_action( 'pre_get_posts', [ $this, 'add_search_options' ] );
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_admin_assets' ] );
 		add_action( 'wp_enqueue_scripts', [ $this, 'enqueue_public_assets' ] );
 		add_filter( 'safe_style_css', [ $this, 'set_custom_allowed_css_properties' ] );
@@ -114,6 +113,9 @@ class P4_Master_Site extends TimberSite {
 		add_action( 'after_setup_theme', [ $this, 'add_image_sizes' ] );
 		add_action( 'save_post', [ $this, 'p4_auto_generate_excerpt' ], 10, 2 );
 
+		if ( wp_doing_ajax() ) {
+			P4_Search::add_general_filters();
+		}
 		add_action( 'wp_ajax_get_paged_posts', [ 'P4_ElasticSearch', 'get_paged_posts' ] );
 		add_action( 'wp_ajax_nopriv_get_paged_posts', [ 'P4_ElasticSearch', 'get_paged_posts' ] );
 
@@ -639,20 +641,6 @@ class P4_Master_Site extends TimberSite {
 	 */
 	public function register_oembed_provider() {
 		wp_oembed_add_provider( '#https?://(?:www\.)?[^/^\.]+\.carto(db)?\.com/\S+#i', 'https://services.carto.com/oembed', true );
-	}
-
-	/**
-	 * Add custom options to the main WP_Query.
-	 *
-	 * @param WP_Query $wp The WP Query to customize.
-	 */
-	public function add_search_options( WP_Query $wp ) {
-		if ( ! $wp->is_main_query() || ! $wp->is_search() ) {
-			return;
-		}
-
-		$wp->set( 'posts_per_page', P4_Search::POSTS_LIMIT );
-		$wp->set( 'no_found_rows', true );
 	}
 
 	/**

--- a/classes/class-p4-post-archive.php
+++ b/classes/class-p4-post-archive.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * A custom post type for P3 posts that were archived.
+ *
+ * @package P4MT
+ */
+
+/**
+ * A custom post type for P3 posts that were archived.
+ */
+class P4_Post_Archive {
+
+	public const POST_TYPE = 'archive';
+
+	/**
+	 * The constructor.
+	 */
+	public function __construct() {
+		$this->hooks();
+	}
+
+	/**
+	 * Class hooks.
+	 */
+	private function hooks() {
+		add_action( 'init', [ $this, 'register_archive_cpt' ] );
+		add_action( 'add_meta_boxes_archive', [ $this, 'add_archive_link' ] );
+	}
+
+	/**
+	 * Register the custom post type.
+	 */
+	public function register_archive_cpt() {
+		$args = [
+			'labels'             => [
+				'name'               => _x( 'Archive', 'post type general name', 'planet4-master-theme-backend' ),
+				'singular_name'      => _x( 'Archive', 'post type singular name', 'planet4-master-theme-backend' ),
+				'menu_name'          => _x( 'Archive', 'admin menu', 'planet4-master-theme-backend' ),
+				'name_admin_bar'     => _x( 'Archive', 'add new on admin bar', 'planet4-master-theme-backend' ),
+				'add_new'            => _x( 'Add New', 'archive', 'planet4-master-theme-backend' ),
+				'add_new_item'       => __( 'Add New archive', 'planet4-master-theme-backend' ),
+				'new_item'           => __( 'New archive', 'planet4-master-theme-backend' ),
+				'edit_item'          => __( 'Edit archive', 'planet4-master-theme-backend' ),
+				'view_item'          => __( 'View archive', 'planet4-master-theme-backend' ),
+				'all_items'          => __( 'All archived posts', 'planet4-master-theme-backend' ),
+				'search_items'       => __( 'Search archives', 'planet4-master-theme-backend' ),
+				'parent_item_colon'  => __( 'Parent archive:', 'planet4-master-theme-backend' ),
+				'not_found'          => __( 'No archives found.', 'planet4-master-theme-backend' ),
+				'not_found_in_trash' => __( 'No archives found in Trash.', 'planet4-master-theme-backend' ),
+			],
+			'description'        => __( 'Archive', 'planet4-master-theme-backend' ),
+			'public'             => true,
+			'publicly_queryable' => false,
+			'show_ui'            => true,
+			'show_in_menu'       => true,
+			'query_var'          => false,
+			'show_in_nav_menus'  => false,
+			'menu_icon'          => 'dashicons-archive',
+			'menu_position'      => 100,
+			'supports'           => [
+				'title',
+				'author',
+				'thumbnail',
+				'excerpt',
+				'revisions',
+				'editor',
+			],
+		];
+
+		register_post_type( self::POST_TYPE, $args );
+
+	}
+
+	/**
+	 * Add a link to the internet archive page.
+	 */
+	public function add_archive_link() {
+		add_meta_box(
+			'archive-url',
+			__( 'Archive URL', 'planet4-master-theme' ),
+			function ( $post ) {
+				echo "<a target=\"_blank\" href=\"{$post->guid}\">{$post->guid}</a>"; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			},
+			null,
+			'side',
+			'high'
+		);
+
+	}
+}

--- a/classes/class-p4-settings.php
+++ b/classes/class-p4-settings.php
@@ -19,13 +19,6 @@ if ( ! class_exists( 'P4_Settings' ) ) {
 		private $key = 'planet4_options';
 
 		/**
-		 * Array of metaboxes/fields
-		 *
-		 * @var array
-		 */
-		protected $option_metabox = [];
-
-		/**
 		 * Options Page title
 		 *
 		 * @var string
@@ -256,6 +249,38 @@ if ( ! class_exists( 'P4_Settings' ) ) {
 					'id'   => 'campaigns_import_exclude_style',
 					'type' => 'checkbox',
 				],
+				[
+					'name'    => __( 'Include archived content in search for', 'planet4-master-theme-backend' ),
+					'id'      => 'include_archive_content_for',
+					'type'    => 'select',
+					'default' => 'nobody',
+					'options' => [
+						'nobody'    => __( 'Nobody', 'planet4-master-theme-backend' ),
+						'logged_in' => __( 'Logged in users', 'planet4-master-theme-backend' ),
+						'all'       => __( 'All users', 'planet4-master-theme-backend' ),
+					],
+				],
+				[
+					'name' => __( 'Search content decay', 'planet4-master-theme-backend' ),
+					'desc' => __(
+						'Amount of lowering of the relevancy score for older results. Between 0 and 1. The lower this number is, the lower older content will be ranked. See image. <br>We use the exponential function (exp, green curve).<br/> <img style="max-width:350px" alt="ElasticSearch decay function graph" src="https://www.elastic.co/guide/en/elasticsearch/reference/current/images/decay_2d.png">',
+						'planet4-master-theme-backend'
+					),
+					'id'   => 'epwr_decay',
+					'type' => 'text',
+				],
+				[
+					'name' => __( 'Search content decay scale', 'planet4-master-theme-backend' ),
+					'desc' => __( 'Timescale for lowering the relevance of older results. See image above.', 'planet4-master-theme-backend' ),
+					'id'   => 'epwr_scale',
+					'type' => 'text',
+				],
+				[
+					'name' => __( 'Search content decay offset', 'planet4-master-theme-backend' ),
+					'desc' => __( 'How old should a post be before relevance is lowered. See image above.', 'planet4-master-theme-backend' ),
+					'id'   => 'epwr_offset',
+					'type' => 'text',
+				],
 			];
 			$this->hooks();
 		}
@@ -411,14 +436,15 @@ if ( ! class_exists( 'P4_Settings' ) ) {
 /**
  * Wrapper function around cmb2_get_option.
  *
- * @param  string $key Options array key.
+ * @param string     $key Options array key.
+ * @param mixed|null $default Optional default value.
  * @return mixed Option value.
  */
-function planet4_get_option( $key = '' ) {
+function planet4_get_option( $key = '', $default = null ) {
 	if ( function_exists( 'cmb2_get_option' ) ) {
-		return cmb2_get_option( 'planet4_options', $key );
-	} else {
-		$options = get_option( 'planet4_options' );
-		return isset( $options[ $key ] ) ? $options[ $key ] : false;
+		return cmb2_get_option( 'planet4_options', $key, $default );
 	}
+
+	$options = get_option( 'planet4_options' );
+	return $options[ $key ] ?? false;
 }

--- a/functions.php
+++ b/functions.php
@@ -5,6 +5,26 @@
  * @package P4MT
  */
 
+/**
+ * A simpler way to add a filter that only returns a static value regardless of the input.
+ *
+ * @param string   $filter_name The WordPress filter.
+ * @param mixed    $value The value to be returned by the filter.
+ * @param int|null $priority The priority for the fitler.
+ *
+ * @return void
+ */
+function simple_value_filter( string $filter_name, $value, $priority = null ): void {
+	add_filter(
+		$filter_name,
+		static function () use ( $value ) {
+			return $value;
+		},
+		$priority,
+		0
+	);
+}
+
 use Timber\Timber;
 
 if ( ! class_exists( 'Timber' ) ) {

--- a/templates/search.twig
+++ b/templates/search.twig
@@ -12,6 +12,9 @@
 			<div class="without-search-result row clearfix">
 				<div class="col-md-12">
 					<h2 class="result-statement">{{ page_title|e('wp_kses_post')|raw }}</h2>
+					{% if query_time %}
+					<i> in {{ query_time }} ms</i>
+					{% endif %}
 					{% if ( not posts ) %}
 						<p class="search-info">{{ exception ?? __( 'We\'re sorry we couldn\'t find any matches for your search term.', 'planet4-master-theme' ) }}</p>
 						<ul class="search-help-info">
@@ -295,7 +298,7 @@
 									{% include ['tease-search.twig', 'tease-'~post.post_type~'.twig', 'tease.twig'] %}
 								{% endfor %}
 							</ul>
-							{% if ( load_more and posts|length > paged_posts|length ) %}
+							{% if ( load_more and found_posts > paged_posts|length ) %}
 								<div class="col-lg-12 mb-5 load-more-button-div">
 									<button
 										class="btn btn-medium btn-small btn-secondary more-btn {{ load_more.async ? 'btn-load-more-async' : '' }} btn-load-more-click-scroll"

--- a/templates/tease-search.twig
+++ b/templates/tease-search.twig
@@ -1,9 +1,9 @@
 
-{% if ( 'action' == posts_data[post.ID].content_type ) %}
+{% if ( 'action' == post.content_type ) %}
 	{% set is_action = true %}
-{% elseif ( 'document' == posts_data[post.ID].content_type ) %}
+{% elseif ( 'document' == post.content_type ) %}
 	{% set is_document = true %}
-{% elseif ( 'campaign' == posts_data[post.ID].content_type ) %}
+{% elseif ( 'campaign' == post.content_type ) %}
 	{% set is_campaign = true %}
 {% elseif ( 'archive' == post.post_type ) %}
 	{% set is_archive = true %}
@@ -15,7 +15,7 @@
 	<div class="search-results-load row-hidden" style="display: none;">
 {% endif %}
 	{% if ( is_action ) %}
-		<li id="result-row-{{ post.ID }}" class="media search-result-list-item search-result-list-item-bg" style="background-image:linear-gradient(180deg, rgba(213, 239, 242, 1), rgba(255, 255, 255, 0.3)), url('{{ post.thumbnail.src }}');">
+		<li id="result-row-{{ post.ID }}" class="media search-result-list-item search-result-list-item-bg" style="background-image:linear-gradient(180deg, rgba(213, 239, 242, 1), rgba(255, 255, 255, 0.3)), url('{{ post.thumbnail }}');">
 			<div class="blank-block"></div>
 	{% else %}
 		<li id="result-row-{{ post.ID }}" class="media search-result-list-item">
@@ -23,8 +23,8 @@
 
 		{% if ( not is_action ) %}
 			<img class="d-flex search-result-item-image lazyload"
-				data-src="{{ post.thumbnail.src('thumbnail') ?? posts_data.dummy_thumbnail }}"
-				 alt="{{ fn('esc_attr', post.thumbnail.alt|default( post.title ) )|raw }}" />
+				data-src="{{ post.thumbnail ?: dummy_thumbnail }}"
+				 alt="{{ fn('esc_attr', post.thumbnail_alt|default( post.post_title ) )|raw }}" />
 		{% endif %}
 
 		<div id="tease-{{ post.ID }}" class="media-body search-result-item-body tease tease-{{ post.post_type }}">
@@ -41,13 +41,13 @@
 					{% endif %}
 
 					<div class="search-result-tags top-page-tags">
-						{% for page_type in posts_data[post.ID].page_types %}
+						{% for page_type in post.p4_page_types %}
 							<button class="search-result-item-head no-btn tag-item tag-item--main page-type" data-href="{{ fn('get_term_link', page_type.term_id) }}">{{ page_type.name|e('wp_kses_post')|raw }}</button>
 						{% endfor %}
 
-						{% if (posts_data[post.ID].tags) %}
+						{% if (post.tags) %}
 							<div class="tag-wrap tags">
-								{% for tag in posts_data[post.ID].tags %}
+								{% for tag in post.tags %}
 									<a href="{{ tag.link }}" class="search-result-item-tag tag-item tag">#{{ tag.name|e('wp_kses_post')|raw }}</a>
 								{% endfor %}
 							</div>
@@ -55,12 +55,12 @@
 					</div>
 
 					{% if ( is_document ) %}
-						{% set title = post.title|e('wp_kses_post') %}
+						{% set title = post.post_title|e('wp_kses_post') %}
 						<a href="{{ fn('wp_get_attachment_url', post.id) }}" class="search-result-item-headline">{{ title|raw|length > 30 ? ( title|striptags|slice(0, 30) ~ '...' )|raw  : title|raw }}</a>
 					{% elseif ( is_archive ) %}
-						<a href="{{ post.link }}" target="_blank" class="search-result-item-headline archive">{{ post.title|e('wp_kses_post')|raw }}</a>
+						<a href="{{ post.link }}" target="_blank" class="search-result-item-headline archive">{{ post.post_title|e('wp_kses_post')|raw }}</a>
 					{% else %}
-						<a href="{{ post.link() }}" class="search-result-item-headline">{{ post.title|e('wp_kses_post')|raw }}</a>
+						<a href="{{ post.link }}" class="search-result-item-headline">{{ post.post_title|e('wp_kses_post')|raw }}</a>
 					{% endif %}
 
 					{% if ( 'page' != post.post_type ) %}
@@ -89,11 +89,7 @@
 				</div>
 			</div>
 
-			{% if not is_archive %}
-				<p class="search-result-item-content">{{ post.preview().read_more('')|excerpt( 25 )|raw }}</p>
-			{%  else %}
-				<p class="search-result-item-content">{{ post.excerpt|raw }}</p>
-			{% endif %}
+			<p class="search-result-item-content">{{ post.post_excerpt|default(post.post_content)|excerpt( 25 )|raw }}</p>
 		</div>
 	</li>
 {% if ( ( loop.index0 % 5 == 4 ) or loop.last ) %}


### PR DESCRIPTION
NOTE TO REVIEWER:
This is a pretty big PR, but most of the changes are in `classes/class-p4-search.php`. I suggest first going through the other files, as those are easier to understand in isolation, and then proceed to `classes/class-p4-search.php`.

I removed the caching of search results, as that was mainly for reducing the footprint of loading all results in memory, which is not needed anymore as aggregations are used instead of looping through all posts to get the totals data.

* Add custom post type for archive.
* Setup search for that post type.
* Make decay params configurable (mainly for making it easier to find good values for these during development, but maybe we can preserve these for NROs to configure).
* Add settings for including archived content for logged in users only,
or publicly.

* Convenience function `simple_value_filter` for when a filter is used just to provide a
value, so that this value can be provided without having to pass a
function.

* Specify which fields to return from ElasticSearch. Otherwise all
data, including post_content is loaded in memory even though it's
not used.

* Use ElasticSearch aggregations for tag and category data, so that we
can limit the amount of posts that are fetched to the a mount per page.

* Remove the filter for the main query. We should ensure that only one
query is used (by either using the main query for search, or by ensuring
the main query is not executed), but that can be taken up later.

* Fix decaying not being applied in ajax requests.
* Fix date ordering not working in ajax requests.
* Fix mime type filter not being applied in ajax requests.
