### PR TITLE
PLANET-4937: Search results post type should use an a tag instead of a button that behaves like an a tag

### DIFF
--- a/assets/src/js/search.js
+++ b/assets/src/js/search.js
@@ -8,6 +8,11 @@ if (!window.lazyLoad) {
 
 // Search page.
 export const setupSearch = function($) {
+  const isSearch = !!$('body.search').length;
+  if (!isSearch) {
+    return;
+  }
+
   const $search_form      = $( '#search_form' );
   const $load_more_button = $( '.btn-load-more-click-scroll' );
   let load_more_count   = 0;
@@ -52,11 +57,6 @@ export const setupSearch = function($) {
   });
 
   let $search_results = $( '.multiple-search-result' );
-  // Add filter by clicking on the page type label inside a result item.
-  // Delegate event handler to the dynamically created descendant elements.
-  $search_results.off( 'click', '.search-result-item-head' ).on( 'click', '.search-result-item-head', function() {
-    window.location.href = $( this ).data( 'href' );
-  });
 
   // Navigate to the page of the search result item when clicking on it's thumbnail image.
   // Delegate event handler to the dynamically created descendant elements.

--- a/classes/class-p4-master-site.php
+++ b/classes/class-p4-master-site.php
@@ -547,7 +547,18 @@ class P4_Master_Site extends TimberSite {
 		wp_register_script( 'lazyload', 'https://cdnjs.cloudflare.com/ajax/libs/vanilla-lazyload/12.3.0/lazyload.min.js', [], '12.3.0', true );
 		wp_register_script( 'cssvarsponyfill', 'https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2', [], '2', false );
 
-		wp_enqueue_script( 'main', $this->theme_dir . '/assets/build/index.js', [ 'jquery', 'lazyload', 'cssvarsponyfill' ], $js_creation, true );
+		// Variables reflected from PHP to the JS side.
+		$localized_variables = [
+			// The ajaxurl variable is a global js variable defined by WP itself but only for the WP admin
+			// For the frontend we need to define it ourselves and pass it to js.
+			'ajaxurl'           => admin_url( 'admin-ajax.php' ),
+			'show_scroll_times' => P4_Search::SHOW_SCROLL_TIMES,
+		];
+
+		wp_register_script( 'main', $this->theme_dir . '/assets/build/index.js', [ 'jquery', 'lazyload', 'cssvarsponyfill' ], $js_creation, true );
+		wp_localize_script( 'main', 'localizations', $localized_variables );
+		wp_enqueue_script( 'main' );
+
 		wp_enqueue_script( 'slick', 'https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.9.0/slick.min.js', [], '1.9.0', true );
 		wp_enqueue_script( 'hammer', 'https://cdnjs.cloudflare.com/ajax/libs/hammer.js/2.0.8/hammer.min.js', [], '2.0.8', true );
 	}

--- a/classes/class-p4-search.php
+++ b/classes/class-p4-search.php
@@ -65,13 +65,6 @@ if ( ! class_exists( 'P4_Search' ) ) {
 		protected $filters;
 
 		/**
-		 * Localizations
-		 *
-		 * @var array $localizations
-		 */
-		protected $localizations;
-
-		/**
 		 * @var int|null The total number of matches.
 		 */
 		protected $total_matches;
@@ -116,13 +109,6 @@ if ( ! class_exists( 'P4_Search' ) ) {
 		 * Initialize the class. Hook necessary actions and filters.
 		 */
 		protected function initialize() {
-			$this->localizations = [
-				// The ajaxurl variable is a global js variable defined by WP itself but only for the WP admin
-				// For the frontend we need to define it ourselves and pass it to js.
-				'ajaxurl'           => admin_url( 'admin-ajax.php' ),
-				'show_scroll_times' => self::SHOW_SCROLL_TIMES,
-			];
-			add_action( 'wp_enqueue_scripts', [ $this, 'enqueue_public_assets' ] );
 			self::add_general_filters();
 		}
 
@@ -1086,17 +1072,6 @@ if ( ! class_exists( 'P4_Search' ) ) {
 					}
 					Timber::render( [ 'tease-search.twig' ], $paged_context, self::DEFAULT_CACHE_TTL, \Timber\Loader::CACHE_OBJECT );
 				}
-			}
-		}
-
-		/**
-		 * Load assets only on the search page.
-		 */
-		public function enqueue_public_assets() {
-			if ( is_search() ) {
-				wp_register_script( 'search', get_template_directory_uri() . '/assets/js/search.js', [ 'jquery' ], '0.2.8', true );
-				wp_localize_script( 'main', 'localizations', $this->localizations );
-				wp_enqueue_script( 'search' );
 			}
 		}
 	}

--- a/templates/tease-search.twig
+++ b/templates/tease-search.twig
@@ -42,7 +42,7 @@
 
 					<div class="search-result-tags top-page-tags">
 						{% for page_type in post.p4_page_types %}
-							<button class="search-result-item-head no-btn tag-item tag-item--main page-type" data-href="{{ fn('get_term_link', page_type.term_id) }}">{{ page_type.name|e('wp_kses_post')|raw }}</button>
+							<a class="search-result-item-head no-btn tag-item tag-item--main page-type" href="{{ fn('get_term_link', page_type.term_id) }}">{{ page_type.name|e('wp_kses_post')|raw }}</a>
 						{% endfor %}
 
 						{% if (post.tags) %}


### PR DESCRIPTION
Changed the `button` tag for post type into an `a` tag in the Search page.

While doing this, I found a weird thing about the `search.js` script, it was triggering a 404 locally. It looks like it's loaded from the search class here: https://github.com/greenpeace/planet4-master-theme/blob/master/classes/class-p4-search.php#L1097 (which actually does nothing, because the `setupSearch` function is never invoked) but also built in: https://github.com/greenpeace/planet4-master-theme/blob/master/assets/src/js/app.js

So I removed the script being loaded from the Search class, and moved the `localizations` variables to the place where we enqueue `index.js`, the main script.