### PR TITLE
PLANET-4801 Add post-type data-attribute to body element

### DIFF
--- a/templates/base.twig
+++ b/templates/base.twig
@@ -4,7 +4,7 @@
 
 {% endblock %}
 
-<body class="{{ body_class }} {{ custom_body_classes|default("") }}" data-nro="{{ site.link }}">
+<body class="{{ body_class }} {{ custom_body_classes|default("") }}" data-nro="{{ site.link }}" data-post-type="{{ fn( 'get_post_type' ) }}">
 
 	<ul class="skip-links">
 		<li><a href="#header">{{ __( 'Skip to Navigation', 'planet4-master-theme' ) }}</a></li>


### PR DESCRIPTION
When converting some blocks to WYSIWYG, for example the Articles block, we need to have the post type easily accessible in the frontend. Therefore it makes sense to add it as a data-attribute on the body element 🙂 