### PR TITLE
PLANET-5060 Remove external links features for Take Action card links

### DIFF
--- a/assets/src/js/external_links.js
+++ b/assets/src/js/external_links.js
@@ -10,7 +10,7 @@ export const setupExternalLinks = function($) {
       </g>
   </svg>`;
 
-  $('div.page-template a:not(.btn), article a:not(.btn)').each(function () {
+  $('div.page-template a:not(.btn):not(.cover-card-heading), article a:not(.btn)').each(function () {
     let href = undefined === $(this).attr('href') ? '' : $(this).attr('href');
     if (href != '' && href.indexOf(siteURL) <= -1 && href.length > 0) {
       if ($(this).text().trim().length == 0) {


### PR DESCRIPTION
For external links we usually show an svg icon, but for the Take Action card (https://jira.greenpeace.org/browse/PLANET-5060) and for the Take Action boxout (https://jira.greenpeace.org/browse/PLANET-5126) it doesn't fit the design.

Also, we usually open external links in a new tab, but Take Action cards always open in the same page, and for the Take Action boxouts it's a setting (open in new tab or not) that is taken care of in this file.