### PR TITLE
PLANET-4987: Prevent sync of non-pdf attachments to ElasticSearch

### DIFF
--- a/classes/class-p4-search.php
+++ b/classes/class-p4-search.php
@@ -232,6 +232,20 @@ if ( ! class_exists( 'P4_Search' ) ) {
 				[ Features::factory()->get_registered_feature( 'documents' ), 'setup_document_search' ],
 				10
 			);
+
+			add_filter(
+				'ep_intercept_remote_request',
+				function() {
+					return true;
+				},
+				10
+			);
+			add_filter(
+				'ep_do_intercept_request',
+				[ self::class, 'intercept_ep_request' ],
+				10,
+				4
+			);
 		}
 
 
@@ -1018,6 +1032,59 @@ if ( ! class_exists( 'P4_Search' ) ) {
 				$where     .= ' AND ' . $wpdb->posts . '.post_mime_type IN("' . $mime_types . '","") ';
 			}
 			return $where;
+		}
+
+		/**
+		 * Intercept ElasticPress request filter.
+		 * All these parameters are passed from EP.
+		 *
+		 * @param object $request Request object from ElasticPress.
+		 * @param array  $query Query from ElasticPress.
+		 * @param array  $args Arguments for the request.
+		 * @param array  $failures Errors array.
+		 */
+		public static function intercept_ep_request( $request, $query = null, $args = null, $failures = null ) {
+			$total_docs_count    = 0;
+			$indexed_docs_count  = 0;
+			$filtered_body_lines = [];
+
+			// Is this a bulk index task on the attachment pipeline?
+			if ( $query && ! ! preg_match( '/_bulk\?pipeline.*attachment/', $query['url'] ) ) {
+				$body_lines      = explode( "\n", $args['body'] );
+				$body_line_count = count( $body_lines );
+
+				for ( $i = 0; $i < $body_line_count; $i += 3 ) {
+
+					$total_docs_count++;
+
+					// e.g.: { index; ... }.
+					$index_header  = $body_lines[ $i ];
+					$index_content = $body_lines[ $i + 1 ];
+
+					$index_content_data = json_decode( $index_content, true );
+
+					// Not an attachment (no MIME type).
+					if ( 'attachment' !== $index_content_data['post_type'] ) {
+						$filtered_body_lines[] = $index_header;
+						$filtered_body_lines[] = $index_content;
+						$filtered_body_lines[] = '';
+						$indexed_docs_count++;
+					} elseif (
+							! empty( $index_content_data['post_mime_type'] ) &&
+							in_array( $index_content_data['post_mime_type'], self::DOCUMENT_TYPES, true )
+						) {
+						$filtered_body_lines[] = $index_header;
+						$filtered_body_lines[] = $index_content;
+						$filtered_body_lines[] = ''; // The third element ($body_lines[$i + 2]) is just an empty string.
+						$indexed_docs_count++;
+					}
+				}
+
+				$args['body'] = implode( "\n", $filtered_body_lines );
+			}
+
+			$request = wp_remote_request( $query['url'], $args );
+			return $request;
 		}
 
 		/**

--- a/package-lock.json
+++ b/package-lock.json
@@ -9124,7 +9124,8 @@
         },
         "yargs-parser": {
           "version": "13.1.1",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
+          "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
           "dev": true,
           "requires": {
             "camelcase": "^5.0.0",


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-4987

This is a PoC of applying [a filter](https://github.com/10up/ElasticPress/blob/develop/includes/classes/Elasticsearch.php#L903) to hijack the "bulk index" requests sent to ElasticSearch for the attachments.

Attachments should be handled by the [Documents class](https://github.com/10up/ElasticPress/blob/develop/includes/classes/Feature/Documents/Documents.php#L226) in ElasticPress, which seems to handle the extensions supported by default by EP (pdf, xls, docx... some others).

But when you enable the Documents feature, "bulk indexing" requests are being sent to ElasticSearch to actually index everything, ignoring any MIME type filtering, this sounds like it's being overlooked by ElasticPress, the Documents feature itself seems to be poorly maintained:  the UI to enable the feature doesn't even work properly.

## How to test this

1. Go to the ElasticPress page on WP's Dashboard, and open the "Documents" section. **But wait!** Don't click **Enable** and **Save** yet:
![image](https://user-images.githubusercontent.com/340766/81851336-ab68e000-952f-11ea-958d-88368c9c7be2.png)
2. Clicking "Enable" and "Save" won't work, first you have to run this line (gently provided by PieterV): `document.querySelector('label[for="feature_active_documents_enabled"] input').setAttribute('data-field-name', 'active')` to add that "field name" attribute to the input.
3. Then click **Save**, the Documents Feature should be enabled now. It should show a circle filled with yellow.
4 _(Feel free to refresh the page to make sure it worked)_
5. Open ElasticHQ by going to: http://localhost:5000/ 
6. Connect to the cluster at http://elasticsearch:9200 (remember the hostname should be `elasticsearch` here, not `localhost`. 
![image](https://user-images.githubusercontent.com/340766/81851876-89239200-9530-11ea-9707-00a3a1d1315b.png)
7. Open the `planet4test-post-1` index. You should see 29 documents indexed (provided you are using the default content):
![image](https://user-images.githubusercontent.com/340766/81852240-1666e680-9531-11ea-968b-b785f5b8b9b6.png)
8. Go back to the ElasticPress admin page and click on the Sync icon (next to the cog wheel on the top-right corner):
![image](https://user-images.githubusercontent.com/340766/81851691-419d0600-9530-11ea-81de-0401d652a09c.png)
9. Once it's finished, go back to ElasticHQ. As there is only one PDF file in the default content, you should see there are now 30 documents indexed.

If you follow these steps in the `master` branch, you'll end up with 262 documents indexed, because it will include all the Media Library files.

## Notes

* A caveat: this is currently only working using the Dashboard Sync, not the CLI. So you can actually test the indexing without the filter running `make elastic` in the `docker-compose` folder. You'll end up with 262 docs synced.
* I added a few `error_log` statements because debugging interactively with Xdebug was impractical, I'll remove those after review.
* Probably needs a few comments about the body format.

## How it works

The body of a bulk index request is separated by new lines and looks like this:
```
{ "index": ...id, (etc.) }
{ "post_id": 123, ...(the full content of the object to be indexed) }
...(an empty line)
{ "index": ... } ... and so on
``` 

The filter looks for attachment and removes the ones that are not in the  `P4_Search::DOCUMENT_TYPES` list from the request's body.






