### PR TITLE
Load aliases before using a class

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -107,6 +107,6 @@ if ( ! class_exists( 'Timber' ) ) {
 	}
 }
 
-Loader::get_instance();
-
 require_once 'load-class-aliases.php';
+
+Loader::get_instance();


### PR DESCRIPTION
Previously planet4-base-fork ran the Activator class by running `wp
eval` with an instantiation of the old class name. We added a command
inside WP instead to avoid eval, but if anyone has a localdev setup with
the old version of base-fork still running this command, it will cause
localdev to break in a confusing way, taking a lot of people's time
debugging it. We can easily still make it work by moving the aliases to
before the first usage of any of the classes.