### PR TITLE
PLANET-5319: Fix cf_img_url error on image srcset null

### DIFF
--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -1166,10 +1166,12 @@ class MasterSite extends TimberSite {
 			new Twig_SimpleFilter(
 				'cf_img_url',
 				$cf_img_optimization
-					? function ( string $source, string $src_set = '' ) use ( $cf_options_txt ) {
-						return $this->img_to_cloudflare( $source, $src_set, $cf_options_txt );
+					? function ( ?string $source, ?string $src_set = '' ) use ( $cf_options_txt ) {
+						return empty( $source )
+							? $source
+							: $this->img_to_cloudflare( $source, $src_set ?? '', $cf_options_txt );
 					}
-					: function ( string $source ) {
+					: function ( ?string $source ) {
 						return $source;
 					}
 			)


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5319
Sentry: https://sentry.greenpeace.org/greenpeace/planet4/issues/1665/

This bug currently blocks the edition of the homepage on GP Denmark.
> Argument 1 passed to P4\MasterTheme\MasterSite::P4\MasterTheme\{closure}() must be of the type string, null given


Fixes an error generated when one of the parameters used by the filter `cf_img_url` is null.  

I couldn't reproduce the bug naturally, it seems to happen on a particular state on the carousel that I can't create through the editor.

## Fix

The fix allows for null values in the twig filter and handle them by returning them right away.

## Tests

**To reproduce the bug**, I edited [`wp-content/plugins/planet4-plugin-gutenberg-blocks/classes/blocks/class-carouselheader.php#L131`](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/blob/master/classes/blocks/class-carouselheader.php#L131) to add `$slide['image_srcset'] = null;`.  
When it's done, you have to try to edit a post/page containing a carousel. The editor won't appear, a type error will be displayed instead.  

With this fix, the editor appears again, and you can edit and save the carousel and page.
You can also activate/desactivate the filter by switching true/false [there](https://github.com/greenpeace/planet4-master-theme/compare/planet-5319?expand=1#diff-5bc221d166fcb4619227bb8679dc1aefL1161) to test both cases.