### PR TITLE
PLANET-5363 Re-add bootstrap card and transitions

### DIFF
--- a/assets/src/scss/bootstrap-build.scss
+++ b/assets/src/scss/bootstrap-build.scss
@@ -37,7 +37,7 @@ Text Domain: planet4-master-theme
 // @import "~bootstrap/scss/_breadcrumb.scss";
 // @import "~bootstrap/scss/_button-group.scss";
 // @import "~bootstrap/scss/_buttons.scss";
-// @import "~bootstrap/scss/_card.scss";
+@import "~bootstrap/scss/_card.scss";
 @import "~bootstrap/scss/_carousel.scss";
 // @import "~bootstrap/scss/_close.scss";
 // @import "~bootstrap/scss/_code.scss";
@@ -63,6 +63,6 @@ Text Domain: planet4-master-theme
 // @import "~bootstrap/scss/_root.scss";
 // @import "~bootstrap/scss/_tables.scss";
 // @import "~bootstrap/scss/_tooltip.scss";
-// @import "~bootstrap/scss/_transitions.scss";
+@import "~bootstrap/scss/_transitions.scss";
 @import "~bootstrap/scss/_type.scss";
 @import "~bootstrap/scss/_utilities.scss";


### PR DESCRIPTION
* These were removed, but turns out that they're needed anyway in a few
places.

We may want to check the other parts to in a later PR, this one just re-adds the ones which we know already are needed.
Ref: https://jira.greenpeace.org/browse/PLANET-5363, also fixes https://jira.greenpeace.org/browse/PLANET-5475

@comzeradd `_cards.scss` is indeed used by the columns block, though at first glance it looks like it's barely actually using it. Most of the rules of those classes are overridden. Probably best for now to re-add it, but maybe afterwards we can add those few rules it does use to our css and drop the dependency.

Test instance:
- search page: https://k8s.p4.greenpeace.org/test-mars/?s=test&orderby=_score
- page with a columns task style block (accordion only on mobile): https://k8s.p4.greenpeace.org/test-mars/act/join-the-movement-for-clean-air/