### PR TITLE
PLANET-4975 Fix document type filtering and page count

### DIFF
--- a/templates/tease-search.twig
+++ b/templates/tease-search.twig
@@ -90,6 +90,9 @@
 			</div>
 
 			<p class="search-result-item-content">{{ post.post_excerpt|default(post.post_content)|excerpt( 25 )|raw }}</p>
+			{% if post.edit_link %}
+				<a href="{{ post.edit_link|raw }}">{{ __('Manage', 'planet4-master-theme') }}</a>
+			{% endif %}
 		</div>
 	</li>
 {% if ( ( loop.index0 % 5 == 4 ) or loop.last ) %}


### PR DESCRIPTION
* Put the document type filter on all queries, by making it an OR query:
either the post type is something else than attachment, or the mime type
is one of the supported types. Remove previous filters that were in
multiple places as the new filter can be used on any result set.
* Don't show numbers lower than 0 for calculated page amount. We
subtract the Act pages from this as they have their own metric, however
in some cases the counts are not reliable and we might end up below 0.
Probably we want to replace this calculation with an aggregation that
already subtracts the Act pages.