### PR TITLE
PLANET-5142 Add Cloudflare's Image Optimization url twig filter(cf_img_url)

### DIFF
--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -1170,54 +1170,72 @@ class MasterSite extends TimberSite {
 		$twig->addFilter(
 			new Twig_SimpleFilter(
 				'cf_img_url',
-				function ( $source, $srcset = '' ) use ( $cf_img_optimization, $cf_options_txt ) {
-					if ( ! $cf_img_optimization ) {
+				$cf_img_optimization
+					? function ( string $source, string $src_set = '' ) use ( $cf_options_txt ) {
+						return $this->img_to_cloudflare( $source, $src_set, $cf_options_txt );
+					}
+					: function ( string $source ) {
 						return $source;
 					}
-
-					// Cloudflare url format - https://zone/cdn-cgi/image/options/source-image .
-					// eg. <img src="/cdn-cgi/image/width=80,quality=75/uploads/avatar1.jpg">.
-					// More info. https://developers.cloudflare.com/images/about .
-					$zone      = '';
-					$prefix    = '/cdn-cgi/image/';
-					$options[] = 'format=auto';
-
-					if ( $cf_options_txt ) {
-						$options[] = esc_attr( $cf_options_txt );
-					}
-
-					// Case 2: Prepare a srcset cloudflare images url.
-					if ( empty( $srcset ) ) {
-						$srcset_array = explode( ',', $source );
-						$cf_srcset    = $source;
-						$options[]    = 'fit=contain';
-
-						foreach ( $srcset_array as $img_data ) {
-							list( $img_url, $img_width ) = explode( ' ', trim( $img_data ) );
-
-							// Update image width in options array.
-							$srcset_options = array_merge( $options, [ 'width=' . (int) $img_width ] );
-							$cf_img_url     = $zone . $prefix . implode( ',', $srcset_options ) . '/' . $img_url;
-
-							$cf_srcset = str_replace( $img_url, $cf_img_url, $cf_srcset );
-						}
-						return $cf_srcset;
-					}
-
-
-					// Case 1: Prepare a src cloudflare image url.
-					preg_match( '/' . preg_quote( $source, '/' ) . '\s(\d+)/', $srcset, $img_width );
-
-					if ( isset( $img_width[1] ) && $img_width[1] ) {
-						$options[] = 'width=' . $img_width[1];
-						return $zone . $prefix . implode( ',', $options ) . '/' . $source;
-					}
-
-					return $source;
-				}
 			)
 		);
 
 		return $twig;
+	}
+
+	/**
+	 * Converts Image urls in src/srcset content to cloudflare optimized image url.
+	 *
+	 * @see More info. https://developers.cloudflare.com/images/about
+	 * @see eg. <img src="/cdn-cgi/image/width=80,quality=75/uploads/avatar1.jpg">.
+	 *
+	 * @param string $source The raw img src/srcset to be filtered.
+	 * @param string $srcset The raw img srcset.
+	 * @param string $cf_options_txt The options value set from P4 settings.
+	 * @return string Converted img src/srcset content.
+	 */
+	public function img_to_cloudflare(
+		string $source,
+		string $srcset = '',
+		string $cf_options_txt = ''
+	): string {
+		$zone      = '';
+		$prefix    = '/cdn-cgi/image/';
+		$options[] = 'format=auto';
+
+		if ( $cf_options_txt ) {
+			$options[] = esc_attr( $cf_options_txt );
+		}
+
+		// Case 2: Prepare a srcset cloudflare images url.
+		if ( empty( $srcset ) ) {
+			$srcset_array = explode( ',', $source );
+			$cf_srcset    = $source;
+			$options[]    = 'fit=contain';
+
+			foreach ( $srcset_array as $img_data ) {
+				list( $img_url, $img_width ) = array_pad( explode( ' ', trim( $img_data ) ), 2, null );
+
+				if ( $img_width ) {
+					// Update image width in options array.
+					$srcset_options = array_merge( $options, [ 'width=' . (int) $img_width ] );
+				} else {
+					$srcset_options = $options;
+				}
+				$cf_img_url = $zone . $prefix . implode( ',', $srcset_options ) . '/' . $img_url;
+
+				$cf_srcset = str_replace( $img_url, $cf_img_url, $cf_srcset );
+			}
+			return $cf_srcset;
+		}
+
+		// Case 1: Prepare a src cloudflare image url.
+		preg_match( '/' . preg_quote( $source, '/' ) . '\s(\d+)/', $srcset, $img_width );
+		if ( isset( $img_width[1] ) && $img_width[1] ) {
+			$options[] = 'width=' . $img_width[1];
+			return $zone . $prefix . implode( ',', $options ) . '/' . $source;
+		}
+
+		return $source;
 	}
 }

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -305,6 +305,20 @@ class Settings {
 					'media_buttons' => false,
 				],
 			],
+
+			[
+				'name' => __( 'Enable Cloudflare Image Optimization', 'planet4-master-theme-backend' ),
+				'desc' => __( 'Enable Cloudflare Image Optimization option for images which uses a "cf_img_url" twig filter. for more info', 'planet4-master-theme-backend' ) . ' <a href="https://developers.cloudflare.com/images/about">' . __( 'click here', 'planet4-master-theme-backend' ) . '</a>.',
+				'id'   => 'cloudflare_img_opt',
+				'type' => 'checkbox',
+			],
+
+			[
+				'name' => __( 'Cloudflare Image Optimization Options', 'planet4-master-theme-backend' ),
+				'desc' => __( 'Add Cloudflare image optimization url "options" value', 'planet4-master-theme-backend' ) . '[Comma-separated text].(https://zone/cdn-cgi/image/options/source-image)<br />e.g. width=80,quality=75,fit=cover',
+				'id'   => 'cloudflare_options_txt',
+				'type' => 'text',
+			],
 		];
 		$this->hooks();
 	}

--- a/tests/test-p4-master-site.php
+++ b/tests/test-p4-master-site.php
@@ -57,4 +57,44 @@ class P4MasterSite extends TestCase {
 
 		$this->assertEquals( $expected, $p4->make_content_images_lazyload( $content ) );
 	}
+
+	/**
+	 * Test cases for cloudflare
+	 */
+	public function cloudflareImageProvider(): array {
+		return [
+			[
+				[ 'path/to/my/image.jpg', 'path/to/my/image.jpg 1200w,path/to/my/image1.jpg 300w', '' ],
+				'/cdn-cgi/image/format=auto,width=1200/path/to/my/image.jpg',
+			],
+			[
+				[ 'http://www.planet4.test/wp-content/uploads/2020/06/GP1STWPE.jpg 1200w, http://www.planet4.test/wp-content/uploads/2020/06/GP1STWPE-300x210.jpg 300w, http://www.planet4.test/wp-content/uploads/2020/06/GP1STWPE-1024x715.jpg 1024w, http://www.planet4.test/wp-content/uploads/2020/06/GP1STWPE-768x536.jpg 768w, http://www.planet4.test/wp-content/uploads/2020/06/GP1STWPE-487x340.jpg 487w', '', '' ],
+				'/cdn-cgi/image/format=auto,fit=contain,width=1200/http://www.planet4.test/wp-content/uploads/2020/06/GP1STWPE.jpg 1200w, /cdn-cgi/image/format=auto,fit=contain,width=300/http://www.planet4.test/wp-content/uploads/2020/06/GP1STWPE-300x210.jpg 300w, /cdn-cgi/image/format=auto,fit=contain,width=1024/http://www.planet4.test/wp-content/uploads/2020/06/GP1STWPE-1024x715.jpg 1024w, /cdn-cgi/image/format=auto,fit=contain,width=768/http://www.planet4.test/wp-content/uploads/2020/06/GP1STWPE-768x536.jpg 768w, /cdn-cgi/image/format=auto,fit=contain,width=487/http://www.planet4.test/wp-content/uploads/2020/06/GP1STWPE-487x340.jpg 487w',
+			],
+			[
+				[ 'http://www.planet4.test/wp-content/uploads/2020/06/GP1STWPE.jpg', 'http://www.planet4.test/wp-content/uploads/2020/06/GP1STWPE.jpg 1200w, http://www.planet4.test/wp-content/uploads/2020/06/GP1STWPE-300x210.jpg 300w, http://www.planet4.test/wp-content/uploads/2020/06/GP1STWPE-1024x715.jpg 1024w, http://www.planet4.test/wp-content/uploads/2020/06/GP1STWPE-768x536.jpg 768w, http://www.planet4.test/wp-content/uploads/2020/06/GP1STWPE-487x340.jpg 487w', 'optionA=valA' ],
+				'/cdn-cgi/image/format=auto,optionA=valA,width=1200/http://www.planet4.test/wp-content/uploads/2020/06/GP1STWPE.jpg',
+			],
+			[
+				[ 'http://www.planet4.test/wp-content/uploads/2020/06/GP1STWPE.jpg 1200w, http://www.planet4.test/wp-content/uploads/2020/06/GP1STWPE-300x210.jpg 300w, http://www.planet4.test/wp-content/uploads/2020/06/GP1STWPE-1024x715.jpg 1024w, http://www.planet4.test/wp-content/uploads/2020/06/GP1STWPE-768x536.jpg 768w, http://www.planet4.test/wp-content/uploads/2020/06/GP1STWPE-487x340.jpg 487w', '', 'optionA=valA' ],
+				'/cdn-cgi/image/format=auto,optionA=valA,fit=contain,width=1200/http://www.planet4.test/wp-content/uploads/2020/06/GP1STWPE.jpg 1200w, /cdn-cgi/image/format=auto,optionA=valA,fit=contain,width=300/http://www.planet4.test/wp-content/uploads/2020/06/GP1STWPE-300x210.jpg 300w, /cdn-cgi/image/format=auto,optionA=valA,fit=contain,width=1024/http://www.planet4.test/wp-content/uploads/2020/06/GP1STWPE-1024x715.jpg 1024w, /cdn-cgi/image/format=auto,optionA=valA,fit=contain,width=768/http://www.planet4.test/wp-content/uploads/2020/06/GP1STWPE-768x536.jpg 768w, /cdn-cgi/image/format=auto,optionA=valA,fit=contain,width=487/http://www.planet4.test/wp-content/uploads/2020/06/GP1STWPE-487x340.jpg 487w',
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider cloudflareImageProvider
+	 *
+	 * @param array  $params   Parameters for img_to_cloudflare().
+	 * @param string $expected Resulting URL expected.
+	 */
+	public function testImgToCloudflare( array $params, string $expected ): void {
+		/** @var MasterSite $p4 */
+		$p4 = $this->getMockBuilder( MasterSite::class )
+		->disableOriginalConstructor()
+		->setMethodsExcept( [ 'img_to_cloudflare' ] )
+		->getMock();
+
+		$this->assertEquals( $expected, $p4->img_to_cloudflare( ...$params ) );
+	}
 }


### PR DESCRIPTION
Ref.
[JIRA 5142](https://jira.greenpeace.org/browse/PLANET-5142)
https://developers.cloudflare.com/images/responsive

- Add a twig filter which returns cloudflare ready(cloudflare optimized) image url
- Add P4 setting to toggle the cloudflare image url functionality
- Option added in P4 setting to try different `options` values from [cloudflare](https://developers.cloudflare.com/images/about) (`https://zone/cdn-cgi/image/options/source-image`) [This field is intended for testing purpose only, we will remove it once finish with testing]

Related PR: [#321](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/321)
