### PR TITLE
PLANET-5526: Add noindex meta tag for no results search page

### DIFF
--- a/src/Search.php
+++ b/src/Search.php
@@ -355,7 +355,7 @@ abstract class Search {
 		$posts = $this->query_posts( $paged );
 
 		if ( empty( $posts ) ) {
-			status_header( 204 );
+			add_action( 'wp_head', 'wp_no_robots' );
 			return [];
 		}
 


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5526

## Modifications
- Revert of https://github.com/greenpeace/planet4-master-theme/pull/1183  
  Code `204` seem to block any content, returning an empty page (it does so locally and in production)
- Call `wp_no_robots()` to add relevant meta tag
  It adds a meta tag `robots` with `noindex,follow`. Search engines will [concatenate multiple directives](https://webmasters.googleblog.com/2007/03/using-robots-meta-tag.html) and follow the most restrictive directive if some are conflicting.

There were other possible solutions:
- Add condition to template `html-header.twig` to replace the existing meta robots there.
- Add an http header `X-Robot-Tag` with the same content.

## Test

For a search giving 0 result (page `/?s=averyuniquesearch` for example), an html tag `<meta name="robots" content="noindex,follow">` should appear on the source.