### PR TITLE
PLANET-5306: Display post type above post title

### DIFF
--- a/single.php
+++ b/single.php
@@ -44,7 +44,7 @@ $post->set_issues_links();
 $page_meta_data                 = get_post_meta( $post->ID );
 $page_meta_data                 = array_map( 'reset', $page_meta_data );
 $page_terms_data                = get_the_terms( $post, 'p4-page-type' );
-$page_terms_data                = array_map( 'reset', $page_terms_data );
+$page_terms_data                = is_array( $page_terms_data ) ? reset( $page_terms_data ) : null;
 $context['background_image']    = $page_meta_data['p4_background_image_override'] ?? '';
 $take_action_page               = $page_meta_data['p4_take_action_page'] ?? '';
 $context['page_type']           = $page_terms_data->name ?? '';


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5306

> According to the single post template, the post type should be displayed with tags before the post title; it doesn't appear anymore

The fix is just an `array_map( 'reset', array )` changed to a more fitting `reset( array )`.  In the best case, `get_the_terms()` returns `WP_Term[]`, and according to the [previous version](https://github.com/greenpeace/planet4-master-theme/blame/a678ed1ce57368d170d8d14f14bf61a4acf706ad/single.php#L46) of the code, we are just using the first one of the terms given.

## Tests

The problem occurs on single post pages; display any post that has a post type, you should get something like this :

### Current display
_Post type is not displayed, and notices are generated by PHP in dev mode._
<img width="708" alt="Screenshot 2020-07-10 at 15 22 43" src="https://user-images.githubusercontent.com/617346/87159833-3e20c380-c2c2-11ea-80a1-789aa2c5bd4e.png">

### Display Fixed
_Post type PRESS RELEASE is displayed, no notice emitted._
<img width="718" alt="Screenshot 2020-07-10 at 15 23 16" src="https://user-images.githubusercontent.com/617346/87159847-44af3b00-c2c2-11ea-88bf-dcb6984c7446.png">
