### PR TITLE
PLANET-5057 . Make search excerpt to be 30 words as documented

### DIFF
--- a/templates/tease-search.twig
+++ b/templates/tease-search.twig
@@ -138,7 +138,7 @@
 				</div>
 			</div>
 
-			<p class="search-result-item-content">{{ post.post_excerpt|default(post.post_content)|excerpt( 25 )|raw }}</p>
+			<p class="search-result-item-content">{{ post.post_excerpt|default(post.post_content)|excerpt( 30 )|raw }}</p>
 			{% if post.edit_link %}
 				<a href="{{ post.edit_link|raw }}">{{ __('Manage', 'planet4-master-theme') }}</a>
 			{% endif %}


### PR DESCRIPTION
[Jira issue](https://jira.greenpeace.org/browse/PLANET-5057) 
While the generated excerpt is 30 words, and everywhere else in the app we show 30 words, in the search we were limiting it via twig to 25 words. This change raises the twig limit to the standard 30 words