### PR TITLE
PLANET-5515 When 0 search results set 204 http header

### DIFF
--- a/src/Search.php
+++ b/src/Search.php
@@ -355,6 +355,7 @@ abstract class Search {
 		$posts = $this->query_posts( $paged );
 
 		if ( empty( $posts ) ) {
+			status_header( 204 );
 			return [];
 		}
 


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5515

Deployed on my test instance. eg. https://k8s.p4.greenpeace.org/nikosdev/?s=blahblah&orderby=_score

The above page returns 0 zero results, with the normal search template. But the http status header is `404`.

This can be tested putting that url at [httpstatus](https://httpstatus.io/) or looking at web console.

![http](https://user-images.githubusercontent.com/939357/94168621-7f267e00-fe96-11ea-9489-70a2bd92f580.png)
