### PR TITLE
PLANET-4808: Display of cmb2 fields in rest api response

### DIFF
--- a/src/Loader.php
+++ b/src/Loader.php
@@ -93,7 +93,7 @@ final class Loader {
 				);
 			}
 
-			// Load P4 Metaboxes only when adding/editing a new Page/Post/Campaign.
+			// Load `Campaigns` class only when adding/editing a new tag.
 			if ( 'edit-tags.php' === $pagenow || 'term.php' === $pagenow ) {
 				$this->default_services[] = Campaigns::class;
 			}
@@ -114,6 +114,10 @@ final class Loader {
 		// Run Activator after theme switched to planet4-master-theme or a planet4 child theme.
 		if ( get_option( 'theme_switched' ) ) {
 			$this->default_services[] = Activator::class;
+		}
+
+		if ( wp_is_json_request() ) {
+			$this->default_services[] = MetaboxRegister::class;
 		}
 
 		$services = array_merge( $services, $this->default_services );

--- a/src/MetaboxRegister.php
+++ b/src/MetaboxRegister.php
@@ -3,6 +3,7 @@
 namespace P4\MasterTheme;
 
 use CMB2_Field;
+use WP_REST_Server;
 
 /**
  * Class MetaboxRegister
@@ -27,7 +28,7 @@ class MetaboxRegister {
 	 * Class hooks.
 	 */
 	private function hooks() {
-		add_action( 'cmb2_admin_init', [ $this, 'register_p4_meta_box' ] );
+		add_action( 'cmb2_init', [ $this, 'register_p4_meta_box' ] );
 	}
 
 	/**
@@ -50,37 +51,41 @@ class MetaboxRegister {
 				'id'           => 'p4_metabox',
 				'title'        => __( 'Page Header Fields', 'planet4-master-theme-backend' ),
 				'object_types' => [ 'page', 'campaign' ], // Post type.
+				'show_in_rest' => WP_REST_Server::READABLE,
 			]
 		);
 
 		$p4_header->add_field(
 			[
-				'name' => __( 'Header Title', 'planet4-master-theme-backend' ),
-				'desc' => __( 'Header title comes here', 'planet4-master-theme-backend' ),
-				'id'   => 'p4_title',
-				'type' => 'text_medium',
+				'name'         => __( 'Header Title', 'planet4-master-theme-backend' ),
+				'desc'         => __( 'Header title comes here', 'planet4-master-theme-backend' ),
+				'id'           => 'p4_title',
+				'type'         => 'text_medium',
+				'show_in_rest' => WP_REST_Server::READABLE,
 			]
 		);
 
 		$p4_header->add_field(
 			[
-				'name' => __( 'Header Subtitle', 'planet4-master-theme-backend' ),
-				'desc' => __( 'Header subtitle comes here', 'planet4-master-theme-backend' ),
-				'id'   => 'p4_subtitle',
-				'type' => 'text_medium',
+				'name'         => __( 'Header Subtitle', 'planet4-master-theme-backend' ),
+				'desc'         => __( 'Header subtitle comes here', 'planet4-master-theme-backend' ),
+				'id'           => 'p4_subtitle',
+				'type'         => 'text_medium',
+				'show_in_rest' => WP_REST_Server::READABLE,
 			]
 		);
 
 		$p4_header->add_field(
 			[
-				'name'    => __( 'Header Description', 'planet4-master-theme-backend' ),
-				'desc'    => __( 'Header description comes here', 'planet4-master-theme-backend' ),
-				'id'      => 'p4_description',
-				'type'    => 'wysiwyg',
-				'options' => [
+				'name'         => __( 'Header Description', 'planet4-master-theme-backend' ),
+				'desc'         => __( 'Header description comes here', 'planet4-master-theme-backend' ),
+				'id'           => 'p4_description',
+				'type'         => 'wysiwyg',
+				'options'      => [
 					'textarea_rows' => 5,
 					'media_buttons' => false,
 				],
+				'show_in_rest' => WP_REST_Server::READABLE,
 			]
 		);
 


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-4808
Related to: https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/358
Doc: https://github.com/CMB2/CMB2/wiki/REST-API#registered-rest-fields

In order to get full functionalities for the [WYSIWYG version of the Split Two Columns block](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/358), I need those fields to appear in the rest api response giving a list of pages.  
The loading of MetaboxRegister is based on `wp_is_json_request()`, which needs a header `Http-Accept` or `Content-Type` with `application/json` if you want to test this. 
I also tried to base this solution on the constant `REST_REQUEST`, but it is defined far too late in the process.

## Test:
Request a list of pages from the rest api.
```console
> curl -v -H "Content-Type: application/json" "http://www.planet4.test/wp-json/wp/v2/pages?per_page=100&sort_order=asc&sort_column=post_title&parent=11&post_status=publish&context=view&_locale=user" | jq
```
Each page returned should have a `cmb2` object, containing a `p4_metabox` object with various fields.

<img width="714" alt="Screenshot 2020-08-12 at 08 14 14" src="https://user-images.githubusercontent.com/617346/89981260-dcae9480-dc73-11ea-9241-72b210b5b0a9.png">

