### PR TITLE
Manually specify master for other repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,7 +106,11 @@ commands:
           working_directory: /home/circleci
           command: |
             echo "Master theme branch is ${CIRCLE_BRANCH}"
-            MASTER_THEME_BRANCH=dev-${CIRCLE_BRANCH} MERGE_SOURCE=git@github.com:greenpeace/planet4-base-fork.git MERGE_REF=develop make
+            MASTER_THEME_BRANCH=dev-${CIRCLE_BRANCH} \
+            PLUGIN_GUTENBERG_BLOCKS_BRANCH=dev-master \
+            MERGE_SOURCE=git@github.com:greenpeace/planet4-base-fork.git \
+            MERGE_REF=develop \
+            make
       - run:
           name: Test - Clone planet4-docker-compose
           command: |


### PR DESCRIPTION
* Due to an issue the assets are not building for the tag. This is a
quick fix to allow tests to pass again while we further check the issue.