### PR TITLE
PLANET-5034 Fix Japanese search results button label overflow

### DIFF
--- a/assets/src/scss/pages/search/_search-results.scss
+++ b/assets/src/scss/pages/search/_search-results.scss
@@ -171,6 +171,7 @@
     background: #97ed90;
     border-radius: 8px;
     color: #1a1a1a;
+    word-break: keep-all;
 
     &.search-results-alternative-label-mobile {
       display: inline-block;


### PR DESCRIPTION
See https://jira.greenpeace.org/browse/PLANET-5034

According to [w3schools](https://www.w3schools.com/cssref/css3_pr_word-break.asp) the description for `keep-all` value is `Word breaks should not be used for Chinese/Japanese/Korean (CJK) text. Non-CJK text behavior is the same as value "normal"`