### PR TITLE
Custom header on search with no result

### DIFF
--- a/src/Search.php
+++ b/src/Search.php
@@ -356,6 +356,9 @@ abstract class Search {
 
 		if ( empty( $posts ) ) {
 			add_action( 'wp_head', 'wp_no_robots' );
+			if ( ! headers_sent() ) {
+				header( 'P4-Search: no-results' );
+			}
 			return [];
 		}
 


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5515
Ref: https://jira.greenpeace.org/browse/PLANET-5526

Demo for custom header added to a search page with no result.  
It is live on [rhea](https://k8s.p4.greenpeace.org/test-rhea/)

```sh
$> curl -IXGET "https://k8s.p4.greenpeace.org/test-rhea/?s=averyuniquetitle" 

HTTP/2 200 
content-type: text/html; charset=UTF-8
date: Thu, 08 Oct 2020 12:05:02 GMT
link: <https://k8s.p4.greenpeace.org/test-rhea/wp-json/>; rel="https://api.w.org/"
p4-search: no-results
server: openresty
set-cookie: wordpress_google_apps_login=d114e606af1acbb3dd77e5245929e4bd; path=/; secure; HttpOnly
vary: Accept-Encoding
vary: Accept-Encoding
x-cache: BYPASS
x-cache-2: BYPASS
x-content-type-options: nosniff
x-elasticpress-query: true
x-frame-options: SAMEORIGIN
x-xss-protection: 1; mode=block
```

Wordpress method `WP::send_headers()` is already called when we get the search results, but content has not been sent yet, so we can add more headers to the list before it is flushed to the client.