### PR TITLE
PLANET-5156: Implement the 8px Grid Template

### DIFF
--- a/assets/src/scss/base/_grid.scss
+++ b/assets/src/scss/base/_grid.scss
@@ -1,0 +1,19 @@
+$grid-breakpoints: (
+  xs: 0,
+  sm: 600px,
+  md: 768px,
+  lg: 992px,
+  xl: 1230px
+);
+
+// Width of .container
+$container-max-widths: (
+  sm: 592px,
+  md: 720px,
+  lg: 960px,
+  xl: 1152px
+);
+
+$grid-columns: 12;
+$grid-gutter-width: 32px;
+$enable-grid-classes: true;

--- a/assets/src/scss/bootstrap-build.scss
+++ b/assets/src/scss/bootstrap-build.scss
@@ -25,6 +25,7 @@ Text Domain: planet4-master-theme
 @import "~bootstrap/scss/mixins";
 
 // TODO: Add variable overrides for the 16px grid here.
+@import "base/grid";
 
 // Optional
 // @import "~bootstrap/scss/reboot";


### PR DESCRIPTION
Labeling this as WIP as I don't know yet how we are going to split this work.

This PR so far is only changing the Bootstrap's grid variables, which is the first bullet point in the ticket:
https://jira.greenpeace.org/browse/PLANET-5156

In order to get to the "pixel perfect" grid example (shown in the ticket's attachments), we need to go through all those modifications.

There is an experimental older branch (no PR) with some of these changes, you can check it to have an idea of what is needed:
https://github.com/greenpeace/planet4-master-theme/compare/fixed-grid-poc

cc @mleray @comzeradd 