### PR TITLE
PLANET-4926 PDF icon not shown in CTA when URL includes GA UTM code

### DIFF
--- a/assets/src/js/pdf_icon.js
+++ b/assets/src/js/pdf_icon.js
@@ -2,7 +2,7 @@
 export const setupPDFIcon = function($) {
   'use strict';
 
-  $('a[href$=".pdf"]').each(function() {
+  $('a[href*=".pdf"]').each(function() {
     const link = $(this);
 
     if (!(link.parent('h1, h2, h3, h4, h5, h6').length || link.has('img').length)) {


### PR DESCRIPTION
- Changed pdf_icon.js to apply icon link class if .pdf appears anywhere in link, as opposed to only at the end