### PR TITLE
PLANET-5037 Add css variable to allow properties

### DIFF
--- a/classes/class-p4-master-site.php
+++ b/classes/class-p4-master-site.php
@@ -402,6 +402,10 @@ class P4_Master_Site extends TimberSite {
 	 */
 	public function set_custom_allowed_css_properties( $allowedproperties ) {
 		$allowedproperties[] = 'object-position';
+		$allowedproperties[] = '--spreadsheet-header-background';
+		$allowedproperties[] = '--spreadsheet-even-row-background';
+		$allowedproperties[] = '--spreadsheet-odd-row-background';
+
 		return $allowedproperties;
 	}
 


### PR DESCRIPTION
* Else they will be stripped by `kses`. This is a temporary solution as
clearly we don't want to have to add each variable we want to use here
as well. Perhaps we should not be stripping attributes that were not
added by the user somehow?