### PR TITLE
PLANET-5222 P4 settings grouped and divided to subpages

### DIFF
--- a/src/DevReport.php
+++ b/src/DevReport.php
@@ -19,7 +19,7 @@ class DevReport {
 	public function __construct() {
 
 		// Set our title.
-		$this->title = 'Planet4 Dev Report';
+		$this->title = 'Development';
 		$this->hooks();
 	}
 

--- a/src/DevReport.php
+++ b/src/DevReport.php
@@ -35,14 +35,21 @@ class DevReport {
 	 */
 	public function hooks() {
 		add_action( 'admin_init', [ $this, 'init' ] );
-		add_action( 'admin_menu', [ $this, 'add_options_page' ] );
+		add_action( 'admin_menu', [ $this, 'add_options_page' ], 99 );
 	}
 
 	/**
 	 * Add menu options page.
 	 */
 	public function add_options_page() {
-		$this->options_page = add_options_page( $this->title, $this->title, 'manage_options', $this->key, [ $this, 'admin_page_display' ] );
+		add_submenu_page(
+			'planet4_settings_navigation',
+			$this->title,
+			$this->title,
+			'manage_options',
+			$this->key,
+			[ $this, 'admin_page_display' ]
+		);
 	}
 
 	/**

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -49,7 +49,7 @@ class Settings {
 	public function __construct() {
 
 		// Set our title.
-		$this->title = __( 'Planet4', 'planet4-master-theme-backend' );
+		$this->title = __( 'Planet 4', 'planet4-master-theme-backend' );
 
 		// Set our subpages.
 		// Each subpage has a title and a path and the fields.
@@ -401,7 +401,9 @@ class Settings {
 				$subpage['title'],
 				'manage_options',
 				$path,
-				[ $this, 'admin_page_display' ]
+				function () use ( $path ) {
+					$this->admin_page_display( $path );
+				}
 			);
 		}
 	}
@@ -499,9 +501,10 @@ class Settings {
 
 	/**
 	 * Admin page markup. Mostly handled by CMB2.
+	 *
+	 * @param string $plugin_page The key for the current page.
 	 */
-	public function admin_page_display() {
-		global $plugin_page;
+	public function admin_page_display( string $plugin_page ) {
 		$fields = $this->subpages[ $plugin_page ]['fields'];
 		?>
 		<div class="wrap <?php echo esc_attr( $this->key ); ?>">

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -15,11 +15,18 @@ class Settings {
 	private const METABOX_ID = 'option_metabox';
 
 	/**
-	 * Option key, and option page slug
+	 * Option key
 	 *
 	 * @var string
 	 */
-	private $key = 'planet4_settings_navigation';
+	private $key = 'planet4_options';
+
+	/**
+	 * Option page slug
+	 *
+	 * @var string
+	 */
+	private $slug = 'planet4_settings_navigation';
 
 	/**
 	 * Options Page title
@@ -393,10 +400,10 @@ class Settings {
 	 * Add menu options page.
 	 */
 	public function add_options_pages() {
-		$this->options_page = add_menu_page( $this->title, $this->title, 'manage_options', $this->key, function () {}, 'dashicons-admin-site-alt' );
+		$this->options_page = add_menu_page( $this->title, $this->title, 'manage_options', $this->slug, function () {}, 'dashicons-admin-site-alt' );
 		foreach ( $this->subpages as $path => $subpage ) {
 			add_submenu_page(
-				$this->key,
+				$this->slug,
 				$subpage['title'],
 				$subpage['title'],
 				'manage_options',

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -19,7 +19,7 @@ class Settings {
 	 *
 	 * @var string
 	 */
-	private $key = 'planet4_options';
+	private $key = 'planet4_settings_navigation';
 
 	/**
 	 * Options Page title
@@ -36,6 +36,14 @@ class Settings {
 	protected $options_page = '';
 
 	/**
+	 * Subpages
+	 *
+	 * @var array
+	 * Includes arrays with the title and fields of each subpage
+	 */
+	protected $subpages = [];
+
+	/**
 	 * Constructor
 	 */
 	public function __construct() {
@@ -43,276 +51,314 @@ class Settings {
 		// Set our title.
 		$this->title = __( 'Planet4', 'planet4-master-theme-backend' );
 
-		$this->fields = [
-			[
-				'name' => __( 'Website Navigation Title', 'planet4-master-theme-backend' ),
-				'id'   => 'website_navigation_title',
-				'type' => 'text',
-			],
-			[
-				'name' => __( 'Select Act Page', 'planet4-master-theme-backend' ),
-				'id'   => 'act_page',
-				'type' => 'act_page_dropdown',
-			],
+		// Set our subpages.
+		// Each subpage has a title and a path and the fields.
+		$this->subpages = [
+			'planet4_settings_navigation'       => [
+				'title'  => 'Navigation',
+				'fields' => [
+					[
+						'name' => __( 'Website Navigation Title', 'planet4-master-theme-backend' ),
+						'id'   => 'website_navigation_title',
+						'type' => 'text',
+					],
+					[
+						'name' => __( 'Select Act Page', 'planet4-master-theme-backend' ),
+						'id'   => 'act_page',
+						'type' => 'act_page_dropdown',
+					],
 
-			[
-				'name' => __( 'Select Explore Page', 'planet4-master-theme-backend' ),
-				'id'   => 'explore_page',
-				'type' => 'explore_page_dropdown',
-			],
+					[
+						'name' => __( 'Select Explore Page', 'planet4-master-theme-backend' ),
+						'id'   => 'explore_page',
+						'type' => 'explore_page_dropdown',
+					],
 
-			[
-				'name' => __( 'Select Issues Parent Category', 'planet4-master-theme-backend' ),
-				'id'   => 'issues_parent_category',
-				'type' => 'category_select_taxonomy',
-			],
-
-			[
-				'name' => __( 'Google Tag Manager Container', 'planet4-master-theme-backend' ),
-				'id'   => 'google_tag_manager_identifier',
-				'type' => 'text',
-			],
-
-			[
-				'name' => __( 'Google Optimize anti-flicker snippet', 'planet4-master-theme-backend' ),
-				'desc' => __( 'It will include the relevant snippet for A/B testing.', 'planet4-master-theme-backend' ),
-				'id'   => 'google_optimizer',
-				'type' => 'checkbox',
-			],
-
-			[
-				'name' => __( 'Facebook Page ID', 'planet4-master-theme-backend' ),
-				'id'   => 'facebook_page_id',
-				'type' => 'text',
-			],
-
-			[
-				'name' => __( 'Default P4 Post Type', 'planet4-master-theme-backend' ),
-				'id'   => 'default_p4_pagetype',
-				'type' => 'pagetype_select_taxonomy',
-			],
-
-			[
-				'name' => __( 'Default title for related articles block', 'planet4-master-theme-backend' ),
-				'id'   => 'articles_block_title',
-				'type' => 'text',
-				'desc' => __( 'If no title set for <b>Article Block</b>, the default title will appear.', 'planet4-master-theme-backend' ),
-			],
-
-			[
-				'name' => __( 'Default button title for related articles block', 'planet4-master-theme-backend' ),
-				'id'   => 'articles_block_button_title',
-				'type' => 'text',
-				'desc' => __( 'If no button title set for <b>Article Block</b>, the default button title will appear.', 'planet4-master-theme-backend' ),
-			],
-
-			[
-				'name'       => __( 'Default Number Of Related Articles', 'planet4-master-theme-backend' ),
-				'id'         => 'articles_count',
-				'type'       => 'text',
-				'attributes' => [
-					'type' => 'number',
-				],
-				'desc'       => __( 'If no number of Related Articles set for <b>Article Block</b>, the default number of Related Articles will appear.', 'planet4-master-theme-backend' ),
-			],
-
-			[
-				'name'       => __( 'Take Action Covers default button text', 'planet4-master-theme-backend' ),
-				'id'         => 'take_action_covers_button_text',
-				'type'       => 'text',
-				'attributes' => [
-					'type' => 'text',
-				],
-				'desc'       => __(
-					'Add default button text which appears on <b>Take Action</b> card of <b>Take Action Covers</b> block. <br>
-									 Also it would be used for Take Action Cards inside Posts and Take Action Cards in search results',
-					'planet4-master-theme-backend'
-				),
-			],
-
-			[
-				'name'       => __( 'Donate button link', 'planet4-master-theme-backend' ),
-				'id'         => 'donate_button',
-				'type'       => 'text',
-				'attributes' => [
-					'type' => 'text',
+					[
+						'name' => __( 'Select Issues Parent Category', 'planet4-master-theme-backend' ),
+						'id'   => 'issues_parent_category',
+						'type' => 'category_select_taxonomy',
+					],
 				],
 			],
+			'planet4_settings_donate_button'    => [
+				'title'  => 'Donate button',
+				'fields' => [
+					[
+						'name'       => __( 'Donate button link', 'planet4-master-theme-backend' ),
+						'id'         => 'donate_button',
+						'type'       => 'text',
+						'attributes' => [
+							'type' => 'text',
+						],
+					],
 
-			[
-				'name'       => __( 'Donate button text', 'planet4-master-theme-backend' ),
-				'id'         => 'donate_text',
-				'type'       => 'text',
-				'attributes' => [
-					'type' => 'text',
+					[
+						'name'       => __( 'Donate button text', 'planet4-master-theme-backend' ),
+						'id'         => 'donate_text',
+						'type'       => 'text',
+						'attributes' => [
+							'type' => 'text',
+						],
+					],
+
+					[
+						'name' => __( 'Show donate button below mobile navigation bar', 'planet4-master-theme-backend' ),
+						'desc' => __( 'Enable visibility of the donate button on the homepage. Please check legal restrictions on images associated with this button before using it.', 'planet4-master-theme-backend' ) . ' <a href="https://planet4.greenpeace.org/handbook/admin-setup/#donate-button-visible-on-mobile">' . __( 'Read more', 'planet4-master-theme-backend' ) . '</a>',
+						'id'   => 'donate_btn_visible_on_mobile',
+						'type' => 'checkbox',
+					],
 				],
 			],
+			'planet4_settings_defaults_content' => [
+				'title'  => 'Defaults content',
+				'fields' => [
+					[
+						'name' => __( 'Default P4 Post Type', 'planet4-master-theme-backend' ),
+						'id'   => 'default_p4_pagetype',
+						'type' => 'pagetype_select_taxonomy',
+					],
 
-			[
-				'name' => __( 'Show donate button below mobile navigation bar', 'planet4-master-theme-backend' ),
-				'desc' => __( 'Enable visibility of the donate button on the homepage. Please check legal restrictions on images associated with this button before using it.', 'planet4-master-theme-backend' ) . ' <a href="https://planet4.greenpeace.org/handbook/admin-setup/#donate-button-visible-on-mobile">' . __( 'Read more', 'planet4-master-theme-backend' ) . '</a>',
-				'id'   => 'donate_btn_visible_on_mobile',
-				'type' => 'checkbox',
-			],
+					[
+						'name' => __( 'Default title for related articles block', 'planet4-master-theme-backend' ),
+						'id'   => 'articles_block_title',
+						'type' => 'text',
+						'desc' => __( 'If no title set for <b>Article Block</b>, the default title will appear.', 'planet4-master-theme-backend' ),
+					],
 
-			[
-				'name'       => __( '404 Background Image', 'planet4-master-theme-backend' ),
-				'id'         => '404_page_bg_image',
-				'type'       => 'file',
-				'options'    => [
-					'url' => false,
-				],
-				'text'       => [
-					'add_upload_file_text' => __( 'Add 404 Page Background Image', 'planet4-master-theme-backend' ),
-				],
-				'query_args' => [
-					'type' => 'image',
-				],
-				'desc'       => __( 'Minimum image width should be 1920px', 'planet4-master-theme-backend' ),
-			],
+					[
+						'name' => __( 'Default button title for related articles block', 'planet4-master-theme-backend' ),
+						'id'   => 'articles_block_button_title',
+						'type' => 'text',
+						'desc' => __( 'If no button title set for <b>Article Block</b>, the default button title will appear.', 'planet4-master-theme-backend' ),
+					],
 
-			[
-				'name'    => __( '404 Page text', 'planet4-master-theme-backend' ),
-				'id'      => '404_page_text',
-				'type'    => 'wysiwyg',
-				'options' => [
-					'textarea_rows' => 3,
-					'media_buttons' => false,
-				],
-				'desc'    => __( 'Add 404 page text', 'planet4-master-theme-backend' ),
-			],
+					[
+						'name'       => __( 'Default Number Of Related Articles', 'planet4-master-theme-backend' ),
+						'id'         => 'articles_count',
+						'type'       => 'text',
+						'attributes' => [
+							'type' => 'number',
+						],
+						'desc'       => __( 'If no number of Related Articles set for <b>Article Block</b>, the default number of Related Articles will appear.', 'planet4-master-theme-backend' ),
+					],
 
-			[
-				'name' => __( 'Happy point Subscribe Form URL', 'planet4-master-theme-backend' ),
-				'id'   => 'engaging_network_form_id',
-				'type' => 'text',
-			],
+					[
+						'name'       => __( 'Take Action Covers default button text', 'planet4-master-theme-backend' ),
+						'id'         => 'take_action_covers_button_text',
+						'type'       => 'text',
+						'attributes' => [
+							'type' => 'text',
+						],
+						'desc'       => __( 'Add default button text which appears on <b>Take Action</b> card of <b>Take Action Covers</b> block. <br>Also it would be used for Take Action Cards inside Posts and Take Action Cards in search results', 'planet4-master-theme-backend' ),
+					],
 
-			[
-				'name'       => __( 'Default Happy Point Background Image', 'planet4-master-theme-backend' ),
-				'id'         => 'happy_point_bg_image',
-				'type'       => 'file',
-				'options'    => [
-					'url' => false,
-				],
-				'text'       => [
-					'add_upload_file_text' => __( 'Add Default Happy Point Background Image', 'planet4-master-theme-backend' ),
-				],
-				'query_args' => [
-					'type' => 'image',
-				],
-				'desc'       => __( 'Minimum image width should be 1920px', 'planet4-master-theme-backend' ),
-			],
+					[
+						'name' => __( 'Happy point Subscribe Form URL', 'planet4-master-theme-backend' ),
+						'id'   => 'engaging_network_form_id',
+						'type' => 'text',
+					],
 
-			[
-				'name'       => __( 'Preconnect Domains', 'planet4-master-theme-backend' ),
-				'desc'       => __( 'Add a list of third-party URLs to "preconnect" (e.g.: https://in.hotjar.com). Look for "preconnect" in the P4 Handbook for details.', 'planet4-master-theme-backend' ),
-				'id'         => 'preconnect_domains',
-				'type'       => 'textarea',
-				'attributes' => [
-					'type' => 'text',
-				],
-			],
-			[
-				'name' => __( 'Exclude campaign styles when importing', 'planet4-master-theme-backend' ),
-				'desc' => __(
-					'Whether to exclude campaign theme and style settings when importing a campaign.',
-					'planet4-master-theme-backend'
-				),
-				'id'   => 'campaigns_import_exclude_style',
-				'type' => 'checkbox',
-			],
-			[
-				'name'    => __( 'Include archived content in search for', 'planet4-master-theme-backend' ),
-				'id'      => 'include_archive_content_for',
-				'type'    => 'select',
-				'default' => 'nobody',
-				'options' => [
-					'nobody'    => __( 'Nobody', 'planet4-master-theme-backend' ),
-					'logged_in' => __( 'Logged in users', 'planet4-master-theme-backend' ),
-					'all'       => __( 'All users', 'planet4-master-theme-backend' ),
+					[
+						'name'       => __( 'Default Happy Point Background Image', 'planet4-master-theme-backend' ),
+						'id'         => 'happy_point_bg_image',
+						'type'       => 'file',
+						'options'    => [
+							'url' => false,
+						],
+						'text'       => [
+							'add_upload_file_text' => __( 'Add Default Happy Point Background Image', 'planet4-master-theme-backend' ),
+						],
+						'query_args' => [
+							'type' => 'image',
+						],
+						'desc'       => __( 'Minimum image width should be 1920px', 'planet4-master-theme-backend' ),
+					],
 				],
 			],
-			[
-				'name' => __( 'Search content decay', 'planet4-master-theme-backend' ),
-				'desc' => __(
-					'Amount of lowering of the relevancy score for older results. Between 0 and 1. The lower this number is, the lower older content will be ranked. See image. <br>We use the exponential function (exp, green curve).<br/> <img style="max-width:350px" alt="ElasticSearch decay function graph" src="https://www.elastic.co/guide/en/elasticsearch/reference/current/images/decay_2d.png">',
-					'planet4-master-theme-backend'
-				),
-				'id'   => 'epwr_decay',
-				'type' => 'text',
-			],
-			[
-				'name' => __( 'Search content decay scale', 'planet4-master-theme-backend' ),
-				'desc' => __( 'Timescale for lowering the relevance of older results. See image above.', 'planet4-master-theme-backend' ),
-				'id'   => 'epwr_scale',
-				'type' => 'text',
-			],
-			[
-				'name' => __( 'Search content decay offset', 'planet4-master-theme-backend' ),
-				'desc' => __( 'How old should a post be before relevance is lowered. See image above.', 'planet4-master-theme-backend' ),
-				'id'   => 'epwr_offset',
-				'type' => 'text',
-			],
-			[
-				'name' => __( 'Local Projects Smartsheet ID', 'planet4-master-theme-backend' ),
-				'desc' => __(
-					'The smartsheet that is used to get analytics values from local(NRO) smartsheet.',
-					'planet4-master-theme-backend'
-				),
-				'id'   => 'analytics_local_smartsheet_id',
-				'type' => 'text',
-			],
-
-			[
-				'name'    => __( 'Cookies Text', 'planet4-master-theme-backend' ),
-				'id'      => 'cookies_field',
-				'type'    => 'wysiwyg',
-				'options' => [
-					'textarea_rows' => 5,
-					'media_buttons' => false,
+			'planet4_settings_search_content'   => [
+				'title'  => 'Search content',
+				'fields' => [
+					[
+						'name'    => __( 'Include archived content in search for', 'planet4-master-theme-backend' ),
+						'id'      => 'include_archive_content_for',
+						'type'    => 'select',
+						'default' => 'nobody',
+						'options' => [
+							'nobody'    => __( 'Nobody', 'planet4-master-theme-backend' ),
+							'logged_in' => __( 'Logged in users', 'planet4-master-theme-backend' ),
+							'all'       => __( 'All users', 'planet4-master-theme-backend' ),
+						],
+					],
+					[
+						'name' => __( 'Search content decay', 'planet4-master-theme-backend' ),
+						'desc' => __( 'Amount of lowering of the relevancy score for older results. Between 0 and 1. The lower this number is, the lower older content will be ranked. See image. <br>We use the exponential function (exp, green curve).<br/> <img style="max-width:350px" alt="ElasticSearch decay function graph" src="https://www.elastic.co/guide/en/elasticsearch/reference/current/images/decay_2d.png">', 'planet4-master-theme-backend' ),
+						'id'   => 'epwr_decay',
+						'type' => 'text',
+					],
+					[
+						'name' => __( 'Search content decay scale', 'planet4-master-theme-backend' ),
+						'desc' => __( 'Timescale for lowering the relevance of older results. See image above.', 'planet4-master-theme-backend' ),
+						'id'   => 'epwr_scale',
+						'type' => 'text',
+					],
+					[
+						'name' => __( 'Search content decay offset', 'planet4-master-theme-backend' ),
+						'desc' => __( 'How old should a post be before relevance is lowered. See image above.', 'planet4-master-theme-backend' ),
+						'id'   => 'epwr_offset',
+						'type' => 'text',
+					],
 				],
 			],
+			'planet4_settings_cookies_text'     => [
+				'title'  => 'Cookies Text',
+				'fields' => [
+					[
+						'name'    => __( 'Cookies Text', 'planet4-master-theme-backend' ),
+						'id'      => 'cookies_field',
+						'type'    => 'wysiwyg',
+						'options' => [
+							'textarea_rows' => 5,
+							'media_buttons' => false,
+						],
+					],
 
-			[
-				'name' => __( 'Enforce Cookies Policy', 'planet4-master-theme-backend' ),
-				'desc' => __( 'GDPR related setting. By enabling this option specific content will be blocked and will require user consent to be shown.', 'planet4-master-theme-backend' ),
-				'id'   => 'enforce_cookies_policy',
-				'type' => 'checkbox',
-			],
-
-			[
-				'name'    => __( 'Copyright Text Line 1', 'planet4-master-theme-backend' ),
-				'id'      => 'copyright_line1',
-				'type'    => 'wysiwyg',
-				'options' => [
-					'textarea_rows' => 3,
-					'media_buttons' => false,
+					[
+						'name' => __( 'Enforce Cookies Policy', 'planet4-master-theme-backend' ),
+						'desc' => __( 'GDPR related setting. By enabling this option specific content will be blocked and will require user consent to be shown.', 'planet4-master-theme-backend' ),
+						'id'   => 'enforce_cookies_policy',
+						'type' => 'checkbox',
+					],
 				],
 			],
+			'planet4_settings_copyright'        => [
+				'title'  => 'Copyright',
+				'fields' => [
+					[
+						'name'    => __( 'Copyright Text Line 1', 'planet4-master-theme-backend' ),
+						'id'      => 'copyright_line1',
+						'type'    => 'wysiwyg',
+						'options' => [
+							'textarea_rows' => 3,
+							'media_buttons' => false,
+						],
+					],
 
-			[
-				'name'    => __( 'Copyright Text Line 2', 'planet4-master-theme-backend' ),
-				'id'      => 'copyright_line2',
-				'type'    => 'wysiwyg',
-				'options' => [
-					'textarea_rows' => 2,
-					'media_buttons' => false,
+					[
+						'name'    => __( 'Copyright Text Line 2', 'planet4-master-theme-backend' ),
+						'id'      => 'copyright_line2',
+						'type'    => 'wysiwyg',
+						'options' => [
+							'textarea_rows' => 2,
+							'media_buttons' => false,
+						],
+					],
 				],
 			],
-
-			[
-				'name' => __( 'Enable Cloudflare Image Optimization', 'planet4-master-theme-backend' ),
-				'desc' => __( 'Enable Cloudflare Image Optimization option for images which uses a "cf_img_url" twig filter. for more info', 'planet4-master-theme-backend' ) . ' <a href="https://developers.cloudflare.com/images/about">' . __( 'click here', 'planet4-master-theme-backend' ) . '</a>.',
-				'id'   => 'cloudflare_img_opt',
-				'type' => 'checkbox',
+			'planet4_settings_social'           => [
+				'title'  => 'Social',
+				'fields' => [
+					[
+						'name' => __( 'Facebook Page ID', 'planet4-master-theme-backend' ),
+						'id'   => 'facebook_page_id',
+						'type' => 'text',
+					],
+					[
+						'name'       => __( 'Preconnect Domains', 'planet4-master-theme-backend' ),
+						'desc'       => __( 'Add a list of third-party URLs to "preconnect" (e.g.: https://in.hotjar.com). Look for "preconnect" in the P4 Handbook for details.', 'planet4-master-theme-backend' ),
+						'id'         => 'preconnect_domains',
+						'type'       => 'textarea',
+						'attributes' => [
+							'type' => 'text',
+						],
+					],
+				],
 			],
+			'planet4_settings_404_page'         => [
+				'title'  => '404 Page',
+				'fields' => [
+					[
+						'name'       => __( '404 Background Image', 'planet4-master-theme-backend' ),
+						'id'         => '404_page_bg_image',
+						'type'       => 'file',
+						'options'    => [
+							'url' => false,
+						],
+						'text'       => [
+							'add_upload_file_text' => __( 'Add 404 Page Background Image', 'planet4-master-theme-backend' ),
+						],
+						'query_args' => [
+							'type' => 'image',
+						],
+						'desc'       => __( 'Minimum image width should be 1920px', 'planet4-master-theme-backend' ),
+					],
 
-			[
-				'name' => __( 'Cloudflare Image Optimization Options', 'planet4-master-theme-backend' ),
-				'desc' => __( 'Add Cloudflare image optimization url "options" value', 'planet4-master-theme-backend' ) . '[Comma-separated text].(https://zone/cdn-cgi/image/options/source-image)<br />e.g. width=80,quality=75,fit=cover',
-				'id'   => 'cloudflare_options_txt',
-				'type' => 'text',
+					[
+						'name'    => __( '404 Page text', 'planet4-master-theme-backend' ),
+						'id'      => '404_page_text',
+						'type'    => 'wysiwyg',
+						'options' => [
+							'textarea_rows' => 3,
+							'media_buttons' => false,
+						],
+						'desc'    => __( 'Add 404 page text', 'planet4-master-theme-backend' ),
+					],
+				],
+			],
+			'planet4_settings_campaigns'        => [
+				'title'  => 'Campaigns',
+				'fields' => [
+					[
+						'name' => __( 'Exclude campaign styles when importing', 'planet4-master-theme-backend' ),
+						'desc' => __(
+							'Whether to exclude campaign theme and style settings when importing a campaign.',
+							'planet4-master-theme-backend'
+						),
+						'id'   => 'campaigns_import_exclude_style',
+						'type' => 'checkbox',
+					],
+				],
+			],
+			'planet4_settings_analytics'        => [
+				'title'  => 'Analytics',
+				'fields' => [
+					[
+						'name' => __( 'Google Tag Manager Container', 'planet4-master-theme-backend' ),
+						'id'   => 'google_tag_manager_identifier',
+						'type' => 'text',
+					],
+
+					[
+						'name' => __( 'Google Optimize anti-flicker snippet', 'planet4-master-theme-backend' ),
+						'desc' => __( 'It will include the relevant snippet for A/B testing.', 'planet4-master-theme-backend' ),
+						'id'   => 'google_optimizer',
+						'type' => 'checkbox',
+					],
+					[
+						'name' => __( 'Local Projects Smartsheet ID', 'planet4-master-theme-backend' ),
+						'desc' => __( 'The smartsheet that is used to get analytics values from local(NRO) smartsheet.', 'planet4-master-theme-backend' ),
+						'id'   => 'analytics_local_smartsheet_id',
+						'type' => 'text',
+					],
+				],
+			],
+			'planet4_settings_features'         => [
+				'title'  => 'Features',
+				'fields' => [
+					[
+						'name' => __( 'Enable Cloudflare Image Optimization', 'planet4-master-theme-backend' ),
+						'desc' => __( 'Enable Cloudflare Image Optimization option for images which uses a "cf_img_url" twig filter. for more info', 'planet4-master-theme-backend' ) . ' <a href="https://developers.cloudflare.com/images/about">' . __( 'click here', 'planet4-master-theme-backend' ) . '</a>.',
+						'id'   => 'cloudflare_img_opt',
+						'type' => 'checkbox',
+					],
+
+					[
+						'name' => __( 'Cloudflare Image Optimization Options', 'planet4-master-theme-backend' ),
+						'desc' => __( 'Add Cloudflare image optimization url "options" value', 'planet4-master-theme-backend' ) . '[Comma-separated text].(https://zone/cdn-cgi/image/options/source-image)<br />e.g. width=80,quality=75,fit=cover',
+						'id'   => 'cloudflare_options_txt',
+						'type' => 'text',
+					],
+				],
 			],
 		];
 		$this->hooks();
@@ -323,7 +369,7 @@ class Settings {
 	 */
 	public function hooks() {
 		add_action( 'admin_init', [ $this, 'init' ] );
-		add_action( 'admin_menu', [ $this, 'add_options_page' ] );
+		add_action( 'admin_menu', [ $this, 'add_options_pages' ] );
 		add_action( 'cmb2_save_options-page_fields_' . self::METABOX_ID, [ $this, 'add_notifications' ] );
 		add_filter( 'cmb2_render_act_page_dropdown', [ $this, 'p4_render_act_page_dropdown' ], 10, 2 );
 		add_filter( 'cmb2_render_explore_page_dropdown', [ $this, 'p4_render_explore_page_dropdown' ], 10, 2 );
@@ -346,9 +392,20 @@ class Settings {
 	/**
 	 * Add menu options page.
 	 */
-	public function add_options_page() {
-		$this->options_page = add_options_page( $this->title, $this->title, 'manage_options', $this->key, [ $this, 'admin_page_display' ] );
+	public function add_options_pages() {
+		$this->options_page = add_menu_page( $this->title, $this->title, 'manage_options', $this->key, function () {}, 'dashicons-admin-site-alt' );
+		foreach ( $this->subpages as $path => $subpage ) {
+			add_submenu_page(
+				$this->key,
+				$subpage['title'],
+				$subpage['title'],
+				'manage_options',
+				$path,
+				[ $this, 'admin_page_display' ]
+			);
+		}
 	}
+
 
 	/**
 	 * Display notifications of success and error
@@ -444,10 +501,12 @@ class Settings {
 	 * Admin page markup. Mostly handled by CMB2.
 	 */
 	public function admin_page_display() {
+		global $plugin_page;
+		$fields = $this->subpages[ $plugin_page ]['fields'];
 		?>
 		<div class="wrap <?php echo esc_attr( $this->key ); ?>">
 			<h2><?php echo esc_html( get_admin_page_title() ); ?></h2>
-			<?php cmb2_metabox_form( $this->option_metabox(), $this->key ); ?>
+			<?php cmb2_metabox_form( $this->option_metabox( $fields ), $this->key ); ?>
 		</div>
 		<?php
 	}
@@ -455,9 +514,11 @@ class Settings {
 	/**
 	 * Defines the theme option metabox and field configuration.
 	 *
+	 * @param array $fields expects the fields (if they exist) of this subpage.
+	 *
 	 * @return array
 	 */
-	public function option_metabox() {
+	public function option_metabox( $fields ) {
 		return [
 			'id'         => self::METABOX_ID,
 			'show_on'    => [
@@ -467,7 +528,7 @@ class Settings {
 				],
 			],
 			'show_names' => true,
-			'fields'     => $this->fields,
+			'fields'     => $fields,
 		];
 	}
 


### PR DESCRIPTION
We roll back this feature yesterday, because it resulted in options being blank at the backend (see screenshot below). I re-picked the initial commits and added one more just to preserve the original options key and use a new slug variable to make sure the menu opens in the first subpage.


![options](https://user-images.githubusercontent.com/939357/88143387-d04c9400-cbff-11ea-8f85-9d59261123a3.jpg)