### PR TITLE
PLANET-4827 Fix document type filtering and page count

### DIFF
--- a/classes/class-p4-elasticsearch.php
+++ b/classes/class-p4-elasticsearch.php
@@ -33,23 +33,7 @@ if ( ! class_exists( 'P4_ElasticSearch' ) ) {
 							case 'ctype':
 								switch ( $filter['id'] ) {
 									case 0:
-										break;
 									case 1:
-										add_filter(
-											'ep_formatted_args',
-											function ( $formatted_args ) use ( $args ) {
-												if ( ! empty( $args['post_mime_type'] ) ) {
-													$formatted_args['post_filter']['bool']['must'] = [
-														'terms' => [
-															'post_mime_type' => $args['post_mime_type'],
-														],
-													];
-												}
-												return $formatted_args;
-											},
-											10,
-											1
-										);
 										break;
 									case 2:
 										// Workaround for making 'post_parent__not_in' to work with ES.
@@ -123,25 +107,11 @@ if ( ! class_exists( 'P4_ElasticSearch' ) ) {
 			add_filter( 'ep_formatted_args', [ $this, 'set_full_text_search' ], 19, 1 );
 			add_filter( 'ep_formatted_args', [ $this, 'set_results_weight' ], 20, 1 );
 
+			add_filter( 'ep_formatted_args', [ $this, 'add_mime_type_filter' ], 21, 1 );
+
 			if ( ! wp_doing_ajax() ) {
 				add_filter( 'ep_formatted_args', [ $this, 'add_aggregations' ], 999, 1 );
 			}
-
-			// Remove from results any Documents that should not be there.
-			// TODO - This is a temp fix until we manage to query ES for only the desired documents.
-			add_filter(
-				'ep_search_results_array',
-				function ( $results, $response, $args, $scope ) {
-					foreach ( $results['posts'] as $key => $post ) {
-						if ( $post['post_mime_type'] && ! in_array( $post['post_mime_type'], self::DOCUMENT_TYPES, true ) ) {
-							unset( $results['posts'][ $key ] );
-						}
-					}
-					return $results;
-				},
-				10,
-				4
-			);
 		}
 
 		/**
@@ -250,6 +220,38 @@ if ( ! class_exists( 'P4_ElasticSearch' ) ) {
 						'p4-page-type' => [
 							'terms' => [
 								'field' => 'terms.p4-page-type.term_id',
+							],
+						],
+					],
+				],
+			];
+
+			return $formatted_args;
+		}
+
+		/**
+		 * Remove items that are an attachment and have a different mime type.
+		 *
+		 * @param array $formatted_args The args that are going to ES.
+		 * @return array Same args with added filter.
+		 */
+		public function add_mime_type_filter( $formatted_args) {
+
+			$formatted_args['post_filter']['bool']['must'][] = [
+				'bool' => [
+					'should' => [
+						[
+							'bool' => [
+								'must_not' => [
+									'terms' => [
+										'post_type.raw' => [ 'attachment' ],
+									],
+								],
+							],
+						],
+						[
+							'terms' => [
+								'post_mime_type' => self::DOCUMENT_TYPES,
 							],
 						],
 					],

--- a/classes/class-p4-search.php
+++ b/classes/class-p4-search.php
@@ -866,7 +866,11 @@ if ( ! class_exists( 'P4_Search' ) ) {
 				foreach ( $aggs['post_type']['buckets'] as $post_type_agg ) {
 					if ( 'page' === $post_type_agg['key'] ) {
 						// We show act pages as a separate item, so subtract there count from the other pages.
-						$context['content_types']['2']['results'] = $post_type_agg['doc_count'] - $act_page_count;
+						// But counts can be off in ES so don't use lower than 0.
+						$context['content_types']['2']['results'] = max(
+							0,
+							$post_type_agg['doc_count'] - $act_page_count
+						);
 					}
 					if ( 'attachment' === $post_type_agg['key'] ) {
 						$context['content_types']['1']['results'] = $post_type_agg['doc_count'];


### PR DESCRIPTION
* Put the document type filter on all queries, by making it an OR query:
either the post type is something else than attachment, or the mime type
is one of the supported types.
* Don't show numbers lower than 0 for calculated page amount. We
subtract the Act pages from this as they have their own metric, however
in some cases the counts are not reliable and we might end up below 0.
Probably we want to replace this calculation with an aggregation that
already subtracts the Act pages.