### PR TITLE
Develop head but diff branch name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,12 +110,7 @@ jobs:
           working_directory: /home/circleci
           command: |
             echo "Master theme branch is ${CIRCLE_BRANCH}"
-            if [ -n "$CIRCLE_PR_NUMBER" ]; then
-              BRANCH="$(./get-fork-pr-branch.sh)"
-              git --git-dir=/home/circleci/checkout/planet4-master-theme/.git checkout -b "${BRANCH}"
-            else
-              BRANCH="${CIRCLE_BRANCH}"
-            fi
+            BRANCH="${CIRCLE_BRANCH}"
             MASTER_THEME_BRANCH=dev-${BRANCH}#${CIRCLE_SHA1} \
             MERGE_SOURCE=git@github.com:greenpeace/planet4-base-fork.git \
             MERGE_REF=develop \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,6 +112,7 @@ jobs:
             echo "Master theme branch is ${CIRCLE_BRANCH}"
             if [ -n "$CIRCLE_PR_NUMBER" ]; then
               BRANCH="$(./get-fork-pr-branch.sh)"
+              git --git-dir=/home/circleci/checkout/planet4-master-theme/.git checkout -b "${BRANCH}"
             else
               BRANCH="${CIRCLE_BRANCH}"
             fi


### PR DESCRIPTION
It still used the pipeline which had run on the same commit in the develop branch of my fork. That one probably failed because it used the "develop" name. Bit inconvenient now but probably not an issue that will occur normally.