### PR TITLE
PLANET-4811 Add backtop markup to base template

### DIFF
--- a/templates/base.twig
+++ b/templates/base.twig
@@ -11,7 +11,8 @@
 		<li><a href="#content">{{ __( 'Skip to Content', 'planet4-master-theme' ) }}</a></li>
 		<li><a href="#footer">{{ __( 'Skip to Footer', 'planet4-master-theme' ) }}</a></li>
 	</ul>
-
+	<a class="back-top d-none" title="{{ __('Go to the top of the page.', 'planet4-master-theme') }}"
+	   onclick="window.scrollTo({top: 0})"></a>
 	{% if google_tag_value %}
 		<!-- Google Tag Manager (noscript) -->
 		<noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ google_tag_value }}"


### PR DESCRIPTION
* Similarly to how .skip-links was already set up, we can add the
backtop markup here and hide it. That way it's already directly under
the body, and we don't need to dynamically append it. Since the click
handler is very short we can directly include it here for simplicity.