### PR TITLE
PLANET-5032 Remove duplicate ES filter on post type

### DIFF
--- a/classes/class-p4-elasticsearch.php
+++ b/classes/class-p4-elasticsearch.php
@@ -48,12 +48,6 @@ if ( ! class_exists( 'P4_ElasticSearch' ) ) {
 														],
 													];
 												}
-												// Make sure it is a Page.
-												$formatted_args['post_filter']['bool']['must'][] = [
-													'terms' => [
-														'post_type' => array_values( (array) $args['post_type'] ),
-													],
-												];
 												return $formatted_args;
 											},
 											10,


### PR DESCRIPTION
see https://jira.greenpeace.org/browse/PLANET-5032
* There is already a WP filter in `class-p4-search.php` that adds the
same ES filter. Moreover, the removed one added it on `post_type`
instead of `post_type.raw`. This caused page filter to break if the
ElasticPress language is something else than English. No idea why it did work for English.