### PR TITLE
PLANET-4955 Fix ES custom weighting not being applied.

### DIFF
--- a/classes/class-p4-elasticsearch.php
+++ b/classes/class-p4-elasticsearch.php
@@ -155,7 +155,7 @@ if ( ! class_exists( 'P4_ElasticSearch' ) ) {
 			 * Use any combination of filters here, any matched filter will adjust
 			 * the weighted results according to the scoring settings set below.
 			 */
-			$formatted_args['query']['function_score']['functions'] = $existing_query['function_score']['functions'] ?? [] + [
+			$formatted_args['query']['function_score']['functions'] = ( $existing_query['function_score']['functions'] ?? [] ) + [
 				[
 					'filter' => [
 						'match' => [


### PR DESCRIPTION
* Since the `??` operator is right-associative, this fallback was not
working as intended without parentheses. Because the functions (left
hand of `??`) are already there in all cases, the custom weighting on
the right hand was never used.