### PR TITLE
PLANET-4779 Planet 4 Bug Report: Author bio: Not visible on Post

### DIFF
--- a/templates/blocks/author_profile.twig
+++ b/templates/blocks/author_profile.twig
@@ -17,8 +17,11 @@
 					{% set author_bio_char_limit = 300 %}
 				{% endif %}
 
-				{% set author_bio = fn('substr', post.author.description, 0, fn('strpos', post.author.description ,' ', author_bio_char_limit)) %}
-				{% set author_bio = post.author.description|length > author_bio_char_limit ? author_bio ~ author_bio_readmore : author_bio %}
+				{% if ( post.author.description|length > author_bio_char_limit ) %}
+					{% set author_bio = fn('substr', post.author.description, 0, fn('strpos', post.author.description ,' ', author_bio_char_limit)) ~ author_bio_readmore %}
+				{% else %}
+					{% set author_bio = post.author.description %}
+				{% endif %}
 
 				<p class="author-block-info-bio" itemprop="description">
 					{{ fn('wpautop', author_bio)|e('wp_kses_post')|raw }}


### PR DESCRIPTION
- Only shorten and add 'read more' to author bio if it's too long
- Trying to find strpos at an offset greater than the string threw an error.

Ref: https://jira.greenpeace.org/browse/PLANET-4779