### PR TITLE
Switch css-vars-ponyfill CDN to cdnjs

### DIFF
--- a/classes/class-p4-master-site.php
+++ b/classes/class-p4-master-site.php
@@ -552,7 +552,7 @@ class P4_Master_Site extends TimberSite {
 		// JS files.
 		wp_register_script( 'jquery', 'https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js', [], '3.3.1', true );
 		wp_register_script( 'lazyload', 'https://cdnjs.cloudflare.com/ajax/libs/vanilla-lazyload/12.3.0/lazyload.min.js', [], '12.3.0', true );
-		wp_register_script( 'cssvarsponyfill', 'https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2', [], '2', false );
+		wp_register_script( 'cssvarsponyfill', 'https://cdnjs.cloudflare.com/ajax/libs/css-vars-ponyfill/2.3.1/css-vars-ponyfill.min.js', [], '2', false );
 
 		// Variables reflected from PHP to the JS side.
 		$localized_variables = [


### PR DESCRIPTION
This lib wasn't available on cdnjs when we included it. It was just recently added to cdnjs. So this a small change, just to avoid resolving/requesting one more domain and instead use the same CDN as the rest of the frontend libraries.