### PR TITLE
PLANET-5373 Remove the "by" string in post details page and taxonomy details page

### DIFF
--- a/templates/single.twig
+++ b/templates/single.twig
@@ -60,7 +60,6 @@
 						<div class="single-post-meta">
 							{% if post.author.name %}
 								<address class="single-post-author">
-									{{ __( 'by', 'planet4-master-theme' ) }}
 									{% if not ( post.get_author_override ) %}
 										<a href="{{ post.author.path }}">{{ post.author.name }}</a>
 									{% else %}

--- a/templates/tease-taxonomy-post.twig
+++ b/templates/tease-taxonomy-post.twig
@@ -47,7 +47,7 @@
 
 		<div class="search-result-item-info">
 			{% if ( post.author ) %}
-				<span class="search-result-item-author">{{ __( 'by', 'planet4-master-theme' ) }}
+				<span class="search-result-item-author">
 					{% if not ( post.get_author_override ) %}
 						<a href="{{ post.author.path }}">{{ post.author }}</a>
 					{% else %}


### PR DESCRIPTION
[JIRA 5373](https://jira.greenpeace.org/browse/PLANET-5373)

Related PR: [#403](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/403)