### PR TITLE
PLANET-5444 Add exception in external links script

### DIFF
--- a/assets/src/js/external_links.js
+++ b/assets/src/js/external_links.js
@@ -17,7 +17,7 @@ export const setupExternalLinks = function($) {
         return;
       }
 
-      if (href.charAt(0) != '/' && href.charAt(0) != '#' && !href.endsWith('.pdf')) {
+      if (href.charAt(0) != '/' && href.charAt(0) != '#' && !href.endsWith('.pdf') && !href.startsWith('javascript:')) {
         $(this).append(inlinedSVG);
         $(this).attr('target', '_blank');
         $(this).addClass('external-link');


### PR DESCRIPTION
Excludes links that contain href="javascript:[...]" from being treated as external links.

Fixes greenpeace/planet4#78