### PR TITLE
PLANET-4987 Exclude unwanted attachments from EP

### DIFF
--- a/exporter-helper.php
+++ b/exporter-helper.php
@@ -6,22 +6,6 @@
  */
 
 /**
- * Generate a bunch of placeholders for use in an IN query.
- * Such a shame WordPress doesn't offer a decent way to do bind IN statement params and we have to do this ourselves.
- *
- * @param array $items The items to generate placeholders for.
- * @param int   $start_index The start index to use for creating the placeholders.
- * @return string The generated placeholders string.
- */
-function generate_list_placeholders( array $items, int $start_index ): string {
-	$placeholders = [];
-	foreach ( range( $start_index, count( $items ) + $start_index - 1 ) as $i ) {
-		$placeholders[] = "%$i\$d";
-	}
-	return implode( ',', $placeholders );
-}
-
-/**
  * Parse the post content and return all attachment ids used in blocks.
  *
  * @param string $content The content to parse.

--- a/functions.php
+++ b/functions.php
@@ -39,6 +39,31 @@ function simple_value_filter( string $filter_name, $value, $priority = null ): v
 }
 
 /**
+ * Generate a bunch of placeholders for use in an IN query.
+ * Unfortunately WordPress doesn't offer a way to do bind IN statement params, it would be a lot easier if we could pass
+ * the array to wpdb->prepare as a whole.
+ *
+ * @param array  $items The items to generate placeholders for.
+ * @param int    $start_index The start index to use for creating the placeholders.
+ * @param string $type The type of value.
+ *
+ * @return string The generated placeholders string.
+ */
+function generate_list_placeholders( array $items, int $start_index, $type = 'd' ): string {
+	$placeholders = [];
+	foreach ( range( $start_index, count( $items ) + $start_index - 1 ) as $i ) {
+		$placeholder = "%{$i}\${$type}";
+		// Quote it if it's a string.
+		if ( 's' === $type ) {
+			$placeholder = "'{$placeholder}'";
+		}
+		$placeholders[] = $placeholder;
+	}
+
+	return implode( ',', $placeholders );
+}
+
+/**
  * Wrapper function around cmb2_get_option.
  *
  * @param string $key Options array key.


### PR DESCRIPTION
While I was debugging why my previous suggested solution didn't work, I stumbled on this other filter that allows us to exclude unwanted attachments from the list of ids that ElasticPress will sync, before it starts looping through these. The benefit is that way it will also show correct numbers in the UI and can prevent issues caused by the number not corresponding to the actual posts being synced.

Unfortunately this was not solvable by adding more args, as WP query args don't support the kind of complex or condition we need (either not post_type attachment or having one of the wanted mime types), so instead I had to first fetch all unwanted ids. It needs to be done with raw SQL, as regular query with args was not returning attachments with no post_parent.

The additional query shouldn't be an issue as this function is only called in non-performance sensitive contexts (CLI and dashboard sync).

Still todo: write the `IN` query with parameters to make it support multiple wanted doc types.