### PR TITLE
Refactor: remove file comment in /src/*

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -38,6 +38,12 @@
         <exclude name="Generic.Arrays.DisallowShortArraySyntax"/>
     </rule>
 
+	<!-- All files in src are classes so already have a required comment before the declaration. The rule also forced
+	to include an @package annotation, which is redundant if there is a namespace. -->
+	<rule ref="Squiz.Commenting.FileComment">
+		<exclude-pattern>src/*</exclude-pattern>
+	</rule>
+
     <!-- Check all PHP files in directory tree by default. -->
     <arg name="extensions" value="php"/>
     <file>.</file>

--- a/src/Activator.php
+++ b/src/Activator.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * P4 Activator Class
- *
- * @package P4MT
- */
 
 namespace P4\MasterTheme;
 

--- a/src/AnalyticsValues.php
+++ b/src/AnalyticsValues.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Data class for post editor analytics values.
- *
- * @package P4MT
- */
 
 namespace P4\MasterTheme;
 

--- a/src/CampaignExporter.php
+++ b/src/CampaignExporter.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Campaign Settings Exporter
- *
- * @package P4MT
- */
 
 namespace P4\MasterTheme;
 

--- a/src/CampaignImporter.php
+++ b/src/CampaignImporter.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Campaign Data(Attachment) Importer
- *
- * @package P4MT
- */
 
 namespace P4\MasterTheme;
 

--- a/src/Campaigner.php
+++ b/src/Campaigner.php
@@ -1,14 +1,8 @@
 <?php
-/**
- * P4 Campaigner Role
- *
- * @package P4MT
- */
 
 namespace P4\MasterTheme;
 
 /**
- * Class Campaigner.
  * Register custom 'campaigner' role and adds custom capabilities.
  */
 class Campaigner {

--- a/src/Campaigns.php
+++ b/src/Campaigns.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * P4 Campaigns
- *
- * @package P4MT
- */
 
 namespace P4\MasterTheme;
 

--- a/src/Context.php
+++ b/src/Context.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * P4 Context Class
- *
- * @package P4MT
- */
 
 namespace P4\MasterTheme;
 

--- a/src/ControlPanel.php
+++ b/src/ControlPanel.php
@@ -1,16 +1,10 @@
 <?php
-/**
- * P4 Control Panel
- *
- * @package P4MT
- */
 
 namespace P4\MasterTheme;
 
 use P4GEN\Controllers\Ensapi_Controller as ENS_API;
 use ElasticPress\Elasticsearch as ES;
 use WP_Error;
-
 
 /**
  * Class ControlPanel

--- a/src/Cookies.php
+++ b/src/Cookies.php
@@ -1,16 +1,9 @@
 <?php
-/**
- * P4 Cookies Class
- *
- * @package P4MT
- */
 
 namespace P4\MasterTheme;
 
 /**
  * Class Cookies
- *
- * @since 1.9
  */
 class Cookies {
 

--- a/src/CustomTaxonomy.php
+++ b/src/CustomTaxonomy.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * P4 Custom Taxonomy
- *
- * @package P4MT
- */
 
 namespace P4\MasterTheme;
 

--- a/src/DevReport.php
+++ b/src/DevReport.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Settings Class
- *
- * @package P4MT
- */
 
 namespace P4\MasterTheme;
 

--- a/src/ElasticSearch.php
+++ b/src/ElasticSearch.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * P4 ElasticSearch Class
- *
- * @package P4MT
- */
 
 namespace P4\MasterTheme;
 

--- a/src/ImageCompression.php
+++ b/src/ImageCompression.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Image Compression Class
- *
- * @package P4MT
- */
 
 namespace P4\MasterTheme;
 

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * P4 Loader Class
- *
- * @package P4MT
- */
 
 namespace P4\MasterTheme;
 

--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * P4 Master Site Class
- *
- * @package P4MT
- */
 
 namespace P4\MasterTheme;
 

--- a/src/MetaboxRegister.php
+++ b/src/MetaboxRegister.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * P4 Metabox Register Class
- *
- * @package P4MT
- */
 
 namespace P4\MasterTheme;
 

--- a/src/Post.php
+++ b/src/Post.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * P4 Post Class
- *
- * @package P4MT
- */
 
 namespace P4\MasterTheme;
 

--- a/src/PostArchive.php
+++ b/src/PostArchive.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * A custom post type for P3 posts that were archived.
- *
- * @package P4MT
- */
 
 namespace P4\MasterTheme;
 

--- a/src/PostCampaign.php
+++ b/src/PostCampaign.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * P4 Post Campaign Template Settings
- *
- * @package P4MT
- */
 
 namespace P4\MasterTheme;
 

--- a/src/PostReportController.php
+++ b/src/PostReportController.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Post report controller
- *
- * @package P4MT
- */
 
 namespace P4\MasterTheme;
 

--- a/src/Search.php
+++ b/src/Search.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * P4 Search Class
- *
- * @package P4MT
- */
 
 namespace P4\MasterTheme;
 

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Settings.
- *
- * @package P4MT
- */
 
 namespace P4\MasterTheme;
 

--- a/src/Sitemap.php
+++ b/src/Sitemap.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * P4 Sitemap Class
- *
- * @package P4MT
- */
 
 namespace P4\MasterTheme;
 

--- a/src/Smartsheet.php
+++ b/src/Smartsheet.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * A data object for SmartSheet API responses.
- *
- * @package P4MT
- */
 
 namespace P4\MasterTheme;
 

--- a/src/SmartsheetClient.php
+++ b/src/SmartsheetClient.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Handles calling the SmartSheet API.
- *
- * @package P4MT
- */
 
 namespace P4\MasterTheme;
 

--- a/src/TaxonomyCampaign.php
+++ b/src/TaxonomyCampaign.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * P4 Campaign Taxonomy
- *
- * @package P4MT
- */
 
 namespace P4\MasterTheme;
 

--- a/src/User.php
+++ b/src/User.php
@@ -1,13 +1,8 @@
 <?php
-/**
- * P4 User
- *
- * @package P4MT
- */
 
 namespace P4\MasterTheme;
 
-use Timber\User as TimberUser;
+use Timber;
 
 
 /**
@@ -15,7 +10,7 @@ use Timber\User as TimberUser;
  *
  * Ref: https://timber.github.io/docs/reference/timber-user/
  */
-class User extends TimberUser {
+class User extends Timber\User {
 
 	/**
 	 * Is a fake user flag


### PR DESCRIPTION
* Exclude file comment rule for all files in /src, as all of them are
classes which already have a comment before the declaration. The file
comment also required an `@package` tag, which is redundant if the class
is in a namespace.
* Remove file comment from all classes.
* Import namespace Timber instead of the User class in that namespace so
we don't need to add an alias.