### PR TITLE
PLANET-5292 create record, move to separate class

### DIFF
--- a/src/Activator.php
+++ b/src/Activator.php
@@ -29,33 +29,7 @@ class Activator {
 	 */
 	public static function run(): void {
 		Campaigner::register_role_and_add_capabilities();
-		self::do_migrations();
+		Migrator::migrate();
 	}
 
-	/**
-	 * Run any new migrations and record them in the log.
-	 */
-	private static function do_migrations(): void {
-		// Fetch migration ids that have run from WP option.
-		$log = MigrationLog::from_wp_options();
-
-		/**
-		 * @var Migration[] $migrations
-		 */
-		$migrations = [
-			M001EnableEnFormFeature::class,
-		];
-
-		// Loop migrations and run those that haven't run yet.
-		foreach ( $migrations as $migration ) {
-			if ( $log->already_ran( $migration::get_id() ) ) {
-				continue;
-			}
-
-			$migration::run();
-			$log->add( $migration::get_id() );
-		}
-
-		$log->persist();
-	}
 }

--- a/src/Exception/MigrationFailed.php
+++ b/src/Exception/MigrationFailed.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace P4\MasterTheme\Exception;
+
+use Exception;
+
+class MigrationFailed extends Exception {
+}

--- a/src/Migration.php
+++ b/src/Migration.php
@@ -2,6 +2,10 @@
 
 namespace P4\MasterTheme;
 
+use Exception;
+use P4\MasterTheme\Exception\MigrationFailed;
+use P4\MasterTheme\Migrations\MigrationRecord;
+
 /**
  * A migration that can be recorded.
  */
@@ -17,6 +21,34 @@ abstract class Migration {
 
 	/**
 	 * Perform the actual migration.
+	 *
+	 * @param MigrationRecord $record
+	 *
+	 * @return void
 	 */
-	abstract public static function run(): void;
+	abstract public static function execute(MigrationRecord $record): void;
+
+	/**
+	 * Log the time and run the migration.
+	 *
+	 * @return MigrationRecord Data on the migration run.
+	 * @throws MigrationFailed If the migration encounters an error.
+	 */
+	public static function run(): MigrationRecord {
+		$record = MigrationRecord::start( static::class );
+
+		try {
+			static::execute( $record );
+		} catch ( Exception $exception ) {
+			throw new MigrationFailed(
+				'Migration ' . $record->get_migration_id() . ' failed. Message: ' . $exception->getMessage(),
+				null,
+				$exception
+			);
+		}
+
+		$record->done();
+
+		return $record;
+	}
 }

--- a/src/MigrationLog.php
+++ b/src/MigrationLog.php
@@ -2,6 +2,8 @@
 
 namespace P4\MasterTheme;
 
+use P4\MasterTheme\Migrations\MigrationRecord;
+
 /**
  * A log of all migrations that have run, saved as a WP option.
  */
@@ -40,7 +42,7 @@ class MigrationLog {
 	 */
 	public function already_ran( string $migration_id ): bool {
 		foreach ( $this->done_migrations as $migration ) {
-			if ( $migration['id'] === $migration_id ) {
+			if ( $migration['id'] === $migration_id && $migration['success'] ) {
 				return true;
 			}
 		}
@@ -49,14 +51,17 @@ class MigrationLog {
 	}
 
 	/**
-	 * Record a migration in the log.
+	 * Record a migration run in the log.
 	 *
-	 * @param string $migration_id Id of the migration to log.
+	 * @param MigrationRecord $record
 	 */
-	public function add( string $migration_id ): void {
+	public function add( MigrationRecord $record ): void {
 		$entry = [
-			'id'   => $migration_id,
-			'date' => time(),
+			'id'         => $record->get_migration_id(),
+			'start_time' => $record->get_start_time(),
+			'end_time'   => $record->get_end_time(),
+			'success'    => $record->was_success(),
+			'logs'       => $record->get_logs(),
 		];
 
 		$this->done_migrations[] = $entry;

--- a/src/Migrations/M001EnableEnFormFeature.php
+++ b/src/Migrations/M001EnableEnFormFeature.php
@@ -14,10 +14,18 @@ class M001EnableEnFormFeature extends Migration {
 	/**
 	 * @inheritDoc
 	 */
-	public static function run(): void {
+	public static function execute( MigrationRecord $record ): void {
 		$settings = get_option( Settings::KEY, [] );
 
 		$settings[ Features::ENGAGING_NETWORKS ] = 'on';
 		update_option( Settings::KEY, $settings );
+		$record->add_log('This is a message from your upgrade script.');
+		$record->add_log('This is a second message from your upgrade script.');
+
+		if ( $settings['Something terribly wrong in the db'] ) {
+			$record->fail();
+		} else {
+			$record->success();
+		}
 	}
 }

--- a/src/Migrations/MigrationRecord.php
+++ b/src/Migrations/MigrationRecord.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace P4\MasterTheme\Migrations;
+
+use DateTime;
+
+class MigrationRecord {
+	private $migration_id;
+	private $start_time;
+	private $end_time;
+	private $successful;
+	private $logs = [];
+
+	public static function start( string $migration_id ): self {
+		$record = new self();
+
+		$record->migration_id = $migration_id;
+		$record->start_time   = new DateTime();
+
+		return $record;
+	}
+
+	public function add_log( string $message ): void {
+		$this->logs[] = $message;
+	}
+
+	public function fail(): void {
+		$this->successful = false;
+	}
+
+	public function success(): void {
+		$this->successful = true;
+	}
+
+	public function done(): void {
+		$this->end_time = new DateTime();
+	}
+
+	public function get_start_time(): DateTime {
+		return $this->start_time;
+	}
+
+	public function get_end_time(): ?DateTime {
+		return $this->end_time;
+	}
+
+	/**
+	 * @return mixed
+	 */
+	public function get_migration_id(): string {
+		return $this->migration_id;
+	}
+
+	public function was_success(): ?bool {
+		return $this->successful;
+	}
+
+	public function get_logs(): array {
+		return $this->logs;
+	}
+}

--- a/src/Migrator.php
+++ b/src/Migrator.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace P4\MasterTheme;
+
+use P4\MasterTheme\Migrations\M001EnableEnFormFeature;
+
+class Migrator {
+
+	/**
+	 * Run any new migrations and record them in the log.
+	 */
+	public static function migrate() {
+
+		// Fetch migration ids that have run from WP option.
+		$log = MigrationLog::from_wp_options();
+
+		/**
+		 * @var Migration[] $migrations
+		 */
+		$migrations = [
+			M001EnableEnFormFeature::class,
+		];
+
+		// Loop migrations and run those that haven't run yet.
+		foreach ( $migrations as $migration ) {
+			if ( $log->already_ran( $migration::get_id() ) ) {
+				continue;
+			}
+
+			$record = $migration::run();
+			$log->add($record);
+		}
+
+		$log->persist();
+	}
+}


### PR DESCRIPTION
* MigrationRecord holds the data of a particular run of a migration
script.
* Move migration logic into it's own class.
* Throw a specific exception.