### PR TITLE
PLANET-4536: Perf: Reduce unused dependencies from bootstrap in code

### DIFF
--- a/assets/src/scss/bootstrap-build.scss
+++ b/assets/src/scss/bootstrap-build.scss
@@ -15,8 +15,8 @@ Text Domain: planet4-master-theme
 // Full bootstrap:
 // @import "~bootstrap/scss/bootstrap";
 
-// @import "~bootstrap/scss/bootstrap-grid.scss";
-// @import "~bootstrap/scss/bootstrap-reboot.scss";
+@import "~bootstrap/scss/bootstrap-grid.scss";
+@import "~bootstrap/scss/bootstrap-reboot.scss";
 
 // Required
 // See: https://getbootstrap.com/docs/4.3/getting-started/theming/#importing
@@ -27,15 +27,14 @@ Text Domain: planet4-master-theme
 // TODO: Add variable overrides for the 16px grid here.
 
 // Optional
-@import "~bootstrap/scss/reboot";
-@import "~bootstrap/scss/type";
-@import "~bootstrap/scss/images";
-@import "~bootstrap/scss/code";
-@import "~bootstrap/scss/grid";
-
+// @import "~bootstrap/scss/reboot";
+// @import "~bootstrap/scss/type";
+// @import "~bootstrap/scss/images";
+// @import "~bootstrap/scss/code";
+// @import "~bootstrap/scss/grid";
 // @import "~bootstrap/scss/_alert.scss";
 // @import "~bootstrap/scss/_badge.scss";
-@import "~bootstrap/scss/_breadcrumb.scss";
+// @import "~bootstrap/scss/_breadcrumb.scss";
 // @import "~bootstrap/scss/_button-group.scss";
 // @import "~bootstrap/scss/_buttons.scss";
 // @import "~bootstrap/scss/_card.scss";
@@ -43,27 +42,27 @@ Text Domain: planet4-master-theme
 // @import "~bootstrap/scss/_close.scss";
 // @import "~bootstrap/scss/_code.scss";
 // @import "~bootstrap/scss/_custom-forms.scss";
-@import "~bootstrap/scss/_dropdown.scss";
+// @import "~bootstrap/scss/_dropdown.scss";
 @import "~bootstrap/scss/_forms.scss";
-@import "~bootstrap/scss/_functions.scss";
+// @import "~bootstrap/scss/_functions.scss";
 // @import "~bootstrap/scss/_grid.scss";
-@import "~bootstrap/scss/_images.scss";
-@import "~bootstrap/scss/_input-group.scss";
+// @import "~bootstrap/scss/_images.scss";
+// @import "~bootstrap/scss/_input-group.scss";
 // @import "~bootstrap/scss/_jumbotron.scss";
-@import "~bootstrap/scss/_list-group.scss";
+// @import "~bootstrap/scss/_list-group.scss";
 @import "~bootstrap/scss/_media.scss";
-@import "~bootstrap/scss/_mixins.scss";
+// @import "~bootstrap/scss/_mixins.scss";
 @import "~bootstrap/scss/_modal.scss";
-@import "~bootstrap/scss/_nav.scss";
-@import "~bootstrap/scss/_navbar.scss";
-@import "~bootstrap/scss/_pagination.scss";
-@import "~bootstrap/scss/_popover.scss";
-@import "~bootstrap/scss/_print.scss";
+// @import "~bootstrap/scss/_nav.scss";
+// @import "~bootstrap/scss/_navbar.scss";
+// @import "~bootstrap/scss/_pagination.scss";
+// @import "~bootstrap/scss/_popover.scss";
+// @import "~bootstrap/scss/_print.scss";
 // @import "~bootstrap/scss/_progress.scss";
 // @import "~bootstrap/scss/_reboot.scss";
-@import "~bootstrap/scss/_root.scss";
-@import "~bootstrap/scss/_tables.scss";
-@import "~bootstrap/scss/_tooltip.scss";
-@import "~bootstrap/scss/_transitions.scss";
+// @import "~bootstrap/scss/_root.scss";
+// @import "~bootstrap/scss/_tables.scss";
+// @import "~bootstrap/scss/_tooltip.scss";
+// @import "~bootstrap/scss/_transitions.scss";
 @import "~bootstrap/scss/_type.scss";
 @import "~bootstrap/scss/_utilities.scss";


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-4536

This is pretty straightforward, just removing parts of Bootstrap we are not using. 
Actually not removing, just commenting them out to keep a reference of what a complete build looks like in case we do want to use any of that in the future.

The Backstop tests look good: 
https://193-238904235-gh.circle-artifacts.com/0/app/backstop_data/html_report/index.html

Test instance here:
https://k8s.p4.greenpeace.org/test-mars/
