### PR TITLE
PLANET-5201 Add data attributes on page header

### DIFF
--- a/templates/blocks/header.twig
+++ b/templates/blocks/header.twig
@@ -17,7 +17,14 @@
 					{% if ( post.issues_nav_data ) %}
 						<div class="tag-wrap issues">
 							{% for issue in post.issues_nav_data %}
-								<a class="tag-item tag-item--main" href="{{ issue.link|default('#') }}">{{ issue.name|e('wp_kses_post')|raw }}</a>
+								<a
+									class="tag-item tag-item--main"
+									href="{{ issue.link|default('#') }}"
+									data-ga-category="Header"
+									data-ga-action="Category Tag"
+									data-ga-label="n/a">
+										{{ issue.name|e('wp_kses_post')|raw }}
+								</a>
 							{% endfor %}
 						</div>
 					{% endif %}
@@ -25,7 +32,14 @@
 					{% if ( campaigns ) %}
 						<div class="tag-wrap issues">
 							{% for campaign in campaigns %}
-								<a class="tag-item tag" href="{{ campaign.link|default('#') }}">#{{ campaign.name|e('wp_kses_post')|raw }}</a>
+								<a
+									class="tag-item tag"
+									href="{{ campaign.link|default('#') }}"
+									data-ga-category="Header"
+									data-ga-action="Navigation Tag"
+									data-ga-label="n/a">
+										#{{ campaign.name|e('wp_kses_post')|raw }}
+								</a>
 							{% endfor %}
 						</div>
 					{% endif %}
@@ -47,11 +61,17 @@
 				{% if ( header_button_title and header_button_link ) %}
 					<div class="row">
 						<div class="col-md-12">
-							<a href="{{ header_button_link }}"
-									{% if ( header_button_link_checkbox ) %}
-										target="_blank"
-									{% endif %}
-							class="btn btn-primary btn-medium page-header-btn">{{ header_button_title }}</a>
+							<a
+								href="{{ header_button_link }}"
+							{% if ( header_button_link_checkbox ) %}
+								target="_blank"
+							{% endif %}
+								class="btn btn-primary btn-medium page-header-btn"
+								data-ga-category="Header"
+								data-ga-action="Call to Action"
+								data-ga-label="n/a">
+									{{ header_button_title }}
+							</a>
 						</div>
 					</div>
 				{% endif %}

--- a/templates/single.twig
+++ b/templates/single.twig
@@ -20,7 +20,14 @@
 					{% if ( post.issues_nav_data ) %}
 						<div class="tag-wrap issues">
 							{% for issue in post.issues_nav_data %}
-								<a class="tag-item tag-item--main" href="{{ issue.link|default('#') }}">{{ issue.name|e('wp_kses_post')|raw }}</a>
+								<a
+									class="tag-item tag-item--main"
+									href="{{ issue.link|default('#') }}"
+									data-ga-category="Header"
+									data-ga-action="Category Tag"
+									data-ga-label="n/a">
+										{{ issue.name|e('wp_kses_post')|raw }}
+								</a>
 							{% endfor %}
 						</div>
 					{% endif %}
@@ -28,7 +35,14 @@
 					{% if (post.tags) %}
 						<div class="tag-wrap tags">
 							{% for tag in post.tags %}
-								<a class="tag-item tag" href="{{ tag.link }}">#{{ tag.name|e('wp_kses_post')|raw }}</a>
+								<a
+									class="tag-item tag"
+									href="{{ tag.link }}"
+									data-ga-category="Header"
+									data-ga-action="Navigation Tag"
+									data-ga-label="n/a">
+									#{{ tag.name|e('wp_kses_post')|raw }}
+								</a>
 							{% endfor %}
 						</div>
 					{% endif %}


### PR DESCRIPTION
Related to [JIRA 5201](https://jira.greenpeace.org/browse/PLANET-5201)

Task -
- Add data attributes on page/post header taxonomy(category and tags) and CTA button element as per JIRA ticket details.

Testing -
- Check the page/post header category, tags and CTA button html element for analytics data attributes values.
- The changes are pinned on [test-venus](https://k8s.p4.greenpeace.org/test-venus/) instance for testing.