### PR TITLE
PLANET-5099 Remove class_exists_checks

### DIFF
--- a/classes/class-p4-campaign-exporter.php
+++ b/classes/class-p4-campaign-exporter.php
@@ -5,112 +5,110 @@
  * @package P4MT
  */
 
-if ( ! class_exists( 'P4_Campaign_Exporter' ) ) {
+/**
+ * Class P4_Campaign_Exporter.
+ */
+class P4_Campaign_Exporter {
 	/**
-	 * Class P4_Campaign_Exporter.
-	 */
-	class P4_Campaign_Exporter {
-		/**
-		 * AutoLoad Hooks
-		 * */
-		public function __construct() {
-			add_action( 'admin_action_export_data', [ $this, 'single_post_export_data' ] );
-			add_filter( 'post_row_actions', [ $this, 'single_post_export' ], 10, 2 );
-			add_filter( 'page_row_actions', [ $this, 'single_post_export' ], 10, 2 );
-			add_action( 'admin_footer-edit.php', [ $this, 'single_post_export_bulk' ] );
-			add_action( 'load-edit.php', [ $this, 'single_post_export_bulk_action' ] );
-			add_action( 'admin_head', [ $this, 'add_import_button' ] );
-		}
-
-		/**
-		 * Main function
-		 */
-		public function single_post_export_data() {
-			$post_id = filter_input( INPUT_GET, 'post', FILTER_SANITIZE_NUMBER_INT ) ?? filter_input( INPUT_POST, 'post', FILTER_SANITIZE_NUMBER_INT );
-			if ( ! empty( $post_id ) && 'export_data' === filter_input( INPUT_GET, 'action', FILTER_SANITIZE_STRING ) ) {
-				include get_template_directory() . '/exporter.php';
-			} else {
-				wp_die( 'No post to export has been supplied!' );
-			}
-		}
-
-		/**
-		 * Export multiple data
-		 */
-		public function single_post_export_bulk() {
-			if ( P4_Post_Campaign::POST_TYPE === filter_input( INPUT_GET, 'post_type', FILTER_SANITIZE_STRING ) &&
-			current_user_can( 'edit_posts' ) ) { ?>
-			<script type="text/javascript">
-				jQuery(function ($) {
-					jQuery('<option>').val('export').text('<?php esc_html_e( 'Export', 'planet4-master-theme-backend' ); ?>').appendTo("select[name='action']");
-				});
-			</script>
-				<?php
-			}
-		}
-
-		/**
-		 * Export Bulk Action
-		 */
-		public function single_post_export_bulk_action() {
-			$wp_list_table   = _get_list_table( 'WP_Posts_List_Table' );
-			$action          = $wp_list_table->current_action();
-			$allowed_actions = [ 'export' ];
-			if ( ! in_array( $action, $allowed_actions, true ) ) {
-				return false;
-			}
-
-			$validated_posts = array_filter(
-				$_REQUEST['post'], // phpcs:ignore
-				function ( $element ) {
-					return filter_var( $element, FILTER_VALIDATE_INT );
-				}
-			);
-
-			switch ( $action ) {
-				case 'export':
-					$sendback = 'admin.php?action=export_data&post=' . join( ',', $validated_posts );
-					break;
-
-				default:
-					return false;
-			}
-			wp_safe_redirect( $sendback );
-			exit();
-		}
-
-		/**
-		 * Add Export Link
-		 *
-		 * @param array   $actions array.
-		 * @param WP_Post $post object.
-		 * @return array  $actions array.
-		 */
-		public function single_post_export( $actions, $post ) : array {
-			if ( P4_Post_Campaign::POST_TYPE === filter_input( INPUT_GET, 'post_type', FILTER_SANITIZE_STRING ) &&
-				current_user_can( 'edit_posts' ) ) {
-				$export_url        = esc_url( admin_url( 'admin.php?action=export_data&amp;post=' . $post->ID ) );
-				$actions['export'] = '<a href="' . $export_url . '" title="' . __( 'Export', 'planet4-master-theme-backend' ) . '" rel="permalink">' . __( 'Export', 'planet4-master-theme-backend' ) . '</a>';
-
-			}
-
-			return $actions;
-		}
-
-		/**
-		 * Add Import Button
-		 */
-		public function add_import_button() {
-			// phpcs:disable WordPress.WP.CapitalPDangit.Misspelled
-			?>
-			<script>
-				jQuery(function(){
-					jQuery("body.post-type-campaign .wrap .page-title-action").after('<a href="admin.php?import=wordpress" class="page-title-action"><?php esc_html_e( 'Import', 'planet4-master-theme-backend' ); ?></a>');
-				});
-			</script>
-			<?php
-			// phpcs:enable
-		}
-
+	 * AutoLoad Hooks
+	 * */
+	public function __construct() {
+		add_action( 'admin_action_export_data', [ $this, 'single_post_export_data' ] );
+		add_filter( 'post_row_actions', [ $this, 'single_post_export' ], 10, 2 );
+		add_filter( 'page_row_actions', [ $this, 'single_post_export' ], 10, 2 );
+		add_action( 'admin_footer-edit.php', [ $this, 'single_post_export_bulk' ] );
+		add_action( 'load-edit.php', [ $this, 'single_post_export_bulk_action' ] );
+		add_action( 'admin_head', [ $this, 'add_import_button' ] );
 	}
+
+	/**
+	 * Main function
+	 */
+	public function single_post_export_data() {
+		$post_id = filter_input( INPUT_GET, 'post', FILTER_SANITIZE_NUMBER_INT ) ?? filter_input( INPUT_POST, 'post', FILTER_SANITIZE_NUMBER_INT );
+		if ( ! empty( $post_id ) && 'export_data' === filter_input( INPUT_GET, 'action', FILTER_SANITIZE_STRING ) ) {
+			include get_template_directory() . '/exporter.php';
+		} else {
+			wp_die( 'No post to export has been supplied!' );
+		}
+	}
+
+	/**
+	 * Export multiple data
+	 */
+	public function single_post_export_bulk() {
+		if ( P4_Post_Campaign::POST_TYPE === filter_input( INPUT_GET, 'post_type', FILTER_SANITIZE_STRING ) &&
+		current_user_can( 'edit_posts' ) ) { ?>
+		<script type="text/javascript">
+			jQuery(function ($) {
+				jQuery('<option>').val('export').text('<?php esc_html_e( 'Export', 'planet4-master-theme-backend' ); ?>').appendTo("select[name='action']");
+			});
+		</script>
+			<?php
+		}
+	}
+
+	/**
+	 * Export Bulk Action
+	 */
+	public function single_post_export_bulk_action() {
+		$wp_list_table   = _get_list_table( 'WP_Posts_List_Table' );
+		$action          = $wp_list_table->current_action();
+		$allowed_actions = [ 'export' ];
+		if ( ! in_array( $action, $allowed_actions, true ) ) {
+			return false;
+		}
+
+		$validated_posts = array_filter(
+			$_REQUEST['post'], // phpcs:ignore
+			function ( $element ) {
+				return filter_var( $element, FILTER_VALIDATE_INT );
+			}
+		);
+
+		switch ( $action ) {
+			case 'export':
+				$sendback = 'admin.php?action=export_data&post=' . join( ',', $validated_posts );
+				break;
+
+			default:
+				return false;
+		}
+		wp_safe_redirect( $sendback );
+		exit();
+	}
+
+	/**
+	 * Add Export Link
+	 *
+	 * @param array   $actions array.
+	 * @param WP_Post $post object.
+	 * @return array  $actions array.
+	 */
+	public function single_post_export( $actions, $post ) : array {
+		if ( P4_Post_Campaign::POST_TYPE === filter_input( INPUT_GET, 'post_type', FILTER_SANITIZE_STRING ) &&
+			current_user_can( 'edit_posts' ) ) {
+			$export_url        = esc_url( admin_url( 'admin.php?action=export_data&amp;post=' . $post->ID ) );
+			$actions['export'] = '<a href="' . $export_url . '" title="' . __( 'Export', 'planet4-master-theme-backend' ) . '" rel="permalink">' . __( 'Export', 'planet4-master-theme-backend' ) . '</a>';
+
+		}
+
+		return $actions;
+	}
+
+	/**
+	 * Add Import Button
+	 */
+	public function add_import_button() {
+		// phpcs:disable WordPress.WP.CapitalPDangit.Misspelled
+		?>
+		<script>
+			jQuery(function(){
+				jQuery("body.post-type-campaign .wrap .page-title-action").after('<a href="admin.php?import=wordpress" class="page-title-action"><?php esc_html_e( 'Import', 'planet4-master-theme-backend' ); ?></a>');
+			});
+		</script>
+		<?php
+		// phpcs:enable
+	}
+
 }

--- a/classes/class-p4-campaign-importer.php
+++ b/classes/class-p4-campaign-importer.php
@@ -5,208 +5,115 @@
  * @package P4MT
  */
 
-if ( ! class_exists( 'P4_Campaign_Importer' ) ) {
+/**
+ * Class P4_Campaign_Importer.
+ */
+class P4_Campaign_Importer {
+
 	/**
-	 * Class P4_Campaign_Importer.
+	 * Old and new attachment ids mapping var
+	 *
+	 * @var array $attachment_mapping
 	 */
-	class P4_Campaign_Importer {
+	private $attachment_mapping = [];
 
-		/**
-		 * Old and new attachment ids mapping var
-		 *
-		 * @var array $attachment_mapping
-		 */
-		private $attachment_mapping = [];
+	/**
+	 * AutoLoad Hooks
+	 * */
+	public function __construct() {
+		add_action( 'wp_import_insert_post', [ $this, 'update_campaign_attachements' ], 10, 4 );
+		add_filter( 'wp_import_post_terms', [ $this, 'filter_wp_import_post_terms' ], 10, 3 );
+		add_filter( 'wp_import_post_meta', [ $this, 'process_campaign_metas' ] );
+		add_filter( 'wp_import_post_data_processed', [ $this, 'set_imported_campaigns_as_drafts' ], 10, 2 );
+		add_action( 'import_end', [ $this, 'action_import_end' ], 10, 0 );
+		add_filter( 'wp_import_post_meta', [ $this, 'skip_duplicate_postmeta_import' ], 10, 2 );
+	}
 
-		/**
-		 * AutoLoad Hooks
-		 * */
-		public function __construct() {
-			add_action( 'wp_import_insert_post', [ $this, 'update_campaign_attachements' ], 10, 4 );
-			add_filter( 'wp_import_post_terms', [ $this, 'filter_wp_import_post_terms' ], 10, 3 );
-			add_filter( 'wp_import_post_meta', [ $this, 'process_campaign_metas' ] );
-			add_filter( 'wp_import_post_data_processed', [ $this, 'set_imported_campaigns_as_drafts' ], 10, 2 );
-			add_action( 'import_end', [ $this, 'action_import_end' ], 10, 0 );
-			add_filter( 'wp_import_post_meta', [ $this, 'skip_duplicate_postmeta_import' ], 10, 2 );
+	/**
+	 * Filter the old attachement Ids from Campaign and replace them with the newly imported attachment Ids.
+	 *
+	 * @param integer $post_id Post ID.
+	 * @param integer $original_post_id Original Post ID.
+	 * @param array   $postdata Post data array.
+	 * @param array   $post Post array.
+	 */
+	public function update_campaign_attachements( $post_id, $original_post_id, $postdata, $post ) {
+		if ( 'campaign' !== $post['post_type'] ) {
+			return;
 		}
 
-		/**
-		 * Filter the old attachement Ids from Campaign and replace them with the newly imported attachment Ids.
-		 *
-		 * @param integer $post_id Post ID.
-		 * @param integer $original_post_id Original Post ID.
-		 * @param array   $postdata Post data array.
-		 * @param array   $post Post array.
-		 */
-		public function update_campaign_attachements( $post_id, $original_post_id, $postdata, $post ) {
-			if ( 'campaign' !== $post['post_type'] ) {
-				return;
-			}
+		$post_content = $post['post_content'];
+		$filter_data  = [];
 
-			$post_content = $post['post_content'];
-			$filter_data  = [];
+		$blocks = parse_blocks( $post_content );
+		foreach ( $blocks as $block ) {
 
-			$blocks = parse_blocks( $post_content );
-			foreach ( $blocks as $block ) {
+			// Fetch the attachement id/s from block fields.
+			switch ( $block['blockName'] ) {
 
-				// Fetch the attachement id/s from block fields.
-				switch ( $block['blockName'] ) {
+				case 'planet4-blocks/enform':
+					$filter_data[] = isset( $block['attrs']['background'] ) ? 'background":' . $block['attrs']['background'] : '';
+					break;
 
-					case 'planet4-blocks/enform':
-						$filter_data[] = isset( $block['attrs']['background'] ) ? 'background":' . $block['attrs']['background'] : '';
-						break;
+				case 'planet4-blocks/happypoint':
+					$filter_data[] = isset( $block['attrs']['id'] ) ? 'id":' . $block['attrs']['id'] : '';
+					break;
 
-					case 'planet4-blocks/happypoint':
-						$filter_data[] = isset( $block['attrs']['id'] ) ? 'id":' . $block['attrs']['id'] : '';
-						break;
+				case 'planet4-blocks/media-video':
+					$filter_data[] = isset( $block['attrs']['video_poster_img'] ) ? 'video_poster_img":' . $block['attrs']['video_poster_img'] : '';
+					break;
 
-					case 'planet4-blocks/media-video':
-						$filter_data[] = isset( $block['attrs']['video_poster_img'] ) ? 'video_poster_img":' . $block['attrs']['video_poster_img'] : '';
-						break;
+				case 'planet4-blocks/gallery':
+					$filter_data[] = isset( $block['attrs']['multiple_image'] ) ? 'multiple_image":"' . $block['attrs']['multiple_image'] : '';
+					break;
 
-					case 'planet4-blocks/gallery':
-						$filter_data[] = isset( $block['attrs']['multiple_image'] ) ? 'multiple_image":"' . $block['attrs']['multiple_image'] : '';
-						break;
-
-					case 'planet4-blocks/carousel-header':
-						if ( isset( $block['attrs']['slides'] ) ) {
-							foreach ( $block['attrs']['slides'] as $slide ) {
-								$filter_data[] = 'image":' . $slide['image'];
-							}
-						}
-						break;
-
-					case 'planet4-blocks/split-two-columns':
-						$filter_data[] = isset( $block['attrs']['issue_image'] ) ? 'issue_image":' . $block['attrs']['issue_image'] : '';
-						$filter_data[] = isset( $block['attrs']['tag_image'] ) ? 'tag_image":' . $block['attrs']['tag_image'] : '';
-						break;
-
-					case 'planet4-blocks/columns':
-						if ( isset( $block['attrs']['columns'] ) ) {
-							foreach ( $block['attrs']['columns'] as $column ) {
-								$filter_data[] = 'attachment":' . $column['attachment'];
-							}
-						}
-						break;
-
-					case 'planet4-blocks/social-media-cards':
-						if ( isset( $block['attrs']['cards'] ) ) {
-							foreach ( $block['attrs']['cards'] as $card ) {
-								$filter_data[] = 'image_id":' . $card['image_id'];
-							}
-						}
-						break;
-
-					case 'planet4-blocks/take-action-boxout':
-						$filter_data[] = isset( $block['attrs']['background_image'] ) ? 'background_image":' . $block['attrs']['background_image'] : '';
-						break;
-
-					case 'core/image':
-						if ( isset( $block['attrs']['id'] ) ) {
-							$filter_data[] = 'id":' . $block['attrs']['id'];
-							$filter_data[] = 'wp-image-' . $block['attrs']['id'];
-						}
-						break;
-				}
-			}
-
-			$filter_data = array_unique( $filter_data );
-
-			// Check if attachement mapping var is empty and update it.
-			if ( empty( $this->attachment_mapping ) ) {
-
-				global $wpdb;
-
-				// phpcs:disable
-				$sql          = 'SELECT post_id, meta_value FROM %1$s WHERE meta_key = \'_wp_attachment_metadata\' AND meta_value LIKE \'%imported_attachment_id%\'';
-				$prepared_sql = $wpdb->prepare( $sql, [ $wpdb->postmeta ] );
-				$result       = $wpdb->get_results( $prepared_sql );
-				// phpcs:enable
-
-				foreach ( $result as $attachment_metadata ) {
-					$new_attachment_id                              = $attachment_metadata->post_id;
-					$attachment_data                                = maybe_unserialize( $attachment_metadata->meta_value );
-					$old_attachment_id                              = $attachment_data['image_meta']['imported_attachment_id'];
-					$this->attachment_mapping[ $old_attachment_id ] = $new_attachment_id;
-				}
-			}
-
-			// Old ids and new ids(attachment ids) string data mapping.
-			$filter_data_mapping = [];
-			foreach ( $filter_data as $filter_str ) {
-				if ( strpos( $filter_str, 'multiple_image' ) !== false || strpos( $filter_str, 'ids' ) !== false ) {
-					$new_filter_str = $filter_str;
-					preg_match_all( '#(\d+)#', $new_filter_str, $matches, PREG_SET_ORDER );
-
-					foreach ( $matches as $old_id ) {
-						if ( isset( $this->attachment_mapping[ $old_id[0] ] ) ) {
-							$new_filter_str = str_replace( $old_id[0], $this->attachment_mapping[ $old_id[0] ], $new_filter_str );
+				case 'planet4-blocks/carousel-header':
+					if ( isset( $block['attrs']['slides'] ) ) {
+						foreach ( $block['attrs']['slides'] as $slide ) {
+							$filter_data[] = 'image":' . $slide['image'];
 						}
 					}
-					$filter_data_mapping[] = [ $filter_str, $new_filter_str ];
-				} else {
-					foreach ( $this->attachment_mapping as $old_id => $new_id ) {
-						$updated_str = str_replace( $old_id, $new_id, $filter_str );
-						if ( $updated_str !== $filter_str ) {
-							$filter_data_mapping[] = [ $filter_str, $updated_str ];
+					break;
+
+				case 'planet4-blocks/split-two-columns':
+					$filter_data[] = isset( $block['attrs']['issue_image'] ) ? 'issue_image":' . $block['attrs']['issue_image'] : '';
+					$filter_data[] = isset( $block['attrs']['tag_image'] ) ? 'tag_image":' . $block['attrs']['tag_image'] : '';
+					break;
+
+				case 'planet4-blocks/columns':
+					if ( isset( $block['attrs']['columns'] ) ) {
+						foreach ( $block['attrs']['columns'] as $column ) {
+							$filter_data[] = 'attachment":' . $column['attachment'];
 						}
 					}
-				}
-			}
+					break;
 
-			// Search replace filter data string(with old attachement ids) with updated attachment ids string.
-			foreach ( $filter_data_mapping as $filter_data ) {
-				$post_content = str_replace( $filter_data[0], $filter_data[1], $post_content );
-			}
-
-			// Update Page header fields background image in postmeta.
-			$campaign_postmeta = [];
-			if ( isset( $post['postmeta'] ) ) {
-				foreach ( $post['postmeta'] as $metakey => $metadata ) {
-					if ( 'background_image_id' === $metadata['key'] ) {
-						if ( isset( $this->attachment_mapping[ $metadata['value'] ] ) ) {
-							$post['postmeta'][ $metakey ]['value'] = $this->attachment_mapping[ $metadata['value'] ];
+				case 'planet4-blocks/social-media-cards':
+					if ( isset( $block['attrs']['cards'] ) ) {
+						foreach ( $block['attrs']['cards'] as $card ) {
+							$filter_data[] = 'image_id":' . $card['image_id'];
 						}
 					}
-				}
-				$campaign_postmeta = $post['postmeta'];
-			}
+					break;
 
-			$updated_post = [
-				'ID'           => $post_id,
-				'post_title'   => $post['post_title'],
-				'post_content' => $post_content,
-				'postmeta'     => $campaign_postmeta,
-			];
-			wp_update_post( wp_slash( $updated_post ) );
+				case 'planet4-blocks/take-action-boxout':
+					$filter_data[] = isset( $block['attrs']['background_image'] ) ? 'background_image":' . $block['attrs']['background_image'] : '';
+					break;
+
+				case 'core/image':
+					if ( isset( $block['attrs']['id'] ) ) {
+						$filter_data[] = 'id":' . $block['attrs']['id'];
+						$filter_data[] = 'wp-image-' . $block['attrs']['id'];
+					}
+					break;
+			}
 		}
 
-		/**
-		 * Update campaign attachement source ID in attachment metadata for future data mapping purpose.
-		 *
-		 * @param array   $post_terms Post term array.
-		 * @param integer $post_id Post ID.
-		 * @param object  $post Post object.
-		 * @return array  $post_terms Post term array.
-		 */
-		public function filter_wp_import_post_terms( $post_terms, $post_id, $post ) {
-			if ( 'attachment' === $post['post_type'] ) {
-				$attachment_metadata = wp_get_attachment_metadata( $post_id );
-				$attachment_metadata['image_meta']['imported_attachment_id'] = $post['post_id'];
-				wp_update_attachment_metadata( $post_id, $attachment_metadata );
+		$filter_data = array_unique( $filter_data );
 
-				if ( ! empty( $this->attachment_mapping ) ) {
-					$this->attachment_mapping = [];
-				}
-			}
+		// Check if attachement mapping var is empty and update it.
+		if ( empty( $this->attachment_mapping ) ) {
 
-			return $post_terms;
-		}
-
-		/**
-		 * Clean the campaign attachment metadata.
-		 */
-		public function action_import_end() {
 			global $wpdb;
 
 			// phpcs:disable
@@ -216,90 +123,181 @@ if ( ! class_exists( 'P4_Campaign_Importer' ) ) {
 			// phpcs:enable
 
 			foreach ( $result as $attachment_metadata ) {
-				$attachment_data = maybe_unserialize( $attachment_metadata->meta_value );
-				unset( $attachment_data['image_meta']['imported_attachment_id'] );
-				wp_update_attachment_metadata( $attachment_metadata->post_id, $attachment_data );
+				$new_attachment_id                              = $attachment_metadata->post_id;
+				$attachment_data                                = maybe_unserialize( $attachment_metadata->meta_value );
+				$old_attachment_id                              = $attachment_data['image_meta']['imported_attachment_id'];
+				$this->attachment_mapping[ $old_attachment_id ] = $new_attachment_id;
 			}
 		}
 
-		/**
-		 * Filter for wp_import_post_data_processed.
-		 * Set imported campaign posts as drafts.
-		 *
-		 * @param array $postdata Post data that can be filtered.
-		 * @param array $post     The post array to be inserted.
-		 *
-		 * @return array
-		 */
-		public function set_imported_campaigns_as_drafts( $postdata, $post ) {
-			if ( 'campaign' === $post['post_type'] ) {
-				$postdata['post_status'] = 'draft';
-			}
+		// Old ids and new ids(attachment ids) string data mapping.
+		$filter_data_mapping = [];
+		foreach ( $filter_data as $filter_str ) {
+			if ( strpos( $filter_str, 'multiple_image' ) !== false || strpos( $filter_str, 'ids' ) !== false ) {
+				$new_filter_str = $filter_str;
+				preg_match_all( '#(\d+)#', $new_filter_str, $matches, PREG_SET_ORDER );
 
-			return $postdata;
-		}
-
-		/**
-		 * 1. Exclude campaign style meta fields if the NRO has this setting enabled.
-		 *
-		 * 2. Populate the "theme" meta field with the contents of its previous name if the new field doesn't exist yet.
-		 *
-		 * @param array $post_meta The to be imported post meta fields.
-		 *
-		 * @return array The normalized post meta fields.
-		 */
-		public function process_campaign_metas( $post_meta ) {
-			$p4_options = get_option( 'planet4_options' );
-			// 1. Exclude style fields the option for that is set or if it's passed in the form data.
-			if (
-				! empty( $p4_options['campaigns_import_exclude_style'] )
-				|| ! empty( $_POST['campaigns_import_exclude_style'] ) //phpcs:ignore WordPress.Security.NonceVerification.Missing
-			) {
-				// Also exclude the old attribute as the code still falls back to it.
-				$excluded_keys = array_merge( P4_Post_Campaign::META_FIELDS, [ '_campaign_page_template' ] );
-				foreach ( $post_meta as $index => $meta ) {
-					if ( in_array( $meta['key'], $excluded_keys, true ) ) {
-						unset( $post_meta[ $index ] );
+				foreach ( $matches as $old_id ) {
+					if ( isset( $this->attachment_mapping[ $old_id[0] ] ) ) {
+						$new_filter_str = str_replace( $old_id[0], $this->attachment_mapping[ $old_id[0] ], $new_filter_str );
 					}
 				}
+				$filter_data_mapping[] = [ $filter_str, $new_filter_str ];
 			} else {
-				// 2. Populate the new `theme` field and unset the old `_campaign_page_template if the new doesn't exist.
-				foreach ( $post_meta as $index => $meta ) {
-					if ( '_campaign_page_template' === $meta['key'] ) {
-						$old_theme = $meta['value'];
-						unset( $post_meta[ $index ] );
-					} elseif ( 'theme' === $meta['key'] ) {
-						$new_theme = $meta['value'];
+				foreach ( $this->attachment_mapping as $old_id => $new_id ) {
+					$updated_str = str_replace( $old_id, $new_id, $filter_str );
+					if ( $updated_str !== $filter_str ) {
+						$filter_data_mapping[] = [ $filter_str, $updated_str ];
 					}
 				}
-				if ( isset( $old_theme ) && ! isset( $new_theme ) ) {
-					$post_meta[] = [
-						'key'   => 'theme',
-						'value' => $old_theme,
-					];
+			}
+		}
+
+		// Search replace filter data string(with old attachement ids) with updated attachment ids string.
+		foreach ( $filter_data_mapping as $filter_data ) {
+			$post_content = str_replace( $filter_data[0], $filter_data[1], $post_content );
+		}
+
+		// Update Page header fields background image in postmeta.
+		$campaign_postmeta = [];
+		if ( isset( $post['postmeta'] ) ) {
+			foreach ( $post['postmeta'] as $metakey => $metadata ) {
+				if ( 'background_image_id' === $metadata['key'] ) {
+					if ( isset( $this->attachment_mapping[ $metadata['value'] ] ) ) {
+						$post['postmeta'][ $metakey ]['value'] = $this->attachment_mapping[ $metadata['value'] ];
+					}
 				}
 			}
-
-			return $post_meta;
+			$campaign_postmeta = $post['postmeta'];
 		}
 
-		/**
-		 * Skip already existing postmeta data from import.
-		 *
-		 * @param array   $postmeta The to be imported post meta fields.
-		 * @param integer $post_id Post ID.
-		 *
-		 * @return array The cleaned post meta fields.
-		 */
-		public function skip_duplicate_postmeta_import( $postmeta, $post_id ) {
-			$existing_postmeta = get_post_meta( $post_id );
+		$updated_post = [
+			'ID'           => $post_id,
+			'post_title'   => $post['post_title'],
+			'post_content' => $post_content,
+			'postmeta'     => $campaign_postmeta,
+		];
+		wp_update_post( wp_slash( $updated_post ) );
+	}
 
-			return array_filter(
-				$postmeta,
-				function( $meta ) use ( $existing_postmeta ) {
-					return ! array_key_exists( $meta['key'], $existing_postmeta );
+	/**
+	 * Update campaign attachement source ID in attachment metadata for future data mapping purpose.
+	 *
+	 * @param array   $post_terms Post term array.
+	 * @param integer $post_id Post ID.
+	 * @param object  $post Post object.
+	 * @return array  $post_terms Post term array.
+	 */
+	public function filter_wp_import_post_terms( $post_terms, $post_id, $post ) {
+		if ( 'attachment' === $post['post_type'] ) {
+			$attachment_metadata = wp_get_attachment_metadata( $post_id );
+			$attachment_metadata['image_meta']['imported_attachment_id'] = $post['post_id'];
+			wp_update_attachment_metadata( $post_id, $attachment_metadata );
+
+			if ( ! empty( $this->attachment_mapping ) ) {
+				$this->attachment_mapping = [];
+			}
+		}
+
+		return $post_terms;
+	}
+
+	/**
+	 * Clean the campaign attachment metadata.
+	 */
+	public function action_import_end() {
+		global $wpdb;
+
+		// phpcs:disable
+		$sql          = 'SELECT post_id, meta_value FROM %1$s WHERE meta_key = \'_wp_attachment_metadata\' AND meta_value LIKE \'%imported_attachment_id%\'';
+		$prepared_sql = $wpdb->prepare( $sql, [ $wpdb->postmeta ] );
+		$result       = $wpdb->get_results( $prepared_sql );
+		// phpcs:enable
+
+		foreach ( $result as $attachment_metadata ) {
+			$attachment_data = maybe_unserialize( $attachment_metadata->meta_value );
+			unset( $attachment_data['image_meta']['imported_attachment_id'] );
+			wp_update_attachment_metadata( $attachment_metadata->post_id, $attachment_data );
+		}
+	}
+
+	/**
+	 * Filter for wp_import_post_data_processed.
+	 * Set imported campaign posts as drafts.
+	 *
+	 * @param array $postdata Post data that can be filtered.
+	 * @param array $post     The post array to be inserted.
+	 *
+	 * @return array
+	 */
+	public function set_imported_campaigns_as_drafts( $postdata, $post ) {
+		if ( 'campaign' === $post['post_type'] ) {
+			$postdata['post_status'] = 'draft';
+		}
+
+		return $postdata;
+	}
+
+	/**
+	 * 1. Exclude campaign style meta fields if the NRO has this setting enabled.
+	 *
+	 * 2. Populate the "theme" meta field with the contents of its previous name if the new field doesn't exist yet.
+	 *
+	 * @param array $post_meta The to be imported post meta fields.
+	 *
+	 * @return array The normalized post meta fields.
+	 */
+	public function process_campaign_metas( $post_meta ) {
+		$p4_options = get_option( 'planet4_options' );
+		// 1. Exclude style fields the option for that is set or if it's passed in the form data.
+		if (
+			! empty( $p4_options['campaigns_import_exclude_style'] )
+			|| ! empty( $_POST['campaigns_import_exclude_style'] ) //phpcs:ignore WordPress.Security.NonceVerification.Missing
+		) {
+			// Also exclude the old attribute as the code still falls back to it.
+			$excluded_keys = array_merge( P4_Post_Campaign::META_FIELDS, [ '_campaign_page_template' ] );
+			foreach ( $post_meta as $index => $meta ) {
+				if ( in_array( $meta['key'], $excluded_keys, true ) ) {
+					unset( $post_meta[ $index ] );
 				}
-			);
+			}
+		} else {
+			// 2. Populate the new `theme` field and unset the old `_campaign_page_template if the new doesn't exist.
+			foreach ( $post_meta as $index => $meta ) {
+				if ( '_campaign_page_template' === $meta['key'] ) {
+					$old_theme = $meta['value'];
+					unset( $post_meta[ $index ] );
+				} elseif ( 'theme' === $meta['key'] ) {
+					$new_theme = $meta['value'];
+				}
+			}
+			if ( isset( $old_theme ) && ! isset( $new_theme ) ) {
+				$post_meta[] = [
+					'key'   => 'theme',
+					'value' => $old_theme,
+				];
+			}
 		}
+
+		return $post_meta;
+	}
+
+	/**
+	 * Skip already existing postmeta data from import.
+	 *
+	 * @param array   $postmeta The to be imported post meta fields.
+	 * @param integer $post_id Post ID.
+	 *
+	 * @return array The cleaned post meta fields.
+	 */
+	public function skip_duplicate_postmeta_import( $postmeta, $post_id ) {
+		$existing_postmeta = get_post_meta( $post_id );
+
+		return array_filter(
+			$postmeta,
+			function( $meta ) use ( $existing_postmeta ) {
+				return ! array_key_exists( $meta['key'], $existing_postmeta );
+			}
+		);
 	}
 }

--- a/classes/class-p4-campaigns.php
+++ b/classes/class-p4-campaigns.php
@@ -5,282 +5,281 @@
  * @package P4MT
  */
 
-if ( ! class_exists( 'P4_Campaigns' ) ) {
+/**
+ * Class P4_Campaigns
+ */
+class P4_Campaigns {
+
 	/**
-	 * Class P4_Campaigns
+	 * Taxonomy
+	 *
+	 * @var string $taxonomy
 	 */
-	class P4_Campaigns {
+	private $taxonomy = 'post_tag';
+	/**
+	 * Page Types
+	 *
+	 * @var array $page_types
+	 */
+	public $page_types = [];
+	/**
+	 * Localizations
+	 *
+	 * @var array $localizations
+	 */
+	public $localizations = [];
 
-		/**
-		 * Taxonomy
-		 *
-		 * @var string $taxonomy
-		 */
-		private $taxonomy = 'post_tag';
-		/**
-		 * Page Types
-		 *
-		 * @var array $page_types
-		 */
-		public $page_types = [];
-		/**
-		 * Localizations
-		 *
-		 * @var array $localizations
-		 */
-		public $localizations = [];
+	/**
+	 * Taxonomy_Image constructor.
+	 */
+	public function __construct() {
+		$this->localizations = [
+			'media_title' => esc_html__( 'Select Image', 'planet4-master-theme-backend' ),
+		];
+		$this->hooks();
+	}
 
-		/**
-		 * Taxonomy_Image constructor.
-		 */
-		public function __construct() {
-			$this->localizations = [
-				'media_title' => esc_html__( 'Select Image', 'planet4-master-theme-backend' ),
+	/**
+	 * Class hooks.
+	 */
+	private function hooks() {
+		add_action( 'post_tag_add_form_fields', [ $this, 'add_taxonomy_form_fields' ] );
+		add_action( 'post_tag_edit_form_fields', [ $this, 'add_taxonomy_form_fields' ] );
+		add_action( 'create_post_tag', [ $this, 'save_taxonomy_meta' ] );
+		add_action( 'edit_post_tag', [ $this, 'save_taxonomy_meta' ] );
+		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_admin_assets' ] );
+
+		add_filter( 'manage_edit-post_tag_columns', [ $this, 'edit_taxonomy_columns' ] );
+		add_filter( 'manage_post_tag_custom_column', [ $this, 'manage_taxonomy_custom_column' ], 10, 3 );
+		add_filter( 'manage_edit-post_tag_sortable_columns', [ $this, 'manage_taxonomy_custom_sortable_column' ], 10, 3 );
+	}
+
+	/**
+	 * Add custom field(s) to taxonomy form.
+	 *
+	 * @param WP_Term $wp_tag The object passed to the callback when on Edit Tag page.
+	 */
+	public function add_taxonomy_form_fields( $wp_tag ) {
+		$this->page_types = get_terms(
+			[
+				'hide_empty' => false,
+				'orderby'    => 'name',
+				'taxonomy'   => 'p4-page-type',
+			]
+		);
+
+		if ( isset( $wp_tag ) && $wp_tag instanceof WP_Term ) {
+			$selected_page_types = get_term_meta( $wp_tag->term_id, 'selected_page_types' );
+			if ( ! isset( $selected_page_types[0] ) ) {
+				$selected_page_types[0] = [];
+			}
+
+			$attachment_id    = get_term_meta( $wp_tag->term_id, 'tag_attachment_id', true );
+			$image_attributes = wp_get_attachment_image_src( $attachment_id, 'full' );
+			$attachment_url   = $image_attributes ? $image_attributes[0] : '';
+
+			$happypoint_attachment_id    = get_term_meta( $wp_tag->term_id, 'happypoint_attachment_id', true );
+			$happypoint_image_attributes = wp_get_attachment_image_src( $happypoint_attachment_id, 'full' );
+			$happypoint_attachment_url   = $happypoint_image_attributes ? $happypoint_image_attributes[0] : '';
+
+			$happypoint_bg_opacity = get_term_meta( $wp_tag->term_id, 'happypoint_bg_opacity', true );
+			$happypoint_bg_opacity = $happypoint_bg_opacity ?? '30';
+
+			$redirect_page = get_term_meta( $wp_tag->term_id, 'redirect_page', true );
+			$dropdown_args = [
+				'show_option_none' => __( 'Select Page', 'planet4-master-theme-backend' ),
+				'hide_empty'       => 0,
+				'hierarchical'     => true,
+				'selected'         => $redirect_page,
+				'name'             => 'redirect_page',
 			];
-			$this->hooks();
-		}
+			?>
 
-		/**
-		 * Class hooks.
-		 */
-		private function hooks() {
-			add_action( 'post_tag_add_form_fields', [ $this, 'add_taxonomy_form_fields' ] );
-			add_action( 'post_tag_edit_form_fields', [ $this, 'add_taxonomy_form_fields' ] );
-			add_action( 'create_post_tag', [ $this, 'save_taxonomy_meta' ] );
-			add_action( 'edit_post_tag', [ $this, 'save_taxonomy_meta' ] );
-			add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_admin_assets' ] );
-
-			add_filter( 'manage_edit-post_tag_columns', [ $this, 'edit_taxonomy_columns' ] );
-			add_filter( 'manage_post_tag_custom_column', [ $this, 'manage_taxonomy_custom_column' ], 10, 3 );
-			add_filter( 'manage_edit-post_tag_sortable_columns', [ $this, 'manage_taxonomy_custom_sortable_column' ], 10, 3 );
-		}
-
-		/**
-		 * Add custom field(s) to taxonomy form.
-		 *
-		 * @param WP_Term $wp_tag The object passed to the callback when on Edit Tag page.
-		 */
-		public function add_taxonomy_form_fields( $wp_tag ) {
-			$this->page_types = get_terms(
-				[
-					'hide_empty' => false,
-					'orderby'    => 'name',
-					'taxonomy'   => 'p4-page-type',
-				]
-			);
-
-			if ( isset( $wp_tag ) && $wp_tag instanceof WP_Term ) {
-				$selected_page_types = get_term_meta( $wp_tag->term_id, 'selected_page_types' );
-				if ( ! isset( $selected_page_types[0] ) ) {
-					$selected_page_types[0] = [];
-				}
-
-				$attachment_id    = get_term_meta( $wp_tag->term_id, 'tag_attachment_id', true );
-				$image_attributes = wp_get_attachment_image_src( $attachment_id, 'full' );
-				$attachment_url   = $image_attributes ? $image_attributes[0] : '';
-
-				$happypoint_attachment_id    = get_term_meta( $wp_tag->term_id, 'happypoint_attachment_id', true );
-				$happypoint_image_attributes = wp_get_attachment_image_src( $happypoint_attachment_id, 'full' );
-				$happypoint_attachment_url   = $happypoint_image_attributes ? $happypoint_image_attributes[0] : '';
-
-				$happypoint_bg_opacity = get_term_meta( $wp_tag->term_id, 'happypoint_bg_opacity', true );
-				$happypoint_bg_opacity = $happypoint_bg_opacity ?? '30';
-
-				$redirect_page = get_term_meta( $wp_tag->term_id, 'redirect_page', true );
-				$dropdown_args = [
-					'show_option_none' => __( 'Select Page', 'planet4-master-theme-backend' ),
-					'hide_empty'       => 0,
-					'hierarchical'     => true,
-					'selected'         => $redirect_page,
-					'name'             => 'redirect_page',
-				];
-				?>
-
-				<tr class="form-field edit-wrap">
-					<th>
-						<label><?php esc_html_e( 'Redirect Page', 'planet4-master-theme-backend' ); ?></label>
-					</th>
-					<td>
-						<?php wp_dropdown_pages( array_map( 'esc_attr', $dropdown_args ) ); ?> <a href="post.php?post=<?php echo esc_attr( $redirect_page ); ?>&action=edit" target="_blank"><?php esc_html_e( 'Edit', 'planet4-master-theme-backend' ); ?></a>
-						<p class="description"><?php esc_html_e( 'Leave this empty if you want to use the automated Tag page. Otherwise pick a page to redirect this Tag to.', 'planet4-master-theme-backend' ); ?></p>
-					</td>
-				</tr>
-				<tr>
-					<th colspan="2">
-						<?php esc_html_e( 'Column block: Choose which Page Types will populate the content of the Column block. If no box is checked Publications will appear by default.', 'planet4-master-theme-backend' ); ?>
-					</th>
-				</tr>
-				<?php foreach ( $this->page_types as $index => $page_type ) { ?>
-					<tr class="form-field edit-wrap term-page-type-<?php echo esc_attr( $page_type->slug ); ?>-wrap">
-						<th></th>
-						<td>
-							<div class="field-block shortcode-ui-field-checkbox shortcode-ui-attribute-p4_page_type_<?php echo esc_attr( $page_type->slug ); ?>">
-								<label for="shortcode-ui-p4_page_type_<?php echo esc_attr( $page_type->slug ); ?>">
-									<input type="checkbox" name="p4_page_type[]" id="shortcode-ui-p4_page_type_<?php echo esc_attr( $page_type->slug ); ?>" value="<?php echo esc_attr( $page_type->slug ); ?>" <?php echo in_array( $page_type->slug, $selected_page_types[0], true ) ? 'checked' : ''; ?>>
-									<?php echo esc_html( $page_type->name ); ?>
-
-								</label>
-							</div>
-						</td>
-					</tr>
-				<?php } ?>
-				<tr class="form-field edit-wrap term-image-wrap">
-					<th>
-						<label><?php esc_html_e( 'Image', 'planet4-master-theme-backend' ); ?></label>
-					</th>
-					<td>
-						<input type="hidden" name="tag_attachment_id" id="tag_attachment_id" class="tag-attachment-id field-id" value="<?php echo esc_attr( $attachment_id ); ?>" />
-						<input type="hidden" name="tag_attachment" id="tag_attachment" class="tag-attachment-url field-url" value="<?php echo esc_url( $attachment_url ); ?>" />
-						<button class="button insert-media add_media" name="insert_image_tag_button" id="insert_image_tag_button" type="button">
-							<?php esc_html_e( 'Select/Upload Image', 'planet4-master-theme-backend' ); ?>
-						</button>
-						<p class="description"><?php esc_html_e( 'Associate this tag with an image.', 'planet4-master-theme-backend' ); ?></p>
-						<img class="attachment-thumbnail size-thumbnail" src="<?php echo esc_url( $attachment_url ); ?>"/>
-						<i class="dashicons dashicons-dismiss <?php echo $image_attributes ? '' : 'hidden'; ?>" style="cursor: pointer;"></i>
-					</td>
-				</tr>
-				<tr class="form-field edit-wrap term-happypoint-wrap">
-					<th>
-						<label><?php esc_html_e( 'Image Subscribe', 'planet4-master-theme-backend' ); ?></label>
-					</th>
-					<td>
-						<input type="hidden" name="happypoint_attachment_id" id="happypoint_attachment_id" class="happypoint-attachment-id field-id" value="<?php echo esc_attr( $happypoint_attachment_id ); ?>" />
-						<input type="hidden" name="happypoint_attachment" id="happypoint_attachment" class="happypoint-attachment-url field-url" value="<?php echo esc_url( $happypoint_attachment_url ); ?>" />
-						<button class="button insert-media add_media" name="insert_happypoint_image_button" id="insert_happypoint_image_button" type="button">
-							<?php esc_html_e( 'Select/Upload Image', 'planet4-master-theme-backend' ); ?>
-						</button>
-						<p class="description"><?php esc_html_e( 'Choose a background image for the Subscribe block.', 'planet4-master-theme-backend' ); ?></p>
-						<img class="attachment-thumbnail size-thumbnail" src="<?php echo esc_url( $happypoint_attachment_url ); ?>"/>
-						<i class="dashicons dashicons-dismiss <?php echo $happypoint_image_attributes ? '' : 'hidden'; ?>" style="cursor: pointer;"></i>
-					</td>
-				</tr>
-				<tr class="form-field edit-wrap term-happypoint-opacity-wrap">
-					<th>
-						<label><?php esc_html_e( 'Happy Point Opacity', 'planet4-master-theme-backend' ); ?></label>
-					</th>
-					<td>
-						<input type="number" name="happypoint_bg_opacity" id="happypoint_bg_opacity" class="happypoint-opacity-id field-id" value="<?php echo esc_attr( $happypoint_bg_opacity ); ?>" min="1" max="100"/>
-						<p class="description"><?php esc_html_e( 'We use an overlay to fade the image back. Use a number between 1 and 100, the higher the number, the more faded the image will look. If you leave this empty, the default of 30 will be used.', 'planet4-master-theme-backend' ); ?></p>
-					</td>
-				</tr>
-				<?php
-			} else {
-				$dropdown_args = [
-					'show_option_none' => __( 'Select Page', 'planet4-master-theme-backend' ),
-					'hide_empty'       => 0,
-					'hierarchical'     => true,
-					'name'             => 'redirect_page',
-				];
-				?>
-				<div class="form-field add-wrap">
+			<tr class="form-field edit-wrap">
+				<th>
 					<label><?php esc_html_e( 'Redirect Page', 'planet4-master-theme-backend' ); ?></label>
-					<?php wp_dropdown_pages( $dropdown_args ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+				</th>
+				<td>
+					<?php wp_dropdown_pages( array_map( 'esc_attr', $dropdown_args ) ); ?> <a href="post.php?post=<?php echo esc_attr( $redirect_page ); ?>&action=edit" target="_blank"><?php esc_html_e( 'Edit', 'planet4-master-theme-backend' ); ?></a>
 					<p class="description"><?php esc_html_e( 'Leave this empty if you want to use the automated Tag page. Otherwise pick a page to redirect this Tag to.', 'planet4-master-theme-backend' ); ?></p>
-				</div>
-				<div class="form-field add-wrap term-image-wrap">
+				</td>
+			</tr>
+			<tr>
+				<th colspan="2">
+					<?php esc_html_e( 'Column block: Choose which Page Types will populate the content of the Column block. If no box is checked Publications will appear by default.', 'planet4-master-theme-backend' ); ?>
+				</th>
+			</tr>
+			<?php foreach ( $this->page_types as $index => $page_type ) { ?>
+				<tr class="form-field edit-wrap term-page-type-<?php echo esc_attr( $page_type->slug ); ?>-wrap">
+					<th></th>
+					<td>
+						<div class="field-block shortcode-ui-field-checkbox shortcode-ui-attribute-p4_page_type_<?php echo esc_attr( $page_type->slug ); ?>">
+							<label for="shortcode-ui-p4_page_type_<?php echo esc_attr( $page_type->slug ); ?>">
+								<input type="checkbox" name="p4_page_type[]" id="shortcode-ui-p4_page_type_<?php echo esc_attr( $page_type->slug ); ?>" value="<?php echo esc_attr( $page_type->slug ); ?>" <?php echo in_array( $page_type->slug, $selected_page_types[0], true ) ? 'checked' : ''; ?>>
+								<?php echo esc_html( $page_type->name ); ?>
+
+							</label>
+						</div>
+					</td>
+				</tr>
+			<?php } ?>
+			<tr class="form-field edit-wrap term-image-wrap">
+				<th>
 					<label><?php esc_html_e( 'Image', 'planet4-master-theme-backend' ); ?></label>
-					<input type="hidden" name="tag_attachment_id" id="tag_attachment_id" class="tag_attachment_id field-id" value="" />
-					<input type="hidden" name="tag_attachment" id="tag_attachment" class="tag-attachment-url field-url" value="" />
+				</th>
+				<td>
+					<input type="hidden" name="tag_attachment_id" id="tag_attachment_id" class="tag-attachment-id field-id" value="<?php echo esc_attr( $attachment_id ); ?>" />
+					<input type="hidden" name="tag_attachment" id="tag_attachment" class="tag-attachment-url field-url" value="<?php echo esc_url( $attachment_url ); ?>" />
 					<button class="button insert-media add_media" name="insert_image_tag_button" id="insert_image_tag_button" type="button">
 						<?php esc_html_e( 'Select/Upload Image', 'planet4-master-theme-backend' ); ?>
 					</button>
 					<p class="description"><?php esc_html_e( 'Associate this tag with an image.', 'planet4-master-theme-backend' ); ?></p>
-					<img class="attachment-thumbnail size-thumbnail" src="" />
-					<i class="dashicons dashicons-dismiss hidden" style="cursor: pointer;"></i>
-				</div>
-				<?php
-			}
+					<img class="attachment-thumbnail size-thumbnail" src="<?php echo esc_url( $attachment_url ); ?>"/>
+					<i class="dashicons dashicons-dismiss <?php echo $image_attributes ? '' : 'hidden'; ?>" style="cursor: pointer;"></i>
+				</td>
+			</tr>
+			<tr class="form-field edit-wrap term-happypoint-wrap">
+				<th>
+					<label><?php esc_html_e( 'Image Subscribe', 'planet4-master-theme-backend' ); ?></label>
+				</th>
+				<td>
+					<input type="hidden" name="happypoint_attachment_id" id="happypoint_attachment_id" class="happypoint-attachment-id field-id" value="<?php echo esc_attr( $happypoint_attachment_id ); ?>" />
+					<input type="hidden" name="happypoint_attachment" id="happypoint_attachment" class="happypoint-attachment-url field-url" value="<?php echo esc_url( $happypoint_attachment_url ); ?>" />
+					<button class="button insert-media add_media" name="insert_happypoint_image_button" id="insert_happypoint_image_button" type="button">
+						<?php esc_html_e( 'Select/Upload Image', 'planet4-master-theme-backend' ); ?>
+					</button>
+					<p class="description"><?php esc_html_e( 'Choose a background image for the Subscribe block.', 'planet4-master-theme-backend' ); ?></p>
+					<img class="attachment-thumbnail size-thumbnail" src="<?php echo esc_url( $happypoint_attachment_url ); ?>"/>
+					<i class="dashicons dashicons-dismiss <?php echo $happypoint_image_attributes ? '' : 'hidden'; ?>" style="cursor: pointer;"></i>
+				</td>
+			</tr>
+			<tr class="form-field edit-wrap term-happypoint-opacity-wrap">
+				<th>
+					<label><?php esc_html_e( 'Happy Point Opacity', 'planet4-master-theme-backend' ); ?></label>
+				</th>
+				<td>
+					<input type="number" name="happypoint_bg_opacity" id="happypoint_bg_opacity" class="happypoint-opacity-id field-id" value="<?php echo esc_attr( $happypoint_bg_opacity ); ?>" min="1" max="100"/>
+					<p class="description"><?php esc_html_e( 'We use an overlay to fade the image back. Use a number between 1 and 100, the higher the number, the more faded the image will look. If you leave this empty, the default of 30 will be used.', 'planet4-master-theme-backend' ); ?></p>
+				</td>
+			</tr>
+			<?php
+		} else {
+			$dropdown_args = [
+				'show_option_none' => __( 'Select Page', 'planet4-master-theme-backend' ),
+				'hide_empty'       => 0,
+				'hierarchical'     => true,
+				'name'             => 'redirect_page',
+			];
+			?>
+			<div class="form-field add-wrap">
+				<label><?php esc_html_e( 'Redirect Page', 'planet4-master-theme-backend' ); ?></label>
+				<?php wp_dropdown_pages( $dropdown_args ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+				<p class="description"><?php esc_html_e( 'Leave this empty if you want to use the automated Tag page. Otherwise pick a page to redirect this Tag to.', 'planet4-master-theme-backend' ); ?></p>
+			</div>
+			<div class="form-field add-wrap term-image-wrap">
+				<label><?php esc_html_e( 'Image', 'planet4-master-theme-backend' ); ?></label>
+				<input type="hidden" name="tag_attachment_id" id="tag_attachment_id" class="tag_attachment_id field-id" value="" />
+				<input type="hidden" name="tag_attachment" id="tag_attachment" class="tag-attachment-url field-url" value="" />
+				<button class="button insert-media add_media" name="insert_image_tag_button" id="insert_image_tag_button" type="button">
+					<?php esc_html_e( 'Select/Upload Image', 'planet4-master-theme-backend' ); ?>
+				</button>
+				<p class="description"><?php esc_html_e( 'Associate this tag with an image.', 'planet4-master-theme-backend' ); ?></p>
+				<img class="attachment-thumbnail size-thumbnail" src="" />
+				<i class="dashicons dashicons-dismiss hidden" style="cursor: pointer;"></i>
+			</div>
+			<?php
+		}
+	}
+
+	/**
+	 * Save taxonomy custom field(s).
+	 *
+	 * @param int $term_id The ID of the WP_Term object that is added or edited.
+	 */
+	public function save_taxonomy_meta( $term_id ) {
+		// Save the selected page types for this campaign.
+		$selected_page_types = $_POST['p4_page_type'] ?? []; // phpcs:ignore
+
+		if ( $this->validate_page_types( $selected_page_types ) ) {
+			update_term_meta( $term_id, 'selected_page_types', $selected_page_types );
 		}
 
-		/**
-		 * Save taxonomy custom field(s).
-		 *
-		 * @param int $term_id The ID of the WP_Term object that is added or edited.
-		 */
-		public function save_taxonomy_meta( $term_id ) {
-			// Save the selected page types for this campaign.
-			$selected_page_types = $_POST['p4_page_type'] ?? []; // phpcs:ignore
+		$field_id       = 'tag_attachment_id';
+		$field_url      = 'tag_attachment';
+		$attachment_id  = filter_input( INPUT_POST, $field_id, FILTER_VALIDATE_INT );
+		$attachment_url = filter_input( INPUT_POST, $field_url, FILTER_VALIDATE_URL );
 
-			if ( $this->validate_page_types( $selected_page_types ) ) {
-				update_term_meta( $term_id, 'selected_page_types', $selected_page_types );
-			}
+		if ( $this->validate( $attachment_id ) ) {
+			update_term_meta( $term_id, $field_id, $attachment_id );
+			update_term_meta( $term_id, $field_url, $attachment_url );
+			$tag_attachment_id  = $attachment_id;
+			$tag_attachment_url = $attachment_url;
+		} else {
+			$tag_attachment_id = '';
+		}
 
-			$field_id       = 'tag_attachment_id';
-			$field_url      = 'tag_attachment';
-			$attachment_id  = filter_input( INPUT_POST, $field_id, FILTER_VALIDATE_INT );
-			$attachment_url = filter_input( INPUT_POST, $field_url, FILTER_VALIDATE_URL );
+		$field_id       = 'happypoint_attachment_id';
+		$field_url      = 'happypoint_attachment';
+		$attachment_id  = filter_input( INPUT_POST, $field_id, FILTER_VALIDATE_INT );
+		$attachment_url = filter_input( INPUT_POST, $field_url, FILTER_VALIDATE_URL );
 
-			if ( $this->validate( $attachment_id ) ) {
-				update_term_meta( $term_id, $field_id, $attachment_id );
-				update_term_meta( $term_id, $field_url, $attachment_url );
-				$tag_attachment_id  = $attachment_id;
-				$tag_attachment_url = $attachment_url;
-			} else {
-				$tag_attachment_id = '';
-			}
+		if ( $this->validate( $attachment_id ) ) {
+			update_term_meta( $term_id, $field_id, $attachment_id );
+			update_term_meta( $term_id, $field_url, $attachment_url );
+			$happy_background_code = $attachment_id;
+		} else {
+			$happy_background_code = '';
+		}
 
-			$field_id       = 'happypoint_attachment_id';
-			$field_url      = 'happypoint_attachment';
-			$attachment_id  = filter_input( INPUT_POST, $field_id, FILTER_VALIDATE_INT );
-			$attachment_url = filter_input( INPUT_POST, $field_url, FILTER_VALIDATE_URL );
+		$field_id              = 'happypoint_bg_opacity';
+		$happypoint_bg_opacity = filter_input( INPUT_POST, $field_id, FILTER_VALIDATE_INT );
 
-			if ( $this->validate( $attachment_id ) ) {
-				update_term_meta( $term_id, $field_id, $attachment_id );
-				update_term_meta( $term_id, $field_url, $attachment_url );
-				$happy_background_code = $attachment_id;
-			} else {
-				$happy_background_code = '';
-			}
+		if ( $this->validate( $happypoint_bg_opacity ) ) {
+			update_term_meta( $term_id, $field_id, $happypoint_bg_opacity );
+		} else {
+			$happypoint_bg_opacity = 30;
+		}
 
-			$field_id              = 'happypoint_bg_opacity';
-			$happypoint_bg_opacity = filter_input( INPUT_POST, $field_id, FILTER_VALIDATE_INT );
+		$redirect_page = filter_input( INPUT_POST, 'redirect_page', FILTER_VALIDATE_INT ) ?? 0;
+		if ( $redirect_page ) {
+			update_term_meta( $term_id, 'redirect_page', $redirect_page );
+		} else {
 
-			if ( $this->validate( $happypoint_bg_opacity ) ) {
-				update_term_meta( $term_id, $field_id, $happypoint_bg_opacity );
-			} else {
-				$happypoint_bg_opacity = 30;
-			}
+			$tag_data = get_term( $term_id );
 
-			$redirect_page = filter_input( INPUT_POST, 'redirect_page', FILTER_VALIDATE_INT ) ?? 0;
-			if ( $redirect_page ) {
-				update_term_meta( $term_id, 'redirect_page', $redirect_page );
-			} else {
+			if ( $tag_data instanceof \WP_Term ) {
 
-				$tag_data = get_term( $term_id );
+				$covers_block1_attributes = [
+					'title'       => __( 'Things you can do', 'planet4-master-theme' ),
+					'description' => __( 'We want you to take action because together we\'re strong.', 'planet4-master-theme' ),
+					'tags'        => [ $term_id ],
+					'posts'       => [],
+					'post_types'  => [],
+					'cover_type'  => '1',
+					'covers_view' => '0',
+				];
 
-				if ( $tag_data instanceof \WP_Term ) {
+				$articles_block_attributes = [
+					'tags'              => [ $term_id ],
+					'ignore_categories' => false,
+				];
 
-					$covers_block1_attributes = [
-						'title'       => __( 'Things you can do', 'planet4-master-theme' ),
-						'description' => __( 'We want you to take action because together we\'re strong.', 'planet4-master-theme' ),
-						'tags'        => [ $term_id ],
-						'posts'       => [],
-						'post_types'  => [],
-						'cover_type'  => '1',
-						'covers_view' => '0',
-					];
+				$covers_block2_attributes = [
+					'title'       => __( 'Publications', 'planet4-master-theme-backend' ),
+					'tags'        => [ $term_id ],
+					'posts'       => [],
+					'post_types'  => [ 62 ],
+					'cover_type'  => '3',
+					'covers_view' => '0',
+				];
 
-					$articles_block_attributes = [
-						'tags'              => [ $term_id ],
-						'ignore_categories' => false,
-					];
+				$happypoint_block_attributes = [
+					'mailing_list_iframe' => true,
+					'opacity'             => $happypoint_bg_opacity ?? 30,
+					'id'                  => $happy_background_code ?? '',
+				];
 
-					$covers_block2_attributes = [
-						'title'       => __( 'Publications', 'planet4-master-theme-backend' ),
-						'tags'        => [ $term_id ],
-						'posts'       => [],
-						'post_types'  => [ 62 ],
-						'cover_type'  => '3',
-						'covers_view' => '0',
-					];
-
-					$happypoint_block_attributes = [
-						'mailing_list_iframe' => true,
-						'opacity'             => $happypoint_bg_opacity ?? 30,
-						'id'                  => $happy_background_code ?? '',
-					];
-
-					$post_content = $this->make_gutenberg_comment( 'planet4-blocks/covers', $covers_block1_attributes ) . '
+				$post_content = $this->make_gutenberg_comment( 'planet4-blocks/covers', $covers_block1_attributes ) . '
 
 ' . $this->make_gutenberg_comment( 'planet4-blocks/articles', $articles_block_attributes ) . '
 
@@ -288,142 +287,141 @@ if ( ! class_exists( 'P4_Campaigns' ) ) {
 
 ' . $this->make_gutenberg_comment( 'planet4-blocks/happypoint', $happypoint_block_attributes );
 
-					$my_post = [
-						'post_title'   => '#' . $tag_data->name,
-						'post_content' => $post_content,
-						'post_status'  => 'publish',
-						'post_type'    => 'page',
-					];
+				$my_post = [
+					'post_title'   => '#' . $tag_data->name,
+					'post_content' => $post_content,
+					'post_status'  => 'publish',
+					'post_type'    => 'page',
+				];
 
-					// Insert the post into the database.
-					$tag_page_id = wp_insert_post( $my_post );
-					if ( is_int( $tag_page_id ) ) {
-						update_post_meta( $tag_page_id, 'p4_description', $tag_data->description );
-						update_post_meta( $tag_page_id, P4_Search::EXCLUDE_FROM_SEARCH, true );
-					}
+				// Insert the post into the database.
+				$tag_page_id = wp_insert_post( $my_post );
+				if ( is_int( $tag_page_id ) ) {
+					update_post_meta( $tag_page_id, 'p4_description', $tag_data->description );
+					update_post_meta( $tag_page_id, P4_Search::EXCLUDE_FROM_SEARCH, true );
+				}
 
-					if ( $tag_attachment_id ) {
-						update_post_meta( $tag_page_id, 'background_image_id', $tag_attachment_id );
-						update_post_meta( $tag_page_id, 'background_image', $tag_attachment_url );
-					}
-					update_term_meta( $term_id, 'redirect_page', $tag_page_id );
+				if ( $tag_attachment_id ) {
+					update_post_meta( $tag_page_id, 'background_image_id', $tag_attachment_id );
+					update_post_meta( $tag_page_id, 'background_image', $tag_attachment_url );
+				}
+				update_term_meta( $term_id, 'redirect_page', $tag_page_id );
+			}
+		}
+	}
+
+	/**
+	 * Add custom column.
+	 *
+	 * @param array $columns Associative array with the columns of the taxonomy.
+	 *
+	 * @return array Associative array with the columns of the taxonomy.
+	 */
+	public function edit_taxonomy_columns( $columns ) : array {
+		$columns['image'] = __( 'Image', 'planet4-master-theme-backend' );
+		return $columns;
+	}
+
+	/**
+	 * Apply custom output to a custom column.
+	 *
+	 * @param string $output The html to be applied to each row of the $column.
+	 * @param string $column The name of the column to be managed.
+	 * @param int    $term_id The ID of the WP_Term object that is added or edited.
+	 *
+	 * @return string The new html to be applied to each row of the $column.
+	 */
+	public function manage_taxonomy_custom_column( $output, $column, $term_id ) : string {
+		if ( 'image' === $column ) {
+			$attachment_id = get_term_meta( $term_id, 'tag_attachment_id', true );
+			$output        = wp_get_attachment_image( $attachment_id );
+		}
+		return $output;
+	}
+
+	/**
+	 * Make column sortable.
+	 *
+	 * @param array $columns Associative array with the columns of the taxonomy.
+	 *
+	 * @return array Associative array with the columns of the taxonomy.
+	 */
+	public function manage_taxonomy_custom_sortable_column( $columns ) : array {
+		$columns['image'] = 'image';
+		return $columns;
+	}
+
+	/**
+	 * Validates the input.
+	 *
+	 * @param int $id The attachment id to be validated.
+	 *
+	 * @return bool True if validation is ok, false if validation fails.
+	 */
+	public function validate( $id ) : bool {
+		if ( $id < 0 ) {
+			return false;
+		}
+		return true;
+	}
+
+	/**
+	 * Validates the page types input.
+	 *
+	 * @param array $selected_page_types The selected page types selected by the editor.
+	 *
+	 * @return bool True if validation is ok, false if validation fails.
+	 */
+	public function validate_page_types( $selected_page_types ) : bool {
+		$page_types_slugs = [];
+		$this->page_types = get_terms(
+			[
+				'hide_empty' => false,
+				'orderby'    => 'name',
+				'taxonomy'   => 'p4-page-type',
+			]
+		);
+
+		if ( $this->page_types ) {
+			foreach ( $this->page_types as $page_type ) {
+				if ( $page_type instanceof WP_Term ) {
+					$page_types_slugs[] = $page_type->slug;
 				}
 			}
 		}
 
-		/**
-		 * Add custom column.
-		 *
-		 * @param array $columns Associative array with the columns of the taxonomy.
-		 *
-		 * @return array Associative array with the columns of the taxonomy.
-		 */
-		public function edit_taxonomy_columns( $columns ) : array {
-			$columns['image'] = __( 'Image', 'planet4-master-theme-backend' );
-			return $columns;
-		}
-
-		/**
-		 * Apply custom output to a custom column.
-		 *
-		 * @param string $output The html to be applied to each row of the $column.
-		 * @param string $column The name of the column to be managed.
-		 * @param int    $term_id The ID of the WP_Term object that is added or edited.
-		 *
-		 * @return string The new html to be applied to each row of the $column.
-		 */
-		public function manage_taxonomy_custom_column( $output, $column, $term_id ) : string {
-			if ( 'image' === $column ) {
-				$attachment_id = get_term_meta( $term_id, 'tag_attachment_id', true );
-				$output        = wp_get_attachment_image( $attachment_id );
-			}
-			return $output;
-		}
-
-		/**
-		 * Make column sortable.
-		 *
-		 * @param array $columns Associative array with the columns of the taxonomy.
-		 *
-		 * @return array Associative array with the columns of the taxonomy.
-		 */
-		public function manage_taxonomy_custom_sortable_column( $columns ) : array {
-			$columns['image'] = 'image';
-			return $columns;
-		}
-
-		/**
-		 * Validates the input.
-		 *
-		 * @param int $id The attachment id to be validated.
-		 *
-		 * @return bool True if validation is ok, false if validation fails.
-		 */
-		public function validate( $id ) : bool {
-			if ( $id < 0 ) {
-				return false;
-			}
-			return true;
-		}
-
-		/**
-		 * Validates the page types input.
-		 *
-		 * @param array $selected_page_types The selected page types selected by the editor.
-		 *
-		 * @return bool True if validation is ok, false if validation fails.
-		 */
-		public function validate_page_types( $selected_page_types ) : bool {
-			$page_types_slugs = [];
-			$this->page_types = get_terms(
-				[
-					'hide_empty' => false,
-					'orderby'    => 'name',
-					'taxonomy'   => 'p4-page-type',
-				]
-			);
-
-			if ( $this->page_types ) {
-				foreach ( $this->page_types as $page_type ) {
-					if ( $page_type instanceof WP_Term ) {
-						$page_types_slugs[] = $page_type->slug;
-					}
+		if ( isset( $selected_page_types ) && is_array( $selected_page_types ) ) {
+			foreach ( $selected_page_types as $selected_page_type ) {
+				if ( ! in_array( $selected_page_type, $page_types_slugs, true ) ) {
+					return false;
 				}
 			}
-
-			if ( isset( $selected_page_types ) && is_array( $selected_page_types ) ) {
-				foreach ( $selected_page_types as $selected_page_type ) {
-					if ( ! in_array( $selected_page_type, $page_types_slugs, true ) ) {
-						return false;
-					}
-				}
-			}
-			return true;
 		}
+		return true;
+	}
 
-		/**
-		 * Uses block's filtered/converted attributes and it's name to convert it to a gutenberg equivalent block.
-		 *
-		 * @param string $block_name Gutenberg block name.
-		 * @param array  $block_attributes block attribute array.
-		 *
-		 * @return string
-		 */
-		protected function make_gutenberg_comment( $block_name, $block_attributes ) {
-			return '<!-- wp:' . $block_name . ' ' . wp_json_encode( $block_attributes, JSON_UNESCAPED_SLASHES ) . ' /-->';
-		}
+	/**
+	 * Uses block's filtered/converted attributes and it's name to convert it to a gutenberg equivalent block.
+	 *
+	 * @param string $block_name Gutenberg block name.
+	 * @param array  $block_attributes block attribute array.
+	 *
+	 * @return string
+	 */
+	protected function make_gutenberg_comment( $block_name, $block_attributes ) {
+		return '<!-- wp:' . $block_name . ' ' . wp_json_encode( $block_attributes, JSON_UNESCAPED_SLASHES ) . ' /-->';
+	}
 
-		/**
-		 * Load assets.
-		 */
-		public function enqueue_admin_assets() {
-			if ( ! is_admin() || strpos( get_current_screen()->taxonomy, $this->taxonomy ) === false ) {
-				return;
-			}
-			wp_register_script( $this->taxonomy, get_template_directory_uri() . "/admin/js/$this->taxonomy.js", [ 'jquery' ], '0.1', true );
-			wp_localize_script( $this->taxonomy, 'localizations', $this->localizations );
-			wp_enqueue_script( $this->taxonomy );
-			wp_enqueue_media();
+	/**
+	 * Load assets.
+	 */
+	public function enqueue_admin_assets() {
+		if ( ! is_admin() || strpos( get_current_screen()->taxonomy, $this->taxonomy ) === false ) {
+			return;
 		}
+		wp_register_script( $this->taxonomy, get_template_directory_uri() . "/admin/js/$this->taxonomy.js", [ 'jquery' ], '0.1', true );
+		wp_localize_script( $this->taxonomy, 'localizations', $this->localizations );
+		wp_enqueue_script( $this->taxonomy );
+		wp_enqueue_media();
 	}
 }

--- a/classes/class-p4-control-panel.php
+++ b/classes/class-p4-control-panel.php
@@ -8,286 +8,284 @@
 use P4GEN\Controllers\Ensapi_Controller as ENS_API;
 use ElasticPress\Elasticsearch as ES;
 
-if ( ! class_exists( 'P4_Control_Panel' ) ) {
+
+/**
+ * Class P4_Control_Panel
+ */
+class P4_Control_Panel {
 
 	/**
-	 * Class P4_Control_Panel
+	 * P4_Control_Panel constructor.
 	 */
-	class P4_Control_Panel {
+	public function __construct() {
+		$this->hooks();
+	}
 
-		/**
-		 * P4_Control_Panel constructor.
-		 */
-		public function __construct() {
-			$this->hooks();
+	/**
+	 * Hooks actions and filters.
+	 */
+	public function hooks() {
+		// Display the Control Panel only to Administrators.
+		if ( current_user_can( 'manage_options' ) || current_user_can( 'editor' ) ) {
+			add_action( 'wp_dashboard_setup', [ $this, 'add_dashboard_widgets' ], 9 );
+
+			add_action( 'wp_ajax_flush_cache', [ $this, 'flush_cache' ] );
+			add_action( 'wp_ajax_check_cache', [ $this, 'check_cache' ] );
+			add_action( 'wp_ajax_check_engaging_networks', [ $this, 'check_engaging_networks' ] );
+			add_action( 'wp_ajax_check_elasticsearch', [ $this, 'check_elasticsearch' ] );
+
+			add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_admin_assets' ] );
 		}
+	}
 
-		/**
-		 * Hooks actions and filters.
-		 */
-		public function hooks() {
-			// Display the Control Panel only to Administrators.
-			if ( current_user_can( 'manage_options' ) || current_user_can( 'editor' ) ) {
-				add_action( 'wp_dashboard_setup', [ $this, 'add_dashboard_widgets' ], 9 );
+	/**
+	 * Adds a new Dashboard widget.
+	 */
+	public function add_dashboard_widgets() {
+		wp_add_dashboard_widget(
+			'planet4_control_panel',
+			__( 'Planet 4 Control Panel', 'planet4-master-theme-backend' ),
+			[ $this, 'add_items' ]
+		);
+	}
 
-				add_action( 'wp_ajax_flush_cache', [ $this, 'flush_cache' ] );
-				add_action( 'wp_ajax_check_cache', [ $this, 'check_cache' ] );
-				add_action( 'wp_ajax_check_engaging_networks', [ $this, 'check_engaging_networks' ] );
-				add_action( 'wp_ajax_check_elasticsearch', [ $this, 'check_elasticsearch' ] );
+	/**
+	 * Adds items to the Control Panel.
+	 */
+	public function add_items() {
+		wp_nonce_field( 'cp-action' );
 
-				add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_admin_assets' ] );
+		if ( current_user_can( 'manage_options' ) || current_user_can( 'editor' ) ) {
+			if ( is_plugin_active( 'wp-redis/wp-redis.php' ) ) {
+				$this->add_item(
+					[
+						'title'    => __( 'Cache', 'planet4-master-theme-backend' ),
+						'subitems' => [
+							[
+								'title'   => __( 'Flush Object Cache', 'planet4-master-theme-backend' ),
+								'action'  => 'flush_cache',
+								'confirm' => __( 'Are you sure you want to delete all Object Cache keys?', 'planet4-master-theme-backend' ),
+							],
+							[
+								'title'  => __( 'Check Object Cache', 'planet4-master-theme-backend' ),
+								'action' => 'check_cache',
+							],
+						],
+					]
+				);
+			}
+
+			if ( is_plugin_active( 'planet4-plugin-gutenberg-engagingnetworks/planet4-gutenberg-engagingnetworks.php' ) ) {
+				$this->add_item(
+					[
+						'title'    => __( 'Engaging Networks', 'planet4-master-theme-backend' ),
+						'subitems' => [
+							[
+								'title'  => __( 'Check Engaging Networks', 'planet4-master-theme-backend' ),
+								'action' => 'check_engaging_networks',
+							],
+						],
+					]
+				);
+			}
+
+			if ( is_plugin_active( 'elasticpress/elasticpress.php' ) ) {
+				$this->add_item(
+					[
+						'title'    => __( 'Search', 'planet4-master-theme-backend' ),
+						'subitems' => [
+							[
+								'title' => __( 'Sync Elasticsearch', 'planet4-master-theme-backend' ),
+								'url'   => 'admin.php?page=elasticpress&do_sync',   // If we give 'url' key instead of 'action' then we will do usual request instead of ajax request.
+								// 'action' => 'ep_index', // Could use this EP action to perform sync asynchronously.
+							],
+							[
+								'title'  => __( 'Check Elasticsearch', 'planet4-master-theme-backend' ),
+								'action' => 'check_elasticsearch',
+							],
+						],
+					]
+				);
 			}
 		}
+	}
 
-		/**
-		 * Adds a new Dashboard widget.
-		 */
-		public function add_dashboard_widgets() {
-			wp_add_dashboard_widget(
-				'planet4_control_panel',
-				__( 'Planet 4 Control Panel', 'planet4-master-theme-backend' ),
-				[ $this, 'add_items' ]
-			);
-		}
-
-		/**
-		 * Adds items to the Control Panel.
-		 */
-		public function add_items() {
-			wp_nonce_field( 'cp-action' );
-
-			if ( current_user_can( 'manage_options' ) || current_user_can( 'editor' ) ) {
-				if ( is_plugin_active( 'wp-redis/wp-redis.php' ) ) {
-					$this->add_item(
-						[
-							'title'    => __( 'Cache', 'planet4-master-theme-backend' ),
-							'subitems' => [
-								[
-									'title'   => __( 'Flush Object Cache', 'planet4-master-theme-backend' ),
-									'action'  => 'flush_cache',
-									'confirm' => __( 'Are you sure you want to delete all Object Cache keys?', 'planet4-master-theme-backend' ),
-								],
-								[
-									'title'  => __( 'Check Object Cache', 'planet4-master-theme-backend' ),
-									'action' => 'check_cache',
-								],
-							],
-						]
-					);
-				}
-
-				if ( is_plugin_active( 'planet4-plugin-gutenberg-engagingnetworks/planet4-gutenberg-engagingnetworks.php' ) ) {
-					$this->add_item(
-						[
-							'title'    => __( 'Engaging Networks', 'planet4-master-theme-backend' ),
-							'subitems' => [
-								[
-									'title'  => __( 'Check Engaging Networks', 'planet4-master-theme-backend' ),
-									'action' => 'check_engaging_networks',
-								],
-							],
-						]
-					);
-				}
-
-				if ( is_plugin_active( 'elasticpress/elasticpress.php' ) ) {
-					$this->add_item(
-						[
-							'title'    => __( 'Search', 'planet4-master-theme-backend' ),
-							'subitems' => [
-								[
-									'title' => __( 'Sync Elasticsearch', 'planet4-master-theme-backend' ),
-									'url'   => 'admin.php?page=elasticpress&do_sync',   // If we give 'url' key instead of 'action' then we will do usual request instead of ajax request.
-									// 'action' => 'ep_index', // Could use this EP action to perform sync asynchronously.
-								],
-								[
-									'title'  => __( 'Check Elasticsearch', 'planet4-master-theme-backend' ),
-									'action' => 'check_elasticsearch',
-								],
-							],
-						]
-					);
-				}
-			}
-		}
-
-		/**
-		 * Adds a new item in the Control Panel and all of its subitems.
-		 *
-		 * @param array $data Associative array with all the data needed to add a new item in the Control Panel.
-		 */
-		public function add_item( $data ) {
-			echo '<div class="cp-item">
-					<div class="welcome-panel"><span><strong>' . esc_html( $data['title'] ) . '</strong></span>';
-			foreach ( $data['subitems'] as $subitem ) {
-				echo '<div>
-						<a href="' . esc_url( $subitem['url'] ?? '#' ) . '" class="btn btn-cp-action ' . esc_attr( $subitem['action'] ?? '' ) . '" data-action="' . esc_attr( $subitem['action'] ?? '' ) . '" data-confirm="' . esc_attr( $subitem['confirm'] ?? '' ) . '">' . esc_html( $subitem['title'] ) . '</a>
-						<span class="cp-subitem-response"></span>
-					</div>';
-			}
-			echo '</div>
+	/**
+	 * Adds a new item in the Control Panel and all of its subitems.
+	 *
+	 * @param array $data Associative array with all the data needed to add a new item in the Control Panel.
+	 */
+	public function add_item( $data ) {
+		echo '<div class="cp-item">
+				<div class="welcome-panel"><span><strong>' . esc_html( $data['title'] ) . '</strong></span>';
+		foreach ( $data['subitems'] as $subitem ) {
+			echo '<div>
+					<a href="' . esc_url( $subitem['url'] ?? '#' ) . '" class="btn btn-cp-action ' . esc_attr( $subitem['action'] ?? '' ) . '" data-action="' . esc_attr( $subitem['action'] ?? '' ) . '" data-confirm="' . esc_attr( $subitem['confirm'] ?? '' ) . '">' . esc_html( $subitem['title'] ) . '</a>
+					<span class="cp-subitem-response"></span>
 				</div>';
 		}
+		echo '</div>
+			</div>';
+	}
 
-		/**
-		 * Adds a flush cache button to delete all keys in Redis database.
-		 */
-		public function flush_cache() {
-			if ( ! current_user_can( 'manage_options' ) && ! current_user_can( 'editor' ) ) {
+	/**
+	 * Adds a flush cache button to delete all keys in Redis database.
+	 */
+	public function flush_cache() {
+		if ( ! current_user_can( 'manage_options' ) && ! current_user_can( 'editor' ) ) {
+			return;
+		}
+
+		// If this is an ajax call.
+		if ( wp_doing_ajax() ) {
+			// Allow this action only to Administrators.
+			$cp_nonce  = filter_input( INPUT_GET, '_wpnonce', FILTER_SANITIZE_STRING );
+			$cp_action = filter_input( INPUT_GET, 'cp-action', FILTER_SANITIZE_STRING );
+
+			// CSRF check and action check.
+			if ( wp_verify_nonce( $cp_nonce, 'cp-action' ) && 'flush_cache' === $cp_action ) {
+				$response = [];
+
+				// If cache flush was successful.
+				if ( wp_cache_flush() ) {
+					$response['message'] = __( 'Object Cache flushed', 'planet4-master-theme-backend' );
+					$response['class']   = 'cp-success';
+				} else {
+					$response['message'] = __( 'Object Cache did not flush', 'planet4-master-theme-backend' );
+					$response['class']   = 'cp-error';
+				}
+
+				if ( $response ) {
+					echo wp_json_encode( $response );
+				}
+			}
+			wp_die();
+		}
+	}
+
+	/**
+	 * Adds a check cache button to check connectivity to the Redis server.
+	 */
+	public function check_cache() {
+		if ( ! current_user_can( 'manage_options' ) && ! current_user_can( 'editor' ) ) {
+			return;
+		}
+
+		// If this is an ajax call.
+		if ( wp_doing_ajax() ) {
+			// Allow this action only to Administrators.
+			$cp_nonce  = filter_input( INPUT_GET, '_wpnonce', FILTER_SANITIZE_STRING );
+			$cp_action = filter_input( INPUT_GET, 'cp-action', FILTER_SANITIZE_STRING );
+
+			// CSRF check and action check.
+			if ( wp_verify_nonce( $cp_nonce, 'cp-action' ) && 'check_cache' === $cp_action ) {
+				$response = [];
+				$info     = wp_redis_get_info();
+
+				if ( $info instanceof WP_Error ) {
+					if ( $info->errors['wp-redis'] && is_array( $info->errors['wp-redis'] ) ) {
+						$response['message'] = $info->errors['wp-redis'][0];
+						$response['class']   = 'cp-error';
+					}
+				} elseif ( 'connected' === $info['status'] ) {
+					$response['message'] = __( 'Planet 4 is connected to Redis.', 'planet4-master-theme-backend' );
+					$response['class']   = 'cp-success';
+				}
+
+				if ( $response ) {
+					echo wp_json_encode( $response );
+				}
+			}
+			wp_die();
+		}
+	}
+
+	/**
+	 * Adds a check cache button to check the ENS API.
+	 */
+	public function check_engaging_networks() {
+		// If this is an ajax call.
+		if ( wp_doing_ajax() ) {
+			// Allow this action only to Administrators.
+			if ( ! current_user_can( 'manage_options' ) ) {
+				return;
+			}
+			$cp_nonce  = filter_input( INPUT_GET, '_wpnonce', FILTER_SANITIZE_STRING );
+			$cp_action = filter_input( INPUT_GET, 'cp-action', FILTER_SANITIZE_STRING );
+
+			// CSRF check and action check.
+			if ( wp_verify_nonce( $cp_nonce, 'cp-action' ) && 'check_engaging_networks' === $cp_action ) {
+				$response      = [];
+				$main_settings = get_option( 'p4en_main_settings' );    // Retrieve stored EN Private API key.
+
+				if ( isset( $main_settings['p4en_private_api'] ) && $main_settings['p4en_private_api'] ) {
+					$ens_private_token = $main_settings['p4en_private_api'];
+					$ens_api           = new ENS_API( $ens_private_token );
+
+					if ( $ens_api->is_authenticated() ) {
+						$response['message'] = __( 'Planet4 is connected to EngagingNetworks', 'planet4-master-theme-backend' );
+						$response['class']   = 'cp-success';
+					} else {
+						$response['message'] = __( 'Planet4 is not connected to EngagingNetworks. Please, make sure you have registered your IP address for the ENS API key you have supplied in plugin settings page.', 'planet4-master-theme-backend' );
+						$response['class']   = 'cp-error';
+					}
+				} else {
+					$response['message'] = __( 'Please check your EngagingNetworks plugin settings', 'planet4-master-theme-backend' );
+					$response['class']   = 'cp-error';
+				}
+
+				if ( $response ) {
+					echo wp_json_encode( $response );
+				}
+			}
+			wp_die();
+		}
+	}
+
+	/**
+	 * Adds a check button to check communication to the ES cluster.
+	 */
+	public function check_elasticsearch() {
+		// If this is an ajax call.
+		if ( wp_doing_ajax() ) {
+			// Allow this action only to Administrators.
+			if ( ! current_user_can( 'manage_options' ) ) {
 				return;
 			}
 
-			// If this is an ajax call.
-			if ( wp_doing_ajax() ) {
-				// Allow this action only to Administrators.
-				$cp_nonce  = filter_input( INPUT_GET, '_wpnonce', FILTER_SANITIZE_STRING );
-				$cp_action = filter_input( INPUT_GET, 'cp-action', FILTER_SANITIZE_STRING );
+			$cp_nonce  = filter_input( INPUT_GET, '_wpnonce', FILTER_SANITIZE_STRING );
+			$cp_action = filter_input( INPUT_GET, 'cp-action', FILTER_SANITIZE_STRING );
 
-				// CSRF check and action check.
-				if ( wp_verify_nonce( $cp_nonce, 'cp-action' ) && 'flush_cache' === $cp_action ) {
-					$response = [];
+			// CSRF check and action check.
+			if ( wp_verify_nonce( $cp_nonce, 'cp-action' ) && 'check_elasticsearch' === $cp_action ) {
+				$response = [];
 
-					// If cache flush was successful.
-					if ( wp_cache_flush() ) {
-						$response['message'] = __( 'Object Cache flushed', 'planet4-master-theme-backend' );
-						$response['class']   = 'cp-success';
-					} else {
-						$response['message'] = __( 'Object Cache did not flush', 'planet4-master-theme-backend' );
-						$response['class']   = 'cp-error';
-					}
-
-					if ( $response ) {
-						echo wp_json_encode( $response );
-					}
+				if ( ( new ES() )->get_elasticsearch_version() ) {   // For version up to 2.8.* we can call ep_elasticsearch_can_connect() to check connection.
+					$response['message'] = __( 'Planet4 is connected to Elasticsearch', 'planet4-master-theme-backend' );
+					$response['class']   = 'cp-success';
+				} else {
+					$response['message'] = __( 'Planet4 is not connected to Elasticsearch', 'planet4-master-theme-backend' );
+					$response['class']   = 'cp-error';
 				}
-				wp_die();
+
+				if ( $response ) {
+					echo wp_json_encode( $response );
+				}
 			}
+			wp_die();
 		}
+	}
 
-		/**
-		 * Adds a check cache button to check connectivity to the Redis server.
-		 */
-		public function check_cache() {
-			if ( ! current_user_can( 'manage_options' ) && ! current_user_can( 'editor' ) ) {
-				return;
-			}
-
-			// If this is an ajax call.
-			if ( wp_doing_ajax() ) {
-				// Allow this action only to Administrators.
-				$cp_nonce  = filter_input( INPUT_GET, '_wpnonce', FILTER_SANITIZE_STRING );
-				$cp_action = filter_input( INPUT_GET, 'cp-action', FILTER_SANITIZE_STRING );
-
-				// CSRF check and action check.
-				if ( wp_verify_nonce( $cp_nonce, 'cp-action' ) && 'check_cache' === $cp_action ) {
-					$response = [];
-					$info     = wp_redis_get_info();
-
-					if ( $info instanceof WP_Error ) {
-						if ( $info->errors['wp-redis'] && is_array( $info->errors['wp-redis'] ) ) {
-							$response['message'] = $info->errors['wp-redis'][0];
-							$response['class']   = 'cp-error';
-						}
-					} elseif ( 'connected' === $info['status'] ) {
-						$response['message'] = __( 'Planet 4 is connected to Redis.', 'planet4-master-theme-backend' );
-						$response['class']   = 'cp-success';
-					}
-
-					if ( $response ) {
-						echo wp_json_encode( $response );
-					}
-				}
-				wp_die();
-			}
+	/**
+	 * Load assets.
+	 */
+	public function enqueue_admin_assets() {
+		// Load these assets only in Dashboard.
+		if ( ! is_admin() || 'dashboard' !== get_current_screen()->base ) {
+			return;
 		}
-
-		/**
-		 * Adds a check cache button to check the ENS API.
-		 */
-		public function check_engaging_networks() {
-			// If this is an ajax call.
-			if ( wp_doing_ajax() ) {
-				// Allow this action only to Administrators.
-				if ( ! current_user_can( 'manage_options' ) ) {
-					return;
-				}
-				$cp_nonce  = filter_input( INPUT_GET, '_wpnonce', FILTER_SANITIZE_STRING );
-				$cp_action = filter_input( INPUT_GET, 'cp-action', FILTER_SANITIZE_STRING );
-
-				// CSRF check and action check.
-				if ( wp_verify_nonce( $cp_nonce, 'cp-action' ) && 'check_engaging_networks' === $cp_action ) {
-					$response      = [];
-					$main_settings = get_option( 'p4en_main_settings' );    // Retrieve stored EN Private API key.
-
-					if ( isset( $main_settings['p4en_private_api'] ) && $main_settings['p4en_private_api'] ) {
-						$ens_private_token = $main_settings['p4en_private_api'];
-						$ens_api           = new ENS_API( $ens_private_token );
-
-						if ( $ens_api->is_authenticated() ) {
-							$response['message'] = __( 'Planet4 is connected to EngagingNetworks', 'planet4-master-theme-backend' );
-							$response['class']   = 'cp-success';
-						} else {
-							$response['message'] = __( 'Planet4 is not connected to EngagingNetworks. Please, make sure you have registered your IP address for the ENS API key you have supplied in plugin settings page.', 'planet4-master-theme-backend' );
-							$response['class']   = 'cp-error';
-						}
-					} else {
-						$response['message'] = __( 'Please check your EngagingNetworks plugin settings', 'planet4-master-theme-backend' );
-						$response['class']   = 'cp-error';
-					}
-
-					if ( $response ) {
-						echo wp_json_encode( $response );
-					}
-				}
-				wp_die();
-			}
-		}
-
-		/**
-		 * Adds a check button to check communication to the ES cluster.
-		 */
-		public function check_elasticsearch() {
-			// If this is an ajax call.
-			if ( wp_doing_ajax() ) {
-				// Allow this action only to Administrators.
-				if ( ! current_user_can( 'manage_options' ) ) {
-					return;
-				}
-
-				$cp_nonce  = filter_input( INPUT_GET, '_wpnonce', FILTER_SANITIZE_STRING );
-				$cp_action = filter_input( INPUT_GET, 'cp-action', FILTER_SANITIZE_STRING );
-
-				// CSRF check and action check.
-				if ( wp_verify_nonce( $cp_nonce, 'cp-action' ) && 'check_elasticsearch' === $cp_action ) {
-					$response = [];
-
-					if ( ( new ES() )->get_elasticsearch_version() ) {   // For version up to 2.8.* we can call ep_elasticsearch_can_connect() to check connection.
-						$response['message'] = __( 'Planet4 is connected to Elasticsearch', 'planet4-master-theme-backend' );
-						$response['class']   = 'cp-success';
-					} else {
-						$response['message'] = __( 'Planet4 is not connected to Elasticsearch', 'planet4-master-theme-backend' );
-						$response['class']   = 'cp-error';
-					}
-
-					if ( $response ) {
-						echo wp_json_encode( $response );
-					}
-				}
-				wp_die();
-			}
-		}
-
-		/**
-		 * Load assets.
-		 */
-		public function enqueue_admin_assets() {
-			// Load these assets only in Dashboard.
-			if ( ! is_admin() || 'dashboard' !== get_current_screen()->base ) {
-				return;
-			}
-			$theme_dir = get_template_directory_uri();
-			wp_enqueue_style( 'dashboard-style', "$theme_dir/admin/css/dashboard.css", [], '0.1.0' );
-			wp_enqueue_script( 'dashboard-script', "$theme_dir/admin/js/dashboard.js", [ 'jquery' ], '0.2.0', true );
-		}
+		$theme_dir = get_template_directory_uri();
+		wp_enqueue_style( 'dashboard-style', "$theme_dir/admin/css/dashboard.css", [], '0.1.0' );
+		wp_enqueue_script( 'dashboard-script', "$theme_dir/admin/js/dashboard.js", [ 'jquery' ], '0.2.0', true );
 	}
 }

--- a/classes/class-p4-cookies.php
+++ b/classes/class-p4-cookies.php
@@ -5,73 +5,70 @@
  * @package P4MT
  */
 
-if ( ! class_exists( 'P4_Cookies' ) ) {
+/**
+ * Class P4_Cookies
+ *
+ * @since 1.9
+ */
+class P4_Cookies {
+
+	const COOKIE_NAME = 'greenpeace';
 
 	/**
-	 * Class P4_Cookies
+	 * P4_Cookies constructor.
+	 */
+	public function __construct() {
+		$this->hooks();
+	}
+
+	/**
+	 * Register actions for WordPress hooks and filters.
+	 */
+	private function hooks() {
+		$options                = get_option( 'planet4_options' );
+		$enforce_cookies_policy = isset( $options['enforce_cookies_policy'] ) ? true : false;
+
+		// Do not add any hook if enforce cookies setting is not set.
+		if ( false === $enforce_cookies_policy ) {
+			return;
+		}
+		// If our cookie is not set then register the following filters.
+		if ( '2' !== $this->read_cookie( self::COOKIE_NAME ) ) {
+
+			add_filter( 'gal_set_login_cookie', [ $this, 'filter_google_login_set_login_cookie' ], 10, 1 );
+		}
+	}
+
+	/**
+	 * Filter setting google login cookie.
+	 *
+	 * @param bool $dosetcookie Whether to set the cookie or not.
 	 *
 	 * @since 1.9
+	 *
+	 * @return bool
 	 */
-	class P4_Cookies {
+	public function filter_google_login_set_login_cookie( $dosetcookie ) {
+		global $pagenow;
 
-		const COOKIE_NAME = 'greenpeace';
-
-		/**
-		 * P4_Cookies constructor.
-		 */
-		public function __construct() {
-			$this->hooks();
-		}
-
-		/**
-		 * Register actions for WordPress hooks and filters.
-		 */
-		private function hooks() {
-			$options                = get_option( 'planet4_options' );
-			$enforce_cookies_policy = isset( $options['enforce_cookies_policy'] ) ? true : false;
-
-			// Do not add any hook if enforce cookies setting is not set.
-			if ( false === $enforce_cookies_policy ) {
-				return;
-			}
-			// If our cookie is not set then register the following filters.
-			if ( '2' !== $this->read_cookie( self::COOKIE_NAME ) ) {
-
-				add_filter( 'gal_set_login_cookie', [ $this, 'filter_google_login_set_login_cookie' ], 10, 1 );
-			}
-		}
-
-		/**
-		 * Filter setting google login cookie.
-		 *
-		 * @param bool $dosetcookie Whether to set the cookie or not.
-		 *
-		 * @since 1.9
-		 *
-		 * @return bool
-		 */
-		public function filter_google_login_set_login_cookie( $dosetcookie ) {
-			global $pagenow;
-
-			return 'wp-login.php' === $pagenow;
-		}
+		return 'wp-login.php' === $pagenow;
+	}
 
 
-		/**
-		 * Get an entry from $_COOKIE super global
-		 *
-		 * @param string $name Cookie name.
-		 *
-		 * @since 1.9
-		 *
-		 * @return bool Return false if entry does not exist, otherwise return cookie value.
-		 */
-		public function read_cookie( $name = '' ) {
-			if ( isset( $_COOKIE[ $name ] ) ) {
-				return $_COOKIE[ $name ];
-			} else {
-				return false;
-			}
+	/**
+	 * Get an entry from $_COOKIE super global
+	 *
+	 * @param string $name Cookie name.
+	 *
+	 * @since 1.9
+	 *
+	 * @return bool Return false if entry does not exist, otherwise return cookie value.
+	 */
+	public function read_cookie( $name = '' ) {
+		if ( isset( $_COOKIE[ $name ] ) ) {
+			return $_COOKIE[ $name ];
+		} else {
+			return false;
 		}
 	}
 }

--- a/classes/class-p4-custom-taxonomy.php
+++ b/classes/class-p4-custom-taxonomy.php
@@ -5,446 +5,443 @@
  * @package P4MT
  */
 
-if ( ! class_exists( 'P4_Custom_Taxonomy' ) ) {
+/**
+ * Class P4_Custom_Taxonomy
+ */
+class P4_Custom_Taxonomy {
+
+	const TAXONOMY           = 'p4-page-type';
+	const TAXONOMY_PARAMETER = 'p4_page_type';
+	const TAXONOMY_SLUG      = 'page-type';
 
 	/**
-	 * Class P4_Custom_Taxonomy
+	 * P4_Custom_Taxonomy constructor.
 	 */
-	class P4_Custom_Taxonomy {
+	public function __construct() {
+		$this->hooks();
+	}
 
-		const TAXONOMY           = 'p4-page-type';
-		const TAXONOMY_PARAMETER = 'p4_page_type';
-		const TAXONOMY_SLUG      = 'page-type';
+	/**
+	 * Register actions for WordPress hooks and filters.
+	 */
+	private function hooks() {
+		add_action( 'init', [ $this, 'register_taxonomy' ], 2 );
+		add_action( 'created_term', [ $this, 'trigger_rewrite_rules' ], 10, 3 );
+		add_action( 'edited_term', [ $this, 'trigger_rewrite_rules' ], 10, 3 );
+		add_action( 'delete_term', [ $this, 'trigger_rewrite_rules' ], 10, 3 );
+		add_action( 'save_post', [ $this, 'save_taxonomy_page_type' ], 10, 2 );
+		add_filter( 'available_permalink_structure_tags', [ $this, 'add_taxonomy_as_permalink_structure' ], 10, 1 );
 
-		/**
-		 * P4_Custom_Taxonomy constructor.
-		 */
-		public function __construct() {
-			$this->hooks();
+		// Rewrites the permalink to a post belonging to this taxonomy.
+		add_filter( 'post_link', [ $this, 'filter_permalink' ], 10, 3 );
+
+		// Rewrites the permalink to this taxonomy's page.
+		add_filter( 'term_link', [ $this, 'filter_term_permalink' ], 10, 3 );
+		add_filter( 'post_rewrite_rules', [ $this, 'replace_taxonomy_terms_in_rewrite_rules' ], 10, 1 );
+		add_filter( 'root_rewrite_rules', [ $this, 'add_terms_rewrite_rules' ], 10, 1 );
+
+		// Provides a filter element for the taxonomy in the posts list.
+		add_action( 'restrict_manage_posts', [ $this, 'filter_posts_by_page_type' ], 10, 2 );
+	}
+
+	/**
+	 * Add p4_page_type structure in available permalink tags for Settings -> Permalinks page.
+	 * available_permalink_structure_tags filter.
+	 *
+	 * @param array $tags   Permalink tags that are displayed in Settings -> Permalinks.
+	 *
+	 * @return mixed
+	 */
+	public function add_taxonomy_as_permalink_structure( $tags ) {
+		$tags[ self::TAXONOMY_PARAMETER ] = __( 'P4 page type (A p4 page type term.)', 'planet4-master-theme-backend' );
+
+		return $tags;
+	}
+
+	/**
+	 * Add a dropdown to choose planet4 post type.
+	 *
+	 * @param WP_Post $post The WordPress that will be filtered/edited.
+	 */
+	public function create_taxonomy_metabox_markup( WP_Post $post ) {
+		$attached_type = get_the_terms( $post, self::TAXONOMY );
+		$current_type  = ( is_array( $attached_type ) ) ? $attached_type[0]->term_id : - 1;
+		$all_types     = $this->get_terms();
+		if ( -1 === $current_type ) {
+			// Assign default p4-pagetype for new POST.
+			$default_p4_pagetype = $this->get_default_p4_pagetype();
+			$current_type        = $default_p4_pagetype->slug;
 		}
 
-		/**
-		 * Register actions for WordPress hooks and filters.
-		 */
-		private function hooks() {
-			add_action( 'init', [ $this, 'register_taxonomy' ], 2 );
-			add_action( 'created_term', [ $this, 'trigger_rewrite_rules' ], 10, 3 );
-			add_action( 'edited_term', [ $this, 'trigger_rewrite_rules' ], 10, 3 );
-			add_action( 'delete_term', [ $this, 'trigger_rewrite_rules' ], 10, 3 );
-			add_action( 'save_post', [ $this, 'save_taxonomy_page_type' ], 10, 2 );
-			add_filter( 'available_permalink_structure_tags', [ $this, 'add_taxonomy_as_permalink_structure' ], 10, 1 );
+		wp_nonce_field( 'p4-save-page-type', 'p4-page-type-nonce' );
+		?>
+		<select name="<?php echo esc_attr( self::TAXONOMY ); ?>">
+			<?php foreach ( $all_types as $term ) : ?>
+				<option <?php selected( $current_type, $term->term_id ); ?>
+					value="<?php echo esc_attr( $term->term_id ); ?>">
+					<?php echo esc_html( $term->name ); ?>
+				</option>
+			<?php endforeach; ?>
+		</select>
+		<?php
+	}
 
-			// Rewrites the permalink to a post belonging to this taxonomy.
-			add_filter( 'post_link', [ $this, 'filter_permalink' ], 10, 3 );
+	/**
+	 * Replace p4_page_type placeholder with the p4_page_type term for posts permalinks.
+	 * Filter for post_link.
+	 *
+	 * @param string  $permalink The post's permalink.
+	 * @param WP_Post $post      The post in question.
+	 * @param bool    $leavename Whether to keep the post name.
+	 *
+	 * @return string   The filtered permalink.
+	 */
+	public function filter_permalink( $permalink, $post, $leavename ) {
 
-			// Rewrites the permalink to this taxonomy's page.
-			add_filter( 'term_link', [ $this, 'filter_term_permalink' ], 10, 3 );
-			add_filter( 'post_rewrite_rules', [ $this, 'replace_taxonomy_terms_in_rewrite_rules' ], 10, 1 );
-			add_filter( 'root_rewrite_rules', [ $this, 'add_terms_rewrite_rules' ], 10, 1 );
-
-			// Provides a filter element for the taxonomy in the posts list.
-			add_action( 'restrict_manage_posts', [ $this, 'filter_posts_by_page_type' ], 10, 2 );
+		if ( strpos( $permalink, '%' . self::TAXONOMY_PARAMETER . '%' ) === false ) {
+			return $permalink;
 		}
 
-		/**
-		 * Add p4_page_type structure in available permalink tags for Settings -> Permalinks page.
-		 * available_permalink_structure_tags filter.
-		 *
-		 * @param array $tags   Permalink tags that are displayed in Settings -> Permalinks.
-		 *
-		 * @return mixed
-		 */
-		public function add_taxonomy_as_permalink_structure( $tags ) {
-			$tags[ self::TAXONOMY_PARAMETER ] = __( 'P4 page type (A p4 page type term.)', 'planet4-master-theme-backend' );
+		// Get post's taxonomy terms.
+		$terms     = wp_get_object_terms( $post->ID, self::TAXONOMY );
+		$all_terms = $this->get_terms();
 
-			return $tags;
-		}
-
-		/**
-		 * Add a dropdown to choose planet4 post type.
-		 *
-		 * @param WP_Post $post The WordPress that will be filtered/edited.
-		 */
-		public function create_taxonomy_metabox_markup( WP_Post $post ) {
-			$attached_type = get_the_terms( $post, self::TAXONOMY );
-			$current_type  = ( is_array( $attached_type ) ) ? $attached_type[0]->term_id : - 1;
-			$all_types     = $this->get_terms();
-			if ( -1 === $current_type ) {
-				// Assign default p4-pagetype for new POST.
-				$default_p4_pagetype = $this->get_default_p4_pagetype();
-				$current_type        = $default_p4_pagetype->slug;
+		// Assign story slug if the taxonomy does not have any terms.
+		$taxonomy_slug = 'story';
+		if ( ! is_wp_error( $terms ) && ! empty( $terms ) && is_object( $terms[0] ) ) {
+			$taxonomy_slug = $terms[0]->slug;
+		} elseif ( ! is_wp_error( $terms ) && empty( $terms ) ) {
+			if ( ! is_wp_error( $all_terms ) && ! empty( $all_terms ) && is_object( $all_terms[0] ) ) {
+				$taxonomy_slug = $all_terms[0]->slug;
 			}
-
-			wp_nonce_field( 'p4-save-page-type', 'p4-page-type-nonce' );
-			?>
-			<select name="<?php echo esc_attr( self::TAXONOMY ); ?>">
-				<?php foreach ( $all_types as $term ) : ?>
-					<option <?php selected( $current_type, $term->term_id ); ?>
-						value="<?php echo esc_attr( $term->term_id ); ?>">
-						<?php echo esc_html( $term->name ); ?>
-					</option>
-				<?php endforeach; ?>
-			</select>
-			<?php
 		}
 
-		/**
-		 * Replace p4_page_type placeholder with the p4_page_type term for posts permalinks.
-		 * Filter for post_link.
-		 *
-		 * @param string  $permalink The post's permalink.
-		 * @param WP_Post $post      The post in question.
-		 * @param bool    $leavename Whether to keep the post name.
-		 *
-		 * @return string   The filtered permalink.
-		 */
-		public function filter_permalink( $permalink, $post, $leavename ) {
+		return str_replace( '%' . self::TAXONOMY_PARAMETER . '%', $taxonomy_slug, $permalink );
+	}
 
-			if ( strpos( $permalink, '%' . self::TAXONOMY_PARAMETER . '%' ) === false ) {
-				return $permalink;
-			}
+	/**
+	 * Get taxonomy's terms.
+	 *
+	 * @return array|int|WP_Error
+	 */
+	public function get_terms() {
+		// Get planet4 page type taxonomy terms.
+		return get_terms(
+			[
+				'fields'     => 'all',
+				'hide_empty' => false,
+				'taxonomy'   => self::TAXONOMY,
+			]
+		);
+	}
 
-			// Get post's taxonomy terms.
-			$terms     = wp_get_object_terms( $post->ID, self::TAXONOMY );
-			$all_terms = $this->get_terms();
-
-			// Assign story slug if the taxonomy does not have any terms.
-			$taxonomy_slug = 'story';
-			if ( ! is_wp_error( $terms ) && ! empty( $terms ) && is_object( $terms[0] ) ) {
-				$taxonomy_slug = $terms[0]->slug;
-			} elseif ( ! is_wp_error( $terms ) && empty( $terms ) ) {
-				if ( ! is_wp_error( $all_terms ) && ! empty( $all_terms ) && is_object( $all_terms[0] ) ) {
-					$taxonomy_slug = $all_terms[0]->slug;
-				}
-			}
-
-			return str_replace( '%' . self::TAXONOMY_PARAMETER . '%', $taxonomy_slug, $permalink );
+	/**
+	 * Get all taxonomy's terms, despite if wpml plugin is activated.
+	 *
+	 * @return array|int|WP_Error
+	 */
+	public function get_all_terms() {
+		// Get taxonomy terms if wpml plugin is installed and activated.
+		if ( function_exists( 'icl_object_id' ) ) {
+			return $this->get_multilingual_terms();
 		}
+		return $this->get_terms();
+	}
 
-		/**
-		 * Get taxonomy's terms.
-		 *
-		 * @return array|int|WP_Error
-		 */
-		public function get_terms() {
-			// Get planet4 page type taxonomy terms.
-			return get_terms(
+	/**
+	 * Get all taxonomy's terms (for all languages available) if wpml is enabled.
+	 *
+	 * @return WP_Term[]
+	 */
+	public function get_multilingual_terms() {
+
+		$all_terms           = [];
+		$current_lang        = apply_filters( 'wpml_current_language', null );
+		$available_languages = apply_filters( 'wpml_active_languages', null, 'orderby=id&order=desc' );
+
+		foreach ( $available_languages as $lang ) {
+			do_action( 'wpml_switch_language', $lang['language_code'] );
+			$terms = get_terms(
 				[
 					'fields'     => 'all',
 					'hide_empty' => false,
 					'taxonomy'   => self::TAXONOMY,
 				]
 			);
-		}
-
-		/**
-		 * Get all taxonomy's terms, despite if wpml plugin is activated.
-		 *
-		 * @return array|int|WP_Error
-		 */
-		public function get_all_terms() {
-			// Get taxonomy terms if wpml plugin is installed and activated.
-			if ( function_exists( 'icl_object_id' ) ) {
-				return $this->get_multilingual_terms();
-			}
-			return $this->get_terms();
-		}
-
-		/**
-		 * Get all taxonomy's terms (for all languages available) if wpml is enabled.
-		 *
-		 * @return WP_Term[]
-		 */
-		public function get_multilingual_terms() {
-
-			$all_terms           = [];
-			$current_lang        = apply_filters( 'wpml_current_language', null );
-			$available_languages = apply_filters( 'wpml_active_languages', null, 'orderby=id&order=desc' );
-
-			foreach ( $available_languages as $lang ) {
-				do_action( 'wpml_switch_language', $lang['language_code'] );
-				$terms = get_terms(
-					[
-						'fields'     => 'all',
-						'hide_empty' => false,
-						'taxonomy'   => self::TAXONOMY,
-					]
-				);
-				if ( ! is_wp_error( $terms ) && ! empty( $terms ) ) {
-					$all_terms = array_merge( $all_terms, $terms );
-				}
-			}
-
-			do_action( 'wpml_switch_language', $current_lang );
-
-			return $all_terms;
-		}
-
-		/**
-		 * Get default P4 pagetype.
-		 *
-		 * @return WP_term|int|WP_Error
-		 */
-		public function get_default_p4_pagetype() {
-			$options             = get_option( 'planet4_options' );
-			$default_p4_pagetype = $options['default_p4_pagetype'] ?? 0;
-
-			if ( 0 === $default_p4_pagetype ) {
-				// If default p4-pagetype setting not found, use taxonomy's first term.
-				$all_terms           = $this->get_terms();
-				$default_p4_pagetype = $all_terms[0] ?? 0;
-			} else {
-				$default_p4_pagetype = get_term( $default_p4_pagetype, self::TAXONOMY );
-			}
-
-			return $default_p4_pagetype;
-		}
-
-		/**
-		 * Register a custom taxonomy for planet4 post types.
-		 */
-		public function register_taxonomy() {
-
-			$p4_page_type = [
-				'name'              => _x( 'Post Types', 'taxonomy general name', 'planet4-master-theme-backend' ),
-				'singular_name'     => _x( 'Post Type', 'taxonomy singular name', 'planet4-master-theme-backend' ),
-				'search_items'      => __( 'Search in Post Type', 'planet4-master-theme-backend' ),
-				'all_items'         => __( 'All Post Types', 'planet4-master-theme-backend' ),
-				'most_used_items'   => null,
-				'parent_item'       => null,
-				'parent_item_colon' => null,
-				'edit_item'         => __( 'Edit Post Type', 'planet4-master-theme-backend' ),
-				'update_item'       => __( 'Update Post Type', 'planet4-master-theme-backend' ),
-				'add_new_item'      => __( 'Add new Post Type', 'planet4-master-theme-backend' ),
-				'new_item_name'     => __( 'New Post Type', 'planet4-master-theme-backend' ),
-				'menu_name'         => __( 'Post Types', 'planet4-master-theme-backend' ),
-			];
-
-			$args = [
-				'hierarchical'      => false,
-				'labels'            => $p4_page_type,
-				'rewrite'           => [
-					'slug' => self::TAXONOMY_SLUG,
-				],
-				'show_in_rest'      => true,
-				'show_ui'           => true,
-				'show_admin_column' => true,
-				'query_var'         => true,
-				'meta_box_cb'       => [ $this, 'create_taxonomy_metabox_markup' ],
-				'show_in_rest'      => true,
-			];
-
-			register_taxonomy( self::TAXONOMY, [ self::TAXONOMY_PARAMETER, 'post' ], $args );
-		}
-
-		/**
-		 * Add each taxonomy term as a rewrite rule.
-		 */
-		public function add_terms_as_rewrite_rules() {
-			// Add a rewrite rule on top of the chain for each slug
-			// of this taxonomy type (e.g.: "publication", "story", etc.).
-			$terms_slugs = $this->get_terms_slugs();
-			foreach ( $terms_slugs as $slug ) {
-				add_rewrite_rule( $slug . '/?$', 'index.php?' . self::TAXONOMY . '=' . $slug, 'top' );
+			if ( ! is_wp_error( $terms ) && ! empty( $terms ) ) {
+				$all_terms = array_merge( $all_terms, $terms );
 			}
 		}
 
-		/**
-		 * Filter for term_link.
-		 *
-		 * @param string $link     The link value.
-		 * @param string $term     The term passed to the filter (unused).
-		 * @param string $taxonomy Taxonomy of the given link.
-		 *
-		 * @return string The filtered permalink for this taxonomy.
-		 */
-		public function filter_term_permalink( $link, $term, $taxonomy ) {
-			if ( self::TAXONOMY !== $taxonomy ) {
-				return $link;
-			}
+		do_action( 'wpml_switch_language', $current_lang );
 
-			return str_replace( self::TAXONOMY_SLUG . '/', '', $link );
+		return $all_terms;
+	}
+
+	/**
+	 * Get default P4 pagetype.
+	 *
+	 * @return WP_term|int|WP_Error
+	 */
+	public function get_default_p4_pagetype() {
+		$options             = get_option( 'planet4_options' );
+		$default_p4_pagetype = $options['default_p4_pagetype'] ?? 0;
+
+		if ( 0 === $default_p4_pagetype ) {
+			// If default p4-pagetype setting not found, use taxonomy's first term.
+			$all_terms           = $this->get_terms();
+			$default_p4_pagetype = $all_terms[0] ?? 0;
+		} else {
+			$default_p4_pagetype = get_term( $default_p4_pagetype, self::TAXONOMY );
 		}
 
-		/**
-		 * Get the slugs for all terms in this taxonomy.
-		 *
-		 * @return array Flat array containing the slug for every term.
-		 */
-		private function get_terms_slugs() : array {
-			// Get planet4 page type taxonomy terms.
-			$terms = $this->get_all_terms();
+		return $default_p4_pagetype;
+	}
 
-			if ( ! is_wp_error( $terms ) ) {
-				$term_slugs = [];
-				if ( ! empty( $terms ) ) {
-					foreach ( $terms as $term ) {
-						$term_slugs[] = $term->slug;
-					}
-				} elseif ( empty( $terms ) ) {
-					// Add story slug also if the taxonomy does not have any terms.
-					$term_slugs[] = 'story';
-				}
+	/**
+	 * Register a custom taxonomy for planet4 post types.
+	 */
+	public function register_taxonomy() {
 
-				return $term_slugs;
-			}
+		$p4_page_type = [
+			'name'              => _x( 'Post Types', 'taxonomy general name', 'planet4-master-theme-backend' ),
+			'singular_name'     => _x( 'Post Type', 'taxonomy singular name', 'planet4-master-theme-backend' ),
+			'search_items'      => __( 'Search in Post Type', 'planet4-master-theme-backend' ),
+			'all_items'         => __( 'All Post Types', 'planet4-master-theme-backend' ),
+			'most_used_items'   => null,
+			'parent_item'       => null,
+			'parent_item_colon' => null,
+			'edit_item'         => __( 'Edit Post Type', 'planet4-master-theme-backend' ),
+			'update_item'       => __( 'Update Post Type', 'planet4-master-theme-backend' ),
+			'add_new_item'      => __( 'Add new Post Type', 'planet4-master-theme-backend' ),
+			'new_item_name'     => __( 'New Post Type', 'planet4-master-theme-backend' ),
+			'menu_name'         => __( 'Post Types', 'planet4-master-theme-backend' ),
+		];
 
-			return [];
+		$args = [
+			'hierarchical'      => false,
+			'labels'            => $p4_page_type,
+			'rewrite'           => [
+				'slug' => self::TAXONOMY_SLUG,
+			],
+			'show_in_rest'      => true,
+			'show_ui'           => true,
+			'show_admin_column' => true,
+			'query_var'         => true,
+			'meta_box_cb'       => [ $this, 'create_taxonomy_metabox_markup' ],
+			'show_in_rest'      => true,
+		];
+
+		register_taxonomy( self::TAXONOMY, [ self::TAXONOMY_PARAMETER, 'post' ], $args );
+	}
+
+	/**
+	 * Add each taxonomy term as a rewrite rule.
+	 */
+	public function add_terms_as_rewrite_rules() {
+		// Add a rewrite rule on top of the chain for each slug
+		// of this taxonomy type (e.g.: "publication", "story", etc.).
+		$terms_slugs = $this->get_terms_slugs();
+		foreach ( $terms_slugs as $slug ) {
+			add_rewrite_rule( $slug . '/?$', 'index.php?' . self::TAXONOMY . '=' . $slug, 'top' );
+		}
+	}
+
+	/**
+	 * Filter for term_link.
+	 *
+	 * @param string $link     The link value.
+	 * @param string $term     The term passed to the filter (unused).
+	 * @param string $taxonomy Taxonomy of the given link.
+	 *
+	 * @return string The filtered permalink for this taxonomy.
+	 */
+	public function filter_term_permalink( $link, $term, $taxonomy ) {
+		if ( self::TAXONOMY !== $taxonomy ) {
+			return $link;
 		}
 
-		/**
-		 * Filter for post_rewrite_rules.
-		 *
-		 * @param array $rules   Post rewrite rules passed by WordPress.
-		 *
-		 * @return array        The filtered post rewrite rules.
-		 */
-		public function replace_taxonomy_terms_in_rewrite_rules( $rules ) {
-			// Get planet4 page type taxonomy terms.
-			$term_slugs = $this->get_terms_slugs();
+		return str_replace( self::TAXONOMY_SLUG . '/', '', $link );
+	}
 
-			if ( $term_slugs ) {
-				$terms_slugs_regex = implode( '|', $term_slugs );
+	/**
+	 * Get the slugs for all terms in this taxonomy.
+	 *
+	 * @return array Flat array containing the slug for every term.
+	 */
+	private function get_terms_slugs() : array {
+		// Get planet4 page type taxonomy terms.
+		$terms = $this->get_all_terms();
 
-				$new_rules = [];
-				foreach ( $rules as $match => $rule ) {
-					$new_match               = str_replace( '%' . self::TAXONOMY_PARAMETER . '%', "($terms_slugs_regex)", $match );
-					$new_rule                = str_replace( '%' . self::TAXONOMY_PARAMETER . '%', self::TAXONOMY . '=', $rule );
-					$new_rules[ $new_match ] = $new_rule;
-				}
-
-				return $new_rules;
-			}
-
-			return $rules;
-		}
-
-		/**
-		 * Add each taxonomy term as a root rewrite rule.
-		 * Filter hook for root_rewrite_rules.
-		 *
-		 * @param array $rules  Root rewrite rules passed by WordPress.
-		 *
-		 * @return array        The filtered root rewrite rules.
-		 */
-		public function add_terms_rewrite_rules( $rules ) {
-			// Add a rewrite rule for each slug of this taxonomy type (e.g.: "publication", "story", etc.)
-			// for p4 page type pages.
-			// e.g | story/?$ | index.php?p4-page-type=story | .
-			$terms_slugs = $this->get_terms_slugs();
-
-			if ( $terms_slugs ) {
-				foreach ( $terms_slugs as $slug ) {
-					$rules[ $slug . '/?$' ] = 'index.php?' . self::TAXONOMY . '=' . $slug;
-				}
-			}
-
-			return $rules;
-		}
-
-		/**
-		 * Regenerate and flush rewrite rules when a new p4_page_type is created/edited/deleted.
-		 *
-		 * @param int    $term_id  Term ID.
-		 * @param int    $tt_id    Term taxonomy ID.
-		 * @param string $taxonomy Taxonomy slug.
-		 */
-		public function trigger_rewrite_rules( $term_id, $tt_id, $taxonomy ) {
-			if ( self::TAXONOMY !== $taxonomy ) {
-				return;
-			}
-
-			flush_rewrite_rules();
-		}
-
-		/**
-		 * Add first term of the taxonomy to the post if the post has not any taxonomy's terms assigned to it.
-		 * Assign only the first term, if more than one terms are assigned to the post.
-		 *
-		 * @param int     $post_id Id of the saved post.
-		 * @param WP_Post $post    Post object.
-		 */
-		public function save_taxonomy_page_type( $post_id, $post ) {
-
-			// Ignore autosave.
-			if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
-				return;
-			}
-
-			// Check user's capabilities.
-			if ( ! current_user_can( 'edit_post', $post_id ) ) {
-				return;
-			}
-
-			// Allow p4-page-type to be set from edit post and quick edit pages.
-			// Make sure there's input.
-			// phpcs:disable WordPress.Security.NonceVerification.Missing
-			if ( isset( $_POST[ self::TAXONOMY ] ) && 'post' === $post->post_type &&
-				filter_var( wp_unslash( $_POST[ self::TAXONOMY ] ), FILTER_VALIDATE_INT ) ) {
-
-				$selected = get_term_by( 'id', intval( $_POST[ self::TAXONOMY ] ), self::TAXONOMY );
-				// phpcs:enable
-				if ( false !== $selected && ! is_wp_error( $selected ) ) {
-					// Save post type.
-					wp_set_post_terms( $post_id, [ $selected->term_id ], self::TAXONOMY );
-				}
-			}
-
-			// Check if post type is POST.
-			// Check if post has a p4 page type term assigned to it and if none if assigned, assign the default p4 page type term.
-			if ( 'post' === $post->post_type ) {
-
-				// Check if post has an assigned term to it.
-				$terms = wp_get_object_terms( $post_id, self::TAXONOMY );
-				if ( ! is_wp_error( $terms ) ) {
-
-					$default_p4_pagetype = $this->get_default_p4_pagetype();
-
-					// Assign default p4-pagetype, if no term is assigned to post.
-					if ( empty( $terms ) ) {
-						if ( $default_p4_pagetype instanceof \WP_Term ) {
-							wp_set_post_terms( $post_id, [ $default_p4_pagetype->term_id ], self::TAXONOMY );
-						}
-					} elseif ( count( $terms ) > 1 && $terms[0] instanceof \WP_Term ) { // Assign the first term, if more than one terms are assigned.
-						wp_set_post_terms( $post_id, [ $terms[0]->term_id ], self::TAXONOMY );
-					}
-				}
-			}
-		}
-
-		/**
-		 * Adds a filter element to the posts list that allows filtering by the custom taxonomy terms.
-		 * Action for restrict_manage_posts.
-		 *
-		 * @param string $post_type WordPress post type slug.
-		 * @param string $which The location of the extra table nav markup ('top' or 'bottom').
-		 */
-		public function filter_posts_by_page_type( $post_type, $which ) {
-			// Apply this only to a specific post type.
-			if ( 'post' !== $post_type ) {
-				return;
-			}
-
-			// Retrieve taxonomy terms.
-			$terms = get_terms( self::TAXONOMY );
-
-			// Display filter HTML.
-			?>
-			<select name="<?php echo esc_attr( self::TAXONOMY ); ?>" id="<?php echo esc_attr( self::TAXONOMY ); ?>" class="postform">
-				<option value=""><?php echo esc_html__( 'All Post Types', 'planet4-master-theme-backend' ); ?></option>
-
-				<?php
+		if ( ! is_wp_error( $terms ) ) {
+			$term_slugs = [];
+			if ( ! empty( $terms ) ) {
 				foreach ( $terms as $term ) {
-					printf(
-						'<option value="%1$s" %2$s>%3$s</option>',
-						esc_html( $term->slug ),
-						( ( isset( $_GET[ self::TAXONOMY ] ) && ( $_GET[ self::TAXONOMY ] === $term->slug ) ) ? ' selected="selected"' : '' ),  // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-						esc_html( $term->name )
-					);
+					$term_slugs[] = $term->slug;
 				}
-				?>
-			</select>
-			<?php
+			} elseif ( empty( $terms ) ) {
+				// Add story slug also if the taxonomy does not have any terms.
+				$term_slugs[] = 'story';
+			}
+
+			return $term_slugs;
 		}
+
+		return [];
+	}
+
+	/**
+	 * Filter for post_rewrite_rules.
+	 *
+	 * @param array $rules   Post rewrite rules passed by WordPress.
+	 *
+	 * @return array        The filtered post rewrite rules.
+	 */
+	public function replace_taxonomy_terms_in_rewrite_rules( $rules ) {
+		// Get planet4 page type taxonomy terms.
+		$term_slugs = $this->get_terms_slugs();
+
+		if ( $term_slugs ) {
+			$terms_slugs_regex = implode( '|', $term_slugs );
+
+			$new_rules = [];
+			foreach ( $rules as $match => $rule ) {
+				$new_match               = str_replace( '%' . self::TAXONOMY_PARAMETER . '%', "($terms_slugs_regex)", $match );
+				$new_rule                = str_replace( '%' . self::TAXONOMY_PARAMETER . '%', self::TAXONOMY . '=', $rule );
+				$new_rules[ $new_match ] = $new_rule;
+			}
+
+			return $new_rules;
+		}
+
+		return $rules;
+	}
+
+	/**
+	 * Add each taxonomy term as a root rewrite rule.
+	 * Filter hook for root_rewrite_rules.
+	 *
+	 * @param array $rules  Root rewrite rules passed by WordPress.
+	 *
+	 * @return array        The filtered root rewrite rules.
+	 */
+	public function add_terms_rewrite_rules( $rules ) {
+		// Add a rewrite rule for each slug of this taxonomy type (e.g.: "publication", "story", etc.)
+		// for p4 page type pages.
+		// e.g | story/?$ | index.php?p4-page-type=story | .
+		$terms_slugs = $this->get_terms_slugs();
+
+		if ( $terms_slugs ) {
+			foreach ( $terms_slugs as $slug ) {
+				$rules[ $slug . '/?$' ] = 'index.php?' . self::TAXONOMY . '=' . $slug;
+			}
+		}
+
+		return $rules;
+	}
+
+	/**
+	 * Regenerate and flush rewrite rules when a new p4_page_type is created/edited/deleted.
+	 *
+	 * @param int    $term_id  Term ID.
+	 * @param int    $tt_id    Term taxonomy ID.
+	 * @param string $taxonomy Taxonomy slug.
+	 */
+	public function trigger_rewrite_rules( $term_id, $tt_id, $taxonomy ) {
+		if ( self::TAXONOMY !== $taxonomy ) {
+			return;
+		}
+
+		flush_rewrite_rules();
+	}
+
+	/**
+	 * Add first term of the taxonomy to the post if the post has not any taxonomy's terms assigned to it.
+	 * Assign only the first term, if more than one terms are assigned to the post.
+	 *
+	 * @param int     $post_id Id of the saved post.
+	 * @param WP_Post $post    Post object.
+	 */
+	public function save_taxonomy_page_type( $post_id, $post ) {
+
+		// Ignore autosave.
+		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+			return;
+		}
+
+		// Check user's capabilities.
+		if ( ! current_user_can( 'edit_post', $post_id ) ) {
+			return;
+		}
+
+		// Allow p4-page-type to be set from edit post and quick edit pages.
+		// Make sure there's input.
+		// phpcs:disable WordPress.Security.NonceVerification.Missing
+		if ( isset( $_POST[ self::TAXONOMY ] ) && 'post' === $post->post_type &&
+			filter_var( wp_unslash( $_POST[ self::TAXONOMY ] ), FILTER_VALIDATE_INT ) ) {
+
+			$selected = get_term_by( 'id', intval( $_POST[ self::TAXONOMY ] ), self::TAXONOMY );
+			// phpcs:enable
+			if ( false !== $selected && ! is_wp_error( $selected ) ) {
+				// Save post type.
+				wp_set_post_terms( $post_id, [ $selected->term_id ], self::TAXONOMY );
+			}
+		}
+
+		// Check if post type is POST.
+		// Check if post has a p4 page type term assigned to it and if none if assigned, assign the default p4 page type term.
+		if ( 'post' === $post->post_type ) {
+
+			// Check if post has an assigned term to it.
+			$terms = wp_get_object_terms( $post_id, self::TAXONOMY );
+			if ( ! is_wp_error( $terms ) ) {
+
+				$default_p4_pagetype = $this->get_default_p4_pagetype();
+
+				// Assign default p4-pagetype, if no term is assigned to post.
+				if ( empty( $terms ) ) {
+					if ( $default_p4_pagetype instanceof \WP_Term ) {
+						wp_set_post_terms( $post_id, [ $default_p4_pagetype->term_id ], self::TAXONOMY );
+					}
+				} elseif ( count( $terms ) > 1 && $terms[0] instanceof \WP_Term ) { // Assign the first term, if more than one terms are assigned.
+					wp_set_post_terms( $post_id, [ $terms[0]->term_id ], self::TAXONOMY );
+				}
+			}
+		}
+	}
+
+	/**
+	 * Adds a filter element to the posts list that allows filtering by the custom taxonomy terms.
+	 * Action for restrict_manage_posts.
+	 *
+	 * @param string $post_type WordPress post type slug.
+	 * @param string $which The location of the extra table nav markup ('top' or 'bottom').
+	 */
+	public function filter_posts_by_page_type( $post_type, $which ) {
+		// Apply this only to a specific post type.
+		if ( 'post' !== $post_type ) {
+			return;
+		}
+
+		// Retrieve taxonomy terms.
+		$terms = get_terms( self::TAXONOMY );
+
+		// Display filter HTML.
+		?>
+		<select name="<?php echo esc_attr( self::TAXONOMY ); ?>" id="<?php echo esc_attr( self::TAXONOMY ); ?>" class="postform">
+			<option value=""><?php echo esc_html__( 'All Post Types', 'planet4-master-theme-backend' ); ?></option>
+
+			<?php
+			foreach ( $terms as $term ) {
+				printf(
+					'<option value="%1$s" %2$s>%3$s</option>',
+					esc_html( $term->slug ),
+					( ( isset( $_GET[ self::TAXONOMY ] ) && ( $_GET[ self::TAXONOMY ] === $term->slug ) ) ? ' selected="selected"' : '' ),  // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+					esc_html( $term->name )
+				);
+			}
+			?>
+		</select>
+		<?php
 	}
 }

--- a/classes/class-p4-dev-report.php
+++ b/classes/class-p4-dev-report.php
@@ -5,77 +5,75 @@
  * @package P4MT
  */
 
-if ( ! class_exists( 'P4_Dev_Report' ) ) {
+/**
+ * Class P4_Dev_Report
+ */
+class P4_Dev_Report {
 	/**
-	 * Class P4_Dev_Report
+	 * Option key, and option page slug
+	 *
+	 * @var string
 	 */
-	class P4_Dev_Report {
-		/**
-		 * Option key, and option page slug
-		 *
-		 * @var string
-		 */
-		private $key = 'planet4_dev_report';
+	private $key = 'planet4_dev_report';
 
-		/**
-		 * Constructor
-		 */
-		public function __construct() {
+	/**
+	 * Constructor
+	 */
+	public function __construct() {
 
-			// Set our title.
-			$this->title = 'Planet4 Dev Report';
-			$this->hooks();
-		}
+		// Set our title.
+		$this->title = 'Planet4 Dev Report';
+		$this->hooks();
+	}
 
-		/**
-		 * Register our setting to WP.
-		 */
-		public function init() {
-			register_setting( $this->key, $this->key );
-		}
+	/**
+	 * Register our setting to WP.
+	 */
+	public function init() {
+		register_setting( $this->key, $this->key );
+	}
 
-		/**
-		 * Initiate our hooks
-		 */
-		public function hooks() {
-			add_action( 'admin_init', [ $this, 'init' ] );
-			add_action( 'admin_menu', [ $this, 'add_options_page' ] );
-		}
+	/**
+	 * Initiate our hooks
+	 */
+	public function hooks() {
+		add_action( 'admin_init', [ $this, 'init' ] );
+		add_action( 'admin_menu', [ $this, 'add_options_page' ] );
+	}
 
-		/**
-		 * Add menu options page.
-		 */
-		public function add_options_page() {
-			$this->options_page = add_options_page( $this->title, $this->title, 'manage_options', $this->key, [ $this, 'admin_page_display' ] );
-		}
+	/**
+	 * Add menu options page.
+	 */
+	public function add_options_page() {
+		$this->options_page = add_options_page( $this->title, $this->title, 'manage_options', $this->key, [ $this, 'admin_page_display' ] );
+	}
 
-		/**
-		 * Admin page markup. Mostly handled by CMB2.
-		 */
-		public function admin_page_display() {
-			echo '<h1>P4 Dev report</h1>' . "\n";
-			$gp_packages = get_option( 'greenpeace_packages' );
+	/**
+	 * Admin page markup. Mostly handled by CMB2.
+	 */
+	public function admin_page_display() {
+		echo '<h1>P4 Dev report</h1>' . "\n";
+		$gp_packages = get_option( 'greenpeace_packages' );
 
-			if ( $gp_packages ) {
-				foreach ( $gp_packages as $gp_package ) {
-					$url = $gp_package[2]['url'];
-					if ( '.git' === substr( $url, -4 ) ) {
-						$url = substr( $url, 0, -4 );
-					}
-					if ( 'dev-' === substr( $gp_package[1], 0, 4 ) ) {
-						$branch = substr( $gp_package[1], 4 );
-					} else {
-						$branch = $gp_package[1];
-					}
-					$branch_history_url = $url . '/commits/' . $branch;
-					$commit_url         = $url . '/commit/' . $gp_package[2]['reference'];
-
-					echo '<h3>' . esc_html( $gp_package[0] ) . "</h3>\n";
-					echo "<p>Version (tag/branch): <a href='" . esc_url( $branch_history_url ) . "'>" . esc_html( $branch ) . "</a></p>\n";
-					echo "<p>Source repo: <a href='" . esc_url( $gp_package[2]['url'] ) . "'>" . esc_html( $gp_package[2]['url'] ) . "</a></p>\n";
-					echo "<p>Source hash: <a href='" . esc_url( $commit_url ) . "'>" . esc_html( $gp_package[2]['reference'] ) . "</a></p>\n";
-
+		if ( $gp_packages ) {
+			foreach ( $gp_packages as $gp_package ) {
+				$url = $gp_package[2]['url'];
+				if ( '.git' === substr( $url, -4 ) ) {
+					$url = substr( $url, 0, -4 );
 				}
+				if ( 'dev-' === substr( $gp_package[1], 0, 4 ) ) {
+					$branch = substr( $gp_package[1], 4 );
+				} else {
+					$branch = $gp_package[1];
+				}
+				$branch_history_url = $url . '/commits/' . $branch;
+				$commit_url         = $url . '/commit/' . $gp_package[2]['reference'];
+
+				echo '<h3>' . esc_html( $gp_package[0] ) . "</h3>\n";
+				echo "<p>Version (tag/branch): <a href='" . esc_url( $branch_history_url ) . "'>" . esc_html( $branch ) . "</a></p>\n";
+				echo "<p>Source repo: <a href='" . esc_url( $gp_package[2]['url'] ) . "'>" . esc_html( $gp_package[2]['url'] ) . "</a></p>\n";
+				echo "<p>Source hash: <a href='" . esc_url( $commit_url ) . "'>" . esc_html( $gp_package[2]['reference'] ) . "</a></p>\n";
+
 			}
 		}
 	}

--- a/classes/class-p4-elasticsearch.php
+++ b/classes/class-p4-elasticsearch.php
@@ -5,254 +5,251 @@
  * @package P4MT
  */
 
-if ( ! class_exists( 'P4_ElasticSearch' ) ) {
+/**
+ * Class P4_ElasticSearch
+ */
+class P4_ElasticSearch extends P4_Search {
 
 	/**
-	 * Class P4_ElasticSearch
+	 * Applies user selected filters to the search if there are any and gets the filtered posts.
+	 *
+	 * @param array $args Query args.
+	 *
+	 * @throws UnexpectedValueException When filter type is not recognized.
 	 */
-	class P4_ElasticSearch extends P4_Search {
+	public function set_filters_args( &$args ) {
+		parent::set_filters_args( $args );
 
-		/**
-		 * Applies user selected filters to the search if there are any and gets the filtered posts.
-		 *
-		 * @param array $args Query args.
-		 *
-		 * @throws UnexpectedValueException When filter type is not recognized.
-		 */
-		public function set_filters_args( &$args ) {
-			parent::set_filters_args( $args );
-
-			if ( $this->filters ) {
-				foreach ( $this->filters as $type => $filter_type ) {
-					foreach ( $filter_type as $filter ) {
-						switch ( $type ) {
-							case 'cat':
-							case 'tag':
-							case 'ptype':
-								break;
-							case 'ctype':
-								switch ( $filter['id'] ) {
-									case 0:
-									case 1:
-										break;
-									case 2:
-										// Workaround for making 'post_parent__not_in' to work with ES.
-										add_filter(
-											'ep_formatted_args',
-											function ( $formatted_args ) use ( $args ) {
-												// Make sure it is not an Action page.
-												if ( ! empty( $args['post_parent__not_in'] ) ) {
-													$formatted_args['post_filter']['bool']['must_not'][] = [
-														'terms' => [
-															'post_parent' => array_values( (array) $args['post_parent__not_in'] ),
-														],
-													];
-												}
-												return $formatted_args;
-											},
-											10,
-											1
-										);
-										break;
-									case 3:
-									case 4:
-										add_filter(
-											'ep_formatted_args',
-											function ( $formatted_args ) use ( $args ) {
-												// Make sure it is a Post.
-												if ( ! empty( $args['post_type'] ) ) {
-													$formatted_args['post_filter']['bool']['must'][] = [
-														'terms' => [
-															'post_type' => array_values( (array) $args['post_type'] ),
-														],
-													];
-												}
-												return $formatted_args;
-											},
-											10,
-											1
-										);
-										break;
-									case 5:
-										break;
-									default:
-										throw new UnexpectedValueException( 'Unexpected content type!' );
-								}
-								break;
-							default:
-								throw new UnexpectedValueException( 'Unexpected filter!' );
-						}
+		if ( $this->filters ) {
+			foreach ( $this->filters as $type => $filter_type ) {
+				foreach ( $filter_type as $filter ) {
+					switch ( $type ) {
+						case 'cat':
+						case 'tag':
+						case 'ptype':
+							break;
+						case 'ctype':
+							switch ( $filter['id'] ) {
+								case 0:
+								case 1:
+									break;
+								case 2:
+									// Workaround for making 'post_parent__not_in' to work with ES.
+									add_filter(
+										'ep_formatted_args',
+										function ( $formatted_args ) use ( $args ) {
+											// Make sure it is not an Action page.
+											if ( ! empty( $args['post_parent__not_in'] ) ) {
+												$formatted_args['post_filter']['bool']['must_not'][] = [
+													'terms' => [
+														'post_parent' => array_values( (array) $args['post_parent__not_in'] ),
+													],
+												];
+											}
+											return $formatted_args;
+										},
+										10,
+										1
+									);
+									break;
+								case 3:
+								case 4:
+									add_filter(
+										'ep_formatted_args',
+										function ( $formatted_args ) use ( $args ) {
+											// Make sure it is a Post.
+											if ( ! empty( $args['post_type'] ) ) {
+												$formatted_args['post_filter']['bool']['must'][] = [
+													'terms' => [
+														'post_type' => array_values( (array) $args['post_type'] ),
+													],
+												];
+											}
+											return $formatted_args;
+										},
+										10,
+										1
+									);
+									break;
+								case 5:
+									break;
+								default:
+									throw new UnexpectedValueException( 'Unexpected content type!' );
+							}
+							break;
+						default:
+							throw new UnexpectedValueException( 'Unexpected filter!' );
 					}
 				}
 			}
 		}
+	}
 
-		/**
-		 * Applies user selected filters to the search if there are any and gets the filtered posts.
-		 *
-		 * @param array $args The array with the arguments that will be passed to WP_Query.
-		 */
-		public function set_engines_args( &$args ) {
-			$args['ep_integrate'] = true;
-			simple_value_filter( 'epwr_scale', planet4_get_option( 'epwr_scale', '28d' ) );
-			simple_value_filter( 'epwr_decay', planet4_get_option( 'epwr_decay', 0.5 ) );
-			simple_value_filter( 'epwr_offset', planet4_get_option( 'epwr_offset', '365d' ) );
+	/**
+	 * Applies user selected filters to the search if there are any and gets the filtered posts.
+	 *
+	 * @param array $args The array with the arguments that will be passed to WP_Query.
+	 */
+	public function set_engines_args( &$args ) {
+		$args['ep_integrate'] = true;
+		simple_value_filter( 'epwr_scale', planet4_get_option( 'epwr_scale', '28d' ) );
+		simple_value_filter( 'epwr_decay', planet4_get_option( 'epwr_decay', 0.5 ) );
+		simple_value_filter( 'epwr_offset', planet4_get_option( 'epwr_offset', '365d' ) );
 
-			add_filter( 'ep_formatted_args', [ $this, 'set_full_text_search' ], 19, 1 );
-			add_filter( 'ep_formatted_args', [ $this, 'set_results_weight' ], 20, 1 );
+		add_filter( 'ep_formatted_args', [ $this, 'set_full_text_search' ], 19, 1 );
+		add_filter( 'ep_formatted_args', [ $this, 'set_results_weight' ], 20, 1 );
 
-			add_filter( 'ep_formatted_args', [ $this, 'add_mime_type_filter' ], 21, 1 );
+		add_filter( 'ep_formatted_args', [ $this, 'add_mime_type_filter' ], 21, 1 );
 
-			if ( ! wp_doing_ajax() ) {
-				add_filter( 'ep_formatted_args', [ $this, 'add_aggregations' ], 999, 1 );
-			}
+		if ( ! wp_doing_ajax() ) {
+			add_filter( 'ep_formatted_args', [ $this, 'add_aggregations' ], 999, 1 );
 		}
+	}
 
-		/**
-		 * Apply full-text search.
-		 *
-		 * @param mixed $formatted_args Assoc array with the args that ES expects.
-		 *
-		 * @return mixed
-		 */
-		public function set_full_text_search( $formatted_args ) {
-			if ( isset( $formatted_args['query']['function_score']['query']['bool'] ) ) {
-				// Create/change the bool query from should to must.
-				$formatted_args['query']['function_score']['query']['bool']['must'] = $formatted_args['query']['function_score']['query']['bool']['should'];
-				// Add the operator AND to the new bool query.
-				$formatted_args['query']['function_score']['query']['bool']['must'][0]['multi_match']['operator'] = 'AND';
-				// Erase the old should query.
-				unset( $formatted_args['query']['function_score']['query']['bool']['should'] );
-				// Erase the phrase matching (to make sure we get results that include both 'courageous' AND 'act' instead of only those with 'courageous act'.
-				unset( $formatted_args['query']['function_score']['query']['bool']['must'][0]['multi_match']['type'] );
-			}
-			return $formatted_args;
+	/**
+	 * Apply full-text search.
+	 *
+	 * @param mixed $formatted_args Assoc array with the args that ES expects.
+	 *
+	 * @return mixed
+	 */
+	public function set_full_text_search( $formatted_args ) {
+		if ( isset( $formatted_args['query']['function_score']['query']['bool'] ) ) {
+			// Create/change the bool query from should to must.
+			$formatted_args['query']['function_score']['query']['bool']['must'] = $formatted_args['query']['function_score']['query']['bool']['should'];
+			// Add the operator AND to the new bool query.
+			$formatted_args['query']['function_score']['query']['bool']['must'][0]['multi_match']['operator'] = 'AND';
+			// Erase the old should query.
+			unset( $formatted_args['query']['function_score']['query']['bool']['should'] );
+			// Erase the phrase matching (to make sure we get results that include both 'courageous' AND 'act' instead of only those with 'courageous act'.
+			unset( $formatted_args['query']['function_score']['query']['bool']['must'][0]['multi_match']['type'] );
 		}
+		return $formatted_args;
+	}
+
+	/**
+	 * Apply custom weight to search results.
+	 *
+	 * @param mixed $formatted_args Assoc array with the args that ES expects.
+	 *
+	 * @return mixed
+	 */
+	public function set_results_weight( $formatted_args ) {
+
+		// Move the existing query.
+		$existing_query = $formatted_args['query'];
+		unset( $formatted_args['query'] );
+		$formatted_args['query']['function_score']['query'] = $existing_query;
+
+		$options = get_option( 'planet4_options' );
 
 		/**
-		 * Apply custom weight to search results.
-		 *
-		 * @param mixed $formatted_args Assoc array with the args that ES expects.
-		 *
-		 * @return mixed
+		 * Use any combination of filters here, any matched filter will adjust
+		 * the weighted results according to the scoring settings set below.
 		 */
-		public function set_results_weight( $formatted_args ) {
-
-			// Move the existing query.
-			$existing_query = $formatted_args['query'];
-			unset( $formatted_args['query'] );
-			$formatted_args['query']['function_score']['query'] = $existing_query;
-
-			$options = get_option( 'planet4_options' );
-
-			/**
-			 * Use any combination of filters here, any matched filter will adjust
-			 * the weighted results according to the scoring settings set below.
-			 */
-			$formatted_args['query']['function_score']['functions'] = ( $existing_query['function_score']['functions'] ?? [] ) + [
-				[
-					'filter' => [
-						'match' => [
-							'post_type' => 'page',
-						],
-					],
-					'weight' => self::DEFAULT_PAGE_WEIGHT,
-				],
-				[
-					'filter' => [
-						'term' => [
-							'post_parent' => esc_sql( $options['act_page'] ),
-						],
-					],
-					'weight' => self::DEFAULT_ACTION_WEIGHT,
-				],
-			];
-
-			// Specify how the computed scores are combined.
-			$formatted_args['query']['function_score']['score_mode'] = 'sum';
-
-			return $formatted_args;
-		}
-
-		/**
-		 * Add some ES aggregations so we can get terms numbers for the complete result set.
-		 *
-		 * We need to add the `with_post_filter` to this otherwise it will show numbers for the result set without that
-		 * filter. Actually we should not be using `with_post_filter` in the first place, as the only point of that is
-		 * that it allows you to perform aggregations on the unfiltered set, which we don't want.
-		 * However due to the complexity of the current setup (we use ElasticPress which creates the ES query based on
-		 * the WP query, and we apply modifications to both queries) this is not easy to change.
-		 *
-		 * @param  array $formatted_args The query that is going to ES.
-		 * @return array The same query, but with added aggregations.
-		 */
-		public function add_aggregations( $formatted_args ) {
-			$formatted_args['aggs'] = [
-				'with_post_filter' => [
-					'filter' => $formatted_args['post_filter'],
-					'aggs'   => [
-						'post_type'    => [
-							'terms' => [
-								'field' => 'post_type.raw',
-							],
-						],
-						'post_parent'  => [
-							'terms' => [
-								'field' => 'post_parent',
-							],
-						],
-						'categories'   => [
-							'terms' => [
-								'field' => 'terms.category.term_id',
-							],
-						],
-						'tags'         => [
-							'terms' => [
-								'field' => 'terms.post_tag.term_id',
-							],
-						],
-						'p4-page-type' => [
-							'terms' => [
-								'field' => 'terms.p4-page-type.term_id',
-							],
-						],
+		$formatted_args['query']['function_score']['functions'] = ( $existing_query['function_score']['functions'] ?? [] ) + [
+			[
+				'filter' => [
+					'match' => [
+						'post_type' => 'page',
 					],
 				],
-			];
+				'weight' => self::DEFAULT_PAGE_WEIGHT,
+			],
+			[
+				'filter' => [
+					'term' => [
+						'post_parent' => esc_sql( $options['act_page'] ),
+					],
+				],
+				'weight' => self::DEFAULT_ACTION_WEIGHT,
+			],
+		];
 
-			return $formatted_args;
-		}
+		// Specify how the computed scores are combined.
+		$formatted_args['query']['function_score']['score_mode'] = 'sum';
 
-		/**
-		 * Remove items that are an attachment and have a different mime type.
-		 *
-		 * @param array $formatted_args The args that are going to ES.
-		 * @return array Same args with added filter.
-		 */
-		public function add_mime_type_filter( $formatted_args ) {
+		return $formatted_args;
+	}
 
-			$formatted_args['post_filter']['bool']['must'][] = [
-				'bool' => [
-					'should' => [
-						[
-							'bool' => [
-								'must_not' => [
-									'terms' => [
-										'post_type.raw' => [ 'attachment' ],
-									],
+	/**
+	 * Add some ES aggregations so we can get terms numbers for the complete result set.
+	 *
+	 * We need to add the `with_post_filter` to this otherwise it will show numbers for the result set without that
+	 * filter. Actually we should not be using `with_post_filter` in the first place, as the only point of that is
+	 * that it allows you to perform aggregations on the unfiltered set, which we don't want.
+	 * However due to the complexity of the current setup (we use ElasticPress which creates the ES query based on
+	 * the WP query, and we apply modifications to both queries) this is not easy to change.
+	 *
+	 * @param  array $formatted_args The query that is going to ES.
+	 * @return array The same query, but with added aggregations.
+	 */
+	public function add_aggregations( $formatted_args ) {
+		$formatted_args['aggs'] = [
+			'with_post_filter' => [
+				'filter' => $formatted_args['post_filter'],
+				'aggs'   => [
+					'post_type'    => [
+						'terms' => [
+							'field' => 'post_type.raw',
+						],
+					],
+					'post_parent'  => [
+						'terms' => [
+							'field' => 'post_parent',
+						],
+					],
+					'categories'   => [
+						'terms' => [
+							'field' => 'terms.category.term_id',
+						],
+					],
+					'tags'         => [
+						'terms' => [
+							'field' => 'terms.post_tag.term_id',
+						],
+					],
+					'p4-page-type' => [
+						'terms' => [
+							'field' => 'terms.p4-page-type.term_id',
+						],
+					],
+				],
+			],
+		];
+
+		return $formatted_args;
+	}
+
+	/**
+	 * Remove items that are an attachment and have a different mime type.
+	 *
+	 * @param array $formatted_args The args that are going to ES.
+	 * @return array Same args with added filter.
+	 */
+	public function add_mime_type_filter( $formatted_args ) {
+
+		$formatted_args['post_filter']['bool']['must'][] = [
+			'bool' => [
+				'should' => [
+					[
+						'bool' => [
+							'must_not' => [
+								'terms' => [
+									'post_type.raw' => [ 'attachment' ],
 								],
 							],
 						],
-						[
-							'terms' => [
-								'post_mime_type' => self::DOCUMENT_TYPES,
-							],
+					],
+					[
+						'terms' => [
+							'post_mime_type' => self::DOCUMENT_TYPES,
 						],
 					],
 				],
-			];
+			],
+		];
 
-			return $formatted_args;
-		}
+		return $formatted_args;
 	}
 }

--- a/classes/class-p4-image-compression.php
+++ b/classes/class-p4-image-compression.php
@@ -5,57 +5,54 @@
  * @package P4MT
  */
 
-if ( ! class_exists( 'P4_Image_Compression' ) ) {
+/**
+ * Class P4_Image_Compression
+ */
+class P4_Image_Compression extends WP_Image_Editor_Imagick {
 
 	/**
-	 * Class P4_Image_Compression
+	 * Image compression filter.
+	 *
+	 * @var string $filter
 	 */
-	class P4_Image_Compression extends WP_Image_Editor_Imagick {
+	protected $filter = 'FILTER_LANCZOS';
 
-		/**
-		 * Image compression filter.
-		 *
-		 * @var string $filter
-		 */
-		protected $filter = 'FILTER_LANCZOS';
+	/**
+	 * Override default imagick compression and use progressive compression instead.
+	 *
+	 * @since 1.9
+	 *
+	 * @param int    $dst_w       The destination width.
+	 * @param int    $dst_h       The destination height.
+	 * @param string $filter_name Optional. The Imagick filter to use when resizing. Default 'FILTER_TRIANGLE'.
+	 * @param bool   $strip_meta  Optional. Strip all profiles, excluding color profiles, from the image. Default true.
+	 * @return bool|WP_Error
+	 */
+	protected function thumbnail_image( $dst_w, $dst_h, $filter_name = 'FILTER_TRIANGLE', $strip_meta = true ) {
+		if ( $this->filter ) {
+			$filter_name = $this->filter;
+		}
+		parent::thumbnail_image( $dst_w, $dst_h, $filter_name, $strip_meta );
 
-		/**
-		 * Override default imagick compression and use progressive compression instead.
-		 *
-		 * @since 1.9
-		 *
-		 * @param int    $dst_w       The destination width.
-		 * @param int    $dst_h       The destination height.
-		 * @param string $filter_name Optional. The Imagick filter to use when resizing. Default 'FILTER_TRIANGLE'.
-		 * @param bool   $strip_meta  Optional. Strip all profiles, excluding color profiles, from the image. Default true.
-		 * @return bool|WP_Error
-		 */
-		protected function thumbnail_image( $dst_w, $dst_h, $filter_name = 'FILTER_TRIANGLE', $strip_meta = true ) {
-			if ( $this->filter ) {
-				$filter_name = $this->filter;
-			}
-			parent::thumbnail_image( $dst_w, $dst_h, $filter_name, $strip_meta );
-
-			// The order of methods applied is: Resize -> Sharpen -> Compress.
-			try {
-				// Sharpen image after it has been resized.
-				if ( 'image/jpeg' === $this->mime_type ) {
-					if ( is_callable( [ $this->image, 'unsharpMaskImage' ] ) ) {
-						$this->image->unsharpMaskImage( 1, 0.45, 3, 0 );
-					}
+		// The order of methods applied is: Resize -> Sharpen -> Compress.
+		try {
+			// Sharpen image after it has been resized.
+			if ( 'image/jpeg' === $this->mime_type ) {
+				if ( is_callable( [ $this->image, 'unsharpMaskImage' ] ) ) {
+					$this->image->unsharpMaskImage( 1, 0.45, 3, 0 );
 				}
-			} catch ( Exception $e ) {
-				return new WP_Error( 'image_sharpening_error', $e->getMessage() );
 			}
+		} catch ( Exception $e ) {
+			return new WP_Error( 'image_sharpening_error', $e->getMessage() );
+		}
 
-			try {
-				// Compress image after it has been sharpened.
-				if ( is_callable( [ $this->image, 'setInterlaceScheme' ] ) && defined( 'Imagick::INTERLACE_PLANE' ) ) {
-					$this->image->setInterlaceScheme( Imagick::INTERLACE_PLANE );
-				}
-			} catch ( Exception $e ) {
-				return new WP_Error( 'image_resize_error', $e->getMessage() );
+		try {
+			// Compress image after it has been sharpened.
+			if ( is_callable( [ $this->image, 'setInterlaceScheme' ] ) && defined( 'Imagick::INTERLACE_PLANE' ) ) {
+				$this->image->setInterlaceScheme( Imagick::INTERLACE_PLANE );
 			}
+		} catch ( Exception $e ) {
+			return new WP_Error( 'image_resize_error', $e->getMessage() );
 		}
 	}
 }

--- a/classes/class-p4-post-campaign.php
+++ b/classes/class-p4-post-campaign.php
@@ -5,569 +5,567 @@
  * @package P4MT
  */
 
-if ( ! class_exists( 'P4_Post_Campaign' ) ) {
+/**
+ * Class P4_Post_Campaign
+ */
+class P4_Post_Campaign {
+
 	/**
-	 * Class P4_Post_Campaign
+	 * Post Type
 	 */
-	class P4_Post_Campaign {
+	const POST_TYPE = 'campaign';
 
-		/**
-		 * Post Type
-		 */
-		const POST_TYPE = 'campaign';
+	const DEFAULT_NAVBAR_THEME = 'planet4';
 
-		const DEFAULT_NAVBAR_THEME = 'planet4';
+	public const META_FIELDS = [
+		'theme',
+		'campaign_logo',
+		'campaign_logo_color',
+		'campaign_nav_type',
+		'campaign_nav_color',
+		'campaign_nav_border',
+		'campaign_header_color',
+		'campaign_primary_color',
+		'campaign_secondary_color',
+		'campaign_header_primary',
+		'campaign_body_font',
+		'campaign_footer_theme',
+		'footer_links_color',
+	];
 
-		public const META_FIELDS = [
-			'theme',
-			'campaign_logo',
-			'campaign_logo_color',
-			'campaign_nav_type',
-			'campaign_nav_color',
-			'campaign_nav_border',
-			'campaign_header_color',
-			'campaign_primary_color',
-			'campaign_secondary_color',
-			'campaign_header_primary',
-			'campaign_body_font',
-			'campaign_footer_theme',
-			'footer_links_color',
+	/**
+	 * Taxonomy_Image constructor.
+	 */
+	public function __construct() {
+		$this->hooks();
+	}
+
+	/**
+	 * Class hooks.
+	 */
+	private function hooks() {
+		add_action( 'init', [ $this, 'register_campaigns_cpt' ] );
+		add_action( 'cmb2_admin_init', [ $this, 'register_campaigns_metaboxes' ] );
+		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_admin_assets' ] );
+		add_action( 'cmb2_render_sidebar_link', [ $this, 'cmb2_render_sidebar_link_field_callback' ], 10, 5 );
+		add_action( 'cmb2_render_footer_icon_link', [ $this, 'cmb2_render_footer_icon_link_field_callback' ], 10, 5 );
+
+		add_filter( 'get_user_option_edit_campaign_per_page', [ $this, 'set_default_items_per_page' ], 10, 3 );
+
+	}
+
+	/**
+	 * Increase the maximum number of items displayed so that there are enough items to collapse any child pages.
+	 *
+	 * @param int|null $result Possibly value chosen by the current user.
+	 * @param string   $option The name of the option.
+	 * @param object   $user The current user.
+	 * @return int The amount of pages that will be used.
+	 */
+	public function set_default_items_per_page( $result, $option, $user ) {
+		if ( (int) $result < 1 ) {
+			return 200;
+		}
+		return $result;
+	}
+
+	/**
+	 * Register campaigns cpt
+	 */
+	public function register_campaigns_cpt() {
+
+		$labels = [
+			'name'               => _x( 'Campaigns', 'post type general name', 'planet4-master-theme-backend' ),
+			'singular_name'      => _x( 'Campaign', 'post type singular name', 'planet4-master-theme-backend' ),
+			'menu_name'          => _x( 'Campaigns', 'admin menu', 'planet4-master-theme-backend' ),
+			'name_admin_bar'     => _x( 'Campaign', 'add new on admin bar', 'planet4-master-theme-backend' ),
+			'add_new'            => _x( 'Add New', 'campaign', 'planet4-master-theme-backend' ),
+			'add_new_item'       => __( 'Add New Campaign', 'planet4-master-theme-backend' ),
+			'new_item'           => __( 'New Campaign', 'planet4-master-theme-backend' ),
+			'edit_item'          => __( 'Edit Campaign', 'planet4-master-theme-backend' ),
+			'view_item'          => __( 'View Campaign', 'planet4-master-theme-backend' ),
+			'all_items'          => __( 'All Campaigns', 'planet4-master-theme-backend' ),
+			'search_items'       => __( 'Search Campaigns', 'planet4-master-theme-backend' ),
+			'parent_item_colon'  => __( 'Parent Campaign:', 'planet4-master-theme-backend' ),
+			'not_found'          => __( 'No campaigns found.', 'planet4-master-theme-backend' ),
+			'not_found_in_trash' => __( 'No campaigns found in Trash.', 'planet4-master-theme-backend' ),
 		];
 
-		/**
-		 * Taxonomy_Image constructor.
-		 */
-		public function __construct() {
-			$this->hooks();
+		$args = [
+			'labels'             => $labels,
+			'description'        => __( 'Campaigns', 'planet4-master-theme-backend' ),
+			'public'             => true,
+			'publicly_queryable' => true,
+			'show_ui'            => true,
+			'show_in_menu'       => true,
+			'query_var'          => true,
+			'rewrite'            => [
+				'slug'       => 'campaign',
+				'with_front' => false,
+			],
+			'capability_type'    => [ 'campaign', 'campaigns' ],
+			'map_meta_cap'       => true,
+			'has_archive'        => true,
+			'hierarchical'       => true,
+			'show_in_nav_menus'  => true,
+			'menu_position'      => null,
+			'menu_icon'          => 'dashicons-megaphone',
+			'show_in_rest'       => true,
+			'supports'           => [
+				'page-attributes',
+				'title',
+				'editor',
+				'author',
+				'thumbnail',
+				'excerpt',
+				'revisions',
+				// Required to expose meta fields in the REST API.
+				'custom-fields',
+			],
+		];
+
+		register_post_type( self::POST_TYPE, $args );
+
+		foreach ( self::META_FIELDS as $field ) {
+			self::campaign_field( $field );
 		}
+	}
 
-		/**
-		 * Class hooks.
-		 */
-		private function hooks() {
-			add_action( 'init', [ $this, 'register_campaigns_cpt' ] );
-			add_action( 'cmb2_admin_init', [ $this, 'register_campaigns_metaboxes' ] );
-			add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_admin_assets' ] );
-			add_action( 'cmb2_render_sidebar_link', [ $this, 'cmb2_render_sidebar_link_field_callback' ], 10, 5 );
-			add_action( 'cmb2_render_footer_icon_link', [ $this, 'cmb2_render_footer_icon_link_field_callback' ], 10, 5 );
-
-			add_filter( 'get_user_option_edit_campaign_per_page', [ $this, 'set_default_items_per_page' ], 10, 3 );
-
-		}
-
-		/**
-		 * Increase the maximum number of items displayed so that there are enough items to collapse any child pages.
-		 *
-		 * @param int|null $result Possibly value chosen by the current user.
-		 * @param string   $option The name of the option.
-		 * @param object   $user The current user.
-		 * @return int The amount of pages that will be used.
-		 */
-		public function set_default_items_per_page( $result, $option, $user ) {
-			if ( (int) $result < 1 ) {
-				return 200;
-			}
-			return $result;
-		}
-
-		/**
-		 * Register campaigns cpt
-		 */
-		public function register_campaigns_cpt() {
-
-			$labels = [
-				'name'               => _x( 'Campaigns', 'post type general name', 'planet4-master-theme-backend' ),
-				'singular_name'      => _x( 'Campaign', 'post type singular name', 'planet4-master-theme-backend' ),
-				'menu_name'          => _x( 'Campaigns', 'admin menu', 'planet4-master-theme-backend' ),
-				'name_admin_bar'     => _x( 'Campaign', 'add new on admin bar', 'planet4-master-theme-backend' ),
-				'add_new'            => _x( 'Add New', 'campaign', 'planet4-master-theme-backend' ),
-				'add_new_item'       => __( 'Add New Campaign', 'planet4-master-theme-backend' ),
-				'new_item'           => __( 'New Campaign', 'planet4-master-theme-backend' ),
-				'edit_item'          => __( 'Edit Campaign', 'planet4-master-theme-backend' ),
-				'view_item'          => __( 'View Campaign', 'planet4-master-theme-backend' ),
-				'all_items'          => __( 'All Campaigns', 'planet4-master-theme-backend' ),
-				'search_items'       => __( 'Search Campaigns', 'planet4-master-theme-backend' ),
-				'parent_item_colon'  => __( 'Parent Campaign:', 'planet4-master-theme-backend' ),
-				'not_found'          => __( 'No campaigns found.', 'planet4-master-theme-backend' ),
-				'not_found_in_trash' => __( 'No campaigns found in Trash.', 'planet4-master-theme-backend' ),
-			];
-
-			$args = [
-				'labels'             => $labels,
-				'description'        => __( 'Campaigns', 'planet4-master-theme-backend' ),
-				'public'             => true,
-				'publicly_queryable' => true,
-				'show_ui'            => true,
-				'show_in_menu'       => true,
-				'query_var'          => true,
-				'rewrite'            => [
-					'slug'       => 'campaign',
-					'with_front' => false,
+	/**
+	 * Register Color Picker Metabox for navigation
+	 */
+	public function register_campaigns_metaboxes() {
+		$cmb = new_cmb2_box(
+			[
+				'id'           => 'campaign_nav_settings_mb',
+				'title'        => __( 'Page Design', 'planet4-master-theme-backend' ),
+				'object_types' => [
+					'campaign',
 				],
-				'capability_type'    => [ 'campaign', 'campaigns' ],
-				'map_meta_cap'       => true,
-				'has_archive'        => true,
-				'hierarchical'       => true,
-				'show_in_nav_menus'  => true,
-				'menu_position'      => null,
-				'menu_icon'          => 'dashicons-megaphone',
-				'show_in_rest'       => true,
-				'supports'           => [
-					'page-attributes',
-					'title',
-					'editor',
-					'author',
-					'thumbnail',
-					'excerpt',
-					'revisions',
-					// Required to expose meta fields in the REST API.
-					'custom-fields',
-				],
-			];
+				'context'      => 'normal',
+				'priority'     => 'high',
+				'show_names'   => true, // Show field names on the left.
+			]
+		);
 
-			register_post_type( self::POST_TYPE, $args );
+		$cmb->add_field(
+			[
+				'id'   => 'new_sidebar_link',
+				'type' => 'sidebar_link',
+			]
+		);
 
-			foreach ( self::META_FIELDS as $field ) {
-				self::campaign_field( $field );
+		$cmb->add_field(
+			[
+				'name' => __( 'Footer item 1', 'planet4-master-theme-backend' ),
+				'id'   => 'campaign_footer_item1',
+				'type' => 'footer_icon_link',
+			]
+		);
+
+		$cmb->add_field(
+			[
+				'name' => __( 'Footer item 2', 'planet4-master-theme-backend' ),
+				'id'   => 'campaign_footer_item2',
+				'type' => 'footer_icon_link',
+			]
+		);
+
+		$cmb->add_field(
+			[
+				'name' => __( 'Footer item 3', 'planet4-master-theme-backend' ),
+				'id'   => 'campaign_footer_item3',
+				'type' => 'footer_icon_link',
+			]
+		);
+
+		$cmb->add_field(
+			[
+				'name' => __( 'Footer item 4', 'planet4-master-theme-backend' ),
+				'id'   => 'campaign_footer_item4',
+				'type' => 'footer_icon_link',
+			]
+		);
+
+		$cmb->add_field(
+			[
+				'name' => __( 'Footer item 5', 'planet4-master-theme-backend' ),
+				'id'   => 'campaign_footer_item5',
+				'type' => 'footer_icon_link',
+			]
+		);
+	}
+
+	/**
+	 * Load assets.
+	 */
+	public function enqueue_admin_assets() {
+		wp_register_style( 'cmb-style', get_template_directory_uri() . '/admin/css/campaign.css', [], '0.1' );
+		wp_enqueue_style( 'cmb-style' );
+	}
+
+	/**
+	 * CMB2 custom field(sidebar_link) callback function.
+	 *
+	 * @param array $field The CMB2 field array.
+	 * @param array $value The CMB2 field Value.
+	 * @param array $object_id The id of the object.
+	 * @param array $object_type The type of object.
+	 * @param array $field_type Instance of the `cmb2_Meta_Box_types` object.
+	 */
+	public function cmb2_render_sidebar_link_field_callback(
+		$field,
+		$value,
+		$object_id,
+		$object_type,
+		$field_type
+	) {
+		?>
+		<a
+			href="#" onclick="openSidebar()"
+			id="new_sidebar_link">
+			<?php
+				esc_html_e( 'Design settings moved to a new sidebar.', 'planet4-master-theme-backend' )
+			?>
+		</a>
+		<script>
+			function openSidebar() {
+				let sidebarButton = document.querySelector( '.edit-post-pinned-plugins button[aria-expanded=false]' );
+				if ( sidebarButton ) {
+					sidebarButton.click();
+				}
 			}
-		}
+		</script>
+		<?php
+	}
 
-		/**
-		 * Register Color Picker Metabox for navigation
-		 */
-		public function register_campaigns_metaboxes() {
-			$cmb = new_cmb2_box(
-				[
-					'id'           => 'campaign_nav_settings_mb',
-					'title'        => __( 'Page Design', 'planet4-master-theme-backend' ),
-					'object_types' => [
-						'campaign',
-					],
-					'context'      => 'normal',
-					'priority'     => 'high',
-					'show_names'   => true, // Show field names on the left.
-				]
-			);
-
-			$cmb->add_field(
-				[
-					'id'   => 'new_sidebar_link',
-					'type' => 'sidebar_link',
-				]
-			);
-
-			$cmb->add_field(
-				[
-					'name' => __( 'Footer item 1', 'planet4-master-theme-backend' ),
-					'id'   => 'campaign_footer_item1',
-					'type' => 'footer_icon_link',
-				]
-			);
-
-			$cmb->add_field(
-				[
-					'name' => __( 'Footer item 2', 'planet4-master-theme-backend' ),
-					'id'   => 'campaign_footer_item2',
-					'type' => 'footer_icon_link',
-				]
-			);
-
-			$cmb->add_field(
-				[
-					'name' => __( 'Footer item 3', 'planet4-master-theme-backend' ),
-					'id'   => 'campaign_footer_item3',
-					'type' => 'footer_icon_link',
-				]
-			);
-
-			$cmb->add_field(
-				[
-					'name' => __( 'Footer item 4', 'planet4-master-theme-backend' ),
-					'id'   => 'campaign_footer_item4',
-					'type' => 'footer_icon_link',
-				]
-			);
-
-			$cmb->add_field(
-				[
-					'name' => __( 'Footer item 5', 'planet4-master-theme-backend' ),
-					'id'   => 'campaign_footer_item5',
-					'type' => 'footer_icon_link',
-				]
-			);
-		}
-
-		/**
-		 * Load assets.
-		 */
-		public function enqueue_admin_assets() {
-			wp_register_style( 'cmb-style', get_template_directory_uri() . '/admin/css/campaign.css', [], '0.1' );
-			wp_enqueue_style( 'cmb-style' );
-		}
-
-		/**
-		 * CMB2 custom field(sidebar_link) callback function.
-		 *
-		 * @param array $field The CMB2 field array.
-		 * @param array $value The CMB2 field Value.
-		 * @param array $object_id The id of the object.
-		 * @param array $object_type The type of object.
-		 * @param array $field_type Instance of the `cmb2_Meta_Box_types` object.
-		 */
-		public function cmb2_render_sidebar_link_field_callback(
-			$field,
+	/**
+	 * CMB2 custom field(footer_icon_link) callback function.
+	 *
+	 * @param array $field The CMB2 field array.
+	 * @param array $value The CMB2 field Value.
+	 * @param array $object_id The id of the object.
+	 * @param array $object_type The type of object.
+	 * @param array $field_type Instance of the `cmb2_Meta_Box_types` object.
+	 */
+	public function cmb2_render_footer_icon_link_field_callback( $field, $value, $object_id, $object_type, $field_type ) {
+		$value = wp_parse_args(
 			$value,
-			$object_id,
-			$object_type,
-			$field_type
-		) {
-			?>
-			<a
-				href="#" onclick="openSidebar()"
-				id="new_sidebar_link">
-				<?php
-					esc_html_e( 'Design settings moved to a new sidebar.', 'planet4-master-theme-backend' )
-				?>
-			</a>
-			<script>
-				function openSidebar() {
-					let sidebarButton = document.querySelector( '.edit-post-pinned-plugins button[aria-expanded=false]' );
-					if ( sidebarButton ) {
-						sidebarButton.click();
-					}
-				}
-			</script>
-			<?php
-		}
-
-		/**
-		 * CMB2 custom field(footer_icon_link) callback function.
-		 *
-		 * @param array $field The CMB2 field array.
-		 * @param array $value The CMB2 field Value.
-		 * @param array $object_id The id of the object.
-		 * @param array $object_type The type of object.
-		 * @param array $field_type Instance of the `cmb2_Meta_Box_types` object.
-		 */
-		public function cmb2_render_footer_icon_link_field_callback( $field, $value, $object_id, $object_type, $field_type ) {
-			$value = wp_parse_args(
-				$value,
+			[
+				'url'  => '',
+				'icon' => '',
+			]
+		);
+		?>
+		<div class="alignleft">
+		<?php
+			echo wp_kses(
+				$field_type->input(
+					[
+						'class'       => 'cmb-type-text-medium',
+						'name'        => esc_attr( $field_type->_name( '[url]' ) ),
+						'id'          => esc_attr( $field_type->_id( '_url' ) ),
+						'type'        => 'text',
+						'value'       => esc_url( $value['url'] ),
+						'placeholder' => __( 'Footer item link', 'planet4-master-theme-backend' ),
+					]
+				),
 				[
-					'url'  => '',
-					'icon' => '',
+					'input' => [
+						'class'       => [],
+						'placeholder' => [],
+						'name'        => [],
+						'id'          => [],
+						'type'        => [],
+						'value'       => [],
+						'data-hash'   => [],
+					],
 				]
 			);
-			?>
-			<div class="alignleft">
-			<?php
-				echo wp_kses(
-					$field_type->input(
-						[
-							'class'       => 'cmb-type-text-medium',
-							'name'        => esc_attr( $field_type->_name( '[url]' ) ),
-							'id'          => esc_attr( $field_type->_id( '_url' ) ),
-							'type'        => 'text',
-							'value'       => esc_url( $value['url'] ),
-							'placeholder' => __( 'Footer item link', 'planet4-master-theme-backend' ),
-						]
-					),
+		?>
+		</div>
+		<div class="alignleft">
+		<?php
+			echo wp_kses(
+				$field_type->input(
 					[
-						'input' => [
-							'class'       => [],
-							'placeholder' => [],
-							'name'        => [],
-							'id'          => [],
-							'type'        => [],
-							'value'       => [],
-							'data-hash'   => [],
-						],
+						'class'       => 'cmb-type-text-medium',
+						'name'        => esc_attr( $field_type->_name( '[icon]' ) ),
+						'id'          => esc_attr( $field_type->_id( '_icon' ) ),
+						'type'        => 'text',
+						'value'       => $value['icon'],
+						'placeholder' => __( 'Footer icon name', 'planet4-master-theme-backend' ),
 					]
-				);
-			?>
-			</div>
-			<div class="alignleft">
-			<?php
-				echo wp_kses(
-					$field_type->input(
-						[
-							'class'       => 'cmb-type-text-medium',
-							'name'        => esc_attr( $field_type->_name( '[icon]' ) ),
-							'id'          => esc_attr( $field_type->_id( '_icon' ) ),
-							'type'        => 'text',
-							'value'       => $value['icon'],
-							'placeholder' => __( 'Footer icon name', 'planet4-master-theme-backend' ),
-						]
-					),
-					[
-						'input' => [
-							'class'       => [],
-							'placeholder' => [],
-							'name'        => [],
-							'id'          => [],
-							'type'        => [],
-							'value'       => [],
-							'data-hash'   => [],
-						],
-					]
-				);
-			?>
-			</div>
-			<div class="alignleft"> <?php esc_html_e( 'In the “Footer icon name” field add the name of the icon you want from the', 'planet4-master-theme-backend' ); ?> <a target="_blank" href="https://github.com/greenpeace/planet4-styleguide/tree/master/src/icons"><?php esc_html_e( 'list of icons in the CSS styleguide', 'planet4-master-theme-backend' ); ?></a>. e.g. twitter-square</div>
-			<?php
-		}
-
-		/**
-		 * Register a key as a post_meta with the argument `show_in_rest` that is needed on all fields so they can be
-		 * used through the REST api. Also set `type` and `single` as both are the same for all attributes.
-		 *
-		 * @param string $meta_key Identifier the post_meta field will be registered with.
-		 * @param array  $args Arguments which are passed on to register_post_meta.
-		 *
-		 * @return void A description of the field.
-		 */
-		private static function campaign_field(
-			string $meta_key,
-			array $args = []
-		): void {
-			$args = array_merge(
+				),
 				[
-					'show_in_rest' => true,
-					'type'         => 'string',
-					'single'       => true,
-				],
-				$args
+					'input' => [
+						'class'       => [],
+						'placeholder' => [],
+						'name'        => [],
+						'id'          => [],
+						'type'        => [],
+						'value'       => [],
+						'data-hash'   => [],
+					],
+				]
 			);
-			register_post_meta( self::POST_TYPE, $meta_key, $args );
-		}
+		?>
+		</div>
+		<div class="alignleft"> <?php esc_html_e( 'In the “Footer icon name” field add the name of the icon you want from the', 'planet4-master-theme-backend' ); ?> <a target="_blank" href="https://github.com/greenpeace/planet4-styleguide/tree/master/src/icons"><?php esc_html_e( 'list of icons in the CSS styleguide', 'planet4-master-theme-backend' ); ?></a>. e.g. twitter-square</div>
+		<?php
+	}
 
-		/**
-		 * Gets the default for a field.
-		 *
-		 * @param array $field A field from the JSON theme file.
-		 * @return string Default value
-		 */
-		private static function get_field_default( $field ) {
-			$default = null;
-			if ( isset( $field['configurations'] ) && isset( $field['configurations']['default'] ) ) {
-				$default_configuration = $field['configurations']['default'];
-				if ( isset( $field['configurations'][ $default_configuration ]['default'] ) ) {
-					$default = $field['configurations'][ $default_configuration ]['default'];
-				}
-			} elseif ( isset( $field['default'] ) ) {
-				$default = $field['default'];
+	/**
+	 * Register a key as a post_meta with the argument `show_in_rest` that is needed on all fields so they can be
+	 * used through the REST api. Also set `type` and `single` as both are the same for all attributes.
+	 *
+	 * @param string $meta_key Identifier the post_meta field will be registered with.
+	 * @param array  $args Arguments which are passed on to register_post_meta.
+	 *
+	 * @return void A description of the field.
+	 */
+	private static function campaign_field(
+		string $meta_key,
+		array $args = []
+	): void {
+		$args = array_merge(
+			[
+				'show_in_rest' => true,
+				'type'         => 'string',
+				'single'       => true,
+			],
+			$args
+		);
+		register_post_meta( self::POST_TYPE, $meta_key, $args );
+	}
+
+	/**
+	 * Gets the default for a field.
+	 *
+	 * @param array $field A field from the JSON theme file.
+	 * @return string Default value
+	 */
+	private static function get_field_default( $field ) {
+		$default = null;
+		if ( isset( $field['configurations'] ) && isset( $field['configurations']['default'] ) ) {
+			$default_configuration = $field['configurations']['default'];
+			if ( isset( $field['configurations'][ $default_configuration ]['default'] ) ) {
+				$default = $field['configurations'][ $default_configuration ]['default'];
 			}
-
-			return $default;
+		} elseif ( isset( $field['default'] ) ) {
+			$default = $field['default'];
 		}
 
-		/**
-		 * Get the theme defaults
-		 *
-		 * @param mixed $theme_json The JSON theme file.
-		 */
-		private static function get_theme_defaults( $theme_json ) {
-			$defaults = [];
-			foreach ( $theme_json['fields'] as $field ) {
-				$defaults[ $field['id'] ] = self::get_field_default( $field );
-			}
+		return $default;
+	}
 
-			return $defaults;
+	/**
+	 * Get the theme defaults
+	 *
+	 * @param mixed $theme_json The JSON theme file.
+	 */
+	private static function get_theme_defaults( $theme_json ) {
+		$defaults = [];
+		foreach ( $theme_json['fields'] as $field ) {
+			$defaults[ $field['id'] ] = self::get_field_default( $field );
 		}
 
-		/**
-		 * Determine the css variables for a certain post.
-		 *
-		 * @param array $meta The meta containing the variable values.
-		 * @return array The values that will be used for the css variables.
-		 */
-		public static function css_vars( array $meta ): array {
-			$theme = self::get_theme( $meta );
+		return $defaults;
+	}
 
-			// TODO: Use wp_safe_remote_get?
-			// TODO: Handle errors.
-			$theme_json = json_decode(
-				// Ignoring the PHPCS error in the next line because it's a local file, not a remote request.
-				file_get_contents( __DIR__ . '/../campaign_themes/' . $theme . '.json' ), // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
-				true
-			);
+	/**
+	 * Determine the css variables for a certain post.
+	 *
+	 * @param array $meta The meta containing the variable values.
+	 * @return array The values that will be used for the css variables.
+	 */
+	public static function css_vars( array $meta ): array {
+		$theme = self::get_theme( $meta );
 
-			$defaults = self::get_theme_defaults( $theme_json );
+		// TODO: Use wp_safe_remote_get?
+		// TODO: Handle errors.
+		$theme_json = json_decode(
+			// Ignoring the PHPCS error in the next line because it's a local file, not a remote request.
+			file_get_contents( __DIR__ . '/../campaign_themes/' . $theme . '.json' ), // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+			true
+		);
 
-			// Use only meta keys that exist in the defaults.
-			$intersect = array_intersect_key( array_filter( $meta ), $defaults );
+		$defaults = self::get_theme_defaults( $theme_json );
 
-			// Replace the defaults with the campaign options where applicable.
-			$css_vars = array_merge( $defaults, $intersect );
+		// Use only meta keys that exist in the defaults.
+		$intersect = array_intersect_key( array_filter( $meta ), $defaults );
 
-			$css_vars = self::get_navbar_theme( $css_vars );
-			$css_vars = self::get_footer_theme( $css_vars );
-			$css_vars = self::get_passive_button_color( $css_vars, $meta );
-			$css_vars = self::replace_font_aliases( $css_vars );
-			$css_vars = self::get_body_font( $css_vars, $meta );
+		// Replace the defaults with the campaign options where applicable.
+		$css_vars = array_merge( $defaults, $intersect );
 
-			$css_vars = array_filter( $css_vars );
+		$css_vars = self::get_navbar_theme( $css_vars );
+		$css_vars = self::get_footer_theme( $css_vars );
+		$css_vars = self::get_passive_button_color( $css_vars, $meta );
+		$css_vars = self::replace_font_aliases( $css_vars );
+		$css_vars = self::get_body_font( $css_vars, $meta );
 
-			return $css_vars;
-		}
+		$css_vars = array_filter( $css_vars );
 
-		/**
-		 * @deprecated This can probably be removed along with the font map.
-		 *
-		 * @param array $css_vars The array containing the CSS variables.
-		 * @param array $meta The meta containing the style settings.
-		 * @return string The body font.
-		 */
-		public static function get_body_font( $css_vars, $meta ): array {
-			// Temporary fix for old campaigns having "campaign_body_font" as a "campaign".
-			if ( isset( $css_vars['campaign_body_font'] ) && 'campaign' === $css_vars['campaign_body_font'] ) {
-				$campaigns_font_map = [
-					'default'   => 'lora',
-					'antarctic' => 'sanctuary',
-					'arctic'    => 'Save the Arctic',
-					'climate'   => 'Jost',
-					'forest'    => 'Kanit',
-					'oceans'    => 'Montserrat',
-					'oil'       => 'Anton',
-					'plastic'   => 'Montserrat',
-				];
-				$theme              = self::get_theme( $meta );
+		return $css_vars;
+	}
 
-				$css_vars['campaign_body_font'] = $campaigns_font_map[ $theme ];
-			}
-
-			return $css_vars;
-		}
-
-		/**
-		 * @deprecated This function replaces some arbitrary font names in the CSS variables.
-		 *
-		 * @param array $css_vars The array containing the CSS variables.
-		 * @return array The variables for the footer theme.
-		 */
-		public static function replace_font_aliases( array $css_vars ): array {
-			// TODO: Remove these special cases.
-			if ( isset( $css_vars['campaign_header_primary'] ) ) {
-				$css_vars['campaign_header_primary'] = str_replace( 'Montserrat_Light', 'Montserrat', $css_vars['campaign_header_primary'] );
-			}
-
-			if ( isset( $css_vars['campaign_body_font'] ) ) {
-				$css_vars['campaign_body_font'] = str_replace( 'Montserrat_Light', 'Montserrat', $css_vars['campaign_body_font'] );
-			}
-
-			return $css_vars;
-		}
-
-		/**
-		 * DEPRECATE: Get the passive button color based on the meta settings.
-		 *
-		 * @param array $css_vars The array containing the CSS variables.
-		 * @param array $meta The meta containing the style settings.
-		 * @return array The variables for the passive button.
-		 */
-		public static function get_passive_button_color( array $css_vars, array $meta ): array {
-			// TODO: Remove this "Passive" color map based on hovers.
-			$passive_button_colors_map = [
-				'#ffd204' => '#f36d3a',
-				'#ffd204' => '#ffe467',
-				'#66cc00' => '#66cc00',
-				'#6ed961' => '#a7e021',
-				'#21cbca' => '#77ebe0',
-				'#7a1805' => '#a01604',
-				'#2077bf' => '#2077bf',
-				'#1b4a1b' => '#1b4a1b',
+	/**
+	 * @deprecated This can probably be removed along with the font map.
+	 *
+	 * @param array $css_vars The array containing the CSS variables.
+	 * @param array $meta The meta containing the style settings.
+	 * @return string The body font.
+	 */
+	public static function get_body_font( $css_vars, $meta ): array {
+		// Temporary fix for old campaigns having "campaign_body_font" as a "campaign".
+		if ( isset( $css_vars['campaign_body_font'] ) && 'campaign' === $css_vars['campaign_body_font'] ) {
+			$campaigns_font_map = [
+				'default'   => 'lora',
+				'antarctic' => 'sanctuary',
+				'arctic'    => 'Save the Arctic',
+				'climate'   => 'Jost',
+				'forest'    => 'Kanit',
+				'oceans'    => 'Montserrat',
+				'oil'       => 'Anton',
+				'plastic'   => 'Montserrat',
 			];
+			$theme              = self::get_theme( $meta );
 
-			$css_vars['passive_button_color'] = isset( $meta['campaign_primary_color'] ) && $meta['campaign_primary_color']
-			? $passive_button_colors_map[ strtolower( $meta['campaign_primary_color'] ) ]
-			: '#f36d3a';
-
-			return $css_vars;
+			$css_vars['campaign_body_font'] = $campaigns_font_map[ $theme ];
 		}
 
-		/**
-		 * Get the navigation bar variables based on the meta settings.
-		 *
-		 * @param array $css_vars The mix of meta fields and defaults.
-		 * @return array The variables for the navigation bar.
-		 */
-		public static function get_navbar_theme( array $css_vars ): array {
-			if ( self::DEFAULT_NAVBAR_THEME === $css_vars['campaign_nav_type'] ) {
-				$css_vars['campaign_logo_color'] = null;
-				$css_vars['campaign_nav_color']  = null;
-				$css_vars['campaign_logo']       = null;
+		return $css_vars;
+	}
+
+	/**
+	 * @deprecated This function replaces some arbitrary font names in the CSS variables.
+	 *
+	 * @param array $css_vars The array containing the CSS variables.
+	 * @return array The variables for the footer theme.
+	 */
+	public static function replace_font_aliases( array $css_vars ): array {
+		// TODO: Remove these special cases.
+		if ( isset( $css_vars['campaign_header_primary'] ) ) {
+			$css_vars['campaign_header_primary'] = str_replace( 'Montserrat_Light', 'Montserrat', $css_vars['campaign_header_primary'] );
+		}
+
+		if ( isset( $css_vars['campaign_body_font'] ) ) {
+			$css_vars['campaign_body_font'] = str_replace( 'Montserrat_Light', 'Montserrat', $css_vars['campaign_body_font'] );
+		}
+
+		return $css_vars;
+	}
+
+	/**
+	 * DEPRECATE: Get the passive button color based on the meta settings.
+	 *
+	 * @param array $css_vars The array containing the CSS variables.
+	 * @param array $meta The meta containing the style settings.
+	 * @return array The variables for the passive button.
+	 */
+	public static function get_passive_button_color( array $css_vars, array $meta ): array {
+		// TODO: Remove this "Passive" color map based on hovers.
+		$passive_button_colors_map = [
+			'#ffd204' => '#f36d3a',
+			'#ffd204' => '#ffe467',
+			'#66cc00' => '#66cc00',
+			'#6ed961' => '#a7e021',
+			'#21cbca' => '#77ebe0',
+			'#7a1805' => '#a01604',
+			'#2077bf' => '#2077bf',
+			'#1b4a1b' => '#1b4a1b',
+		];
+
+		$css_vars['passive_button_color'] = isset( $meta['campaign_primary_color'] ) && $meta['campaign_primary_color']
+		? $passive_button_colors_map[ strtolower( $meta['campaign_primary_color'] ) ]
+		: '#f36d3a';
+
+		return $css_vars;
+	}
+
+	/**
+	 * Get the navigation bar variables based on the meta settings.
+	 *
+	 * @param array $css_vars The mix of meta fields and defaults.
+	 * @return array The variables for the navigation bar.
+	 */
+	public static function get_navbar_theme( array $css_vars ): array {
+		if ( self::DEFAULT_NAVBAR_THEME === $css_vars['campaign_nav_type'] ) {
+			$css_vars['campaign_logo_color'] = null;
+			$css_vars['campaign_nav_color']  = null;
+			$css_vars['campaign_logo']       = null;
+		}
+
+		return $css_vars;
+	}
+
+	/**
+	 * Get the footer variables based on the meta settings.
+	 *
+	 * @param array $css_vars The array containing the CSS variables.
+	 * @return array The variables for the footer theme.
+	 */
+	public static function get_footer_theme( array $css_vars ): array {
+		$footer_theme = ! empty( $css_vars['campaign_footer_theme'] )
+											? $css_vars['campaign_footer_theme']
+											: null;
+
+		$default_footer_links_color = $css_vars['campaign_nav_color'] ? $css_vars['campaign_nav_color'] : '#1A1A1A';
+
+		if ( 'white' === $footer_theme ) {
+			$css_vars['footer_links_color'] = $css_vars['footer_links_color'] ? $css_vars['footer_links_color'] : $default_footer_links_color;
+			$css_vars['footer_color']       = '#FFFFFF';
+		} elseif ( self::DEFAULT_NAVBAR_THEME === $css_vars['campaign_nav_type'] ) {
+			$css_vars['footer_links_color'] = null;
+			$css_vars['footer_color']       = null;
+		} else {
+			switch ( ( $css_vars['campaign_logo_color'] ?? null ) ) {
+				case 'dark':
+					$css_vars['footer_links_color'] = '#1A1A1A';
+					break;
+				case 'green':
+					$css_vars['footer_links_color'] = '#62CE00';
+					break;
+				default:
+					$css_vars['footer_links_color'] = '#FFFFFF';
 			}
-
-			return $css_vars;
+			$css_vars['footer_color'] = $css_vars['campaign_nav_color'];
 		}
 
-		/**
-		 * Get the footer variables based on the meta settings.
-		 *
-		 * @param array $css_vars The array containing the CSS variables.
-		 * @return array The variables for the footer theme.
-		 */
-		public static function get_footer_theme( array $css_vars ): array {
-			$footer_theme = ! empty( $css_vars['campaign_footer_theme'] )
-												? $css_vars['campaign_footer_theme']
-												: null;
+		return $css_vars;
+	}
 
-			$default_footer_links_color = $css_vars['campaign_nav_color'] ? $css_vars['campaign_nav_color'] : '#1A1A1A';
+	/**
+	 * Get the theme based on the meta settings.
+	 *
+	 * @param array $meta The meta containing the style settings.
+	 * @return string The identifier of the theme.
+	 */
+	public static function get_theme( array $meta ): string {
+		$theme = $meta['theme'] ?? $meta['_campaign_page_template'] ?? null;
+		$theme = $theme ? $theme : 'default';
 
-			if ( 'white' === $footer_theme ) {
-				$css_vars['footer_links_color'] = $css_vars['footer_links_color'] ? $css_vars['footer_links_color'] : $default_footer_links_color;
-				$css_vars['footer_color']       = '#FFFFFF';
-			} elseif ( self::DEFAULT_NAVBAR_THEME === $css_vars['campaign_nav_type'] ) {
-				$css_vars['footer_links_color'] = null;
-				$css_vars['footer_color']       = null;
-			} else {
-				switch ( ( $css_vars['campaign_logo_color'] ?? null ) ) {
-					case 'dark':
-						$css_vars['footer_links_color'] = '#1A1A1A';
-						break;
-					case 'green':
-						$css_vars['footer_links_color'] = '#62CE00';
-						break;
-					default:
-						$css_vars['footer_links_color'] = '#FFFFFF';
-				}
-				$css_vars['footer_color'] = $css_vars['campaign_nav_color'];
-			}
+		return $theme;
+	}
 
-			return $css_vars;
+	/**
+	 * Get the logo based on the meta settings. Ensures that no other campaign logo will be used even if that's the value stored.
+	 *
+	 * @param array $meta The meta containing the style settings.
+	 * @return string The identifier of the logo.
+	 */
+	public static function get_logo( array $meta ): string {
+		$logo = $meta['campaign_logo'] ?? null;
+		if ( ! $logo ) {
+			return 'greenpeace';
 		}
 
-		/**
-		 * Get the theme based on the meta settings.
-		 *
-		 * @param array $meta The meta containing the style settings.
-		 * @return string The identifier of the theme.
-		 */
-		public static function get_theme( array $meta ): string {
-			$theme = $meta['theme'] ?? $meta['_campaign_page_template'] ?? null;
-			$theme = $theme ? $theme : 'default';
+		$theme = self::get_theme( $meta );
 
-			return $theme;
+		if ( 'default' !== $theme ) {
+			return 'greenpeace' === $logo ? 'greenpeace' : $theme;
 		}
 
-		/**
-		 * Get the logo based on the meta settings. Ensures that no other campaign logo will be used even if that's the value stored.
-		 *
-		 * @param array $meta The meta containing the style settings.
-		 * @return string The identifier of the logo.
-		 */
-		public static function get_logo( array $meta ): string {
-			$logo = $meta['campaign_logo'] ?? null;
-			if ( ! $logo ) {
-				return 'greenpeace';
-			}
-
-			$theme = self::get_theme( $meta );
-
-			if ( 'default' !== $theme ) {
-				return 'greenpeace' === $logo ? 'greenpeace' : $theme;
-			}
-
-			return $logo ? $logo : 'greenpeace';
-		}
+		return $logo ? $logo : 'greenpeace';
 	}
 }

--- a/classes/class-p4-post-report-controller.php
+++ b/classes/class-p4-post-report-controller.php
@@ -5,124 +5,120 @@
  * @package P4MT
  */
 
-if ( ! class_exists( 'P4_Post_Report_Controller' ) ) {
+/**
+ * Class P4_Post_Report_Controller
+ */
+class P4_Post_Report_Controller {
 
 	/**
-	 * Class P4_Post_Report_Controller
+	 * Theme directory
+	 *
+	 * @var string $theme_dir Theme's base directory.
 	 */
-	class P4_Post_Report_Controller {
+	protected $theme_dir;
 
-		/**
-		 * Theme directory
-		 *
-		 * @var string $theme_dir Theme's base directory.
-		 */
-		protected $theme_dir;
+	/**
+	 * P4_Custom_Taxonomy constructor.
+	 */
+	public function __construct() {
+		$this->hooks();
+		$this->theme_dir = get_template_directory_uri();
+	}
 
-		/**
-		 * P4_Custom_Taxonomy constructor.
-		 */
-		public function __construct() {
-			$this->hooks();
-			$this->theme_dir = get_template_directory_uri();
-		}
+	/**
+	 * Register actions for WordPress hooks and filters.
+	 */
+	private function hooks() {
+		add_action( 'admin_menu', [ $this, 'add_posts_report_admin_menu_item' ] );
+		add_filter( 'rest_post_query', [ $this, 'add_posts_param_to_endpoint' ], 10, 2 );
+		add_filter( 'rest_page_query', [ $this, 'add_posts_param_to_endpoint' ], 10, 2 );
+		add_filter( 'rest_post_collection_params', [ $this, 'filter_post_params_endpoint' ] );
+		add_filter( 'rest_page_collection_params', [ $this, 'filter_post_params_endpoint' ] );
+	}
 
-		/**
-		 * Register actions for WordPress hooks and filters.
-		 */
-		private function hooks() {
-			add_action( 'admin_menu', [ $this, 'add_posts_report_admin_menu_item' ] );
-			add_filter( 'rest_post_query', [ $this, 'add_posts_param_to_endpoint' ], 10, 2 );
-			add_filter( 'rest_page_query', [ $this, 'add_posts_param_to_endpoint' ], 10, 2 );
-			add_filter( 'rest_post_collection_params', [ $this, 'filter_post_params_endpoint' ] );
-			add_filter( 'rest_page_collection_params', [ $this, 'filter_post_params_endpoint' ] );
-		}
-
-		/**
-		 * Add extra date column in post rest endpoint.
-		 *
-		 * @param array $args Arguments array passed to endpoint.
-		 * @param array $request Initial request parameters to the endpoint.
-		 *
-		 * @return mixed
-		 */
-		public function add_posts_param_to_endpoint( $args, $request ) {
-			if ( ! isset( $request['before'] ) && ! isset( $request['after'] ) ) {
-				return $args;
-			}
-
-			if ( isset( $request['date_query_column'] ) ) {
-				$args['date_query'][0]['column'] = $request['date_query_column'];
-			}
-
+	/**
+	 * Add extra date column in post rest endpoint.
+	 *
+	 * @param array $args Arguments array passed to endpoint.
+	 * @param array $request Initial request parameters to the endpoint.
+	 *
+	 * @return mixed
+	 */
+	public function add_posts_param_to_endpoint( $args, $request ) {
+		if ( ! isset( $request['before'] ) && ! isset( $request['after'] ) ) {
 			return $args;
 		}
 
-		/**
-		 * Add post report submenu item.
-		 */
-		public function add_posts_report_admin_menu_item() {
-			add_posts_page(
-				__( 'Posts Report', 'planet4-master-theme-backend' ),
-				__( 'Posts Report', 'planet4-master-theme-backend' ),
-				'read',
-				'posts-report',
-				[ $this, 'render_posts_report_page' ]
-			);
+		if ( isset( $request['date_query_column'] ) ) {
+			$args['date_query'][0]['column'] = $request['date_query_column'];
 		}
 
-		/**
-		 * Use date_query_column added in post rest endpoint in order to query on posts/pages modified attribute.
-		 *
-		 * @param array $query_params Rest endpoint query parameters.
-		 *
-		 * @return mixed
-		 */
-		public function filter_post_params_endpoint( $query_params ) {
-			$query_params['date_query_column'] = [
-				'description' => __( 'The date query column.', 'planet4-master-theme-backend' ),
-				'type'        => 'string',
-				'enum'        => [ 'post_date', 'post_date_gmt', 'post_modified', 'post_modified_gmt' ],
-			];
+		return $args;
+	}
 
-			return $query_params;
-		}
+	/**
+	 * Add post report submenu item.
+	 */
+	public function add_posts_report_admin_menu_item() {
+		add_posts_page(
+			__( 'Posts Report', 'planet4-master-theme-backend' ),
+			__( 'Posts Report', 'planet4-master-theme-backend' ),
+			'read',
+			'posts-report',
+			[ $this, 'render_posts_report_page' ]
+		);
+	}
 
-		/**
-		 * Callback function to render posts report page.
-		 */
-		public function render_posts_report_page() {
-			wp_enqueue_script( 'jquery-ui-core' );
-			wp_enqueue_script( 'jquery-ui-datepicker' );
-			wp_register_script(
-				'posts-report',
-				$this->theme_dir . '/admin/js/posts_report.js',
-				[
-					'jquery',
-					'wp-api',
-					'wp-backbone',
-				],
-				'0.2',
-				true
-			);
-			wp_localize_script(
-				'posts-report',
-				'p4_data',
-				[
-					'api_url' => get_site_url() . '/wp-json/wp/v2',
-					'nonce'   => wp_create_nonce( 'wp_rest' ),
-				]
-			);
-			wp_enqueue_script( 'posts-report' );
-			wp_register_style(
-				'jquery-ui-datepicker',
-				'https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/themes/overcast/jquery-ui.min.css',
-				[],
-				'0.1'
-			);
-			wp_enqueue_style( 'jquery-ui-datepicker' );
-			include dirname( __FILE__ ) . '/../posts-report.php';
-		}
+	/**
+	 * Use date_query_column added in post rest endpoint in order to query on posts/pages modified attribute.
+	 *
+	 * @param array $query_params Rest endpoint query parameters.
+	 *
+	 * @return mixed
+	 */
+	public function filter_post_params_endpoint( $query_params ) {
+		$query_params['date_query_column'] = [
+			'description' => __( 'The date query column.', 'planet4-master-theme-backend' ),
+			'type'        => 'string',
+			'enum'        => [ 'post_date', 'post_date_gmt', 'post_modified', 'post_modified_gmt' ],
+		];
+
+		return $query_params;
+	}
+
+	/**
+	 * Callback function to render posts report page.
+	 */
+	public function render_posts_report_page() {
+		wp_enqueue_script( 'jquery-ui-core' );
+		wp_enqueue_script( 'jquery-ui-datepicker' );
+		wp_register_script(
+			'posts-report',
+			$this->theme_dir . '/admin/js/posts_report.js',
+			[
+				'jquery',
+				'wp-api',
+				'wp-backbone',
+			],
+			'0.2',
+			true
+		);
+		wp_localize_script(
+			'posts-report',
+			'p4_data',
+			[
+				'api_url' => get_site_url() . '/wp-json/wp/v2',
+				'nonce'   => wp_create_nonce( 'wp_rest' ),
+			]
+		);
+		wp_enqueue_script( 'posts-report' );
+		wp_register_style(
+			'jquery-ui-datepicker',
+			'https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/themes/overcast/jquery-ui.min.css',
+			[],
+			'0.1'
+		);
+		wp_enqueue_style( 'jquery-ui-datepicker' );
+		include dirname( __FILE__ ) . '/../posts-report.php';
 	}
 }
-

--- a/classes/class-p4-post.php
+++ b/classes/class-p4-post.php
@@ -8,432 +8,430 @@
 use Timber\Post as TimberPost;
 use Timber\Term as TimberTerm;
 
-if ( ! class_exists( 'P4_Post' ) ) {
+
+/**
+ * Class P4_Post extends TimberPost to add planet4 specific functionality.
+ */
+class P4_Post extends TimberPost {
 
 	/**
-	 * Class P4_Post extends TimberPost to add planet4 specific functionality.
+	 * Issues navigation
+	 *
+	 * @var array $issues_nav_data
 	 */
-	class P4_Post extends TimberPost {
+	protected $issues_nav_data;
 
-		/**
-		 * Issues navigation
-		 *
-		 * @var array $issues_nav_data
-		 */
-		protected $issues_nav_data;
+	/**
+	 * Content type
+	 *
+	 * @var string $content_type
+	 */
+	protected $content_type;
 
-		/**
-		 * Content type
-		 *
-		 * @var string $content_type
-		 */
-		protected $content_type;
+	/**
+	 * Page types
+	 *
+	 * @var TimberTerm[] $page_types
+	 */
+	protected $page_types;
 
-		/**
-		 * Page types
-		 *
-		 * @var TimberTerm[] $page_types
-		 */
-		protected $page_types;
+	/**
+	 * Author
+	 *
+	 * @var P4_User $author
+	 */
+	protected $author;
 
-		/**
-		 * Author
-		 *
-		 * @var P4_User $author
-		 */
-		protected $author;
+	/**
+	 * Associative array with the values to be passed to GTM Data Layer.
+	 *
+	 * @var array $datalayer
+	 */
+	protected $data_layer;
 
-		/**
-		 * Associative array with the values to be passed to GTM Data Layer.
-		 *
-		 * @var array $datalayer
-		 */
-		protected $data_layer;
+	/**
+	 * P4_Post constructor.
+	 *
+	 * @param mixed $pid The post id. If left null it will try to figure out the current post id based on being inside The_Loop.
+	 */
+	public function __construct( $pid = null ) {
+		parent::__construct( $pid );
+		$this->set_page_types();
+		$this->set_author();
+	}
 
-		/**
-		 * P4_Post constructor.
-		 *
-		 * @param mixed $pid The post id. If left null it will try to figure out the current post id based on being inside The_Loop.
-		 */
-		public function __construct( $pid = null ) {
-			parent::__construct( $pid );
-			$this->set_page_types();
-			$this->set_author();
+	/**
+	 * Sets the GTM Data Layer values of current P4 Post.
+	 */
+	public function set_data_layer() {
+		if ( is_front_page() ) {
+			$this->data_layer['page_category'] = 'Homepage';
+		} elseif ( $this->is_act_page() ) {
+			$this->data_layer['page_category'] = 'Act';
+		} elseif ( $this->is_explore_page() ) {
+			$this->data_layer['page_category'] = 'Explore';
+		} elseif ( $this->is_take_action_page() ) {
+			$this->data_layer['page_category'] = 'Take Action';
+		} elseif ( $this->is_issue_page() ) {
+			$this->data_layer['page_category'] = 'Issue Page';
+		} elseif ( $this->is_campaign_page() ) {
+			$this->data_layer['page_category'] = 'Campaign Page';
+		} elseif ( is_tag() ) {
+			$this->data_layer['page_category'] = 'Tag Page';
+		} else {
+			$this->data_layer['page_category'] = 'Default Page';
 		}
+	}
 
-		/**
-		 * Sets the GTM Data Layer values of current P4 Post.
-		 */
-		public function set_data_layer() {
-			if ( is_front_page() ) {
-				$this->data_layer['page_category'] = 'Homepage';
-			} elseif ( $this->is_act_page() ) {
-				$this->data_layer['page_category'] = 'Act';
-			} elseif ( $this->is_explore_page() ) {
-				$this->data_layer['page_category'] = 'Explore';
-			} elseif ( $this->is_take_action_page() ) {
-				$this->data_layer['page_category'] = 'Take Action';
-			} elseif ( $this->is_issue_page() ) {
-				$this->data_layer['page_category'] = 'Issue Page';
-			} elseif ( $this->is_campaign_page() ) {
-				$this->data_layer['page_category'] = 'Campaign Page';
-			} elseif ( is_tag() ) {
-				$this->data_layer['page_category'] = 'Tag Page';
-			} else {
-				$this->data_layer['page_category'] = 'Default Page';
-			}
-		}
+	/**
+	 * Get the array for the GTM Data Layer.
+	 */
+	public function get_data_layer() {
+		return $this->data_layer;
+	}
+	/**
+	 * Checks if post is the Act page.
+	 *
+	 * @return bool
+	 */
+	public function is_act_page() : bool {
+		$act_page_id = planet4_get_option( 'act_page' );
 
-		/**
-		 * Get the array for the GTM Data Layer.
-		 */
-		public function get_data_layer() {
-			return $this->data_layer;
-		}
-		/**
-		 * Checks if post is the Act page.
-		 *
-		 * @return bool
-		 */
-		public function is_act_page() : bool {
-			$act_page_id = planet4_get_option( 'act_page' );
+		return absint( $act_page_id ) === $this->id;
+	}
 
-			return absint( $act_page_id ) === $this->id;
-		}
+	/**
+	 * Checks if post is the Explore page.
+	 *
+	 * @return bool
+	 */
+	public function is_explore_page() : bool {
+		$explore_page_id = planet4_get_option( 'explore_page' );
 
-		/**
-		 * Checks if post is the Explore page.
-		 *
-		 * @return bool
-		 */
-		public function is_explore_page() : bool {
-			$explore_page_id = planet4_get_option( 'explore_page' );
+		return absint( $explore_page_id ) === $this->id;
+	}
 
-			return absint( $explore_page_id ) === $this->id;
-		}
+	/**
+	 * Checks if post is a Take Action page (child of act page).
+	 *
+	 * @return bool
+	 */
+	public function is_take_action_page() : bool {
+		$act_page_id = planet4_get_option( 'act_page' );
+		$pages       = [];
 
-		/**
-		 * Checks if post is a Take Action page (child of act page).
-		 *
-		 * @return bool
-		 */
-		public function is_take_action_page() : bool {
-			$act_page_id = planet4_get_option( 'act_page' );
-			$pages       = [];
-
-			if ( 0 !== absint( $act_page_id ) ) {
-				$take_action_pages_args = [
-					'post_type'        => 'page',
-					'post_parent'      => $act_page_id,
-					'numberposts'      => - 1,
-					'fields'           => 'ids',
-					'suppress_filters' => false,
-				];
-
-				$pages = get_posts( $take_action_pages_args );
-			}
-
-			return in_array( $this->id, $pages, true );
-		}
-
-		/**
-		 * Checks if post is an Issue page (child of explore page).
-		 *
-		 * @return bool
-		 */
-		public function is_issue_page() : bool {
-			$explore_page_id = planet4_get_option( 'explore_page' );
-			$pages           = [];
-
-			if ( 0 !== absint( $explore_page_id ) ) {
-				$issue_pages_args = [
-					'post_type'        => 'page',
-					'post_parent'      => $explore_page_id,
-					'numberposts'      => - 1,
-					'fields'           => 'ids',
-					'suppress_filters' => false,
-				];
-
-				$pages = get_posts( $issue_pages_args );
-			}
-
-			return in_array( $this->id, $pages, true );
-		}
-
-		/**
-		 * Checks if post is Campaign page.
-		 *
-		 * @return bool
-		 */
-		public function is_campaign_page() : bool {
-			return P4_Post_Campaign::POST_TYPE === $this->post_type;
-		}
-
-		/**
-		 * Loads in context information on the navigation links for Issue pages relevant to current Post's categories.
-		 */
-		public function set_issues_links() {
-			// Retrieve P4 settings in order to check that we add only categories that are children of the Issues category.
-			$options         = get_option( 'planet4_options' );
-			$explore_page_id = $options['explore_page'] ?? '';
-			$categories      = get_the_category( $this->ID );
-
-			// Handle navigation links.
-			if ( $categories ) {
-				$categories_ids = [];
-
-				foreach ( $categories as $category ) {
-					$categories_ids[] = $category->term_id;
-				}
-				// Get the Issue pages that are relevant to the Categories of the current Post.
-				if ( $categories_ids && $explore_page_id ) {
-					$args = [
-						'post_parent' => $explore_page_id,
-						'post_type'   => 'page',
-						'post_status' => 'publish',
-					];
-
-					$args['category__in'] = $categories_ids;
-					$issues               = ( new WP_Query( $args ) )->posts;
-
-					if ( $issues ) {
-						foreach ( $issues as $issue ) {
-							if ( $issue && $this->post_parent !== (int) $explore_page_id ) {
-								$this->issues_nav_data[] = [
-									'name' => $issue->post_title,
-									'link' => get_permalink( $issue ),
-								];
-							}
-						}
-					}
-				}
-			}
-		}
-
-		/**
-		 * Retrieves the accounts for each social media item found within the footer social menu.
-		 *
-		 * @param array $social_menu Array of a post objects for each menu item.
-		 *
-		 * @return array Associative array with the social media accounts.
-		 */
-		public function get_social_accounts( $social_menu ) : array {
-			return self::filter_social_accounts( $social_menu );
-		}
-
-		/**
-		 * Get post's planet4 custom taxonomy terms.
-		 *
-		 * @return WP_Term[]
-		 */
-		public function get_custom_terms() {
-			$terms = get_the_terms( $this->id, P4_Custom_Taxonomy::TAXONOMY );
-			if ( false !== $terms && ! $terms instanceof WP_Error ) {
-				return $terms;
-			}
-
-			return [];
-		}
-
-		/**
-		 * Sets the page types for this P4_Post.
-		 */
-		public function set_page_types() {
-			$taxonomies = $this->get_terms( P4_Custom_Taxonomy::TAXONOMY );
-
-			if ( $taxonomies && ! is_wp_error( $taxonomies ) ) {
-				$this->page_types = $taxonomies;
-			}
-		}
-
-		/**
-		 * Gets the page types of this P4_Post.
-		 */
-		public function get_page_types() {
-			return $this->page_types;
-		}
-
-		/**
-		 * Sets post/page custom planet4 type.
-		 * ACTION, DOCUMENT, PAGE, POST
-		 */
-		public function set_content_type() {
-			switch ( $this->post_type ) {
-				case 'page':
-					if ( $this->is_take_action_page() ) {
-						$this->content_type = __( 'ACTION', 'planet4-master-theme' );
-					} else {
-						$this->content_type = __( 'PAGE', 'planet4-master-theme' );
-					}
-					break;
-				case 'attachment':
-					$this->content_type = __( 'DOCUMENT', 'planet4-master-theme' );
-					break;
-				default:
-					$this->content_type = __( 'POST', 'planet4-master-theme' );
-			}
-		}
-
-		/**
-		 * Get post/page custom planet4 type.
-		 * ACTION, DOCUMENT, PAGE, POST
-		 *
-		 * @return string
-		 */
-		public function get_content_type() {
-			return $this->content_type;
-		}
-
-		/**
-		 * Get value for open graph title meta.
-		 *
-		 * @return string
-		 */
-		public function get_og_title() {
-			$og_title = get_post_meta( $this->id, 'p4_og_title', true );
-			if ( '' === $og_title ) {
-				if ( '' !== $this->post_title ) {
-					return $this->post_title . ' - ' . get_bloginfo( 'name' );
-				} else {
-					return get_bloginfo( 'name' );
-				}
-			}
-
-			return $og_title;
-		}
-
-		/**
-		 * Get value for open graph description meta.
-		 *
-		 * @return string
-		 */
-		public function get_og_description() {
-			$og_desc = get_post_meta( $this->id, 'p4_og_description', true );
-			if ( '' === $og_desc ) {
-				return $this->post_excerpt;
-			}
-
-			return $og_desc;
-		}
-
-		/**
-		 * Get image data for open graph image meta.
-		 *
-		 * @return array
-		 */
-		public function get_og_image() {
-			$meta        = get_post_meta( $this->id );
-			$image_id    = null;
-			$image_metas = [ 'p4_og_image_id', '_thumbnail_id', 'background_image_id' ];
-			foreach ( $image_metas as $image_meta ) {
-				if ( isset( $meta[ $image_meta ][0] ) ) {
-					$image_id = $meta[ $image_meta ][0];
-					break;
-				}
-			}
-
-			if ( null !== $image_id ) {
-				$image_data = wp_get_attachment_image_src( $image_id, 'full' );
-				$og_image   = [];
-				if ( $image_data ) {
-					$og_image['url']    = $image_data[0];
-					$og_image['width']  = $image_data[1];
-					$og_image['height'] = $image_data[2];
-				}
-
-				return $og_image;
-			}
-
-			return [];
-		}
-
-		/**
-		 * Get values for share buttons content.
-		 *
-		 * @return string
-		 */
-		public function share_meta() {
-			$og_title       = get_post_meta( $this->id, 'p4_og_title', true );
-			$og_description = get_post_meta( $this->id, 'p4_og_description', true );
-			$link           = get_permalink( $this->id );
-
-			if ( '' === $og_title ) {
-				if ( '' !== $this->post_title ) {
-					$og_title = $this->post_title;
-				}
-			}
-
-			$social_meta = [
-				'title'       => $og_title,
-				'description' => $og_description,
-				'link'        => $link,
+		if ( 0 !== absint( $act_page_id ) ) {
+			$take_action_pages_args = [
+				'post_type'        => 'page',
+				'post_parent'      => $act_page_id,
+				'numberposts'      => - 1,
+				'fields'           => 'ids',
+				'suppress_filters' => false,
 			];
 
-			return $social_meta;
+			$pages = get_posts( $take_action_pages_args );
 		}
 
-		/**
-		 * Get post's author override status.
-		 *
-		 * @return bool
-		 */
-		public function get_author_override() {
-			$author_override = get_post_meta( $this->id, 'p4_author_override', true );
-			if ( $author_override ) {
-				return true;
+		return in_array( $this->id, $pages, true );
+	}
+
+	/**
+	 * Checks if post is an Issue page (child of explore page).
+	 *
+	 * @return bool
+	 */
+	public function is_issue_page() : bool {
+		$explore_page_id = planet4_get_option( 'explore_page' );
+		$pages           = [];
+
+		if ( 0 !== absint( $explore_page_id ) ) {
+			$issue_pages_args = [
+				'post_type'        => 'page',
+				'post_parent'      => $explore_page_id,
+				'numberposts'      => - 1,
+				'fields'           => 'ids',
+				'suppress_filters' => false,
+			];
+
+			$pages = get_posts( $issue_pages_args );
+		}
+
+		return in_array( $this->id, $pages, true );
+	}
+
+	/**
+	 * Checks if post is Campaign page.
+	 *
+	 * @return bool
+	 */
+	public function is_campaign_page() : bool {
+		return P4_Post_Campaign::POST_TYPE === $this->post_type;
+	}
+
+	/**
+	 * Loads in context information on the navigation links for Issue pages relevant to current Post's categories.
+	 */
+	public function set_issues_links() {
+		// Retrieve P4 settings in order to check that we add only categories that are children of the Issues category.
+		$options         = get_option( 'planet4_options' );
+		$explore_page_id = $options['explore_page'] ?? '';
+		$categories      = get_the_category( $this->ID );
+
+		// Handle navigation links.
+		if ( $categories ) {
+			$categories_ids = [];
+
+			foreach ( $categories as $category ) {
+				$categories_ids[] = $category->term_id;
 			}
-			return false;
-		}
-
-		/**
-		 * Sets the P4_User author of this P4_Post.
-		 */
-		public function set_author() {
-			$author_override = get_post_meta( $this->id, 'p4_author_override', true );
-			if ( '' !== $author_override ) {
-				$this->author = new P4_User( false, $author_override );     // Create fake P4_User.
-			} else {
-				$this->author = new P4_User( (int) $this->post_author );
-			}
-		}
-
-		/**
-		 * Gets the P4_User author of this P4_Post.
-		 *
-		 * @return P4_User
-		 */
-		public function get_author() {
-			return $this->author;
-		}
-
-		/**
-		 * Filter the accounts for each social media item found within the footer social menu.
-		 *
-		 * @param array $social_menu Array of a post objects for each menu item.
-		 *
-		 * @return array Associative array with the social media accounts.
-		 */
-		public static function filter_social_accounts( $social_menu ) : array {
-			$social_accounts = [];
-			if ( isset( $social_menu ) && is_iterable( $social_menu ) ) {
-
-				$brands = [
-					'facebook',
-					'twitter',
-					'youtube',
-					'instagram',
+			// Get the Issue pages that are relevant to the Categories of the current Post.
+			if ( $categories_ids && $explore_page_id ) {
+				$args = [
+					'post_parent' => $explore_page_id,
+					'post_type'   => 'page',
+					'post_status' => 'publish',
 				];
-				foreach ( $social_menu as $social_menu_item ) {
-					$url_parts = explode( '/', rtrim( $social_menu_item->url, '/' ) );
-					foreach ( $brands as $brand ) {
-						if ( false !== strpos( $social_menu_item->url, $brand ) ) {
-							$social_accounts[ $brand ] = count( $url_parts ) > 0 ? $url_parts[ count( $url_parts ) - 1 ] : '';
+
+				$args['category__in'] = $categories_ids;
+				$issues               = ( new WP_Query( $args ) )->posts;
+
+				if ( $issues ) {
+					foreach ( $issues as $issue ) {
+						if ( $issue && $this->post_parent !== (int) $explore_page_id ) {
+							$this->issues_nav_data[] = [
+								'name' => $issue->post_title,
+								'link' => get_permalink( $issue ),
+							];
 						}
 					}
 				}
 			}
-
-			return $social_accounts;
 		}
+	}
+
+	/**
+	 * Retrieves the accounts for each social media item found within the footer social menu.
+	 *
+	 * @param array $social_menu Array of a post objects for each menu item.
+	 *
+	 * @return array Associative array with the social media accounts.
+	 */
+	public function get_social_accounts( $social_menu ) : array {
+		return self::filter_social_accounts( $social_menu );
+	}
+
+	/**
+	 * Get post's planet4 custom taxonomy terms.
+	 *
+	 * @return WP_Term[]
+	 */
+	public function get_custom_terms() {
+		$terms = get_the_terms( $this->id, P4_Custom_Taxonomy::TAXONOMY );
+		if ( false !== $terms && ! $terms instanceof WP_Error ) {
+			return $terms;
+		}
+
+		return [];
+	}
+
+	/**
+	 * Sets the page types for this P4_Post.
+	 */
+	public function set_page_types() {
+		$taxonomies = $this->get_terms( P4_Custom_Taxonomy::TAXONOMY );
+
+		if ( $taxonomies && ! is_wp_error( $taxonomies ) ) {
+			$this->page_types = $taxonomies;
+		}
+	}
+
+	/**
+	 * Gets the page types of this P4_Post.
+	 */
+	public function get_page_types() {
+		return $this->page_types;
+	}
+
+	/**
+	 * Sets post/page custom planet4 type.
+	 * ACTION, DOCUMENT, PAGE, POST
+	 */
+	public function set_content_type() {
+		switch ( $this->post_type ) {
+			case 'page':
+				if ( $this->is_take_action_page() ) {
+					$this->content_type = __( 'ACTION', 'planet4-master-theme' );
+				} else {
+					$this->content_type = __( 'PAGE', 'planet4-master-theme' );
+				}
+				break;
+			case 'attachment':
+				$this->content_type = __( 'DOCUMENT', 'planet4-master-theme' );
+				break;
+			default:
+				$this->content_type = __( 'POST', 'planet4-master-theme' );
+		}
+	}
+
+	/**
+	 * Get post/page custom planet4 type.
+	 * ACTION, DOCUMENT, PAGE, POST
+	 *
+	 * @return string
+	 */
+	public function get_content_type() {
+		return $this->content_type;
+	}
+
+	/**
+	 * Get value for open graph title meta.
+	 *
+	 * @return string
+	 */
+	public function get_og_title() {
+		$og_title = get_post_meta( $this->id, 'p4_og_title', true );
+		if ( '' === $og_title ) {
+			if ( '' !== $this->post_title ) {
+				return $this->post_title . ' - ' . get_bloginfo( 'name' );
+			} else {
+				return get_bloginfo( 'name' );
+			}
+		}
+
+		return $og_title;
+	}
+
+	/**
+	 * Get value for open graph description meta.
+	 *
+	 * @return string
+	 */
+	public function get_og_description() {
+		$og_desc = get_post_meta( $this->id, 'p4_og_description', true );
+		if ( '' === $og_desc ) {
+			return $this->post_excerpt;
+		}
+
+		return $og_desc;
+	}
+
+	/**
+	 * Get image data for open graph image meta.
+	 *
+	 * @return array
+	 */
+	public function get_og_image() {
+		$meta        = get_post_meta( $this->id );
+		$image_id    = null;
+		$image_metas = [ 'p4_og_image_id', '_thumbnail_id', 'background_image_id' ];
+		foreach ( $image_metas as $image_meta ) {
+			if ( isset( $meta[ $image_meta ][0] ) ) {
+				$image_id = $meta[ $image_meta ][0];
+				break;
+			}
+		}
+
+		if ( null !== $image_id ) {
+			$image_data = wp_get_attachment_image_src( $image_id, 'full' );
+			$og_image   = [];
+			if ( $image_data ) {
+				$og_image['url']    = $image_data[0];
+				$og_image['width']  = $image_data[1];
+				$og_image['height'] = $image_data[2];
+			}
+
+			return $og_image;
+		}
+
+		return [];
+	}
+
+	/**
+	 * Get values for share buttons content.
+	 *
+	 * @return string
+	 */
+	public function share_meta() {
+		$og_title       = get_post_meta( $this->id, 'p4_og_title', true );
+		$og_description = get_post_meta( $this->id, 'p4_og_description', true );
+		$link           = get_permalink( $this->id );
+
+		if ( '' === $og_title ) {
+			if ( '' !== $this->post_title ) {
+				$og_title = $this->post_title;
+			}
+		}
+
+		$social_meta = [
+			'title'       => $og_title,
+			'description' => $og_description,
+			'link'        => $link,
+		];
+
+		return $social_meta;
+	}
+
+	/**
+	 * Get post's author override status.
+	 *
+	 * @return bool
+	 */
+	public function get_author_override() {
+		$author_override = get_post_meta( $this->id, 'p4_author_override', true );
+		if ( $author_override ) {
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Sets the P4_User author of this P4_Post.
+	 */
+	public function set_author() {
+		$author_override = get_post_meta( $this->id, 'p4_author_override', true );
+		if ( '' !== $author_override ) {
+			$this->author = new P4_User( false, $author_override );     // Create fake P4_User.
+		} else {
+			$this->author = new P4_User( (int) $this->post_author );
+		}
+	}
+
+	/**
+	 * Gets the P4_User author of this P4_Post.
+	 *
+	 * @return P4_User
+	 */
+	public function get_author() {
+		return $this->author;
+	}
+
+	/**
+	 * Filter the accounts for each social media item found within the footer social menu.
+	 *
+	 * @param array $social_menu Array of a post objects for each menu item.
+	 *
+	 * @return array Associative array with the social media accounts.
+	 */
+	public static function filter_social_accounts( $social_menu ) : array {
+		$social_accounts = [];
+		if ( isset( $social_menu ) && is_iterable( $social_menu ) ) {
+
+			$brands = [
+				'facebook',
+				'twitter',
+				'youtube',
+				'instagram',
+			];
+			foreach ( $social_menu as $social_menu_item ) {
+				$url_parts = explode( '/', rtrim( $social_menu_item->url, '/' ) );
+				foreach ( $brands as $brand ) {
+					if ( false !== strpos( $social_menu_item->url, $brand ) ) {
+						$social_accounts[ $brand ] = count( $url_parts ) > 0 ? $url_parts[ count( $url_parts ) - 1 ] : '';
+					}
+				}
+			}
+		}
+
+		return $social_accounts;
 	}
 }

--- a/classes/class-p4-search.php
+++ b/classes/class-p4-search.php
@@ -8,1090 +8,1088 @@
 use ElasticPress\Features;
 use Timber\Timber;
 
-if ( ! class_exists( 'P4_Search' ) ) {
+
+/**
+ * Abstract Class P4_Search
+ */
+abstract class P4_Search {
+
+	const POSTS_PER_LOAD        = 5;
+	const SHOW_SCROLL_TIMES     = 2;
+	const DEFAULT_SORT          = '_score';
+	const DEFAULT_MIN_WEIGHT    = 1;
+	const DEFAULT_PAGE_WEIGHT   = 100;
+	const DEFAULT_ACTION_WEIGHT = 2000;
+	const DEFAULT_MAX_WEIGHT    = 3000;
+	const DEFAULT_CACHE_TTL     = 600;
+	const DUMMY_THUMBNAIL       = '/images/dummy-thumbnail.png';
+	const EXCLUDE_FROM_SEARCH   = 'p4_do_not_index';
+	const DOCUMENT_TYPES        = [
+		'application/pdf',
+	];
 
 	/**
-	 * Abstract Class P4_Search
+	 * Search Query
+	 *
+	 * @var string $search_query
 	 */
-	abstract class P4_Search {
+	protected $search_query;
 
-		const POSTS_PER_LOAD        = 5;
-		const SHOW_SCROLL_TIMES     = 2;
-		const DEFAULT_SORT          = '_score';
-		const DEFAULT_MIN_WEIGHT    = 1;
-		const DEFAULT_PAGE_WEIGHT   = 100;
-		const DEFAULT_ACTION_WEIGHT = 2000;
-		const DEFAULT_MAX_WEIGHT    = 3000;
-		const DEFAULT_CACHE_TTL     = 600;
-		const DUMMY_THUMBNAIL       = '/images/dummy-thumbnail.png';
-		const EXCLUDE_FROM_SEARCH   = 'p4_do_not_index';
-		const DOCUMENT_TYPES        = [
-			'application/pdf',
-		];
+	/**
+	 * Posts
+	 *
+	 * @var array|bool|null $posts
+	 */
+	protected $posts;
 
-		/**
-		 * Search Query
-		 *
-		 * @var string $search_query
-		 */
-		protected $search_query;
+	/**
+	 * Paged Posts
+	 *
+	 * @var array|bool|null $paged_posts
+	 */
+	protected $paged_posts;
 
-		/**
-		 * Posts
-		 *
-		 * @var array|bool|null $posts
-		 */
-		protected $posts;
+	/**
+	 * Selected sort criteria
+	 *
+	 * @var array $selected_sort
+	 */
+	protected $selected_sort;
 
-		/**
-		 * Paged Posts
-		 *
-		 * @var array|bool|null $paged_posts
-		 */
-		protected $paged_posts;
+	/**
+	 * FIlters
+	 *
+	 * @var array $filters
+	 */
+	protected $filters;
 
-		/**
-		 * Selected sort criteria
-		 *
-		 * @var array $selected_sort
-		 */
-		protected $selected_sort;
+	/**
+	 * @var int|null The total number of matches.
+	 */
+	protected $total_matches;
 
-		/**
-		 * FIlters
-		 *
-		 * @var array $filters
-		 */
-		protected $filters;
+	/**
+	 * Templates
+	 *
+	 * @var array $templates
+	 */
+	public $templates;
 
-		/**
-		 * @var int|null The total number of matches.
-		 */
-		protected $total_matches;
+	/**
+	 * Context
+	 *
+	 * @var array $context
+	 */
+	public $context;
 
-		/**
-		 * Templates
-		 *
-		 * @var array $templates
-		 */
-		public $templates;
+	/**
+	 * Current Page
+	 *
+	 * @var int $current_page
+	 */
+	public $current_page;
 
-		/**
-		 * Context
-		 *
-		 * @var array $context
-		 */
-		public $context;
+	/**
+	 * @var array|null Aggregations on the complete result set.
+	 */
+	protected $aggregations;
 
-		/**
-		 * Current Page
-		 *
-		 * @var int $current_page
-		 */
-		public $current_page;
+	/**
+	 * @var int The time it took ElasticSearch to execute the query.
+	 */
+	protected $query_time;
 
-		/**
-		 * @var array|null Aggregations on the complete result set.
-		 */
-		protected $aggregations;
+	/**
+	 * P4_Search constructor.
+	 */
+	public function __construct() {}
 
-		/**
-		 * @var int The time it took ElasticSearch to execute the query.
-		 */
-		protected $query_time;
+	/**
+	 * Initialize the class. Hook necessary actions and filters.
+	 */
+	protected function initialize() {
+		self::add_general_filters();
+	}
 
-		/**
-		 * P4_Search constructor.
-		 */
-		public function __construct() {}
+	/**
+	 * Add filters that are needed by both the initial page load and subsequent ajax page loads.
+	 */
+	public static function add_general_filters(): void {
+		// Call apply filters to catch issue in WPML's ElasticPress integration, which uses the wrong filter name.
+		add_filter(
+			'ep_formatted_args',
+			function ( $args ) {
+				return apply_filters( 'ep_search_args', $args );
+			},
+			10,
+			1
+		);
+		// Not sure if still needed, but there were cases in which the filters were not suppressed, causing content
+		// to be unintentionally translated while syncing.
+		add_filter(
+			'ep_index_posts_args',
+			function ( $args ) {
+				return array_merge( $args, [ 'suppress_filters' => true ] );
+			},
+			20
+		);
+		// Certain attachments could have these meta keys many times over with the same value, which can cause OOM
+		// when syncing ElasticSearch. We don't need `sm_cloud` in ES and we only need one of `_wp_attachment_image_alt`.
+		add_filter(
+			'ep_prepare_meta_data',
+			function ( $meta, $post ) {
+				if ( isset( $meta['sm_cloud'] ) ) {
+					unset( $meta['sm_cloud'] );
+				}
+				if ( ! empty( $meta['_wp_attachment_image_alt'] ) ) {
+					$meta['_wp_attachment_image_alt'] = [ $meta['_wp_attachment_image_alt'][0] ];
+				}
+				return $meta;
+			},
+			20,
+			2
+		);
+		// Switch the language to the language of the current post while doing a sync of a post.
+		// This is needed because otherwise WPML black magic will translate some parts of synced data for this post
+		// into the language of the current admin, causing search results in the wrong language. As these syncs are
+		// queued and then executed in random wp admin requests, this language is pretty much random.
+		// It's safe to switch the language in this filter, as the ES queue is only processed at the very end of the
+		// request, and calling `switch_lang` has no effect outside the request.
+		// We need to abuse the `ep_ignore_invalid_dates` filter as it's the only one available to switch the
+		// language in time that has the post available.
+		add_filter(
+			'ep_ignore_invalid_dates',
+			function ( $ignore, $post_id, $post ) {
+				/**
+				 * @var SitePress
+				 */
+				global $sitepress;
+				if ( $sitepress ) {
+					$lang_code = ( new WPML_Post_Element( $post->ID, $sitepress ) )->get_language_code();
+					$sitepress->switch_lang( $lang_code );
+				}
+			},
+			20,
+			3
+		);
+		// Specify which fields to fetch so that we don't need to fetch the post content.
+		add_filter(
+			'ep_formatted_args',
+			function ( $formatted_args, $args ) {
+				$formatted_args['_source'] = [
+					'post_id',
+					'ID',
+					'post_author',
+					'post_date',
+					'post_date_gmt',
+					'post_title',
+					'post_excerpt',
+					'post_name',
+					'post_modified',
+					'post_modified_gmt',
+					'post_content',
+					'post_parent',
+					'post_type',
+					'post_mime_type',
+					'permalink',
+					'post_slug',
+					'terms',
+					'date_terms',
+					'comment_count',
+					'comment_status',
+					'guid',
+					'post_lang',
+				];
+				return $formatted_args;
+			},
+			10,
+			2
+		);
+		// Make it return the post guid as that's where we put the external url for the archive post type.
+		add_filter(
+			'ep_search_post_return_args',
+			function ( $args ) {
+				$args[] = 'guid';
+				$args[] = 'terms';
 
-		/**
-		 * Initialize the class. Hook necessary actions and filters.
-		 */
-		protected function initialize() {
-			self::add_general_filters();
-		}
-
-		/**
-		 * Add filters that are needed by both the initial page load and subsequent ajax page loads.
-		 */
-		public static function add_general_filters(): void {
-			// Call apply filters to catch issue in WPML's ElasticPress integration, which uses the wrong filter name.
+				return $args;
+			}
+		);
+		// Because of how the search is currently set up (using admin-ajax) this ElasticPress filter was not being
+		// applied for subsequent page loads, only for the initial one.
+		if ( ( ! isset( $_GET['orderby'] ) || '_score' === $_GET['orderby'] ) && wp_doing_ajax() ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			add_filter(
 				'ep_formatted_args',
-				function ( $args ) {
-					return apply_filters( 'ep_search_args', $args );
-				},
-				10,
-				1
-			);
-			// Not sure if still needed, but there were cases in which the filters were not suppressed, causing content
-			// to be unintentionally translated while syncing.
-			add_filter(
-				'ep_index_posts_args',
-				function ( $args ) {
-					return array_merge( $args, [ 'suppress_filters' => true ] );
-				},
-				20
-			);
-			// Certain attachments could have these meta keys many times over with the same value, which can cause OOM
-			// when syncing ElasticSearch. We don't need `sm_cloud` in ES and we only need one of `_wp_attachment_image_alt`.
-			add_filter(
-				'ep_prepare_meta_data',
-				function ( $meta, $post ) {
-					if ( isset( $meta['sm_cloud'] ) ) {
-						unset( $meta['sm_cloud'] );
-					}
-					if ( ! empty( $meta['_wp_attachment_image_alt'] ) ) {
-						$meta['_wp_attachment_image_alt'] = [ $meta['_wp_attachment_image_alt'][0] ];
-					}
-					return $meta;
-				},
-				20,
-				2
-			);
-			// Switch the language to the language of the current post while doing a sync of a post.
-			// This is needed because otherwise WPML black magic will translate some parts of synced data for this post
-			// into the language of the current admin, causing search results in the wrong language. As these syncs are
-			// queued and then executed in random wp admin requests, this language is pretty much random.
-			// It's safe to switch the language in this filter, as the ES queue is only processed at the very end of the
-			// request, and calling `switch_lang` has no effect outside the request.
-			// We need to abuse the `ep_ignore_invalid_dates` filter as it's the only one available to switch the
-			// language in time that has the post available.
-			add_filter(
-				'ep_ignore_invalid_dates',
-				function ( $ignore, $post_id, $post ) {
-					/**
-					 * @var SitePress
-					 */
-					global $sitepress;
-					if ( $sitepress ) {
-						$lang_code = ( new WPML_Post_Element( $post->ID, $sitepress ) )->get_language_code();
-						$sitepress->switch_lang( $lang_code );
-					}
-				},
-				20,
-				3
-			);
-			// Specify which fields to fetch so that we don't need to fetch the post content.
-			add_filter(
-				'ep_formatted_args',
-				function ( $formatted_args, $args ) {
-					$formatted_args['_source'] = [
-						'post_id',
-						'ID',
-						'post_author',
-						'post_date',
-						'post_date_gmt',
-						'post_title',
-						'post_excerpt',
-						'post_name',
-						'post_modified',
-						'post_modified_gmt',
-						'post_content',
-						'post_parent',
-						'post_type',
-						'post_mime_type',
-						'permalink',
-						'post_slug',
-						'terms',
-						'date_terms',
-						'comment_count',
-						'comment_status',
-						'guid',
-						'post_lang',
-					];
-					return $formatted_args;
-				},
+				[ new \ElasticPress\Feature\Search\Search(), 'weight_recent' ],
 				10,
 				2
 			);
-			// Make it return the post guid as that's where we put the external url for the archive post type.
-			add_filter(
-				'ep_search_post_return_args',
-				function ( $args ) {
-					$args[] = 'guid';
-					$args[] = 'terms';
-
-					return $args;
-				}
-			);
-			// Because of how the search is currently set up (using admin-ajax) this ElasticPress filter was not being
-			// applied for subsequent page loads, only for the initial one.
-			if ( ( ! isset( $_GET['orderby'] ) || '_score' === $_GET['orderby'] ) && wp_doing_ajax() ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-				add_filter(
-					'ep_formatted_args',
-					[ new \ElasticPress\Feature\Search\Search(), 'weight_recent' ],
-					10,
-					2
-				);
-			}
-			add_filter( 'posts_where', [ self::class, 'edit_search_mime_types' ] );
-			remove_filter(
-				'pre_get_posts',
-				[ Features::factory()->get_registered_feature( 'documents' ), 'setup_document_search' ],
-				10
-			);
 		}
+		add_filter( 'posts_where', [ self::class, 'edit_search_mime_types' ] );
+		remove_filter(
+			'pre_get_posts',
+			[ Features::factory()->get_registered_feature( 'documents' ), 'setup_document_search' ],
+			10
+		);
+	}
 
 
-		/**
-		 * Conducts the actual search.
-		 *
-		 * @param string     $search_query The searched term.
-		 * @param string     $selected_sort The selected order_by.
-		 * @param array      $filters The selected filters.
-		 * @param array      $templates An indexed array with template file names. The first to be found will be used.
-		 * @param array|null $context An associative array with all the context needed to render the template found first.
-		 */
-		public function load(
-			$search_query,
-			$selected_sort = self::DEFAULT_SORT,
-			$filters = [],
-			$templates = [ 'search.twig', 'archive.twig', 'index.twig' ],
-			$context = null
-		) {
-			$this->initialize();
-			$this->search_query = $search_query;
-			$this->templates    = $templates;
+	/**
+	 * Conducts the actual search.
+	 *
+	 * @param string     $search_query The searched term.
+	 * @param string     $selected_sort The selected order_by.
+	 * @param array      $filters The selected filters.
+	 * @param array      $templates An indexed array with template file names. The first to be found will be used.
+	 * @param array|null $context An associative array with all the context needed to render the template found first.
+	 */
+	public function load(
+		$search_query,
+		$selected_sort = self::DEFAULT_SORT,
+		$filters = [],
+		$templates = [ 'search.twig', 'archive.twig', 'index.twig' ],
+		$context = null
+	) {
+		$this->initialize();
+		$this->search_query = $search_query;
+		$this->templates    = $templates;
 
-			if ( $context ) {
-				$this->context = $context;
-			} else {
-				$this->context = Timber::get_context();
+		if ( $context ) {
+			$this->context = $context;
+		} else {
+			$this->context = Timber::get_context();
 
-				// Validate user input (sort, filters, etc).
-				if ( $this->validate( $selected_sort, $filters, $this->context ) ) {
-					$this->selected_sort = $selected_sort;
-					$this->filters       = $filters;
-				}
-
-				$this->posts = $this->get_posts();
-
-				if ( $this->posts ) {
-					$this->paged_posts = array_slice( $this->posts, 0, self::POSTS_PER_LOAD );
-				}
-
-				$this->current_page = ( 0 === get_query_var( 'paged' ) ) ? 1 : get_query_var( 'paged' );
-
-				$this->set_context( $this->context );
+			// Validate user input (sort, filters, etc).
+			if ( $this->validate( $selected_sort, $filters, $this->context ) ) {
+				$this->selected_sort = $selected_sort;
+				$this->filters       = $filters;
 			}
+
+			$this->posts = $this->get_posts();
+
+			if ( $this->posts ) {
+				$this->paged_posts = array_slice( $this->posts, 0, self::POSTS_PER_LOAD );
+			}
+
+			$this->current_page = ( 0 === get_query_var( 'paged' ) ) ? 1 : get_query_var( 'paged' );
+
+			$this->set_context( $this->context );
 		}
+	}
 
-		/**
-		 * Callback for Lazy-loading the next results.
-		 * Gets the paged posts that belong to the next page/load and are to be used with the twig template.
-		 */
-		public function get_paged_posts() {
-			// If this is an ajax call.
-			if ( wp_doing_ajax() ) {
-				$search_action = filter_input( INPUT_GET, 'search-action', FILTER_SANITIZE_STRING );
-				$paged         = filter_input( INPUT_GET, 'paged', FILTER_SANITIZE_STRING );
+	/**
+	 * Callback for Lazy-loading the next results.
+	 * Gets the paged posts that belong to the next page/load and are to be used with the twig template.
+	 */
+	public function get_paged_posts() {
+		// If this is an ajax call.
+		if ( wp_doing_ajax() ) {
+			$search_action = filter_input( INPUT_GET, 'search-action', FILTER_SANITIZE_STRING );
+			$paged         = filter_input( INPUT_GET, 'paged', FILTER_SANITIZE_STRING );
 
-				// Check if call action is correct.
-				if ( 'get_paged_posts' === $search_action ) {
-					$search_async = new static();
-					$search_async->set_context( $search_async->context );
-					$search_async->search_query = urldecode( filter_input( INPUT_GET, 'search_query', FILTER_SANITIZE_STRING ) );
+			// Check if call action is correct.
+			if ( 'get_paged_posts' === $search_action ) {
+				$search_async = new static();
+				$search_async->set_context( $search_async->context );
+				$search_async->search_query = urldecode( filter_input( INPUT_GET, 'search_query', FILTER_SANITIZE_STRING ) );
 
-					// Get the decoded url query string and then use it as key for redis.
-					$query_string_full = urldecode( filter_input( INPUT_SERVER, 'QUERY_STRING', FILTER_SANITIZE_STRING ) );
-					$query_string      = str_replace( '&query-string=', '', strstr( $query_string_full, '&query-string=' ) );
+				// Get the decoded url query string and then use it as key for redis.
+				$query_string_full = urldecode( filter_input( INPUT_SERVER, 'QUERY_STRING', FILTER_SANITIZE_STRING ) );
+				$query_string      = str_replace( '&query-string=', '', strstr( $query_string_full, '&query-string=' ) );
 
-					$search_async->current_page = $paged;
+				$search_async->current_page = $paged;
 
-					parse_str( $query_string, $filters_array );
-					$selected_sort    = $filters_array['orderby'] ?? self::DEFAULT_SORT;
-					$selected_filters = $filters_array['f'] ?? [];
-					$filters          = [];
+				parse_str( $query_string, $filters_array );
+				$selected_sort    = $filters_array['orderby'] ?? self::DEFAULT_SORT;
+				$selected_filters = $filters_array['f'] ?? [];
+				$filters          = [];
 
-					// Handle submitted filter options.
-					if ( $selected_filters && is_array( $selected_filters ) ) {
-						foreach ( $selected_filters as $type => $filter_type ) {
-							if ( ! is_array( $filter_type ) ) {
-								continue;
-							}
-							foreach ( $filter_type as $name => $id ) {
-								$filters[ $type ][] = [
-									'id'   => $id,
-									'name' => $name,
-								];
-							}
+				// Handle submitted filter options.
+				if ( $selected_filters && is_array( $selected_filters ) ) {
+					foreach ( $selected_filters as $type => $filter_type ) {
+						if ( ! is_array( $filter_type ) ) {
+							continue;
+						}
+						foreach ( $filter_type as $name => $id ) {
+							$filters[ $type ][] = [
+								'id'   => $id,
+								'name' => $name,
+							];
 						}
 					}
-
-					// Validate user input (sort, filters, etc).
-					if ( $search_async->validate( $selected_sort, $filters, $search_async->context ) ) {
-						$search_async->selected_sort = $selected_sort;
-						$search_async->filters       = $filters;
-					}
-
-					$search_async->paged_posts = $search_async->get_posts( $search_async->current_page );
-
-					// If there are paged results then set their context and send them back to client.
-					if ( $search_async->paged_posts ) {
-						$search_async->set_results_context( $search_async->context );
-						$search_async->view_paged_posts();
-					}
 				}
-				wp_die();
+
+				// Validate user input (sort, filters, etc).
+				if ( $search_async->validate( $selected_sort, $filters, $search_async->context ) ) {
+					$search_async->selected_sort = $selected_sort;
+					$search_async->filters       = $filters;
+				}
+
+				$search_async->paged_posts = $search_async->get_posts( $search_async->current_page );
+
+				// If there are paged results then set their context and send them back to client.
+				if ( $search_async->paged_posts ) {
+					$search_async->set_results_context( $search_async->context );
+					$search_async->view_paged_posts();
+				}
+			}
+			wp_die();
+		}
+	}
+
+	/**
+	 * Gets the respective Timber Posts, to be used with the twig template.
+	 * If there are not then uses Timber's get_posts to retrieve all of them (up to the limit set).
+	 *
+	 * @param int $paged The number of the page of the results to be shown when using pagination/load_more.
+	 *
+	 * @return array The respective Timber Posts.
+	 */
+	protected function get_posts( $paged = 1 ) : array {
+		$template_posts = [];
+
+		$posts = $this->query_posts( $paged );
+
+		if ( empty( $posts ) ) {
+			return [];
+		}
+
+		foreach ( $posts as $post ) {
+			if ( P4_Post_Archive::POST_TYPE === $post->post_type ) {
+				$archive_post               = new stdClass();
+				$archive_post->id           = $post->ID;
+				$archive_post->post_title   = $post->post_title;
+				$archive_post->link         = $post->guid;
+				$archive_post->post_type    = P4_Post_Archive::POST_TYPE;
+				$archive_post->post_date    = $post->post_date_gmt;
+				$archive_post->post_excerpt = $post->post_excerpt;
+
+				if ( current_user_can( 'edit_posts' ) ) {
+					$archive_post->edit_link = get_edit_post_link( $post->ID );
+				}
+
+				$template_posts[] = $archive_post;
+			} else {
+				$template_post                = $post;
+				$template_post->id            = $post->ID;
+				$template_post->link          = $post->permalink;
+				$template_post->preview       = $post->excerpt;
+				$thumbnail                    = get_the_post_thumbnail_url( $post->ID, 'thumbnail' );
+				$template_post->thumbnail_alt = get_the_post_thumbnail_caption( $post->ID );
+				$template_post->thumbnail     = $thumbnail;
+
+				$tags          = $post->terms['post_tag'] ?? [];
+				$p4_page_types = $post->terms['p4-page-type'] ?? [];
+				// @todo Ensure the term link is synced to ElasticSearch so we don't have to fetch it here.
+				$template_post->tags          = self::filter_existing_terms( $tags );
+				$template_post->p4_page_types = self::filter_existing_terms( $p4_page_types );
+
+				$template_posts[] = $template_post;
 			}
 		}
 
-		/**
-		 * Gets the respective Timber Posts, to be used with the twig template.
-		 * If there are not then uses Timber's get_posts to retrieve all of them (up to the limit set).
-		 *
-		 * @param int $paged The number of the page of the results to be shown when using pagination/load_more.
-		 *
-		 * @return array The respective Timber Posts.
-		 */
-		protected function get_posts( $paged = 1 ) : array {
-			$template_posts = [];
+		return $template_posts;
+	}
 
-			$posts = $this->query_posts( $paged );
+	/**
+	 * Applies user selected filters to the search if there are any and gets the filtered posts.
+	 *
+	 * @param int $paged The number of the page of the results to be shown when using pagination/load_more.
+	 *
+	 * @return array The posts of the search.
+	 */
+	public function query_posts( $paged = 1 ) : array {
+		// Set General Query arguments.
+		$args = $this->get_general_args( $paged );
 
-			if ( empty( $posts ) ) {
-				return [];
-			}
-
-			foreach ( $posts as $post ) {
-				if ( P4_Post_Archive::POST_TYPE === $post->post_type ) {
-					$archive_post               = new stdClass();
-					$archive_post->id           = $post->ID;
-					$archive_post->post_title   = $post->post_title;
-					$archive_post->link         = $post->guid;
-					$archive_post->post_type    = P4_Post_Archive::POST_TYPE;
-					$archive_post->post_date    = $post->post_date_gmt;
-					$archive_post->post_excerpt = $post->post_excerpt;
-
-					if ( current_user_can( 'edit_posts' ) ) {
-						$archive_post->edit_link = get_edit_post_link( $post->ID );
-					}
-
-					$template_posts[] = $archive_post;
-				} else {
-					$template_post                = $post;
-					$template_post->id            = $post->ID;
-					$template_post->link          = $post->permalink;
-					$template_post->preview       = $post->excerpt;
-					$thumbnail                    = get_the_post_thumbnail_url( $post->ID, 'thumbnail' );
-					$template_post->thumbnail_alt = get_the_post_thumbnail_caption( $post->ID );
-					$template_post->thumbnail     = $thumbnail;
-
-					$tags          = $post->terms['post_tag'] ?? [];
-					$p4_page_types = $post->terms['p4-page-type'] ?? [];
-					// @todo Ensure the term link is synced to ElasticSearch so we don't have to fetch it here.
-					$template_post->tags          = self::filter_existing_terms( $tags );
-					$template_post->p4_page_types = self::filter_existing_terms( $p4_page_types );
-
-					$template_posts[] = $template_post;
-				}
-			}
-
-			return $template_posts;
+		// Set Filters Query arguments.
+		try {
+			$this->set_filters_args( $args );
+		} catch ( UnexpectedValueException $e ) {
+			$this->context['exception'] = $e->getMessage();
+			return [];
 		}
 
-		/**
-		 * Applies user selected filters to the search if there are any and gets the filtered posts.
-		 *
-		 * @param int $paged The number of the page of the results to be shown when using pagination/load_more.
-		 *
-		 * @return array The posts of the search.
-		 */
-		public function query_posts( $paged = 1 ) : array {
-			// Set General Query arguments.
-			$args = $this->get_general_args( $paged );
-
-			// Set Filters Query arguments.
-			try {
-				$this->set_filters_args( $args );
-			} catch ( UnexpectedValueException $e ) {
-				$this->context['exception'] = $e->getMessage();
-				return [];
+		// Set Engine Query arguments.
+		$this->set_engines_args( $args );
+		add_action(
+			'ep_valid_response',
+			function ( $response ) {
+				$this->aggregations = $response['aggregations'];
+				$this->query_time   = $response['took'];
 			}
+		);
 
-			// Set Engine Query arguments.
-			$this->set_engines_args( $args );
-			add_action(
-				'ep_valid_response',
-				function ( $response ) {
-					$this->aggregations = $response['aggregations'];
-					$this->query_time   = $response['took'];
-				}
-			);
+		$query = ( new WP_Query() );
+		$posts = $query->query( $args );
 
-			$query = ( new WP_Query() );
-			$posts = $query->query( $args );
+		$this->total_matches = $query->found_posts;
 
-			$this->total_matches = $query->found_posts;
+		return (array) $posts;
+	}
 
-			return (array) $posts;
+	/**
+	 * Sets arguments for the WP_Query that are related to the application.
+	 *
+	 * @param int $paged The number of the page of the results to be shown when using pagination/load_more.
+	 * @return array
+	 */
+	protected function get_general_args( $paged ): array {
+		$args = [
+			'posts_per_page' => self::POSTS_PER_LOAD,
+			'no_found_rows'  => true,
+			'post_type'      => self::get_post_types(),
+			'post_status'    => [ 'publish', 'inherit' ],
+		];
+
+		if ( $paged > 1 ) {
+			$args['paged'] = $paged;
 		}
 
-		/**
-		 * Sets arguments for the WP_Query that are related to the application.
-		 *
-		 * @param int $paged The number of the page of the results to be shown when using pagination/load_more.
-		 * @return array
-		 */
-		protected function get_general_args( $paged ): array {
-			$args = [
-				'posts_per_page' => self::POSTS_PER_LOAD,
-				'no_found_rows'  => true,
-				'post_type'      => self::get_post_types(),
-				'post_status'    => [ 'publish', 'inherit' ],
+		if ( $this->search_query ) {
+			$args['s']          = $this->search_query;
+			$args['meta_query'] = [
+				[
+					'key'     => self::EXCLUDE_FROM_SEARCH,
+					'compare' => 'NOT EXISTS',
+				],
 			];
-
-			if ( $paged > 1 ) {
-				$args['paged'] = $paged;
-			}
-
-			if ( $this->search_query ) {
-				$args['s']          = $this->search_query;
-				$args['meta_query'] = [
+		} else {
+			$args2 = [
+				'orderby'    => 'meta_value date',  // If we search for everything then order first by 'weight' and then by 'post_date'.
+				'order'      => 'DESC DESC',
+				'meta_query' => [
+					'relation' => 'AND',
+					[
+						'relation' => 'OR',
+						[
+							'key'     => 'weight',
+							'compare' => 'NOT EXISTS',
+						],
+						[
+							'key'     => 'weight',
+							'compare' => 'EXISTS',
+						],
+					],
 					[
 						'key'     => self::EXCLUDE_FROM_SEARCH,
 						'compare' => 'NOT EXISTS',
 					],
-				];
-			} else {
-				$args2 = [
-					'orderby'    => 'meta_value date',  // If we search for everything then order first by 'weight' and then by 'post_date'.
-					'order'      => 'DESC DESC',
-					'meta_query' => [
-						'relation' => 'AND',
-						[
-							'relation' => 'OR',
-							[
-								'key'     => 'weight',
-								'compare' => 'NOT EXISTS',
-							],
-							[
-								'key'     => 'weight',
-								'compare' => 'EXISTS',
-							],
-						],
-						[
-							'key'     => self::EXCLUDE_FROM_SEARCH,
-							'compare' => 'NOT EXISTS',
-						],
-					],
-				];
-				$args  = array_merge( $args, $args2 );
-			}
-
-			$args['s'] = $this->search_query;
-			// Add sort by date.
-			if ( wp_doing_ajax() ) {
-				// Get the decoded url query string and then use it as key for redis.
-				$query_string_full = urldecode( filter_input( INPUT_SERVER, 'QUERY_STRING', FILTER_SANITIZE_STRING ) );
-				$query_string      = str_replace(
-					'&query-string=',
-					'',
-					strstr( $query_string_full, '&query-string=' )
-				);
-				parse_str( $query_string, $filters_array );
-				$selected_sort = $filters_array['orderby'] ?? self::DEFAULT_SORT;
-			} else {
-				$selected_sort = filter_input( INPUT_GET, 'orderby', FILTER_SANITIZE_STRING );
-			}
-			$selected_sort = sanitize_sql_orderby( $selected_sort );
-
-			if ( $selected_sort && self::DEFAULT_SORT !== $selected_sort ) {
-				$args['orderby'] = 'date';
-				$args['order']   = 'desc';
-			}
-
-			$args['search_fields'] = [
-				'post_title',
-				'post_content',
-				'post_excerpt',
-				'post_author.display_name',
+				],
 			];
-
-			return $args;
+			$args  = array_merge( $args, $args2 );
 		}
 
-		/**
-		 * Get the post types that should be available in search.
-		 *
-		 * @return array The post types that should be in search.
-		 */
-		private static function get_post_types() {
-			$types = [
-				'page',
-				'campaign',
-				'post',
-				'attachment',
-			];
-
-			if ( self::should_include_archive() ) {
-				$types[] = P4_Post_Archive::POST_TYPE;
-			}
-
-			return $types;
-		}
-
-		/**
-		 * Whether archived content should be in the results.
-		 *
-		 * @return bool Whether archived content should be in the results.
-		 */
-		private static function should_include_archive(): bool {
-			$setting = planet4_get_option( 'include_archive_content_for' );
-
-			return 'all' === $setting || ( 'logged_in' === $setting && is_user_logged_in() );
-		}
-
-		/**
-		 * Return only existing terms with their link.
-		 * We need to do this as the term might have been removed but ES could still have it.
-		 *
-		 * @param array $terms The terms to filter.
-		 * @return mixed|null All existing terms, with link.
-		 */
-		private static function filter_existing_terms( array $terms ) {
-			return array_reduce(
-				$terms,
-				static function ( $carry, $term ) {
-					$link = get_term_link( $term['term_id'] );
-
-					if ( ! is_wp_error( $link ) ) {
-						$term['link'] = $link;
-						$carry[]      = $term;
-					}
-
-					return $carry;
-				},
-				[]
+		$args['s'] = $this->search_query;
+		// Add sort by date.
+		if ( wp_doing_ajax() ) {
+			// Get the decoded url query string and then use it as key for redis.
+			$query_string_full = urldecode( filter_input( INPUT_SERVER, 'QUERY_STRING', FILTER_SANITIZE_STRING ) );
+			$query_string      = str_replace(
+				'&query-string=',
+				'',
+				strstr( $query_string_full, '&query-string=' )
 			);
+			parse_str( $query_string, $filters_array );
+			$selected_sort = $filters_array['orderby'] ?? self::DEFAULT_SORT;
+		} else {
+			$selected_sort = filter_input( INPUT_GET, 'orderby', FILTER_SANITIZE_STRING );
+		}
+		$selected_sort = sanitize_sql_orderby( $selected_sort );
+
+		if ( $selected_sort && self::DEFAULT_SORT !== $selected_sort ) {
+			$args['orderby'] = 'date';
+			$args['order']   = 'desc';
 		}
 
-		/**
-		 * Adds arguments for the WP_Query that are related only to the search engine.
-		 *
-		 * @param array $args The search query args.
-		 */
-		abstract public function set_engines_args( &$args );
+		$args['search_fields'] = [
+			'post_title',
+			'post_content',
+			'post_excerpt',
+			'post_author.display_name',
+		];
 
-		/**
-		 * Applies user selected filters to the search if there are any and gets the filtered posts.
-		 *
-		 * @param array $args The search query args.
-		 *
-		 * @throws UnexpectedValueException When filter type is not recognized.
-		 */
-		public function set_filters_args( &$args ) {
-			if ( $this->filters ) {
-				foreach ( $this->filters as $type => $filter_type ) {
-					foreach ( $filter_type as $filter ) {
-						switch ( $type ) {
-							case 'cat':
-								$args['tax_query'][] = [
-									'taxonomy' => 'category',
-									'field'    => 'term_id',
-									'terms'    => $filter['id'],
-								];
-								break;
-							case 'tag':
-								$args['tax_query'][] = [
-									'taxonomy' => 'post_tag',
-									'field'    => 'term_id',
-									'terms'    => $filter['id'],
-								];
-								break;
-							case 'ptype':
-								// This taxonomy is used only for Posts.
-								$args['post_type']   = 'post';
-								$args['tax_query'][] = [
-									'taxonomy' => 'p4-page-type',
-									'field'    => 'term_id',
-									'terms'    => $filter['id'],
-								];
-								break;
-							case 'ctype':
-								switch ( $filter['id'] ) {
-									case 0:
-										$args['post_type']   = 'page';
-										$args['post_status'] = 'publish';
-										$options             = get_option( 'planet4_options' );
-										$args['post_parent'] = esc_sql( $options['act_page'] );
-										break;
-									case 1:
-										$args['post_type']      = 'attachment';
-										$args['post_status']    = 'inherit';
-										$args['post_mime_type'] = self::DOCUMENT_TYPES;
-										break;
-									case 2:
-										$args['post_type']             = 'page';
-										$args['post_status']           = 'publish';
-										$options                       = get_option( 'planet4_options' );
-										$args['post_parent__not_in'][] = esc_sql( $options['act_page'] );
-										break;
-									case 3:
-										$args['post_type']   = 'post';
-										$args['post_status'] = 'publish';
-										break;
-									case 4:
-										$args['post_type']   = 'campaign';
-										$args['post_status'] = 'publish';
-										break;
-									case 5:
-										$args['post_type'] = 'archive';
-										break;
-									default:
-										throw new UnexpectedValueException( 'Unexpected content type!' );
-								}
-								break;
-							default:
-								throw new UnexpectedValueException( 'Unexpected filter!' );
-						}
+		return $args;
+	}
+
+	/**
+	 * Get the post types that should be available in search.
+	 *
+	 * @return array The post types that should be in search.
+	 */
+	private static function get_post_types() {
+		$types = [
+			'page',
+			'campaign',
+			'post',
+			'attachment',
+		];
+
+		if ( self::should_include_archive() ) {
+			$types[] = P4_Post_Archive::POST_TYPE;
+		}
+
+		return $types;
+	}
+
+	/**
+	 * Whether archived content should be in the results.
+	 *
+	 * @return bool Whether archived content should be in the results.
+	 */
+	private static function should_include_archive(): bool {
+		$setting = planet4_get_option( 'include_archive_content_for' );
+
+		return 'all' === $setting || ( 'logged_in' === $setting && is_user_logged_in() );
+	}
+
+	/**
+	 * Return only existing terms with their link.
+	 * We need to do this as the term might have been removed but ES could still have it.
+	 *
+	 * @param array $terms The terms to filter.
+	 * @return mixed|null All existing terms, with link.
+	 */
+	private static function filter_existing_terms( array $terms ) {
+		return array_reduce(
+			$terms,
+			static function ( $carry, $term ) {
+				$link = get_term_link( $term['term_id'] );
+
+				if ( ! is_wp_error( $link ) ) {
+					$term['link'] = $link;
+					$carry[]      = $term;
+				}
+
+				return $carry;
+			},
+			[]
+		);
+	}
+
+	/**
+	 * Adds arguments for the WP_Query that are related only to the search engine.
+	 *
+	 * @param array $args The search query args.
+	 */
+	abstract public function set_engines_args( &$args );
+
+	/**
+	 * Applies user selected filters to the search if there are any and gets the filtered posts.
+	 *
+	 * @param array $args The search query args.
+	 *
+	 * @throws UnexpectedValueException When filter type is not recognized.
+	 */
+	public function set_filters_args( &$args ) {
+		if ( $this->filters ) {
+			foreach ( $this->filters as $type => $filter_type ) {
+				foreach ( $filter_type as $filter ) {
+					switch ( $type ) {
+						case 'cat':
+							$args['tax_query'][] = [
+								'taxonomy' => 'category',
+								'field'    => 'term_id',
+								'terms'    => $filter['id'],
+							];
+							break;
+						case 'tag':
+							$args['tax_query'][] = [
+								'taxonomy' => 'post_tag',
+								'field'    => 'term_id',
+								'terms'    => $filter['id'],
+							];
+							break;
+						case 'ptype':
+							// This taxonomy is used only for Posts.
+							$args['post_type']   = 'post';
+							$args['tax_query'][] = [
+								'taxonomy' => 'p4-page-type',
+								'field'    => 'term_id',
+								'terms'    => $filter['id'],
+							];
+							break;
+						case 'ctype':
+							switch ( $filter['id'] ) {
+								case 0:
+									$args['post_type']   = 'page';
+									$args['post_status'] = 'publish';
+									$options             = get_option( 'planet4_options' );
+									$args['post_parent'] = esc_sql( $options['act_page'] );
+									break;
+								case 1:
+									$args['post_type']      = 'attachment';
+									$args['post_status']    = 'inherit';
+									$args['post_mime_type'] = self::DOCUMENT_TYPES;
+									break;
+								case 2:
+									$args['post_type']             = 'page';
+									$args['post_status']           = 'publish';
+									$options                       = get_option( 'planet4_options' );
+									$args['post_parent__not_in'][] = esc_sql( $options['act_page'] );
+									break;
+								case 3:
+									$args['post_type']   = 'post';
+									$args['post_status'] = 'publish';
+									break;
+								case 4:
+									$args['post_type']   = 'campaign';
+									$args['post_status'] = 'publish';
+									break;
+								case 5:
+									$args['post_type'] = 'archive';
+									break;
+								default:
+									throw new UnexpectedValueException( 'Unexpected content type!' );
+							}
+							break;
+						default:
+							throw new UnexpectedValueException( 'Unexpected filter!' );
 					}
 				}
 			}
 		}
+	}
 
-		/**
-		 * Sets the P4 Search page context.
-		 *
-		 * @param array $context Associative array with the data to be passed to the view.
-		 */
-		protected function set_context( &$context ) {
-			$this->set_general_context( $context );
-			try {
-				$this->set_filters_context( $context );
-			} catch ( UnexpectedValueException $e ) {
-				$this->context['exception'] = $e->getMessage();
-			}
-			$this->set_results_context( $context );
+	/**
+	 * Sets the P4 Search page context.
+	 *
+	 * @param array $context Associative array with the data to be passed to the view.
+	 */
+	protected function set_context( &$context ) {
+		$this->set_general_context( $context );
+		try {
+			$this->set_filters_context( $context );
+		} catch ( UnexpectedValueException $e ) {
+			$this->context['exception'] = $e->getMessage();
+		}
+		$this->set_results_context( $context );
+	}
+
+	/**
+	 * Sets the general context for the Search page.
+	 *
+	 * @param array $context Associative array with the data to be passed to the view.
+	 */
+	protected function set_general_context( &$context ) {
+
+		// Search context.
+		$context['posts']            = $this->posts;
+		$context['paged_posts']      = $this->paged_posts;
+		$context['current_page']     = $this->current_page;
+		$context['search_query']     = $this->search_query;
+		$context['selected_sort']    = $this->selected_sort;
+		$context['default_sort']     = self::DEFAULT_SORT;
+		$context['filters']          = $this->filters;
+		$context['found_posts']      = $this->total_matches;
+		$context['source_selection'] = false;
+		$context['page_category']    = 'Search Page';
+		$context['sort_options']     = [
+			'_score'    => [
+				'name'  => __( 'Most relevant', 'planet4-master-theme' ),
+				'order' => 'DESC',
+			],
+			'post_date' => [
+				'name'  => __( 'Most recent', 'planet4-master-theme' ),
+				'order' => 'DESC',
+			],
+		];
+
+		if ( $this->search_query ) {
+			$context['page_title'] = sprintf(
+				// translators: %1$d = Number of results.
+				_n( '%1$d result for \'%2$s\'', '%1$d results for \'%2$s\'', $context['found_posts'], 'planet4-master-theme' ),
+				$context['found_posts'],
+				$this->search_query
+			);
+		} else {
+			// translators: %d = Number of results.
+			$context['page_title'] = sprintf( _n( '%d result', '%d results', $context['found_posts'], 'planet4-master-theme' ), $context['found_posts'] );
 		}
 
-		/**
-		 * Sets the general context for the Search page.
-		 *
-		 * @param array $context Associative array with the data to be passed to the view.
-		 */
-		protected function set_general_context( &$context ) {
-
-			// Search context.
-			$context['posts']            = $this->posts;
-			$context['paged_posts']      = $this->paged_posts;
-			$context['current_page']     = $this->current_page;
-			$context['search_query']     = $this->search_query;
-			$context['selected_sort']    = $this->selected_sort;
-			$context['default_sort']     = self::DEFAULT_SORT;
-			$context['filters']          = $this->filters;
-			$context['found_posts']      = $this->total_matches;
-			$context['source_selection'] = false;
-			$context['page_category']    = 'Search Page';
-			$context['sort_options']     = [
-				'_score'    => [
-					'name'  => __( 'Most relevant', 'planet4-master-theme' ),
-					'order' => 'DESC',
-				],
-				'post_date' => [
-					'name'  => __( 'Most recent', 'planet4-master-theme' ),
-					'order' => 'DESC',
-				],
-			];
-
-			if ( $this->search_query ) {
-				$context['page_title'] = sprintf(
-					// translators: %1$d = Number of results.
-					_n( '%1$d result for \'%2$s\'', '%1$d results for \'%2$s\'', $context['found_posts'], 'planet4-master-theme' ),
-					$context['found_posts'],
-					$this->search_query
-				);
-			} else {
-				// translators: %d = Number of results.
-				$context['page_title'] = sprintf( _n( '%d result', '%d results', $context['found_posts'], 'planet4-master-theme' ), $context['found_posts'] );
-			}
-
-			if ( is_user_logged_in() ) {
-				$context['query_time'] = $this->query_time;
-			}
+		if ( is_user_logged_in() ) {
+			$context['query_time'] = $this->query_time;
 		}
+	}
 
-		/**
-		 * Set filters context
-		 *
-		 * @param mixed $context Context.
-		 *
-		 * @throws UnexpectedValueException When filter type is not recognized.
-		 */
-		protected function set_filters_context( &$context ) {
-			// Retrieve P4 settings in order to check that we add only categories that are children of the Issues category.
-			$options = get_option( 'planet4_options' );
+	/**
+	 * Set filters context
+	 *
+	 * @param mixed $context Context.
+	 *
+	 * @throws UnexpectedValueException When filter type is not recognized.
+	 */
+	protected function set_filters_context( &$context ) {
+		// Retrieve P4 settings in order to check that we add only categories that are children of the Issues category.
+		$options = get_option( 'planet4_options' );
 
-			// Category <-> Issue.
-			// Consider Issues that have multiple Categories.
-			$categories = get_categories( [ 'child_of' => $options['issues_parent_category'] ] );
-			if ( $categories ) {
-				foreach ( $categories as $category ) {
-					$context['categories'][ $category->term_id ] = [
-						'term_id' => $category->term_id,
-						'name'    => $category->name,
-						'results' => 0,
-					];
-				}
-			}
-
-			// Tag <-> Campaign.
-			$tags = get_terms(
-				[
-					'taxonomy'   => 'post_tag',
-					'hide_empty' => false,
-				]
-			);
-			if ( $tags ) {
-				foreach ( (array) $tags as $tag ) {
-					// Tag filters.
-					$context['tags'][ $tag->term_id ] = [
-						'term_id' => $tag->term_id,
-						'name'    => $tag->name,
-						'results' => 0,
-					];
-				}
-			}
-
-			// Page Type <-> Category.
-			$page_types = get_terms(
-				[
-					'taxonomy'   => 'p4-page-type',
-					'hide_empty' => false,
-				]
-			);
-			if ( $page_types ) {
-				foreach ( (array) $page_types as $page_type ) {
-					// p4-page-type filters.
-					$context['page_types'][ $page_type->term_id ] = [
-						'term_id' => $page_type->term_id,
-						'name'    => $page_type->name,
-						'results' => 0,
-					];
-				}
-			}
-
-			// Post Type (+Action) <-> Content Type.
-			$context['content_types']['0'] = [
-				'name'    => __( 'Action', 'planet4-master-theme' ),
-				'results' => 0,
-			];
-			$context['content_types']['4'] = [
-				'name'    => __( 'Campaign', 'planet4-master-theme' ),
-				'results' => 0,
-			];
-			$context['content_types']['1'] = [
-				'name'    => __( 'Document', 'planet4-master-theme' ),
-				'results' => 0,
-			];
-			$context['content_types']['2'] = [
-				'name'    => __( 'Page', 'planet4-master-theme' ),
-				'results' => 0,
-			];
-			$context['content_types']['3'] = [
-				'name'    => __( 'Post', 'planet4-master-theme' ),
-				'results' => 0,
-			];
-			if ( self::should_include_archive() ) {
-				$context['content_types']['5'] = [
-					'name'    => __( 'Archive', 'planet4-master-theme' ),
+		// Category <-> Issue.
+		// Consider Issues that have multiple Categories.
+		$categories = get_categories( [ 'child_of' => $options['issues_parent_category'] ] );
+		if ( $categories ) {
+			foreach ( $categories as $category ) {
+				$context['categories'][ $category->term_id ] = [
+					'term_id' => $category->term_id,
+					'name'    => $category->name,
 					'results' => 0,
 				];
 			}
+		}
 
-			// Keep track of which filters are already checked.
-			if ( $this->filters ) {
-				foreach ( $this->filters as $type => $filter_type ) {
-					foreach ( $filter_type as $filter ) {
-						switch ( $type ) {
-							case 'cat':
-								$context['categories'][ $filter['id'] ]['checked'] = 'checked';
-								break;
-							case 'tag':
-								$context['tags'][ $filter['id'] ]['checked'] = 'checked';
-								break;
-							case 'ptype':
-								$context['page_types'][ $filter['id'] ]['checked'] = 'checked';
-								break;
-							case 'ctype':
-								$context['content_types'][ $filter['id'] ]['checked'] = 'checked';
-								break;
-							default:
-								throw new UnexpectedValueException( 'Unexpected filter!' );
-						}
-					}
-				}
-			}
-
-			// Sort associative array with filters alphabetically.
-			if ( $context['categories'] ?? false ) {
-				uasort(
-					$context['categories'],
-					function ( $a, $b ) {
-						return strcmp( $a['name'], $b['name'] );
-					}
-				);
-			}
-			if ( $context['tags'] ?? false ) {
-				uasort(
-					$context['tags'],
-					function ( $a, $b ) {
-						return strcmp( $a['name'], $b['name'] );
-					}
-				);
+		// Tag <-> Campaign.
+		$tags = get_terms(
+			[
+				'taxonomy'   => 'post_tag',
+				'hide_empty' => false,
+			]
+		);
+		if ( $tags ) {
+			foreach ( (array) $tags as $tag ) {
+				// Tag filters.
+				$context['tags'][ $tag->term_id ] = [
+					'term_id' => $tag->term_id,
+					'name'    => $tag->name,
+					'results' => 0,
+				];
 			}
 		}
 
-		/**
-		 * Sets the context for the results of the Search.
-		 *
-		 * Categories are Issues.
-		 * Tags       are Campaigns.
-		 * Page types are Categories.
-		 * Post_types are Content Types.
-		 *
-		 * @param array $context Associative array with the data to be passed to the view.
-		 */
-		protected function set_results_context( &$context ) {
-
-			$posts = $this->posts ?? $this->paged_posts;
-
-			// Retrieve P4 settings in order to check that we add only categories that are children of the Issues category.
-			$options = get_option( 'planet4_options' );
-
-			// Pass planet4 settings.
-			$context['settings'] = $options;
-
-			// Set default thumbnail.
-			$context['dummy_thumbnail'] = get_template_directory_uri() . self::DUMMY_THUMBNAIL;
-
-			$act_page_count = null;
-
-			if ( ! empty( $this->aggregations ) ) {
-				$aggs = $this->aggregations['with_post_filter'];
-				foreach ( $aggs['post_parent']['buckets'] as $parent_agg ) {
-					if ( $parent_agg['key'] === (int) $options['act_page'] ) {
-						$act_page_count                           = $parent_agg['doc_count'];
-						$context['content_types']['0']['results'] = $act_page_count;
-					}
-				}
-
-				foreach ( $aggs['post_type']['buckets'] as $post_type_agg ) {
-					if ( 'page' === $post_type_agg['key'] ) {
-						// We show act pages as a separate item, so subtract there count from the other pages.
-						// But counts can be off in ES so don't use lower than 0.
-						$context['content_types']['2']['results'] = max(
-							0,
-							$post_type_agg['doc_count'] - $act_page_count
-						);
-					}
-					if ( 'attachment' === $post_type_agg['key'] ) {
-						$context['content_types']['1']['results'] = $post_type_agg['doc_count'];
-					}
-					if ( 'post' === $post_type_agg['key'] ) {
-						$context['content_types']['3']['results'] = $post_type_agg['doc_count'];
-					}
-					if ( 'campaign' === $post_type_agg['key'] ) {
-						$context['content_types']['4']['results'] = $post_type_agg['doc_count'];
-					}
-					if ( 'archive' === $post_type_agg['key'] && self::should_include_archive() ) {
-						$context['content_types']['5']['results'] = $post_type_agg['doc_count'];
-					}
-				}
-
-				foreach ( $aggs['p4-page-type']['buckets'] as $p4_post_type_agg ) {
-					$p4_post_type_id = (int) $p4_post_type_agg['key'];
-
-					$p4_post_type = self::get_p4_post_type( $p4_post_type_id );
-
-					$context['page_types'][ $p4_post_type_id ] = [
-						'term_id' => $p4_post_type_id,
-						'name'    => $p4_post_type->name,
-						'results' => $p4_post_type_agg['doc_count'],
-					];
-				}
-
-				foreach ( $aggs['categories']['buckets'] as $category_agg ) {
-					// TODO get the parent from ES so no fetch is needed here.
-					$category = get_category( $category_agg['key'] );
-
-					// Category <-> Issue.
-					// Consider Issues that have multiple Categories.
-					if ( $category->parent === (int) $options['issues_parent_category'] ) {
-						$context['categories'][ $category->term_id ]['results'] = $category_agg['doc_count'];
-					}
-				}
-
-				foreach ( $aggs['tags']['buckets'] as $tag_agg ) {
-					// Tag filters.
-					$tag = get_tag( $tag_agg['key'] );
-
-					$context['tags'][ $tag->term_id ]['results'] = $tag_agg['doc_count'];
-				}
-			}
-
-			foreach ( (array) $posts as $post ) {
-				// Post Type (+Action) <-> Content Type.
-				switch ( $post->post_type ) {
-					case 'page':
-						if ( $post->post_parent === (int) $options['act_page'] ) {
-							$content_type_text = __( 'ACTION', 'planet4-master-theme' );
-							$content_type      = 'action';
-						} else {
-							$content_type_text = __( 'PAGE', 'planet4-master-theme' );
-							$content_type      = 'page';
-						}
-						break;
-					case 'campaign':
-						$content_type_text = __( 'CAMPAIGN', 'planet4-master-theme' );
-						$content_type      = 'campaign';
-						break;
-					case 'attachment':
-						$content_type_text = __( 'DOCUMENT', 'planet4-master-theme' );
-						$content_type      = 'document';
-						break;
-					case 'post':
-						$content_type_text = __( 'POST', 'planet4-master-theme' );
-						$content_type      = 'post';
-						break;
-					case P4_Post_Archive::POST_TYPE:
-						$content_type_text = __( 'Archive', 'planet4-master-theme' );
-						$content_type      = 'archive';
-						break;
-					default:
-						continue 2;     // Ignore other post_types and continue with next $post.
-				}
-
-				if ( ! isset( $post->ID ) ) {
-					$post->ID = $post->link;
-				}
-				$post->content_type_text = $content_type_text;
-				$post->content_type      = $content_type;
-
-				// Page Type <-> Category. This taxonomy is used only for Posts.
-				if ( 'post' === $post->post_type && ! empty( $post->terms['p4-page-type'] ) ) {
-					$post->page_types = [
-						self::get_p4_post_type(
-							$post->terms['p4-page-type'][0]
-						),
-					];
-				}
+		// Page Type <-> Category.
+		$page_types = get_terms(
+			[
+				'taxonomy'   => 'p4-page-type',
+				'hide_empty' => false,
+			]
+		);
+		if ( $page_types ) {
+			foreach ( (array) $page_types as $page_type ) {
+				// p4-page-type filters.
+				$context['page_types'][ $page_type->term_id ] = [
+					'term_id' => $page_type->term_id,
+					'name'    => $page_type->name,
+					'results' => 0,
+				];
 			}
 		}
 
-		/**
-		 * Load the p4 page type.
-		 *
-		 * @todo Get this from ES.
-		 *
-		 * @param string|int $id The ID of the p4 page type.
-		 * @return mixed|null The p4 page type.
-		 */
-		private static function get_p4_post_type( $id ) {
-			$p4_post_types = get_terms( 'p4-page-type' );
-
-			foreach ( $p4_post_types as $p4_post_type ) {
-				if ( $id === $p4_post_type->term_id ) {
-					return $p4_post_type;
-				}
-			}
-
-			return null;
-		}
-
-		/**
-		 * Customize which mime types we want to search for regarding attachments.
-		 *
-		 * @param string $where The WHERE clause of the query.
-		 *
-		 * @return string The edited WHERE clause.
-		 */
-		public static function edit_search_mime_types( $where ) : string {
-			global $wpdb;
-
-			$search_action = filter_input( INPUT_GET, 'search-action', FILTER_SANITIZE_STRING );
-
-			if ( ( ! is_admin() && is_search() ) || ( wp_doing_ajax() && ( 'get_paged_posts' === $search_action ) ) ) {
-				$mime_types = implode( ',', self::DOCUMENT_TYPES );
-				$where     .= ' AND ' . $wpdb->posts . '.post_mime_type IN("' . $mime_types . '","") ';
-			}
-			return $where;
-		}
-
-		/**
-		 * Validates the input.
-		 *
-		 * @param string $selected_sort The selected orderby to be validated.
-		 * @param array  $filters The selected filters to be validated.
-		 * @param array  $context Associative array with the data to be passed to the view.
-		 *
-		 * @return bool True if validation is ok, false if validation fails.
-		 */
-		public function validate( &$selected_sort, &$filters, $context ): bool {
-			$selected_sort = filter_var( $selected_sort, FILTER_SANITIZE_STRING );
-
-			if (
-				! isset( $context['sort_options'] )
-				|| ! array_key_exists( $selected_sort, $context['sort_options'] )
-			) {
-				$selected_sort = self::DEFAULT_SORT;
-			}
-
-			if ( $filters ) {
-				foreach ( $filters as &$filter_type ) {
-					foreach ( $filter_type as &$filter ) {
-						$filter['id'] = filter_var( $filter['id'], FILTER_VALIDATE_INT );
-						if ( false === $filter['id'] || null === $filter['id'] || $filter['id'] < 0 ) {
-							return false;
-						}
-					}
-				}
-			}
-			return true;
-		}
-
-		/**
-		 * Adds a section with a Load more button.
-		 *
-		 * @param array|null $args The array with the data for the pagination.
-		 */
-		public function add_load_more( $args = null ) {
-			$this->context['load_more'] = $args ?? [
-				'posts_per_load' => self::POSTS_PER_LOAD,
-				// Translators: %s = number of results per page.
-				'button_text'    => sprintf( __( 'SHOW %s MORE RESULTS', 'planet4-master-theme' ), self::POSTS_PER_LOAD ),
-				'async'          => true,
+		// Post Type (+Action) <-> Content Type.
+		$context['content_types']['0'] = [
+			'name'    => __( 'Action', 'planet4-master-theme' ),
+			'results' => 0,
+		];
+		$context['content_types']['4'] = [
+			'name'    => __( 'Campaign', 'planet4-master-theme' ),
+			'results' => 0,
+		];
+		$context['content_types']['1'] = [
+			'name'    => __( 'Document', 'planet4-master-theme' ),
+			'results' => 0,
+		];
+		$context['content_types']['2'] = [
+			'name'    => __( 'Page', 'planet4-master-theme' ),
+			'results' => 0,
+		];
+		$context['content_types']['3'] = [
+			'name'    => __( 'Post', 'planet4-master-theme' ),
+			'results' => 0,
+		];
+		if ( self::should_include_archive() ) {
+			$context['content_types']['5'] = [
+				'name'    => __( 'Archive', 'planet4-master-theme' ),
+				'results' => 0,
 			];
 		}
 
-		/**
-		 * View the Search page template.
-		 */
-		public function view() {
-			Timber::render( $this->templates, $this->context, self::DEFAULT_CACHE_TTL, \Timber\Loader::CACHE_OBJECT );
+		// Keep track of which filters are already checked.
+		if ( $this->filters ) {
+			foreach ( $this->filters as $type => $filter_type ) {
+				foreach ( $filter_type as $filter ) {
+					switch ( $type ) {
+						case 'cat':
+							$context['categories'][ $filter['id'] ]['checked'] = 'checked';
+							break;
+						case 'tag':
+							$context['tags'][ $filter['id'] ]['checked'] = 'checked';
+							break;
+						case 'ptype':
+							$context['page_types'][ $filter['id'] ]['checked'] = 'checked';
+							break;
+						case 'ctype':
+							$context['content_types'][ $filter['id'] ]['checked'] = 'checked';
+							break;
+						default:
+							throw new UnexpectedValueException( 'Unexpected filter!' );
+					}
+				}
+			}
 		}
 
-		/**
-		 * View the paged posts of the next page/load.
-		 */
-		public function view_paged_posts() {
-			// TODO - The $paged_context related code should be transferred to set_results_context method for better separation of concerns.
-			if ( $this->paged_posts ) {
-				$paged_context['settings'] = get_option( 'planet4_options' );
-
-				$paged_context['dummy_thumbnail'] = get_template_directory_uri() . self::DUMMY_THUMBNAIL;
-
-				foreach ( $this->paged_posts as $index => $post ) {
-					$paged_context['post'] = $post;
-					if ( 0 === $index % self::POSTS_PER_LOAD ) {
-						$paged_context['first_of_the_page'] = true;
-					} else {
-						$paged_context['first_of_the_page'] = false;
-					}
-					Timber::render( [ 'tease-search.twig' ], $paged_context, self::DEFAULT_CACHE_TTL, \Timber\Loader::CACHE_OBJECT );
+		// Sort associative array with filters alphabetically.
+		if ( $context['categories'] ?? false ) {
+			uasort(
+				$context['categories'],
+				function ( $a, $b ) {
+					return strcmp( $a['name'], $b['name'] );
 				}
+			);
+		}
+		if ( $context['tags'] ?? false ) {
+			uasort(
+				$context['tags'],
+				function ( $a, $b ) {
+					return strcmp( $a['name'], $b['name'] );
+				}
+			);
+		}
+	}
+
+	/**
+	 * Sets the context for the results of the Search.
+	 *
+	 * Categories are Issues.
+	 * Tags       are Campaigns.
+	 * Page types are Categories.
+	 * Post_types are Content Types.
+	 *
+	 * @param array $context Associative array with the data to be passed to the view.
+	 */
+	protected function set_results_context( &$context ) {
+
+		$posts = $this->posts ?? $this->paged_posts;
+
+		// Retrieve P4 settings in order to check that we add only categories that are children of the Issues category.
+		$options = get_option( 'planet4_options' );
+
+		// Pass planet4 settings.
+		$context['settings'] = $options;
+
+		// Set default thumbnail.
+		$context['dummy_thumbnail'] = get_template_directory_uri() . self::DUMMY_THUMBNAIL;
+
+		$act_page_count = null;
+
+		if ( ! empty( $this->aggregations ) ) {
+			$aggs = $this->aggregations['with_post_filter'];
+			foreach ( $aggs['post_parent']['buckets'] as $parent_agg ) {
+				if ( $parent_agg['key'] === (int) $options['act_page'] ) {
+					$act_page_count                           = $parent_agg['doc_count'];
+					$context['content_types']['0']['results'] = $act_page_count;
+				}
+			}
+
+			foreach ( $aggs['post_type']['buckets'] as $post_type_agg ) {
+				if ( 'page' === $post_type_agg['key'] ) {
+					// We show act pages as a separate item, so subtract there count from the other pages.
+					// But counts can be off in ES so don't use lower than 0.
+					$context['content_types']['2']['results'] = max(
+						0,
+						$post_type_agg['doc_count'] - $act_page_count
+					);
+				}
+				if ( 'attachment' === $post_type_agg['key'] ) {
+					$context['content_types']['1']['results'] = $post_type_agg['doc_count'];
+				}
+				if ( 'post' === $post_type_agg['key'] ) {
+					$context['content_types']['3']['results'] = $post_type_agg['doc_count'];
+				}
+				if ( 'campaign' === $post_type_agg['key'] ) {
+					$context['content_types']['4']['results'] = $post_type_agg['doc_count'];
+				}
+				if ( 'archive' === $post_type_agg['key'] && self::should_include_archive() ) {
+					$context['content_types']['5']['results'] = $post_type_agg['doc_count'];
+				}
+			}
+
+			foreach ( $aggs['p4-page-type']['buckets'] as $p4_post_type_agg ) {
+				$p4_post_type_id = (int) $p4_post_type_agg['key'];
+
+				$p4_post_type = self::get_p4_post_type( $p4_post_type_id );
+
+				$context['page_types'][ $p4_post_type_id ] = [
+					'term_id' => $p4_post_type_id,
+					'name'    => $p4_post_type->name,
+					'results' => $p4_post_type_agg['doc_count'],
+				];
+			}
+
+			foreach ( $aggs['categories']['buckets'] as $category_agg ) {
+				// TODO get the parent from ES so no fetch is needed here.
+				$category = get_category( $category_agg['key'] );
+
+				// Category <-> Issue.
+				// Consider Issues that have multiple Categories.
+				if ( $category->parent === (int) $options['issues_parent_category'] ) {
+					$context['categories'][ $category->term_id ]['results'] = $category_agg['doc_count'];
+				}
+			}
+
+			foreach ( $aggs['tags']['buckets'] as $tag_agg ) {
+				// Tag filters.
+				$tag = get_tag( $tag_agg['key'] );
+
+				$context['tags'][ $tag->term_id ]['results'] = $tag_agg['doc_count'];
+			}
+		}
+
+		foreach ( (array) $posts as $post ) {
+			// Post Type (+Action) <-> Content Type.
+			switch ( $post->post_type ) {
+				case 'page':
+					if ( $post->post_parent === (int) $options['act_page'] ) {
+						$content_type_text = __( 'ACTION', 'planet4-master-theme' );
+						$content_type      = 'action';
+					} else {
+						$content_type_text = __( 'PAGE', 'planet4-master-theme' );
+						$content_type      = 'page';
+					}
+					break;
+				case 'campaign':
+					$content_type_text = __( 'CAMPAIGN', 'planet4-master-theme' );
+					$content_type      = 'campaign';
+					break;
+				case 'attachment':
+					$content_type_text = __( 'DOCUMENT', 'planet4-master-theme' );
+					$content_type      = 'document';
+					break;
+				case 'post':
+					$content_type_text = __( 'POST', 'planet4-master-theme' );
+					$content_type      = 'post';
+					break;
+				case P4_Post_Archive::POST_TYPE:
+					$content_type_text = __( 'Archive', 'planet4-master-theme' );
+					$content_type      = 'archive';
+					break;
+				default:
+					continue 2;     // Ignore other post_types and continue with next $post.
+			}
+
+			if ( ! isset( $post->ID ) ) {
+				$post->ID = $post->link;
+			}
+			$post->content_type_text = $content_type_text;
+			$post->content_type      = $content_type;
+
+			// Page Type <-> Category. This taxonomy is used only for Posts.
+			if ( 'post' === $post->post_type && ! empty( $post->terms['p4-page-type'] ) ) {
+				$post->page_types = [
+					self::get_p4_post_type(
+						$post->terms['p4-page-type'][0]
+					),
+				];
+			}
+		}
+	}
+
+	/**
+	 * Load the p4 page type.
+	 *
+	 * @todo Get this from ES.
+	 *
+	 * @param string|int $id The ID of the p4 page type.
+	 * @return mixed|null The p4 page type.
+	 */
+	private static function get_p4_post_type( $id ) {
+		$p4_post_types = get_terms( 'p4-page-type' );
+
+		foreach ( $p4_post_types as $p4_post_type ) {
+			if ( $id === $p4_post_type->term_id ) {
+				return $p4_post_type;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Customize which mime types we want to search for regarding attachments.
+	 *
+	 * @param string $where The WHERE clause of the query.
+	 *
+	 * @return string The edited WHERE clause.
+	 */
+	public static function edit_search_mime_types( $where ) : string {
+		global $wpdb;
+
+		$search_action = filter_input( INPUT_GET, 'search-action', FILTER_SANITIZE_STRING );
+
+		if ( ( ! is_admin() && is_search() ) || ( wp_doing_ajax() && ( 'get_paged_posts' === $search_action ) ) ) {
+			$mime_types = implode( ',', self::DOCUMENT_TYPES );
+			$where     .= ' AND ' . $wpdb->posts . '.post_mime_type IN("' . $mime_types . '","") ';
+		}
+		return $where;
+	}
+
+	/**
+	 * Validates the input.
+	 *
+	 * @param string $selected_sort The selected orderby to be validated.
+	 * @param array  $filters The selected filters to be validated.
+	 * @param array  $context Associative array with the data to be passed to the view.
+	 *
+	 * @return bool True if validation is ok, false if validation fails.
+	 */
+	public function validate( &$selected_sort, &$filters, $context ): bool {
+		$selected_sort = filter_var( $selected_sort, FILTER_SANITIZE_STRING );
+
+		if (
+			! isset( $context['sort_options'] )
+			|| ! array_key_exists( $selected_sort, $context['sort_options'] )
+		) {
+			$selected_sort = self::DEFAULT_SORT;
+		}
+
+		if ( $filters ) {
+			foreach ( $filters as &$filter_type ) {
+				foreach ( $filter_type as &$filter ) {
+					$filter['id'] = filter_var( $filter['id'], FILTER_VALIDATE_INT );
+					if ( false === $filter['id'] || null === $filter['id'] || $filter['id'] < 0 ) {
+						return false;
+					}
+				}
+			}
+		}
+		return true;
+	}
+
+	/**
+	 * Adds a section with a Load more button.
+	 *
+	 * @param array|null $args The array with the data for the pagination.
+	 */
+	public function add_load_more( $args = null ) {
+		$this->context['load_more'] = $args ?? [
+			'posts_per_load' => self::POSTS_PER_LOAD,
+			// Translators: %s = number of results per page.
+			'button_text'    => sprintf( __( 'SHOW %s MORE RESULTS', 'planet4-master-theme' ), self::POSTS_PER_LOAD ),
+			'async'          => true,
+		];
+	}
+
+	/**
+	 * View the Search page template.
+	 */
+	public function view() {
+		Timber::render( $this->templates, $this->context, self::DEFAULT_CACHE_TTL, \Timber\Loader::CACHE_OBJECT );
+	}
+
+	/**
+	 * View the paged posts of the next page/load.
+	 */
+	public function view_paged_posts() {
+		// TODO - The $paged_context related code should be transferred to set_results_context method for better separation of concerns.
+		if ( $this->paged_posts ) {
+			$paged_context['settings'] = get_option( 'planet4_options' );
+
+			$paged_context['dummy_thumbnail'] = get_template_directory_uri() . self::DUMMY_THUMBNAIL;
+
+			foreach ( $this->paged_posts as $index => $post ) {
+				$paged_context['post'] = $post;
+				if ( 0 === $index % self::POSTS_PER_LOAD ) {
+					$paged_context['first_of_the_page'] = true;
+				} else {
+					$paged_context['first_of_the_page'] = false;
+				}
+				Timber::render( [ 'tease-search.twig' ], $paged_context, self::DEFAULT_CACHE_TTL, \Timber\Loader::CACHE_OBJECT );
 			}
 		}
 	}

--- a/classes/class-p4-settings.php
+++ b/classes/class-p4-settings.php
@@ -5,467 +5,465 @@
  * @package P4MT
  */
 
-if ( ! class_exists( 'P4_Settings' ) ) {
+/**
+ * Class P4_Settings
+ */
+class P4_Settings {
+
 	/**
-	 * Class P4_Settings
+	 * ID of the Metabox
 	 */
-	class P4_Settings {
+	private const METABOX_ID = 'option_metabox';
 
-		/**
-		 * ID of the Metabox
-		 */
-		private const METABOX_ID = 'option_metabox';
+	/**
+	 * Option key, and option page slug
+	 *
+	 * @var string
+	 */
+	private $key = 'planet4_options';
 
-		/**
-		 * Option key, and option page slug
-		 *
-		 * @var string
-		 */
-		private $key = 'planet4_options';
+	/**
+	 * Options Page title
+	 *
+	 * @var string
+	 */
+	protected $title = '';
 
-		/**
-		 * Options Page title
-		 *
-		 * @var string
-		 */
-		protected $title = '';
+	/**
+	 * Options Page hook
+	 *
+	 * @var string
+	 */
+	protected $options_page = '';
 
-		/**
-		 * Options Page hook
-		 *
-		 * @var string
-		 */
-		protected $options_page = '';
+	/**
+	 * Constructor
+	 */
+	public function __construct() {
 
-		/**
-		 * Constructor
-		 */
-		public function __construct() {
+		// Set our title.
+		$this->title = __( 'Planet4', 'planet4-master-theme-backend' );
 
-			// Set our title.
-			$this->title = __( 'Planet4', 'planet4-master-theme-backend' );
+		$this->fields = [
+			[
+				'name' => __( 'Website Navigation Title', 'planet4-master-theme-backend' ),
+				'id'   => 'website_navigation_title',
+				'type' => 'text',
+			],
+			[
+				'name' => __( 'Select Act Page', 'planet4-master-theme-backend' ),
+				'id'   => 'act_page',
+				'type' => 'act_page_dropdown',
+			],
 
-			$this->fields = [
-				[
-					'name' => __( 'Website Navigation Title', 'planet4-master-theme-backend' ),
-					'id'   => 'website_navigation_title',
+			[
+				'name' => __( 'Select Explore Page', 'planet4-master-theme-backend' ),
+				'id'   => 'explore_page',
+				'type' => 'explore_page_dropdown',
+			],
+
+			[
+				'name' => __( 'Select Issues Parent Category', 'planet4-master-theme-backend' ),
+				'id'   => 'issues_parent_category',
+				'type' => 'category_select_taxonomy',
+			],
+
+			[
+				'name' => __( 'Google Tag Manager Container', 'planet4-master-theme-backend' ),
+				'id'   => 'google_tag_manager_identifier',
+				'type' => 'text',
+			],
+
+			[
+				'name' => __( 'Google Optimize anti-flicker snippet', 'planet4-master-theme-backend' ),
+				'desc' => __( 'It will include the relevant snippet for A/B testing.', 'planet4-master-theme-backend' ),
+				'id'   => 'google_optimizer',
+				'type' => 'checkbox',
+			],
+
+			[
+				'name' => __( 'Facebook Page ID', 'planet4-master-theme-backend' ),
+				'id'   => 'facebook_page_id',
+				'type' => 'text',
+			],
+
+			[
+				'name' => __( 'Default P4 Post Type', 'planet4-master-theme-backend' ),
+				'id'   => 'default_p4_pagetype',
+				'type' => 'pagetype_select_taxonomy',
+			],
+
+			[
+				'name' => __( 'Default title for related articles block', 'planet4-master-theme-backend' ),
+				'id'   => 'articles_block_title',
+				'type' => 'text',
+				'desc' => __( 'If no title set for <b>Article Block</b>, the default title will appear.', 'planet4-master-theme-backend' ),
+			],
+
+			[
+				'name' => __( 'Default button title for related articles block', 'planet4-master-theme-backend' ),
+				'id'   => 'articles_block_button_title',
+				'type' => 'text',
+				'desc' => __( 'If no button title set for <b>Article Block</b>, the default button title will appear.', 'planet4-master-theme-backend' ),
+			],
+
+			[
+				'name'       => __( 'Default Number Of Related Articles', 'planet4-master-theme-backend' ),
+				'id'         => 'articles_count',
+				'type'       => 'text',
+				'attributes' => [
+					'type' => 'number',
+				],
+				'desc'       => __( 'If no number of Related Articles set for <b>Article Block</b>, the default number of Related Articles will appear.', 'planet4-master-theme-backend' ),
+			],
+
+			[
+				'name'       => __( 'Take Action Covers default button text', 'planet4-master-theme-backend' ),
+				'id'         => 'take_action_covers_button_text',
+				'type'       => 'text',
+				'attributes' => [
 					'type' => 'text',
 				],
-				[
-					'name' => __( 'Select Act Page', 'planet4-master-theme-backend' ),
-					'id'   => 'act_page',
-					'type' => 'act_page_dropdown',
-				],
+				'desc'       => __(
+					'Add default button text which appears on <b>Take Action</b> card of <b>Take Action Covers</b> block. <br>
+									 Also it would be used for Take Action Cards inside Posts and Take Action Cards in search results',
+					'planet4-master-theme-backend'
+				),
+			],
 
-				[
-					'name' => __( 'Select Explore Page', 'planet4-master-theme-backend' ),
-					'id'   => 'explore_page',
-					'type' => 'explore_page_dropdown',
-				],
-
-				[
-					'name' => __( 'Select Issues Parent Category', 'planet4-master-theme-backend' ),
-					'id'   => 'issues_parent_category',
-					'type' => 'category_select_taxonomy',
-				],
-
-				[
-					'name' => __( 'Google Tag Manager Container', 'planet4-master-theme-backend' ),
-					'id'   => 'google_tag_manager_identifier',
+			[
+				'name'       => __( 'Donate button link', 'planet4-master-theme-backend' ),
+				'id'         => 'donate_button',
+				'type'       => 'text',
+				'attributes' => [
 					'type' => 'text',
 				],
+			],
 
-				[
-					'name' => __( 'Google Optimize anti-flicker snippet', 'planet4-master-theme-backend' ),
-					'desc' => __( 'It will include the relevant snippet for A/B testing.', 'planet4-master-theme-backend' ),
-					'id'   => 'google_optimizer',
-					'type' => 'checkbox',
-				],
-
-				[
-					'name' => __( 'Facebook Page ID', 'planet4-master-theme-backend' ),
-					'id'   => 'facebook_page_id',
+			[
+				'name'       => __( 'Donate button text', 'planet4-master-theme-backend' ),
+				'id'         => 'donate_text',
+				'type'       => 'text',
+				'attributes' => [
 					'type' => 'text',
 				],
+			],
 
-				[
-					'name' => __( 'Default P4 Post Type', 'planet4-master-theme-backend' ),
-					'id'   => 'default_p4_pagetype',
-					'type' => 'pagetype_select_taxonomy',
+			[
+				'name' => __( 'Show donate button below mobile navigation bar', 'planet4-master-theme-backend' ),
+				'desc' => __( 'Enable visibility of the donate button on the homepage. Please check legal restrictions on images associated with this button before using it.', 'planet4-master-theme-backend' ) . ' <a href="https://planet4.greenpeace.org/handbook/admin-setup/#donate-button-visible-on-mobile">' . __( 'Read more', 'planet4-master-theme-backend' ) . '</a>',
+				'id'   => 'donate_btn_visible_on_mobile',
+				'type' => 'checkbox',
+			],
+
+			[
+				'name'       => __( '404 Background Image', 'planet4-master-theme-backend' ),
+				'id'         => '404_page_bg_image',
+				'type'       => 'file',
+				'options'    => [
+					'url' => false,
 				],
-
-				[
-					'name' => __( 'Default title for related articles block', 'planet4-master-theme-backend' ),
-					'id'   => 'articles_block_title',
-					'type' => 'text',
-					'desc' => __( 'If no title set for <b>Article Block</b>, the default title will appear.', 'planet4-master-theme-backend' ),
+				'text'       => [
+					'add_upload_file_text' => __( 'Add 404 Page Background Image', 'planet4-master-theme-backend' ),
 				],
-
-				[
-					'name' => __( 'Default button title for related articles block', 'planet4-master-theme-backend' ),
-					'id'   => 'articles_block_button_title',
-					'type' => 'text',
-					'desc' => __( 'If no button title set for <b>Article Block</b>, the default button title will appear.', 'planet4-master-theme-backend' ),
+				'query_args' => [
+					'type' => 'image',
 				],
+				'desc'       => __( 'Minimum image width should be 1920px', 'planet4-master-theme-backend' ),
+			],
 
-				[
-					'name'       => __( 'Default Number Of Related Articles', 'planet4-master-theme-backend' ),
-					'id'         => 'articles_count',
-					'type'       => 'text',
-					'attributes' => [
-						'type' => 'number',
-					],
-					'desc'       => __( 'If no number of Related Articles set for <b>Article Block</b>, the default number of Related Articles will appear.', 'planet4-master-theme-backend' ),
+			[
+				'name'    => __( '404 Page text', 'planet4-master-theme-backend' ),
+				'id'      => '404_page_text',
+				'type'    => 'wysiwyg',
+				'options' => [
+					'textarea_rows' => 3,
+					'media_buttons' => false,
 				],
+				'desc'    => __( 'Add 404 page text', 'planet4-master-theme-backend' ),
+			],
 
-				[
-					'name'       => __( 'Take Action Covers default button text', 'planet4-master-theme-backend' ),
-					'id'         => 'take_action_covers_button_text',
-					'type'       => 'text',
-					'attributes' => [
-						'type' => 'text',
-					],
-					'desc'       => __(
-						'Add default button text which appears on <b>Take Action</b> card of <b>Take Action Covers</b> block. <br>
-					                     Also it would be used for Take Action Cards inside Posts and Take Action Cards in search results',
-						'planet4-master-theme-backend'
-					),
+			[
+				'name' => __( 'Happy point Subscribe Form URL', 'planet4-master-theme-backend' ),
+				'id'   => 'engaging_network_form_id',
+				'type' => 'text',
+			],
+
+			[
+				'name'       => __( 'Default Happy Point Background Image', 'planet4-master-theme-backend' ),
+				'id'         => 'happy_point_bg_image',
+				'type'       => 'file',
+				'options'    => [
+					'url' => false,
 				],
-
-				[
-					'name'       => __( 'Donate button link', 'planet4-master-theme-backend' ),
-					'id'         => 'donate_button',
-					'type'       => 'text',
-					'attributes' => [
-						'type' => 'text',
-					],
+				'text'       => [
+					'add_upload_file_text' => __( 'Add Default Happy Point Background Image', 'planet4-master-theme-backend' ),
 				],
-
-				[
-					'name'       => __( 'Donate button text', 'planet4-master-theme-backend' ),
-					'id'         => 'donate_text',
-					'type'       => 'text',
-					'attributes' => [
-						'type' => 'text',
-					],
+				'query_args' => [
+					'type' => 'image',
 				],
+				'desc'       => __( 'Minimum image width should be 1920px', 'planet4-master-theme-backend' ),
+			],
 
-				[
-					'name' => __( 'Show donate button below mobile navigation bar', 'planet4-master-theme-backend' ),
-					'desc' => __( 'Enable visibility of the donate button on the homepage. Please check legal restrictions on images associated with this button before using it.', 'planet4-master-theme-backend' ) . ' <a href="https://planet4.greenpeace.org/handbook/admin-setup/#donate-button-visible-on-mobile">' . __( 'Read more', 'planet4-master-theme-backend' ) . '</a>',
-					'id'   => 'donate_btn_visible_on_mobile',
-					'type' => 'checkbox',
-				],
-
-				[
-					'name'       => __( '404 Background Image', 'planet4-master-theme-backend' ),
-					'id'         => '404_page_bg_image',
-					'type'       => 'file',
-					'options'    => [
-						'url' => false,
-					],
-					'text'       => [
-						'add_upload_file_text' => __( 'Add 404 Page Background Image', 'planet4-master-theme-backend' ),
-					],
-					'query_args' => [
-						'type' => 'image',
-					],
-					'desc'       => __( 'Minimum image width should be 1920px', 'planet4-master-theme-backend' ),
-				],
-
-				[
-					'name'    => __( '404 Page text', 'planet4-master-theme-backend' ),
-					'id'      => '404_page_text',
-					'type'    => 'wysiwyg',
-					'options' => [
-						'textarea_rows' => 3,
-						'media_buttons' => false,
-					],
-					'desc'    => __( 'Add 404 page text', 'planet4-master-theme-backend' ),
-				],
-
-				[
-					'name' => __( 'Happy point Subscribe Form URL', 'planet4-master-theme-backend' ),
-					'id'   => 'engaging_network_form_id',
+			[
+				'name'       => __( 'Preconnect Domains', 'planet4-master-theme-backend' ),
+				'desc'       => __( 'Add a list of third-party URLs to "preconnect" (e.g.: https://in.hotjar.com). Look for "preconnect" in the P4 Handbook for details.', 'planet4-master-theme-backend' ),
+				'id'         => 'preconnect_domains',
+				'type'       => 'textarea',
+				'attributes' => [
 					'type' => 'text',
 				],
+			],
+			[
+				'name' => __( 'Exclude campaign styles when importing', 'planet4-master-theme-backend' ),
+				'desc' => __(
+					'Whether to exclude campaign theme and style settings when importing a campaign.',
+					'planet4-master-theme-backend'
+				),
+				'id'   => 'campaigns_import_exclude_style',
+				'type' => 'checkbox',
+			],
+			[
+				'name'    => __( 'Include archived content in search for', 'planet4-master-theme-backend' ),
+				'id'      => 'include_archive_content_for',
+				'type'    => 'select',
+				'default' => 'nobody',
+				'options' => [
+					'nobody'    => __( 'Nobody', 'planet4-master-theme-backend' ),
+					'logged_in' => __( 'Logged in users', 'planet4-master-theme-backend' ),
+					'all'       => __( 'All users', 'planet4-master-theme-backend' ),
+				],
+			],
+			[
+				'name' => __( 'Search content decay', 'planet4-master-theme-backend' ),
+				'desc' => __(
+					'Amount of lowering of the relevancy score for older results. Between 0 and 1. The lower this number is, the lower older content will be ranked. See image. <br>We use the exponential function (exp, green curve).<br/> <img style="max-width:350px" alt="ElasticSearch decay function graph" src="https://www.elastic.co/guide/en/elasticsearch/reference/current/images/decay_2d.png">',
+					'planet4-master-theme-backend'
+				),
+				'id'   => 'epwr_decay',
+				'type' => 'text',
+			],
+			[
+				'name' => __( 'Search content decay scale', 'planet4-master-theme-backend' ),
+				'desc' => __( 'Timescale for lowering the relevance of older results. See image above.', 'planet4-master-theme-backend' ),
+				'id'   => 'epwr_scale',
+				'type' => 'text',
+			],
+			[
+				'name' => __( 'Search content decay offset', 'planet4-master-theme-backend' ),
+				'desc' => __( 'How old should a post be before relevance is lowered. See image above.', 'planet4-master-theme-backend' ),
+				'id'   => 'epwr_offset',
+				'type' => 'text',
+			],
+			[
+				'name' => __( 'Local Projects Smartsheet ID', 'planet4-master-theme-backend' ),
+				'desc' => __(
+					'The smartsheet that is used to get analytics values from local(NRO) smartsheet.',
+					'planet4-master-theme-backend'
+				),
+				'id'   => 'analytics_local_smartsheet_id',
+				'type' => 'text',
+			],
 
-				[
-					'name'       => __( 'Default Happy Point Background Image', 'planet4-master-theme-backend' ),
-					'id'         => 'happy_point_bg_image',
-					'type'       => 'file',
-					'options'    => [
-						'url' => false,
-					],
-					'text'       => [
-						'add_upload_file_text' => __( 'Add Default Happy Point Background Image', 'planet4-master-theme-backend' ),
-					],
-					'query_args' => [
-						'type' => 'image',
-					],
-					'desc'       => __( 'Minimum image width should be 1920px', 'planet4-master-theme-backend' ),
+			[
+				'name'    => __( 'Cookies Text', 'planet4-master-theme-backend' ),
+				'id'      => 'cookies_field',
+				'type'    => 'wysiwyg',
+				'options' => [
+					'textarea_rows' => 5,
+					'media_buttons' => false,
 				],
+			],
 
-				[
-					'name'       => __( 'Preconnect Domains', 'planet4-master-theme-backend' ),
-					'desc'       => __( 'Add a list of third-party URLs to "preconnect" (e.g.: https://in.hotjar.com). Look for "preconnect" in the P4 Handbook for details.', 'planet4-master-theme-backend' ),
-					'id'         => 'preconnect_domains',
-					'type'       => 'textarea',
-					'attributes' => [
-						'type' => 'text',
-					],
-				],
-				[
-					'name' => __( 'Exclude campaign styles when importing', 'planet4-master-theme-backend' ),
-					'desc' => __(
-						'Whether to exclude campaign theme and style settings when importing a campaign.',
-						'planet4-master-theme-backend'
-					),
-					'id'   => 'campaigns_import_exclude_style',
-					'type' => 'checkbox',
-				],
-				[
-					'name'    => __( 'Include archived content in search for', 'planet4-master-theme-backend' ),
-					'id'      => 'include_archive_content_for',
-					'type'    => 'select',
-					'default' => 'nobody',
-					'options' => [
-						'nobody'    => __( 'Nobody', 'planet4-master-theme-backend' ),
-						'logged_in' => __( 'Logged in users', 'planet4-master-theme-backend' ),
-						'all'       => __( 'All users', 'planet4-master-theme-backend' ),
-					],
-				],
-				[
-					'name' => __( 'Search content decay', 'planet4-master-theme-backend' ),
-					'desc' => __(
-						'Amount of lowering of the relevancy score for older results. Between 0 and 1. The lower this number is, the lower older content will be ranked. See image. <br>We use the exponential function (exp, green curve).<br/> <img style="max-width:350px" alt="ElasticSearch decay function graph" src="https://www.elastic.co/guide/en/elasticsearch/reference/current/images/decay_2d.png">',
-						'planet4-master-theme-backend'
-					),
-					'id'   => 'epwr_decay',
-					'type' => 'text',
-				],
-				[
-					'name' => __( 'Search content decay scale', 'planet4-master-theme-backend' ),
-					'desc' => __( 'Timescale for lowering the relevance of older results. See image above.', 'planet4-master-theme-backend' ),
-					'id'   => 'epwr_scale',
-					'type' => 'text',
-				],
-				[
-					'name' => __( 'Search content decay offset', 'planet4-master-theme-backend' ),
-					'desc' => __( 'How old should a post be before relevance is lowered. See image above.', 'planet4-master-theme-backend' ),
-					'id'   => 'epwr_offset',
-					'type' => 'text',
-				],
-				[
-					'name' => __( 'Local Projects Smartsheet ID', 'planet4-master-theme-backend' ),
-					'desc' => __(
-						'The smartsheet that is used to get analytics values from local(NRO) smartsheet.',
-						'planet4-master-theme-backend'
-					),
-					'id'   => 'analytics_local_smartsheet_id',
-					'type' => 'text',
-				],
+			[
+				'name' => __( 'Enforce Cookies Policy', 'planet4-master-theme-backend' ),
+				'desc' => __( 'GDPR related setting. By enabling this option specific content will be blocked and will require user consent to be shown.', 'planet4-master-theme-backend' ),
+				'id'   => 'enforce_cookies_policy',
+				'type' => 'checkbox',
+			],
 
-				[
-					'name'    => __( 'Cookies Text', 'planet4-master-theme-backend' ),
-					'id'      => 'cookies_field',
-					'type'    => 'wysiwyg',
-					'options' => [
-						'textarea_rows' => 5,
-						'media_buttons' => false,
-					],
+			[
+				'name'    => __( 'Copyright Text Line 1', 'planet4-master-theme-backend' ),
+				'id'      => 'copyright_line1',
+				'type'    => 'wysiwyg',
+				'options' => [
+					'textarea_rows' => 3,
+					'media_buttons' => false,
 				],
+			],
 
-				[
-					'name' => __( 'Enforce Cookies Policy', 'planet4-master-theme-backend' ),
-					'desc' => __( 'GDPR related setting. By enabling this option specific content will be blocked and will require user consent to be shown.', 'planet4-master-theme-backend' ),
-					'id'   => 'enforce_cookies_policy',
-					'type' => 'checkbox',
+			[
+				'name'    => __( 'Copyright Text Line 2', 'planet4-master-theme-backend' ),
+				'id'      => 'copyright_line2',
+				'type'    => 'wysiwyg',
+				'options' => [
+					'textarea_rows' => 2,
+					'media_buttons' => false,
 				],
+			],
+		];
+		$this->hooks();
+	}
 
-				[
-					'name'    => __( 'Copyright Text Line 1', 'planet4-master-theme-backend' ),
-					'id'      => 'copyright_line1',
-					'type'    => 'wysiwyg',
-					'options' => [
-						'textarea_rows' => 3,
-						'media_buttons' => false,
-					],
-				],
+	/**
+	 * Initiate our hooks
+	 */
+	public function hooks() {
+		add_action( 'admin_init', [ $this, 'init' ] );
+		add_action( 'admin_menu', [ $this, 'add_options_page' ] );
+		add_action( 'cmb2_save_options-page_fields_' . self::METABOX_ID, [ $this, 'add_notifications' ] );
+		add_filter( 'cmb2_render_act_page_dropdown', [ $this, 'p4_render_act_page_dropdown' ], 10, 2 );
+		add_filter( 'cmb2_render_explore_page_dropdown', [ $this, 'p4_render_explore_page_dropdown' ], 10, 2 );
+		add_filter( 'cmb2_render_category_select_taxonomy', [ $this, 'p4_render_category_dropdown' ], 10, 2 );
+		add_filter( 'cmb2_render_pagetype_select_taxonomy', [ $this, 'p4_render_pagetype_dropdown' ], 10, 2 );
 
-				[
-					'name'    => __( 'Copyright Text Line 2', 'planet4-master-theme-backend' ),
-					'id'      => 'copyright_line2',
-					'type'    => 'wysiwyg',
-					'options' => [
-						'textarea_rows' => 2,
-						'media_buttons' => false,
-					],
-				],
-			];
-			$this->hooks();
+		// Make settings multilingual if wpml plugin is installed and activated.
+		if ( function_exists( 'icl_object_id' ) ) {
+			add_action( 'init', [ $this, 'make_settings_multilingual' ] );
+		}
+	}
+
+	/**
+	 * Register our setting to WP.
+	 */
+	public function init() {
+		register_setting( $this->key, $this->key );
+	}
+
+	/**
+	 * Add menu options page.
+	 */
+	public function add_options_page() {
+		$this->options_page = add_options_page( $this->title, $this->title, 'manage_options', $this->key, [ $this, 'admin_page_display' ] );
+	}
+
+	/**
+	 * Display notifications of success and error
+	 * This is the method used by WordPress to add a success notification
+	 *
+	 * @see https://github.com/WordPress/WordPress/blob/57fb3c6cf016678ab38d7a636b8df41fa2d955f1/wp-admin/options.php#L313
+	 */
+	public function add_notifications(): void {
+		if ( ! count( get_settings_errors() ) ) {
+			add_settings_error( 'general', 'settings_updated', __( 'Settings saved.', 'planet4-master-theme-backend' ), 'success' );
 		}
 
-		/**
-		 * Initiate our hooks
-		 */
-		public function hooks() {
-			add_action( 'admin_init', [ $this, 'init' ] );
-			add_action( 'admin_menu', [ $this, 'add_options_page' ] );
-			add_action( 'cmb2_save_options-page_fields_' . self::METABOX_ID, [ $this, 'add_notifications' ] );
-			add_filter( 'cmb2_render_act_page_dropdown', [ $this, 'p4_render_act_page_dropdown' ], 10, 2 );
-			add_filter( 'cmb2_render_explore_page_dropdown', [ $this, 'p4_render_explore_page_dropdown' ], 10, 2 );
-			add_filter( 'cmb2_render_category_select_taxonomy', [ $this, 'p4_render_category_dropdown' ], 10, 2 );
-			add_filter( 'cmb2_render_pagetype_select_taxonomy', [ $this, 'p4_render_pagetype_dropdown' ], 10, 2 );
+		settings_errors();
+	}
 
-			// Make settings multilingual if wpml plugin is installed and activated.
-			if ( function_exists( 'icl_object_id' ) ) {
-				add_action( 'init', [ $this, 'make_settings_multilingual' ] );
-			}
-		}
+	/**
+	 * Render act page dropdown.
+	 *
+	 * @param array  $field_args Field arguments.
+	 * @param string $value Value.
+	 */
+	public function p4_render_act_page_dropdown( $field_args, $value ) {
+		wp_dropdown_pages(
+			[
+				'show_option_none' => esc_html__( 'Select Page', 'planet4-master-theme-backend' ),
+				'hide_empty'       => 0,
+				'hierarchical'     => true,
+				'selected'         => esc_attr( $value ),
+				'name'             => 'act_page',
+			]
+		);
+	}
 
-		/**
-		 * Register our setting to WP.
-		 */
-		public function init() {
-			register_setting( $this->key, $this->key );
-		}
+	/**
+	 * Render explore page dropdown.
+	 *
+	 * @param array  $field_args Field arguments.
+	 * @param string $value Value.
+	 */
+	public function p4_render_explore_page_dropdown( $field_args, $value ) {
+		wp_dropdown_pages(
+			[
+				'show_option_none' => esc_html__( 'Select Page', 'planet4-master-theme-backend' ),
+				'hide_empty'       => 0,
+				'hierarchical'     => true,
+				'selected'         => esc_attr( $value ),
+				'name'             => 'explore_page',
+			]
+		);
+	}
 
-		/**
-		 * Add menu options page.
-		 */
-		public function add_options_page() {
-			$this->options_page = add_options_page( $this->title, $this->title, 'manage_options', $this->key, [ $this, 'admin_page_display' ] );
-		}
+	/**
+	 * Render category dropdown.
+	 *
+	 * @param array  $field_args Field arguments.
+	 * @param string $value Value.
+	 */
+	public function p4_render_category_dropdown( $field_args, $value ) {
 
-		/**
-		 * Display notifications of success and error
-		 * This is the method used by WordPress to add a success notification
-		 *
-		 * @see https://github.com/WordPress/WordPress/blob/57fb3c6cf016678ab38d7a636b8df41fa2d955f1/wp-admin/options.php#L313
-		 */
-		public function add_notifications(): void {
-			if ( ! count( get_settings_errors() ) ) {
-				add_settings_error( 'general', 'settings_updated', __( 'Settings saved.', 'planet4-master-theme-backend' ), 'success' );
-			}
+		wp_dropdown_categories(
+			[
+				'show_option_none' => __( 'Select Category', 'planet4-master-theme-backend' ),
+				'hide_empty'       => 0,
+				'hierarchical'     => true,
+				'orderby'          => 'name',
+				'selected'         => $value,
+				'name'             => 'issues_parent_category',
+			]
+		);
+	}
 
-			settings_errors();
-		}
+	/**
+	 * Render p4-pagetype dropdown.
+	 *
+	 * @param CMB2_Field $field_args CMB2 field Object.
+	 * @param int        $value Pagetype taxonomy ID.
+	 */
+	public function p4_render_pagetype_dropdown( $field_args, $value ) {
 
-		/**
-		 * Render act page dropdown.
-		 *
-		 * @param array  $field_args Field arguments.
-		 * @param string $value Value.
-		 */
-		public function p4_render_act_page_dropdown( $field_args, $value ) {
-			wp_dropdown_pages(
-				[
-					'show_option_none' => esc_html__( 'Select Page', 'planet4-master-theme-backend' ),
-					'hide_empty'       => 0,
-					'hierarchical'     => true,
-					'selected'         => esc_attr( $value ),
-					'name'             => 'act_page',
-				]
-			);
-		}
+		wp_dropdown_categories(
+			[
+				'show_option_none' => __( 'Select Posttype', 'planet4-master-theme-backend' ),
+				'hide_empty'       => 0,
+				'orderby'          => 'name',
+				'selected'         => $value,
+				'name'             => 'default_p4_pagetype',
+				'taxonomy'         => 'p4-page-type',
+			]
+		);
+	}
 
-		/**
-		 * Render explore page dropdown.
-		 *
-		 * @param array  $field_args Field arguments.
-		 * @param string $value Value.
-		 */
-		public function p4_render_explore_page_dropdown( $field_args, $value ) {
-			wp_dropdown_pages(
-				[
-					'show_option_none' => esc_html__( 'Select Page', 'planet4-master-theme-backend' ),
-					'hide_empty'       => 0,
-					'hierarchical'     => true,
-					'selected'         => esc_attr( $value ),
-					'name'             => 'explore_page',
-				]
-			);
-		}
+	/**
+	 * Admin page markup. Mostly handled by CMB2.
+	 */
+	public function admin_page_display() {
+		?>
+		<div class="wrap <?php echo esc_attr( $this->key ); ?>">
+			<h2><?php echo esc_html( get_admin_page_title() ); ?></h2>
+			<?php cmb2_metabox_form( $this->option_metabox(), $this->key ); ?>
+		</div>
+		<?php
+	}
 
-		/**
-		 * Render category dropdown.
-		 *
-		 * @param array  $field_args Field arguments.
-		 * @param string $value Value.
-		 */
-		public function p4_render_category_dropdown( $field_args, $value ) {
-
-			wp_dropdown_categories(
-				[
-					'show_option_none' => __( 'Select Category', 'planet4-master-theme-backend' ),
-					'hide_empty'       => 0,
-					'hierarchical'     => true,
-					'orderby'          => 'name',
-					'selected'         => $value,
-					'name'             => 'issues_parent_category',
-				]
-			);
-		}
-
-		/**
-		 * Render p4-pagetype dropdown.
-		 *
-		 * @param CMB2_Field $field_args CMB2 field Object.
-		 * @param int        $value Pagetype taxonomy ID.
-		 */
-		public function p4_render_pagetype_dropdown( $field_args, $value ) {
-
-			wp_dropdown_categories(
-				[
-					'show_option_none' => __( 'Select Posttype', 'planet4-master-theme-backend' ),
-					'hide_empty'       => 0,
-					'orderby'          => 'name',
-					'selected'         => $value,
-					'name'             => 'default_p4_pagetype',
-					'taxonomy'         => 'p4-page-type',
-				]
-			);
-		}
-
-		/**
-		 * Admin page markup. Mostly handled by CMB2.
-		 */
-		public function admin_page_display() {
-			?>
-			<div class="wrap <?php echo esc_attr( $this->key ); ?>">
-				<h2><?php echo esc_html( get_admin_page_title() ); ?></h2>
-				<?php cmb2_metabox_form( $this->option_metabox(), $this->key ); ?>
-			</div>
-			<?php
-		}
-
-		/**
-		 * Defines the theme option metabox and field configuration.
-		 *
-		 * @return array
-		 */
-		public function option_metabox() {
-			return [
-				'id'         => self::METABOX_ID,
-				'show_on'    => [
-					'key'   => 'options-page',
-					'value' => [
-						$this->key,
-					],
+	/**
+	 * Defines the theme option metabox and field configuration.
+	 *
+	 * @return array
+	 */
+	public function option_metabox() {
+		return [
+			'id'         => self::METABOX_ID,
+			'show_on'    => [
+				'key'   => 'options-page',
+				'value' => [
+					$this->key,
 				],
-				'show_names' => true,
-				'fields'     => $this->fields,
-			];
-		}
+			],
+			'show_names' => true,
+			'fields'     => $this->fields,
+		];
+	}
 
-		/**
-		 * Hook for wpml plugin.
-		 * Enables the possibility to save a different value per language for the theme options using WPML language switcher.
-		 */
-		public function make_settings_multilingual() {
-			do_action( 'wpml_multilingual_options', 'planet4_options' );
-		}
+	/**
+	 * Hook for wpml plugin.
+	 * Enables the possibility to save a different value per language for the theme options using WPML language switcher.
+	 */
+	public function make_settings_multilingual() {
+		do_action( 'wpml_multilingual_options', 'planet4_options' );
 	}
 }
 

--- a/classes/class-p4-sitemap.php
+++ b/classes/class-p4-sitemap.php
@@ -5,163 +5,160 @@
  * @package P4MT
  */
 
-if ( ! class_exists( 'P4_Sitemap' ) ) {
+/**
+ * Class P4_Sitemap
+ */
+class P4_Sitemap {
 
 	/**
-	 * Class P4_Sitemap
+	 * Limit the number of evergreen pages
 	 */
-	class P4_Sitemap {
+	const MAX_EVERGREEN_PAGES = 100;
 
-		/**
-		 * Limit the number of evergreen pages
-		 */
-		const MAX_EVERGREEN_PAGES = 100;
+	/**
+	 * Gets data for the Action pages.
+	 *
+	 * @return array
+	 */
+	public function get_actions() : array {
+		$options   = get_option( 'planet4_options' );
+		$parent_id = $options['act_page'];
+		$actions   = [];
 
-		/**
-		 * Gets data for the Action pages.
-		 *
-		 * @return array
-		 */
-		public function get_actions() : array {
-			$options   = get_option( 'planet4_options' );
-			$parent_id = $options['act_page'];
-			$actions   = [];
-
-			if ( 0 !== absint( $parent_id ) ) {
-				$args    = [
-					'post_type'        => 'page',
-					'post_status'      => 'publish',
-					'post_parent'      => $parent_id,
-					'orderby'          => 'post_title',
-					'order'            => 'ASC',
-					'suppress_filters' => false,
-					'numberposts'      => -1,
-				];
-				$actions = get_posts( $args );
-			}
-
-			$actions_data = [];
-			if ( is_array( $actions ) && $actions ) {
-				foreach ( $actions as $action ) {
-					$actions_data[] = [
-						'title' => $action->post_title,
-						'link'  => get_permalink( $action->ID ),
-					];
-				}
-			}
-
-			return $actions_data;
-		}
-
-		/**
-		 * Gets data for the Issue pages.
-		 *
-		 * @return array
-		 */
-		public function get_issues() : array {
-			$options   = get_option( 'planet4_options' );
-			$parent_id = $options['explore_page'];
-			$issues    = [];
-
-			if ( 0 !== absint( $parent_id ) ) {
-				$args   = [
-					'post_type'        => 'page',
-					'post_status'      => 'publish',
-					'post_parent'      => $parent_id,
-					'orderby'          => 'post_title',
-					'order'            => 'ASC',
-					'suppress_filters' => false,
-					'numberposts'      => -1,
-				];
-				$issues = get_posts( $args );
-			}
-
-			$issues_data = [];
-			if ( is_array( $issues ) && $issues ) {
-				foreach ( $issues as $issue ) {
-
-					// Get campaigns for this issue.
-					$page_tags = wp_get_post_tags( $issue->ID );
-					$tags      = [];
-
-					if ( is_array( $page_tags ) && $page_tags ) {
-						foreach ( $page_tags as $page_tag ) {
-							$tags[] = [
-								'name' => $page_tag->name,
-								'link' => get_tag_link( $page_tag ),
-							];
-						}
-					}
-
-					$issues_data[] = [
-						'title'     => $issue->post_title,
-						'link'      => get_permalink( $issue->ID ),
-						'campaigns' => $tags,
-					];
-				}
-			}
-
-			return $issues_data;
-		}
-
-		/**
-		 * Gets data for the Evergreen pages.
-		 *
-		 * @return array
-		 */
-		public function get_evergreen_pages() : array {
-
-			$args  = [
+		if ( 0 !== absint( $parent_id ) ) {
+			$args    = [
 				'post_type'        => 'page',
 				'post_status'      => 'publish',
-				'meta_key'         => '_wp_page_template',
-				'meta_value'       => 'page-templates/evergreen.php',
+				'post_parent'      => $parent_id,
 				'orderby'          => 'post_title',
 				'order'            => 'ASC',
 				'suppress_filters' => false,
-				'numberposts'      => self::MAX_EVERGREEN_PAGES,
+				'numberposts'      => -1,
 			];
-			$pages = get_posts( $args );
-
-			$evergreen_data = [];
-			if ( is_array( $pages ) && $pages ) {
-				foreach ( $pages as $page ) {
-					$evergreen_data[] = [
-						'title' => $page->post_title,
-						'link'  => get_permalink( $page->ID ),
-					];
-				}
-			}
-
-			return $evergreen_data;
+			$actions = get_posts( $args );
 		}
 
-		/**
-		 * Gets data for the custom article types.
-		 *
-		 * @return array
-		 */
-		public function get_page_types() : array {
-
-			$article_types = get_terms(
-				[
-					'hide_empty' => false,
-					'orderby'    => 'name',
-					'taxonomy'   => 'p4-page-type',
-				]
-			);
-
-			$article_types_data = [];
-			if ( is_array( $article_types ) && $article_types ) {
-				foreach ( $article_types as $article_type ) {
-					$article_types_data[] = [
-						'name' => $article_type->name,
-						'link' => get_term_link( $article_type->term_id ),
-					];
-				}
+		$actions_data = [];
+		if ( is_array( $actions ) && $actions ) {
+			foreach ( $actions as $action ) {
+				$actions_data[] = [
+					'title' => $action->post_title,
+					'link'  => get_permalink( $action->ID ),
+				];
 			}
-
-			return $article_types_data;
 		}
+
+		return $actions_data;
+	}
+
+	/**
+	 * Gets data for the Issue pages.
+	 *
+	 * @return array
+	 */
+	public function get_issues() : array {
+		$options   = get_option( 'planet4_options' );
+		$parent_id = $options['explore_page'];
+		$issues    = [];
+
+		if ( 0 !== absint( $parent_id ) ) {
+			$args   = [
+				'post_type'        => 'page',
+				'post_status'      => 'publish',
+				'post_parent'      => $parent_id,
+				'orderby'          => 'post_title',
+				'order'            => 'ASC',
+				'suppress_filters' => false,
+				'numberposts'      => -1,
+			];
+			$issues = get_posts( $args );
+		}
+
+		$issues_data = [];
+		if ( is_array( $issues ) && $issues ) {
+			foreach ( $issues as $issue ) {
+
+				// Get campaigns for this issue.
+				$page_tags = wp_get_post_tags( $issue->ID );
+				$tags      = [];
+
+				if ( is_array( $page_tags ) && $page_tags ) {
+					foreach ( $page_tags as $page_tag ) {
+						$tags[] = [
+							'name' => $page_tag->name,
+							'link' => get_tag_link( $page_tag ),
+						];
+					}
+				}
+
+				$issues_data[] = [
+					'title'     => $issue->post_title,
+					'link'      => get_permalink( $issue->ID ),
+					'campaigns' => $tags,
+				];
+			}
+		}
+
+		return $issues_data;
+	}
+
+	/**
+	 * Gets data for the Evergreen pages.
+	 *
+	 * @return array
+	 */
+	public function get_evergreen_pages() : array {
+
+		$args  = [
+			'post_type'        => 'page',
+			'post_status'      => 'publish',
+			'meta_key'         => '_wp_page_template',
+			'meta_value'       => 'page-templates/evergreen.php',
+			'orderby'          => 'post_title',
+			'order'            => 'ASC',
+			'suppress_filters' => false,
+			'numberposts'      => self::MAX_EVERGREEN_PAGES,
+		];
+		$pages = get_posts( $args );
+
+		$evergreen_data = [];
+		if ( is_array( $pages ) && $pages ) {
+			foreach ( $pages as $page ) {
+				$evergreen_data[] = [
+					'title' => $page->post_title,
+					'link'  => get_permalink( $page->ID ),
+				];
+			}
+		}
+
+		return $evergreen_data;
+	}
+
+	/**
+	 * Gets data for the custom article types.
+	 *
+	 * @return array
+	 */
+	public function get_page_types() : array {
+
+		$article_types = get_terms(
+			[
+				'hide_empty' => false,
+				'orderby'    => 'name',
+				'taxonomy'   => 'p4-page-type',
+			]
+		);
+
+		$article_types_data = [];
+		if ( is_array( $article_types ) && $article_types ) {
+			foreach ( $article_types as $article_type ) {
+				$article_types_data[] = [
+					'name' => $article_type->name,
+					'link' => get_term_link( $article_type->term_id ),
+				];
+			}
+		}
+
+		return $article_types_data;
 	}
 }

--- a/classes/class-p4-taxonomy-campaign.php
+++ b/classes/class-p4-taxonomy-campaign.php
@@ -7,60 +7,58 @@
 
 use Timber\Timber;
 
-if ( ! class_exists( 'P4_Taxonomy_Campaign' ) ) {
+
+/**
+ * Class P4_Taxonomy_Campaign
+ */
+class P4_Taxonomy_Campaign {
 
 	/**
-	 * Class P4_Taxonomy_Campaign
+	 * Context
+	 *
+	 * @var array $context
 	 */
-	class P4_Taxonomy_Campaign {
+	public $context = [];
 
-		/**
-		 * Context
-		 *
-		 * @var array $context
-		 */
-		public $context = [];
+	/**
+	 * Templates
+	 *
+	 * @var array $templates
+	 */
+	protected $templates = [];
 
-		/**
-		 * Templates
-		 *
-		 * @var array $templates
-		 */
-		protected $templates = [];
+	/**
+	 * P4_Taxonomy_Campaign constructor.
+	 *
+	 * @param array $templates An indexed array with template file names. The first to be found will be used.
+	 * @param array $context An associative array with all the context needed to render the template found first.
+	 */
+	public function __construct( $templates = [ 'archive.twig', 'index.twig' ], $context = [] ) {
+		$this->templates = $templates;
+		$this->context   = $context;
+	}
 
-		/**
-		 * P4_Taxonomy_Campaign constructor.
-		 *
-		 * @param array $templates An indexed array with template file names. The first to be found will be used.
-		 * @param array $context An associative array with all the context needed to render the template found first.
-		 */
-		public function __construct( $templates = [ 'archive.twig', 'index.twig' ], $context = [] ) {
-			$this->templates = $templates;
-			$this->context   = $context;
-		}
+	/**
+	 * Add a block to the Campaign template.
+	 *
+	 * @param string $block_name The name of the block to be added.
+	 * @param array  $block_attributes An associative array with data needed by the block.
+	 */
+	public function add_block( $block_name, $block_attributes ) {
 
-		/**
-		 * Add a block to the Campaign template.
-		 *
-		 * @param string $block_name The name of the block to be added.
-		 * @param array  $block_attributes An associative array with data needed by the block.
-		 */
-		public function add_block( $block_name, $block_attributes ) {
-
-			if ( $block_name && $block_attributes ) {
-				if ( 'happy_point' === $block_name ) {
-					$block_name = 'happypoint';
-				}
-
-				$this->context['blocks'][] = '<!-- wp:planet4-blocks/' . $block_name . ' ' . wp_json_encode( $block_attributes, JSON_UNESCAPED_SLASHES ) . ' /-->';
+		if ( $block_name && $block_attributes ) {
+			if ( 'happy_point' === $block_name ) {
+				$block_name = 'happypoint';
 			}
-		}
 
-		/**
-		 * View the Campaign template.
-		 */
-		public function view() {
-			Timber::render( $this->templates, $this->context );
+			$this->context['blocks'][] = '<!-- wp:planet4-blocks/' . $block_name . ' ' . wp_json_encode( $block_attributes, JSON_UNESCAPED_SLASHES ) . ' /-->';
 		}
+	}
+
+	/**
+	 * View the Campaign template.
+	 */
+	public function view() {
+		Timber::render( $this->templates, $this->context );
 	}
 }

--- a/classes/class-p4-user.php
+++ b/classes/class-p4-user.php
@@ -7,87 +7,85 @@
 
 use Timber\User as TimberUser;
 
-if ( ! class_exists( 'P4_User' ) ) {
+
+/**
+ * Class P4_User extends Timber\User.
+ *
+ * Ref: https://timber.github.io/docs/reference/timber-user/
+ */
+class P4_User extends TimberUser {
 
 	/**
-	 * Class P4_User extends Timber\User.
+	 * Is a fake user flag
 	 *
-	 * Ref: https://timber.github.io/docs/reference/timber-user/
+	 * @var bool $is_fake
 	 */
-	class P4_User extends TimberUser {
+	public $is_fake = false;
 
-		/**
-		 * Is a fake user flag
-		 *
-		 * @var bool $is_fake
-		 */
-		public $is_fake = false;
-
-		/**
-		 * P4_User constructor.
-		 *
-		 * @param object|int|bool $uid The P4_User id.
-		 * @param string          $author_override The author override display name.
-		 */
-		public function __construct( $uid = false, $author_override = '' ) {
-			if ( ! $author_override ) {
-				parent::__construct( $uid );
-			} else {
-				$this->display_name = $author_override;
-				$this->is_fake      = true;
-			}
+	/**
+	 * P4_User constructor.
+	 *
+	 * @param object|int|bool $uid The P4_User id.
+	 * @param string          $author_override The author override display name.
+	 */
+	public function __construct( $uid = false, $author_override = '' ) {
+		if ( ! $author_override ) {
+			parent::__construct( $uid );
+		} else {
+			$this->display_name = $author_override;
+			$this->is_fake      = true;
 		}
+	}
 
-		/**
-		 * The P4_User profile page url.
-		 *
-		 * @return string
-		 */
-		public function link() : string {
-			if ( $this->is_fake ) {
-				return '#';
-			} else {
-				return parent::link();
-			}
+	/**
+	 * The P4_User profile page url.
+	 *
+	 * @return string
+	 */
+	public function link() : string {
+		if ( $this->is_fake ) {
+			return '#';
+		} else {
+			return parent::link();
 		}
+	}
 
-		/**
-		 * The relative path of the P4_User profile page.
-		 *
-		 * @return string
-		 */
-		public function path() : string {
-			if ( $this->is_fake ) {
-				return '#';
-			} else {
-				return parent::path();
-			}
+	/**
+	 * The relative path of the P4_User profile page.
+	 *
+	 * @return string
+	 */
+	public function path() : string {
+		if ( $this->is_fake ) {
+			return '#';
+		} else {
+			return parent::path();
 		}
+	}
 
-		/**
-		 * Author display name.
-		 *
-		 * @return string
-		 */
-		public function name() : ?string {
-			if ( $this->is_fake ) {
-				return (string) $this->display_name;
-			} else {
-				return parent::name();
-			}
+	/**
+	 * Author display name.
+	 *
+	 * @return string
+	 */
+	public function name() : ?string {
+		if ( $this->is_fake ) {
+			return (string) $this->display_name;
+		} else {
+			return parent::name();
 		}
+	}
 
-		/**
-		 * Stringifies the P4_User object.
-		 *
-		 * @return null|string
-		 */
-		public function __toString() {
-			if ( $this->is_fake ) {
-				return $this->name();
-			} else {
-				return parent::__toString();
-			}
+	/**
+	 * Stringifies the P4_User object.
+	 *
+	 * @return null|string
+	 */
+	public function __toString() {
+		if ( $this->is_fake ) {
+			return $this->name();
+		} else {
+			return parent::__toString();
 		}
 	}
 }


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5099
Deployed on test instance, though it fails when trying to run the `01-run-p4-activator.sh`: https://circleci.com/gh/greenpeace/planet4-test-uranus/90

This doesn't seem related to the changes in this PR though, as running the test instance with `master` of master-theme and otherwise the same setup runs into the same error.
https://circleci.com/gh/greenpeace/planet4-test-uranus/94

Not sure what's going on over there, it is looking for the class in `classes/class-p4mt\p4-activator.php`, even though the `p4mt` string is only present in `@package` annotations in our code.