### PR TITLE
PLANET-4927 Planet 4 Bug Report: Page, Evergreen: Spacing issue when using background image

### DIFF
--- a/assets/src/scss/pages/_evergreen.scss
+++ b/assets/src/scss/pages/_evergreen.scss
@@ -25,11 +25,15 @@
     -webkit-mask-image: linear-gradient(170deg, rgba(0, 0, 0, 1), rgba(0, 0, 0, .2), rgba(0, 0, 0, 0), rgba(0, 0, 0, 0), rgba(0, 0, 0, 0));
     mask-size: 100%;
     mask-repeat: no-repeat;
-    mask-position: left top;
 
     html[dir="rtl"] & {
       mask-image: linear-gradient(-170deg, rgba(0, 0, 0, 1), rgba(0, 0, 0, .2), rgba(0, 0, 0, 0), rgba(0, 0, 0, 0), rgba(0, 0, 0, 0));
       -webkit-mask-image: linear-gradient(-170deg, rgba(0, 0, 0, 1), rgba(0, 0, 0, .2), rgba(0, 0, 0, 0), rgba(0, 0, 0, 0), rgba(0, 0, 0, 0));
+    }
+
+    top: $menu-height-small;
+    @include medium-and-up {
+      top: $menu-height-large;
     }
   }
 


### PR DESCRIPTION
- mask-position doesn't work well on chrome browser
- positioned the overlay with 'top' and the value of the height of the navbar

Ref: https://jira.greenpeace.org/browse/PLANET-4927