### PR TITLE
[No issue]: Font size for XL screens in pages.

### DIFF
--- a/assets/src/scss/pages/_page.scss
+++ b/assets/src/scss/pages/_page.scss
@@ -15,6 +15,7 @@ div.page-template {
   }
 
   @include x-large-and-up {
+    font-size: 1.125rem;
     width: 1140px;
   }
 


### PR DESCRIPTION
This just adjusts the base font size for the `.page-template` class (present in pages and campaigns) in XL screens.