### PR TITLE
Load ponyfill only for ie

### DIFF
--- a/assets/src/js/cssvarsponyfill.js
+++ b/assets/src/js/cssvarsponyfill.js
@@ -1,4 +1,6 @@
 /* global cssVars */
 export const setupCSSVarsPonyfill = () => {
-  cssVars();
+  if ('undefined' !== typeof cssVars) {
+    cssVars();
+  }
 };

--- a/assets/src/js/cssvarsponyfill.js
+++ b/assets/src/js/cssvarsponyfill.js
@@ -1,5 +1,17 @@
 /* global cssVars */
 export const setupCSSVarsPonyfill = () => {
+  // Taken from https://stackoverflow.com/questions/36653217/opera-mini-browser-detection-using-javascript.
+  const isOperaMini = Object.prototype.toString.call(window.operamini) === '[object OperaMini]';
+
+  if (isOperaMini) {
+    const script = document.createElement('script');
+    script.src = 'https://cdnjs.cloudflare.com/ajax/libs/css-vars-ponyfill/2.3.1/css-vars-ponyfill.min.js';
+    script.onload = () => cssVars();
+    document.head.append(script);
+
+    return;
+  }
+
   if ('undefined' !== typeof cssVars) {
     cssVars();
   }

--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -689,6 +689,7 @@ class MasterSite extends TimberSite {
 		wp_register_script( 'main', $this->theme_dir . '/assets/build/index.js', [ 'jquery', 'cssvarsponyfill' ], $js_creation, true );
 		wp_localize_script( 'main', 'localizations', $localized_variables );
 		wp_enqueue_script( 'main' );
+		wp_script_add_data( 'cssvarsponyfill', 'conditional', 'lte IE 11' );
 
 		wp_enqueue_script( 'slick', 'https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.9.0/slick.min.js', [], '1.9.0', true );
 		wp_enqueue_script( 'hammer', 'https://cdnjs.cloudflare.com/ajax/libs/hammer.js/2.0.8/hammer.min.js', [], '2.0.8', true );


### PR DESCRIPTION
The ponyfill is only needed for ie11 and Opera mini (ignoring some browsers with virtually no usage).
https://caniuse.com/css-variables
We can add a conditional if we only want to support ie11, though the ponyfill then wouldn't apply to Opera Mini.

I still need to do some tests on ie if it always loads the script.