### PR TITLE
PLANET-5221 Use CircleCI checkout code and remove gcloud activation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,7 +114,7 @@ jobs:
             else
               MASTER_THEME_BRANCH="${CIRCLE_BRANCH}"
             fi
-            MASTER_THEME_BRANCH=dev-${MASTER_THEME_BRANCH} \
+            MASTER_THEME_BRANCH=dev-${MASTER_THEME_BRANCH}#${CIRCLE_SHA1} \
             MERGE_SOURCE=git@github.com:greenpeace/planet4-base-fork.git \
             MERGE_REF=develop \
             FORK_USER=$CIRCLE_PR_USERNAME \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,7 @@ jobs:
 
   acceptance-tests:
     docker:
-      - image: greenpeaceinternational/p4-builder:latest
+      - image: greenpeaceinternational/p4-builder:planet-5221
     working_directory:  /home/circleci/
     environment:
       APP_HOSTNAME: www.planet4.test
@@ -107,7 +107,17 @@ jobs:
           working_directory: /home/circleci
           command: |
             echo "Master theme branch is ${CIRCLE_BRANCH}"
-            MASTER_THEME_BRANCH=dev-${CIRCLE_BRANCH} MERGE_SOURCE=git@github.com:greenpeace/planet4-base-fork.git MERGE_REF=develop make ci
+            if [ -n "$CIRCLE_PR_NUMBER" ]; then
+              MASTER_THEME_BRANCH="$(./get-fork-pr-branch.sh)"
+            else
+              MASTER_THEME_BRANCH="${CIRCLE_BRANCH}"
+            fi
+            MASTER_THEME_BRANCH=dev-${MASTER_THEME_BRANCH} \
+            MERGE_SOURCE=git@github.com:greenpeace/planet4-base-fork.git \
+            MERGE_REF=develop \
+            FORK_USER=$CIRCLE_PR_USERNAME \
+            FORK_REPO=$CIRCLE_PR_REPONAME \
+            make ci
       - run:
           name: Test - Clone planet4-docker-compose
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,7 +99,6 @@ jobs:
       - run:
           name: Build - Configure
           command: |
-            activate-gcloud-account.sh
             mkdir -p /tmp/workspace/var
             mkdir -p /tmp/workspace/src
             echo "${CIRCLE_BUILD_NUM}" > /tmp/workspace/var/circle-build-num
@@ -108,7 +107,7 @@ jobs:
           working_directory: /home/circleci
           command: |
             echo "Master theme branch is ${CIRCLE_BRANCH}"
-            MASTER_THEME_BRANCH=dev-${CIRCLE_BRANCH} MERGE_SOURCE=git@github.com:greenpeace/planet4-base-fork.git MERGE_REF=develop make
+            MASTER_THEME_BRANCH=dev-${CIRCLE_BRANCH} MERGE_SOURCE=git@github.com:greenpeace/planet4-base-fork.git MERGE_REF=develop make ci
       - run:
           name: Test - Clone planet4-docker-compose
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,6 +96,8 @@ jobs:
     steps:
       - setup_remote_docker:
           docker_layer_caching: true
+      - checkout:
+          path: /home/circleci/theme-src
       - run:
           name: Build - Configure
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,7 @@ jobs:
 
   acceptance-tests:
     docker:
-      - image: greenpeaceinternational/p4-builder:planet-5221
+      - image: greenpeaceinternational/p4-builder:latest
     working_directory:  /home/circleci/
     environment:
       APP_HOSTNAME: www.planet4.test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,11 +110,12 @@ jobs:
           command: |
             echo "Master theme branch is ${CIRCLE_BRANCH}"
             if [ -n "$CIRCLE_PR_NUMBER" ]; then
-              BRANCH="$(./get-fork-pr-branch.sh)"
+              BRANCH=contrib
+              git --git-dir=/home/circleci/checkout/planet4-master-theme/.git checkout -b contrib
             else
               BRANCH="${CIRCLE_BRANCH}"
             fi
-            MASTER_THEME_BRANCH=dev-${BRANCH}#${CIRCLE_SHA1} \
+            MASTER_THEME_BRANCH=${BRANCH}#${CIRCLE_SHA1} \
             MERGE_SOURCE=git@github.com:greenpeace/planet4-base-fork.git \
             MERGE_REF=develop \
             make ci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,7 +97,7 @@ jobs:
       - setup_remote_docker:
           docker_layer_caching: true
       - checkout:
-          path: /home/circleci/theme-src
+          path: /home/circleci/checkout/planet4-master-theme
       - run:
           name: Build - Configure
           command: |
@@ -110,15 +110,13 @@ jobs:
           command: |
             echo "Master theme branch is ${CIRCLE_BRANCH}"
             if [ -n "$CIRCLE_PR_NUMBER" ]; then
-              MASTER_THEME_BRANCH="$(./get-fork-pr-branch.sh)"
+              BRANCH="$(./get-fork-pr-branch.sh)"
             else
-              MASTER_THEME_BRANCH="${CIRCLE_BRANCH}"
+              BRANCH="${CIRCLE_BRANCH}"
             fi
-            MASTER_THEME_BRANCH=dev-${MASTER_THEME_BRANCH}#${CIRCLE_SHA1} \
+            MASTER_THEME_BRANCH=dev-${BRANCH}#${CIRCLE_SHA1} \
             MERGE_SOURCE=git@github.com:greenpeace/planet4-base-fork.git \
             MERGE_REF=develop \
-            FORK_USER=$CIRCLE_PR_USERNAME \
-            FORK_REPO=$CIRCLE_PR_REPONAME \
             make ci
       - run:
           name: Test - Clone planet4-docker-compose


### PR DESCRIPTION
* In order to run the same pipeline as internal PRs on fork PRs too, I needed to get around some authentication difficulties in fetching that repository with composer. The simplest way seemed to be to use CircleCI's "checkout code" step, which works regardless of whether it's internal or a fork. In https://github.com/greenpeace/planet4-builder/pull/45/files#diff-54216e5f4228fa168f9fa147150a842bR75 some logic was added so that it uses this checked out code instead by adding a composer repository pointing to the folder.
* Remove the `activate-gcloud-account.sh` script as it depends on secrets (not available for forks), and is not used anyway.