### PR TITLE
PLANET-5099 Use ::class references instead of strings

### DIFF
--- a/author.php
+++ b/author.php
@@ -51,14 +51,14 @@ if ( get_query_var( 'page' ) ) {
 	$page_num           = get_query_var( 'page' );
 	$post_args['paged'] = $page_num;
 
-	$author_posts = new PostQuery( $post_args, 'P4_Post' );
+	$author_posts = new PostQuery( $post_args, P4_Post::class );
 	foreach ( $author_posts as $author_post ) {
 		$context['post'] = $author_post;
 		Timber::render( $templates, $context );
 	}
 } else {
 	$templates        = [ 'author.twig', 'archive.twig' ];
-	$context['posts'] = new PostQuery( $post_args, 'P4_Post' );
+	$context['posts'] = new PostQuery( $post_args, P4_Post::class );
 
 	Timber::render( $templates, $context );
 }

--- a/category.php
+++ b/category.php
@@ -28,13 +28,13 @@ $context['dummy_thumbnail'] = get_template_directory_uri() . '/images/dummy-thum
 if ( get_query_var( 'page' ) ) {
 	$templates          = [ 'tease-taxonomy-post.twig' ];
 	$post_args['paged'] = get_query_var( 'page' );
-	$pagetype_posts     = new \Timber\PostQuery( $post_args, 'P4_Post' );
+	$pagetype_posts     = new \Timber\PostQuery( $post_args, P4_Post::class );
 	foreach ( $pagetype_posts as $pagetype_post ) {
 		$context['post'] = $pagetype_post;
 		Timber::render( $templates, $context );
 	}
 } else {
-	$pagetype_posts   = new \Timber\PostQuery( $post_args, 'P4_Post' );
+	$pagetype_posts   = new \Timber\PostQuery( $post_args, P4_Post::class );
 	$context['posts'] = $pagetype_posts;
 	Timber::render( $templates, $context );
 }

--- a/classes/class-p4-loader.php
+++ b/classes/class-p4-loader.php
@@ -96,11 +96,11 @@ final class P4_Loader {
 			global $pagenow;
 
 			// Load P4 Control Panel only on Dashboard page.
-			$this->default_services[] = 'P4_Control_Panel';
+			$this->default_services[] = P4_Control_Panel::class;
 
 			// Load P4 Metaboxes only when adding/editing a new Page/Post/Campaign.
 			if ( 'post-new.php' === $pagenow || 'post.php' === $pagenow ) {
-				$this->default_services[] = 'P4_Metabox_Register';
+				$this->default_services[] = P4_Metabox_Register::class;
 				add_action(
 					'cmb2_save_field_p4_campaign_name',
 					[ P4_Metabox_Register::class, 'save_global_project_id' ],
@@ -111,25 +111,25 @@ final class P4_Loader {
 
 			// Load P4 Metaboxes only when adding/editing a new Page/Post/Campaign.
 			if ( 'edit-tags.php' === $pagenow || 'term.php' === $pagenow ) {
-				$this->default_services[] = 'P4_Campaigns';
+				$this->default_services[] = P4_Campaigns::class;
 			}
 
 			// Load `P4_Campaign_Exporter` class on admin campaign listing page and campaign export only.
 			if ( 'campaign' === filter_input( INPUT_GET, 'post_type', FILTER_SANITIZE_STRING ) || 'export_data' === filter_input( INPUT_GET, 'action', FILTER_SANITIZE_STRING ) ) {
-				$this->default_services[] = 'P4_Campaign_Exporter';
+				$this->default_services[] = P4_Campaign_Exporter::class;
 			}
 
 			// Load `P4_Campaign_Importer` class on admin campaign import only.
 			// phpcs:disable
 			if ( 'wordpress' === filter_input( INPUT_GET, 'import', FILTER_SANITIZE_STRING ) ) {
 				// phpcs:enable
-				$this->default_services[] = 'P4_Campaign_Importer';
+				$this->default_services[] = P4_Campaign_Importer::class;
 			}
 		}
 
 		// Run P4_Activator after theme switched to planet4-master-theme or a planet4 child theme.
 		if ( get_option( 'theme_switched' ) ) {
-			$this->default_services[] = 'P4_Activator';
+			$this->default_services[] = P4_Activator::class;
 		}
 
 		$services = array_merge( $services, $this->default_services );

--- a/classes/class-p4-master-site.php
+++ b/classes/class-p4-master-site.php
@@ -37,13 +37,6 @@ class P4_Master_Site extends TimberSite {
 	protected $sort_options;
 
 	/**
-	 * Child CSS
-	 *
-	 * @var array $child_css
-	 */
-	protected $child_css = [];
-
-	/**
 	 * Variable that lets us know if the user has or hasn't used google to log in
 	 *
 	 * @var boolean $google_login_error
@@ -123,8 +116,8 @@ class P4_Master_Site extends TimberSite {
 		if ( wp_doing_ajax() ) {
 			P4_Search::add_general_filters();
 		}
-		add_action( 'wp_ajax_get_paged_posts', [ 'P4_ElasticSearch', 'get_paged_posts' ] );
-		add_action( 'wp_ajax_nopriv_get_paged_posts', [ 'P4_ElasticSearch', 'get_paged_posts' ] );
+		add_action( 'wp_ajax_get_paged_posts', [ P4_ElasticSearch::class, 'get_paged_posts' ] );
+		add_action( 'wp_ajax_nopriv_get_paged_posts', [ P4_ElasticSearch::class, 'get_paged_posts' ] );
 
 		add_action( 'admin_head', [ $this, 'add_help_sidebar' ] );
 
@@ -285,7 +278,7 @@ class P4_Master_Site extends TimberSite {
 	 * Force WordPress to use P4_Image_Compression as image manipulation editor.
 	 */
 	public function allowedEditors() {
-		return [ 'P4_Image_Compression' ];
+		return [ P4_Image_Compression::class ];
 	}
 
 	/**

--- a/single-campaign.php
+++ b/single-campaign.php
@@ -15,7 +15,7 @@ $context = Timber::get_context();
  *
  * @var P4_Post $post
  * */
-$post            = Timber::query_post( false, 'P4_Post' ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+$post            = Timber::query_post( false, P4_Post::class ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 $context['post'] = $post;
 
 $meta = get_post_meta( $post->ID );

--- a/single.php
+++ b/single.php
@@ -18,7 +18,7 @@ $context = Timber::get_context();
  *
  * @var P4_Post $post
  */
-$post            = Timber::query_post( false, 'P4_Post' ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+$post            = Timber::query_post( false, P4_Post::class ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 $context['post'] = $post;
 
 // Strip Take Action Boxout block from the post content to add outside the normal block container.

--- a/taxonomy.php
+++ b/taxonomy.php
@@ -31,13 +31,13 @@ $context['dummy_thumbnail'] = get_template_directory_uri() . '/images/dummy-thum
 if ( get_query_var( 'page' ) ) {
 	$templates          = [ 'tease-taxonomy-post.twig' ];
 	$post_args['paged'] = get_query_var( 'page' );
-	$pagetype_posts     = new \Timber\PostQuery( $post_args, 'P4_Post' );
+	$pagetype_posts     = new \Timber\PostQuery( $post_args, P4_Post::class );
 	foreach ( $pagetype_posts as $pagetype_post ) {
 		$context['post'] = $pagetype_post;
 		Timber::render( $templates, $context );
 	}
 } else {
-	$pagetype_posts   = new \Timber\PostQuery( $post_args, 'P4_Post' );
+	$pagetype_posts   = new \Timber\PostQuery( $post_args, P4_Post::class );
 	$context['posts'] = $pagetype_posts;
 	Timber::render( $templates, $context );
 }

--- a/tests/test-p4-master-theme.php
+++ b/tests/test-p4-master-theme.php
@@ -29,7 +29,7 @@ class P4MasterThemeTest extends P4_TestCase {
 	 */
 	public function testFunctionsPHP() {
 		$context = Timber::get_context();
-		$this->assertEquals( 'P4_Master_Site', get_class( $context['site'] ) );
+		$this->assertEquals( P4_Master_Site::class, get_class( $context['site'] ) );
 		$this->assertTrue( current_theme_supports( 'post-thumbnails' ) );
 		$this->assertEquals( 'bar', $context['foo'] );
 	}


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5099

So that we don't miss any when changing file names/structure.

Tested here: https://github.com/greenpeace/planet4-test-uranus/blob/6e76e4316e8f34f751a1b2013c6b518348fedaf8/composer-local.json