### PR TITLE
PLANET-5186: Switch script version to filectime

### DIFF
--- a/classes/class-p4-campaigns.php
+++ b/classes/class-p4-campaigns.php
@@ -419,7 +419,13 @@ class P4_Campaigns {
 		if ( ! is_admin() || strpos( get_current_screen()->taxonomy, $this->taxonomy ) === false ) {
 			return;
 		}
-		wp_register_script( $this->taxonomy, get_template_directory_uri() . "/admin/js/$this->taxonomy.js", [ 'jquery' ], '0.1', true );
+		wp_register_script(
+			$this->taxonomy,
+			get_template_directory_uri() . "/admin/js/$this->taxonomy.js",
+			[ 'jquery' ],
+			P4_Loader::theme_file_ver( "admin/js/$this->taxonomy.js" ),
+			true
+		);
 		wp_localize_script( $this->taxonomy, 'localizations', $this->localizations );
 		wp_enqueue_script( $this->taxonomy );
 		wp_enqueue_media();

--- a/classes/class-p4-control-panel.php
+++ b/classes/class-p4-control-panel.php
@@ -284,8 +284,20 @@ class P4_Control_Panel {
 		if ( ! is_admin() || 'dashboard' !== get_current_screen()->base ) {
 			return;
 		}
-		$theme_dir = get_template_directory_uri();
-		wp_enqueue_style( 'dashboard-style', "$theme_dir/admin/css/dashboard.css", [], '0.1.0' );
-		wp_enqueue_script( 'dashboard-script', "$theme_dir/admin/js/dashboard.js", [ 'jquery' ], '0.2.0', true );
+
+		$theme_uri = get_template_directory_uri();
+		wp_enqueue_style(
+			'dashboard-style',
+			"$theme_uri/admin/css/dashboard.css",
+			[],
+			P4_Loader::theme_file_ver( 'admin/css/dashboard.css' )
+		);
+		wp_enqueue_script(
+			'dashboard-script',
+			"$theme_uri/admin/js/dashboard.js",
+			[ 'jquery' ],
+			P4_Loader::theme_file_ver( 'admin/js/dashboard.js' ),
+			true
+		);
 	}
 }

--- a/classes/class-p4-loader.php
+++ b/classes/class-p4-loader.php
@@ -201,4 +201,18 @@ final class P4_Loader {
 
 		return false;
 	}
+
+	/**
+	 * @param string $rel_path Relative path to the file.
+	 * @return int timestamp of file creation
+	 */
+	public static function theme_file_ver( string $rel_path ): int {
+		$filepath = trailingslashit( get_template_directory() ) . $rel_path;
+		$ctime    = filectime( $filepath );
+		if ( $ctime ) {
+			return $ctime;
+		}
+
+		return time();
+	}
 }

--- a/classes/class-p4-master-site.php
+++ b/classes/class-p4-master-site.php
@@ -217,7 +217,12 @@ class P4_Master_Site extends TimberSite {
 	 * Sets a custom stylesheet for the login page.
 	 */
 	public function add_login_stylesheet() {
-		wp_enqueue_style( 'custom-login', $this->theme_dir . '/admin/css/login.css', [], '0.2' );
+		wp_enqueue_style(
+			'custom-login',
+			$this->theme_dir . '/admin/css/login.css',
+			[],
+			P4_Loader::theme_file_ver( 'admin/css/login.css' )
+		);
 	}
 
 	/**
@@ -551,7 +556,12 @@ class P4_Master_Site extends TimberSite {
 		$js_creation  = filectime( get_template_directory() . '/assets/build/index.js' );
 
 		// CSS files.
-		wp_enqueue_style( 'bootstrap', $this->theme_dir . '/assets/build/bootstrap.min.css', [], '4.1.1' );
+		wp_enqueue_style(
+			'bootstrap',
+			$this->theme_dir . '/assets/build/bootstrap.min.css',
+			[],
+			P4_Loader::theme_file_ver( 'assets/build/bootstrap.min.css' )
+		);
 		wp_enqueue_style( 'slick', 'https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.9.0/slick.min.css', [], '1.9.0' );
 
 		// This loads a linked style file since the relative images paths are outside the build directory.

--- a/classes/class-p4-post-campaign.php
+++ b/classes/class-p4-post-campaign.php
@@ -200,7 +200,12 @@ class P4_Post_Campaign {
 	 * Load assets.
 	 */
 	public function enqueue_admin_assets() {
-		wp_register_style( 'cmb-style', get_template_directory_uri() . '/admin/css/campaign.css', [], '0.1' );
+		wp_register_style(
+			'cmb-style',
+			get_template_directory_uri() . '/admin/css/campaign.css',
+			[],
+			P4_Loader::theme_file_ver( 'admin/css/campaign.css' )
+		);
 		wp_enqueue_style( 'cmb-style' );
 	}
 

--- a/classes/class-p4-post-report-controller.php
+++ b/classes/class-p4-post-report-controller.php
@@ -100,7 +100,7 @@ class P4_Post_Report_Controller {
 				'wp-api',
 				'wp-backbone',
 			],
-			'0.2',
+			P4_Loader::theme_file_ver( 'admin/js/posts_report.js' ),
 			true
 		);
 		wp_localize_script(
@@ -116,7 +116,7 @@ class P4_Post_Report_Controller {
 			'jquery-ui-datepicker',
 			'https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/themes/overcast/jquery-ui.min.css',
 			[],
-			'0.1'
+			'1.12.1'
 		);
 		wp_enqueue_style( 'jquery-ui-datepicker' );
 		include dirname( __FILE__ ) . '/../posts-report.php';


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5186
Linked: https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/302

Script version is not automatically updated when we make changes, which leads to cache problems if we forget it.

## Fix

Switch enqueue/register scripts from hardcoded version to `filectime`.

Versions were found with regex `[0-9]{1,2}\.[0-9]{1,2}`, and by looking at `wp_enqueue_style` and `wp_enqueue_script` usage.
_I didn't write a specific larger function for this, because at this point I would prefer to create a new class that could be used in other repos and would have the paths needed and version function for each equivalent wordpress enqueue/register functions; and I'm not doing that because we currently are in a namespace refactoring + another large refactoring. This modification seems like enough at the moment._

## Test

On the editor side while editing a campaing, in the network calls or in html source, calls to `planet4-master-theme/` assets should be versioned with a timestamp as version number. You can filter by `ver=159` or `planet4-master-theme` to see those calls.  
No network call related to this theme should be a 404, on the public and the admin sides.
