### PR TITLE
Class to facilitate parameterized queries

### DIFF
--- a/src/Exception/SqlInIsEmpty.php
+++ b/src/Exception/SqlInIsEmpty.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace P4\MasterTheme\Exception;
+
+use Exception;
+
+/**
+ * An empty array was given to be used in a SQL IN query, but that doesn't work.
+ */
+class SqlInIsEmpty extends Exception {
+
+}

--- a/src/Search.php
+++ b/src/Search.php
@@ -1114,12 +1114,14 @@ abstract class Search {
 	public static function exclude_unwanted_attachments( $args ) {
 		global $wpdb;
 
-		$in_placeholders = generate_list_placeholders( self::DOCUMENT_TYPES, 2, 's' );
+		$params = new SqlParameters();
 
-		$sql = 'SELECT id FROM %1$s WHERE post_type = "attachment" AND post_mime_type NOT IN (' . $in_placeholders . ')';
+		$sql = 'SELECT id FROM ' . $params->object( $wpdb->posts )
+			. ' WHERE post_type = "attachment"'
+			. ' AND post_mime_type NOT IN (' . $params->string_array( self::DOCUMENT_TYPES ) . ')';
 
 		$unwanted_attachment_ids = $wpdb->get_col(
-			$wpdb->prepare( $sql, array_merge( [ $wpdb->posts ], self::DOCUMENT_TYPES ) ) // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+			$wpdb->prepare( $sql, $params->get_values() ) // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 		);
 
 		$args['post__not_in'] = $unwanted_attachment_ids;

--- a/src/Search.php
+++ b/src/Search.php
@@ -1110,15 +1110,16 @@ abstract class Search {
 	 * @param mixed[] $args The args ElasticPress will use to fetch the ids of posts that will be synced.
 	 *
 	 * @return mixed The args with exclusion of unwanted ids.
+	 * @throws Exception\SqlInIsEmpty Well it really won't unless we make self::DOCUMENT_TYPES into an empty array.
 	 */
 	public static function exclude_unwanted_attachments( $args ) {
 		global $wpdb;
 
 		$params = new SqlParameters();
 
-		$sql = 'SELECT id FROM ' . $params->object( $wpdb->posts )
+		$sql = 'SELECT id FROM ' . $params->identifier( $wpdb->posts )
 			. ' WHERE post_type = "attachment"'
-			. ' AND post_mime_type NOT IN (' . $params->string_array( self::DOCUMENT_TYPES ) . ')';
+			. ' AND post_mime_type NOT IN ' . $params->string_list( self::DOCUMENT_TYPES );
 
 		$unwanted_attachment_ids = $wpdb->get_col(
 			$wpdb->prepare( $sql, $params->get_values() ) // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared

--- a/src/SqlParameters.php
+++ b/src/SqlParameters.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace P4\MasterTheme;
+
+/**
+ * Holds the parameter values and returns a placeholder string while constructing a SQL statement with input.
+ * That way the order of the parameters will correspond to the order of the placeholders automatically, so we can just
+ * pass `$this->values` to `$wbdb->prepare`.
+ *
+ * Because the placeholders are added with a number it shouldn't matter in which order the sql is constructed.
+ * I.e. the following should work as intended.
+ * ```$sqlEnd = "WHERE field = " . $params->string('foo');
+ *    $sqlStart = "SELECT * FROM " . $params->object('myTable');
+ *    $wpdb->prepare($sqlStart . $sqlEnd, $params->getValues());
+ */
+class SqlParameters {
+	/**
+	 * @var mixed[] The values of the parameters in the order they were added.
+	 */
+	private $values = [];
+
+	/**
+	 * Add a parameter for a SQL object (mainly table but works for other things too).
+	 *
+	 * @param string $name The name of the object.
+	 *
+	 * @return string Numbered placeholder.
+	 */
+	public function object( string $name ) {
+		$this->values[] = $name;
+
+		$n = count( $this->values );
+
+		return "%$n\$s";
+	}
+
+	/**
+	 * Add a parameter for an integer.
+	 *
+	 * @param int $value The value the parameter has.
+	 *
+	 * @return string Numbered placeholder.
+	 */
+	public function int( int $value ): string {
+		$this->values[] = $value;
+
+		$n = count( $this->values );
+
+		return "%$n\$d";
+	}
+
+	/**
+	 * Add a parameter for a string.
+	 *
+	 * @param string $value The value the parameter has.
+	 *
+	 * @return string Numbered placeholder.
+	 */
+	public function string( string $value ): string {
+		$this->values[] = $value;
+
+		$n = count( $this->values );
+
+		return "'%$n\$s'";
+	}
+
+	/**
+	 * Add int parameters for an IN query.
+	 *
+	 * @param int[] $values The values for the IN statement.
+	 *
+	 * @return string Concatenated numbered placeholders.
+	 */
+	public function int_array( array $values ): string {
+		$params = [];
+		foreach ( $values as $value ) {
+			$params[] = $this->int( $value );
+		}
+
+		return implode( ',', $params );
+	}
+
+	/**
+	 * Add string parameters for an IN query.
+	 *
+	 * @param string[] $values The values for the IN statement.
+	 *
+	 * @return string Concatenated numbered placeholders.
+	 */
+	public function string_array( array $values ): string {
+		$params = [];
+		foreach ( $values as $value ) {
+			$params[] = $this->string( $value );
+		}
+
+		return implode( ',', $params );
+	}
+
+	/**
+	 * Get all values in the order they were added.
+	 *
+	 * @return mixed[] All values.
+	 */
+	public function get_values(): array {
+		return $this->values;
+	}
+}

--- a/src/SqlParameters.php
+++ b/src/SqlParameters.php
@@ -2,6 +2,8 @@
 
 namespace P4\MasterTheme;
 
+use P4\MasterTheme\Exception\SqlInIsEmpty;
+
 /**
  * Holds the parameter values and returns a placeholder string while constructing a SQL statement with input.
  * That way the order of the parameters will correspond to the order of the placeholders automatically, so we can just
@@ -20,18 +22,18 @@ class SqlParameters {
 	private $values = [];
 
 	/**
-	 * Add a parameter for a SQL object (mainly table but works for other things too).
+	 * Add a parameter for a SQL identifier (mainly table but works for other things too).
 	 *
 	 * @param string $name The name of the object.
 	 *
 	 * @return string Numbered placeholder.
 	 */
-	public function object( string $name ) {
+	public function identifier( string $name ): string {
 		$this->values[] = $name;
 
 		$n = count( $this->values );
 
-		return "%$n\$s";
+		return "`%$n\$s`";
 	}
 
 	/**
@@ -70,14 +72,20 @@ class SqlParameters {
 	 * @param int[] $values The values for the IN statement.
 	 *
 	 * @return string Concatenated numbered placeholders.
+	 * @throws SqlInIsEmpty If $values is an empty array.
 	 */
-	public function int_array( array $values ): string {
+	public function int_list( array $values ): string {
+		if ( empty( $values ) ) {
+			throw new SqlInIsEmpty(
+				'An IN query does not work if there are no values, please check before passing as an argument.'
+			);
+		}
 		$params = [];
 		foreach ( $values as $value ) {
 			$params[] = $this->int( $value );
 		}
 
-		return implode( ',', $params );
+		return ' (' . implode( ',', $params ) . ') ';
 	}
 
 	/**
@@ -86,14 +94,20 @@ class SqlParameters {
 	 * @param string[] $values The values for the IN statement.
 	 *
 	 * @return string Concatenated numbered placeholders.
+	 * @throws SqlInIsEmpty If $values is an empty array.
 	 */
-	public function string_array( array $values ): string {
+	public function string_list( array $values ): string {
+		if ( empty( $values ) ) {
+			throw new SqlInIsEmpty(
+				'An IN query does not work if there are no values, please check before passing as an argument.'
+			);
+		}
 		$params = [];
 		foreach ( $values as $value ) {
 			$params[] = $this->string( $value );
 		}
 
-		return implode( ',', $params );
+		return ' (' . implode( ',', $params ) . ') ';
 	}
 
 	/**

--- a/tests/SqlParameters.php
+++ b/tests/SqlParameters.php
@@ -1,0 +1,42 @@
+<?php
+
+class SqlParameters extends \PHPUnit\Framework\TestCase
+{
+	public function testOrder() {
+		$params = new \P4\MasterTheme\SqlParameters();
+
+		$partB = 'part B with param 1: ' . $params->string('param 1');
+		$partA = 'part A with param 2: ' . $params->int(2);
+		$partC = 'part C with param 3: ' . $params->object('param 3');
+
+		$this->assertEquals(
+			'part A with param 2: %2$d,part B with param 1: \'%1$s\',part C with param 3: %3$s',
+			implode(',', [$partA, $partB, $partC])
+		);
+
+		$this->assertEquals(
+			['param 1', 2, 'param 3'],
+			$params->get_values()
+		);
+	}
+
+	public function testPrepare() {
+		global $wpdb;
+		$params = new \P4\MasterTheme\SqlParameters();
+
+		$counter = 'counter = ' . $params->int(3);
+		$query = 'SELECT col_a, col_b, col_c FROM ' . $params->object('my_table')
+				. ' WHERE content LIKE ' . $params->string('foo')
+				. ' AND ' . $counter;
+		$prepared = $wpdb->prepare(
+			$query,
+			$params->get_values()
+		);
+
+		$this->assertEquals(
+			'SELECT col_a, col_b, col_c FROM my_table'
+			. ' WHERE content LIKE \'foo\' AND counter = 3',
+			$prepared
+		);
+	}
+}

--- a/tests/SqlParameters.php
+++ b/tests/SqlParameters.php
@@ -1,42 +1,32 @@
 <?php
+/**
+ * P4 Test Case Class
+ *
+ * @package P4MT
+ */
 
-class SqlParameters extends \PHPUnit\Framework\TestCase
-{
+/**
+ * Class SqlParameters.
+ */
+class SqlParameters extends \PHPUnit\Framework\TestCase {
+	/**
+	 * Ensure that in whichever order the sql is constructed, it will add the params in the right place.
+	 */
 	public function testOrder() {
 		$params = new \P4\MasterTheme\SqlParameters();
 
-		$partB = 'part B with param 1: ' . $params->string('param 1');
-		$partA = 'part A with param 2: ' . $params->int(2);
-		$partC = 'part C with param 3: ' . $params->object('param 3');
+		$part_b = 'part B with param 1: ' . $params->string( 'param 1' );
+		$part_a = 'part A with param 2: ' . $params->int( 2 );
+		$part_c = 'part C with param 3: ' . $params->identifier( 'param 3' );
 
 		$this->assertEquals(
-			'part A with param 2: %2$d,part B with param 1: \'%1$s\',part C with param 3: %3$s',
-			implode(',', [$partA, $partB, $partC])
+			'part A with param 2: %2$d,part B with param 1: \'%1$s\',part C with param 3: `%3$s`',
+			implode( ',', [ $part_a, $part_b, $part_c ] )
 		);
 
 		$this->assertEquals(
-			['param 1', 2, 'param 3'],
+			[ 'param 1', 2, 'param 3' ],
 			$params->get_values()
-		);
-	}
-
-	public function testPrepare() {
-		global $wpdb;
-		$params = new \P4\MasterTheme\SqlParameters();
-
-		$counter = 'counter = ' . $params->int(3);
-		$query = 'SELECT col_a, col_b, col_c FROM ' . $params->object('my_table')
-				. ' WHERE content LIKE ' . $params->string('foo')
-				. ' AND ' . $counter;
-		$prepared = $wpdb->prepare(
-			$query,
-			$params->get_values()
-		);
-
-		$this->assertEquals(
-			'SELECT col_a, col_b, col_c FROM my_table'
-			. ' WHERE content LIKE \'foo\' AND counter = 3',
-			$prepared
 		);
 	}
 }


### PR DESCRIPTION
* Sql query parameters need to be be passed separately to $wpdb->prepare
and the values need to be in the same order as the placeholders in the
query. This makes the code hard to read and prone to bugs if a mistake
in the position is made. The class introduced here solves this problem
by allowing to specify these values in the query, where it will echo
back a placeholder and keep track of all values in the order they were
passed in. This ensure that the order will be the same, and that the
values can be seen in the position they will be used.