### PR TITLE
PLANET-5048 Explicitly pass thumbnail size

### DIFF
--- a/classes/class-p4-search.php
+++ b/classes/class-p4-search.php
@@ -372,7 +372,7 @@ if ( ! class_exists( 'P4_Search' ) ) {
 						$template_post->id            = $post->ID;
 						$template_post->link          = $post->permalink;
 						$template_post->preview       = $post->excerpt;
-						$thumbnail                    = get_the_post_thumbnail_url( $post->ID );
+						$thumbnail                    = get_the_post_thumbnail_url( $post->ID, 'thumbnail' );
 						$template_post->thumbnail_alt = get_the_post_thumbnail_caption( $post->ID );
 						$template_post->thumbnail     = $thumbnail;
 						$template_post->tags          = $post->terms['post_tag'] ?? [];


### PR DESCRIPTION
* If you don't it will default to 'post-thumbnail', which interestingly
is a size that does not exist by default, only 'thumb' and 'thumbnail'
do. 'post-thumbnail' exists only after `set_post_thumbnail_size` is
called. Since WordPress can't map it to a size when calling
`get_the_post_thumbnail_url`, the thumbnail was using the full size by
default.