### PR TITLE
PLANET-5099 Add a command as alternative for eval

### DIFF
--- a/classes/class-p4-activator.php
+++ b/classes/class-p4-activator.php
@@ -29,21 +29,6 @@ class P4_Activator {
 	 * Run activation functions.
 	 */
 	public static function run(): void {
-		self::add_custom_roles_and_capabilities();
-	}
-
-	/**
-	 * Add campaigner role and its capabilities.
-	 */
-	private static function add_custom_roles_and_capabilities(): void {
-
-		$campaigner = new P4_Campaigner();
-		$campaigner->register_role_and_add_capabilities();
-
-		// Needed to allow the editor rule to change the author of a post in the document sidebar. The users data for that
-		// control is fetched using the REST API, where WordPress by default doesn't perform a permissions check, however
-		// the Wordfence plugin adds this check in `\wordfence::jsonAPIAuthorFilter`.
-		$roles = wp_roles();
-		$roles->add_cap( 'editor', 'list_users' );
+		P4_Campaigner::register_role_and_add_capabilities();
 	}
 }

--- a/classes/class-p4-activator.php
+++ b/classes/class-p4-activator.php
@@ -22,20 +22,20 @@ class P4_Activator {
 	 * Hooks the activator functions.
 	 */
 	protected function hooks() {
-		add_action( 'after_switch_theme', [ $this, 'run' ] );
+		add_action( 'after_switch_theme', [ self::class, 'run' ] );
 	}
 
 	/**
 	 * Run activation functions.
 	 */
-	public function run() {
-		$this->add_custom_roles_and_capabilities();
+	public static function run(): void {
+		self::add_custom_roles_and_capabilities();
 	}
 
 	/**
 	 * Add campaigner role and its capabilities.
 	 */
-	public function add_custom_roles_and_capabilities() {
+	private static function add_custom_roles_and_capabilities(): void {
 
 		$campaigner = new P4_Campaigner();
 		$campaigner->register_role_and_add_capabilities();

--- a/classes/class-p4-campaigner.php
+++ b/classes/class-p4-campaigner.php
@@ -12,93 +12,62 @@
 class P4_Campaigner {
 
 	/**
-	 * P4_Campaigner constructor.
+	 * @var [[string]] List of capabilities for each standard WordPress role.
 	 */
-	public function __construct() {
-	}
+	private const CAPABILITIES_MAP = [
+		'administrator' => [
+			'edit_campaign',
+			'read_campaign',
+			'delete_campaign',
+			'edit_campaigns',
+			'edit_others_campaigns',
+			'publish_campaigns',
+			'read_private_campaigns',
+			'delete_campaigns',
+			'delete_private_campaigns',
+			'delete_published_campaigns',
+			'delete_others_campaigns',
+			'edit_private_campaigns',
+			'edit_published_campaigns',
+		],
+		'editor'        => [
+			'edit_campaign',
+			'read_campaign',
+			'delete_campaign',
+			'edit_campaigns',
+			'edit_others_campaigns',
+			'publish_campaigns',
+			'delete_campaigns',
+			'delete_published_campaigns',
+			'delete_others_campaigns',
+			'edit_published_campaigns',
 
-	/**
-	 * Register campaigner role and add custom capabilities.
-	 */
-	public function register_role_and_add_capabilities() {
-		$this->add_campaigner_role();
-		$this->add_campaign_caps_admin();
-		$this->add_campaign_caps_editor();
-		$this->add_campaign_caps_author();
-		$this->add_campaign_caps_contributor();
-		$this->add_campaigner_caps_import();
-	}
-
-	/**
-	 * Add Campaign capabilities to Administrator User.
-	 */
-	public function add_campaign_caps_admin() {
-		$role = get_role( 'administrator' );
-
-		$role->add_cap( 'edit_campaign' );
-		$role->add_cap( 'read_campaign' );
-		$role->add_cap( 'delete_campaign' );
-		$role->add_cap( 'edit_campaigns' );
-		$role->add_cap( 'edit_others_campaigns' );
-		$role->add_cap( 'publish_campaigns' );
-		$role->add_cap( 'read_private_campaigns' );
-		$role->add_cap( 'delete_campaigns' );
-		$role->add_cap( 'delete_private_campaigns' );
-		$role->add_cap( 'delete_published_campaigns' );
-		$role->add_cap( 'delete_others_campaigns' );
-		$role->add_cap( 'edit_private_campaigns' );
-		$role->add_cap( 'edit_published_campaigns' );
-	}
-
-	/**
-	 * Add Campaign capabilities to Editor User.
-	 */
-	public function add_campaign_caps_editor() {
-		$role = get_role( 'editor' );
-
-		$role->add_cap( 'edit_campaign' );
-		$role->add_cap( 'read_campaign' );
-		$role->add_cap( 'delete_campaign' );
-		$role->add_cap( 'edit_campaigns' );
-		$role->add_cap( 'edit_others_campaigns' );
-		$role->add_cap( 'publish_campaigns' );
-		$role->add_cap( 'delete_campaigns' );
-		$role->add_cap( 'delete_published_campaigns' );
-		$role->add_cap( 'delete_others_campaigns' );
-		$role->add_cap( 'edit_published_campaigns' );
-	}
-
-	/**
-	 * Add Campaign capabilities to Author User.
-	 */
-	public function add_campaign_caps_author() {
-		$role = get_role( 'author' );
-
-		$role->add_cap( 'edit_campaign' );
-		$role->add_cap( 'read_campaign' );
-		$role->add_cap( 'delete_campaign' );
-		$role->add_cap( 'edit_campaigns' );
-		$role->add_cap( 'publish_campaigns' );
-		$role->add_cap( 'delete_published_campaigns' );
-		$role->add_cap( 'edit_published_campaigns' );
-	}
-
-	/**
-	 * Add Campaign capabilities to Author User.
-	 */
-	public function add_campaign_caps_contributor() {
-		$role = get_role( 'contributor' );
-
-		$role->add_cap( 'edit_campaign' );
-		$role->add_cap( 'read_campaign' );
-		$role->add_cap( 'edit_campaigns' );
-		$role->add_cap( 'edit_published_campaigns' );
-	}
+			// Needed to allow the editor rule to change the author of a post in the document sidebar. The users data for that
+			// control is fetched using the REST API, where WordPress by default doesn't perform a permissions check, however
+			// the Wordfence plugin adds this check in `\wordfence::jsonAPIAuthorFilter`.
+			'list_users',
+		],
+		'author'        => [
+			'edit_campaign',
+			'read_campaign',
+			'delete_campaign',
+			'edit_campaigns',
+			'publish_campaigns',
+			'delete_published_campaigns',
+			'edit_published_campaigns',
+		],
+		'contributor'   => [
+			'edit_campaign',
+			'read_campaign',
+			'edit_campaigns',
+			'edit_published_campaigns',
+		],
+	];
 
 	/**
 	 * Add Campaigner role.
 	 */
-	public function add_campaigner_role() {
+	private static function add_campaigner_role() {
 		add_role(
 			'campaigner',
 			__( 'Campaigner', 'planet4-master-theme-backend' ),
@@ -129,16 +98,21 @@ class P4_Campaigner {
 				'delete_others_campaigns'    => true,
 				'edit_private_campaigns'     => true,
 				'edit_published_campaigns'   => true,
+				'import'                     => true,
 			]
 		);
 	}
 
 	/**
-	 * Add Campaign import capabilities to Campaigner User.
+	 * Register campaigner role and add custom capabilities.
 	 */
-	public function add_campaigner_caps_import() {
-		$role = get_role( 'campaigner' );
-
-		$role->add_cap( 'import' );
+	public static function register_role_and_add_capabilities() {
+		foreach ( self::CAPABILITIES_MAP as $role_name => $capabilities ) {
+			$role = get_role( $role_name );
+			foreach ( $capabilities as $capability ) {
+				$role->add_cap( $capability );
+			}
+		}
+		self::add_campaigner_role();
 	}
 }

--- a/classes/class-p4-loader.php
+++ b/classes/class-p4-loader.php
@@ -53,6 +53,7 @@ final class P4_Loader {
 		$this->load_files();
 		$this->load_services( $services );
 		$this->add_filters();
+		$this->load_commands();
 	}
 
 	/**
@@ -156,6 +157,21 @@ final class P4_Loader {
 	 */
 	private function add_filters(): void {
 		add_filter( 'pre_delete_post', [ $this, 'do_not_delete_autosave' ], 1, 3 );
+	}
+
+	/**
+	 * Registers WP_CLI commands.
+	 */
+	public function load_commands() {
+		if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
+			return;
+		}
+
+		$command = static function ( $args, $assoc_args ) {
+			P4_Activator::run();
+		};
+
+		WP_CLI::add_command( 'p4-run-activator', $command );
 	}
 
 	/**


### PR DESCRIPTION
* The usage of `wp eval` in planet4-docker-compose makes it hard to
provide backwards compatibility for P4_Activator when we move to psr-4,
so provide a WP CLI command instead.

PR for the post deploy task in base-fork: https://github.com/greenpeace/planet4-master-theme/pull/1125

Also cleaned up role registration a bit: 
* There were 2 separate calls outside of the functions per role which also added some capabilities, while there was no reason for them to be separate so I added them with the rest.
* Create a map with all roles and their capabilities, which is less noisy to watch than a `add_cap` call inside of separate functions + mandatory docblock ...
* Made functions static so we don't need to create pointless instances.

Deployed here https://github.com/greenpeace/planet4-test-uranus/commit/0695728f02053e478561b2de976c09ece7917ea6
Ref: https://jira.greenpeace.org/browse/PLANET-5099