### PR TITLE
PLANET-5563 Preload fonts and set swap display

### DIFF
--- a/templates/html-header.twig
+++ b/templates/html-header.twig
@@ -79,6 +79,10 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 	<meta name="robots" content="max-snippet:-1, max-image-preview:large, max-video-preview:-1">
 	<link rel="shortcut icon" type="image/ico" href="{{ theme.uri }}/favicon.ico"/>
+	<link rel="preload" as="style" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700,900&display=swap"/>
+	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700,900&display=swap"/>
+	<link rel="preload" as="style" href="https://fonts.googleapis.com/css?family=Lora:400,400i,700&subset=latin-ext&display=swap"/>
+	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lora:400,400i,700&subset=latin-ext&display=swap"/>
 
 	{% if hreflang %}
 		<!-- hreflang metadata -->


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5563

* The fonts were loaded to late, causing the browser to not render text
until the files are loaded. To mitigate this adds a preload tag for
these fonts, which makes them more likely to be loaded in time.
* Add the fonts in the head so they're next to the preload tag.
* Add `&display=swap` to the fonts url, which will cause the browser to
render the text with a local font while the url is not yet loaded.

Deployed on cidev instance. 
https://www.greenpeace.org/cidev/publication/260/mauris-quis-dictum-magna/

related styleguide PR to remove font loading from files:
https://github.com/greenpeace/planet4-styleguide/pull/77