### PR TITLE
PLANET-5128: Expand images lazy-loading on Image block

### DIFF
--- a/classes/class-p4-master-site.php
+++ b/classes/class-p4-master-site.php
@@ -168,6 +168,7 @@ class P4_Master_Site extends TimberSite {
 			10,
 			2
 		);
+		add_filter( 'the_content', [ $this, 'make_content_images_lazyload' ] );
 
 		add_action( 'init', [ $this, 'login_redirect' ], 1 );
 		add_filter( 'attachment_fields_to_edit', [ $this, 'add_image_attachment_fields_to_edit' ], 10, 2 );
@@ -919,5 +920,44 @@ class P4_Master_Site extends TimberSite {
 			'core/image',
 			[ 'render_callback' => [ $this, 'p4_core_image_block_render' ] ]
 		);
+	}
+
+	/**
+	 * Filter 'img' elements in post content to replace 'src', 'srcset' and 'sizes' attributes
+	 * with their data-{} counterpart and add a 'lazyload' class.
+	 * Does not alter images already qualified as lazyload,
+	 * or images that look already altered by another function
+	 *
+	 * @see https://github.com/verlok/vanilla-lazyload#lazy-responsive-image-with-srcset-and-sizes
+	 * @see wp_make_content_images_responsive()
+	 *
+	 * @param string $content The raw post content to be filtered.
+	 * @return string Converted content.
+	 */
+	public function make_content_images_lazyload( string $content ): string {
+		if ( ! preg_match_all( '/<img [^>]+>/', $content, $matches ) ) {
+			return $content;
+		}
+
+		foreach ( $matches[0] as $image ) {
+			// If image is already qualified as lazyload, pass.
+			if ( 1 === preg_match( '/class=("|"[^"]*\s)(lazyload|preload)(\s|")/', $image ) ) {
+				continue;
+			}
+			// If image already has one of the needed attributes, don't modify it.
+			if ( 1 === preg_match( '/data-src=|data-srcset=|data-sizes=/', $image ) ) {
+				continue;
+			}
+
+			// Add or edit class list, replace attributes.
+			$lazyfied = strpos( $image, ' class=' ) === false
+				? str_replace( '<img ', '<img class="lazyload" ', $image )
+				: preg_replace( '/\sclass="([^"]*)"/', ' class="$1 lazyload"', $image );
+			$lazyfied = preg_replace( '/\s(src|srcset|sizes)="([^"]*)"/', ' data-$1="$2"', $lazyfied );
+
+			$content = str_replace( $image, $lazyfied, $content );
+		}
+
+		return $content;
 	}
 }

--- a/tests/test-p4-master-site.php
+++ b/tests/test-p4-master-site.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * MasterThemeTest Class
+ *
+ * @package P4MT
+ */
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class P4MasterSite
+ */
+class P4MasterSite extends TestCase {
+
+	/**
+	 * Test cases provider
+	 */
+	public function contentImageProvider(): array {
+		return [
+			'basic test'          => [ '<img src="img-url" />', '<img class="lazyload" data-src="img-url" />' ],
+			'all attrs'           => [
+				'<img src="img-url" srcset="img-srcset" sizes="img-srcsizes" />',
+				'<img class="lazyload" data-src="img-url" data-srcset="img-srcset" data-sizes="img-srcsizes" />',
+			],
+			'll present 1'        => [ '<img src="img-url" class="lazyload" />', null ],
+			'll present 2'        => [ '<img src="img-url" class="foo lazyload" />', null ],
+			'll present 3'        => [ '<img src="img-url" class="lazyload bar" />', null ],
+			'll present 4'        => [ '<img src="img-url" class="foo lazyload bar" />', null ],
+			'data-src present'    => [ '<img src="img-url" data-src="src" />', null ],
+			'data-srcset present' => [ '<img src="img-url" data-srcset="srcset" />', null ],
+			'data-sizes'          => [ '<img src="img-url" data-sizes="sizes" />', null ],
+		];
+	}
+
+	/**
+	 * @dataProvider contentImageProvider
+	 *
+	 * If $expected is null, it will be replaced by $content,
+	 * to check if nothing has changed
+	 *
+	 * @param string  $content Html content given.
+	 * @param ?string $expected Html content expected.
+	 */
+	public function testMakeContentImageLazyLoad( string $content, ?string $expected ): void {
+		/** @var P4_Master_Site $p4 */
+		$p4 = $this->getMockBuilder( P4_Master_Site::class )
+			->disableOriginalConstructor()
+			->setMethodsExcept( [ 'make_content_images_lazyload' ] )
+			->getMock();
+
+		if ( null === $expected ) {
+			$expected = $content;
+		}
+
+		$this->assertEquals( $expected, $p4->make_content_images_lazyload( $content ) );
+	}
+}


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5128

### Note
Wordpress 5.5 will add the `loading` attribute for all images by default. We will have to check if this does not break our own implementation on browsers that support it (and see if we want to migrate to it ? Browser support might not be good enough).
- Implementation in browsers: https://caniuse.com/#feat=loading-lazy-attr
- Announcement: https://make.wordpress.org/core/2020/01/29/lazy-loading-images-in-wordpress-core/
- Changes on `core`: https://core.trac.wordpress.org/changeset/47554

## Changes

The approach I took follows function [`wp_make_content_images_responsive`](https://github.com/WordPress/WordPress/blob/5.4-branch/wp-includes/media.php#L1490) that adds `srcset` and `sizes` attributes to all wp images in content. This `scrset` attribute triggers a network call, so it has to be edited before display.  
The modification currently impacts all images in content that are not already lazy-loaded, so it also impacts Columns block for example, but it can be limited to images with "wp-image-{}" class (image block) if you think it's better.

## Tests

Images added by the Image block should have attributes `data-src`, `data-srcset` and `data-sizes`, and should not trigger a network call if they are out of the viewport.  
Other images like Columns block in the Explore page should also be lazy-loaded.  
Images already marked as `lazyload` or `preload` should not change.  
Test instance available on [Tavros](https://k8s.p4.greenpeace.org/test-tavros/)

_I have unit tests there https://gist.github.com/lithrel/2ab39f07391390e66d13b5fcd0121cbb but I don't know yet how to integrate them properly_