### PR TITLE
Planet 5501 - Consistent styles for buttons

### DIFF
--- a/assets/src/scss/pages/search/_filter-sidebar.scss
+++ b/assets/src/scss/pages/search/_filter-sidebar.scss
@@ -137,14 +137,11 @@
     }
 
     .btn-filter {
-      font-size: $font-size-sm;
       height: 40px;
       width: 130px;
       line-height: 40px;
       background: $orange;
-      font-weight: bold;
       padding: 0 $n10;
-      text-transform: uppercase;
       color: $white;
 
       &:hover {

--- a/assets/src/scss/pages/search/_search-bar.scss
+++ b/assets/src/scss/pages/search/_search-bar.scss
@@ -21,55 +21,8 @@
     }
   }
 
-  .btn-secondary {
-    background-color: transparentize($white, .8);
-    border-color: $grey-20;
-    color: $grey-80;
-    text-transform: capitalize;
-    width: 50%;
-    cursor: pointer;
-    margin-bottom: 10px;
-
-    @include small-and-up {
-      margin-bottom: 0;
-    }
-
-    &.active {
-      background-color: $dark-blue;
-      border-color: transparent;
-      color: $white;
-
-      &:before {
-        content: "";
-        position: absolute;
-        top: 0;
-        left: 0;
-        width: 8px;
-        height: 8px;
-        background-color: $white;
-        margin-top: 18px;
-        margin-left: 5px;
-
-        @include large-and-up {
-          margin-top: 25px;
-          margin-left: 12px;
-        }
-      }
-
-      &:hover {
-        z-index: 2;
-        background-color: $dark-blue;
-      }
-    }
-
-    &:hover {
-      z-index: 0;
-      background-color: $grey-20;
-    }
-  }
-
-  .search-btn,
-  .btn-secondary {
+  .search-btn {
+    box-shadow: 0 8px 15px rgba(0, 0, 0, 0.1);
     font-size: $font-size-sm;
     line-height: 2.75;
 
@@ -88,9 +41,5 @@
         margin-top: 27px;
       }
     }
-  }
-
-  .search-btn {
-    box-shadow: 0 8px 15px rgba(0, 0, 0, 0.1);
   }
 }

--- a/assets/src/scss/pages/search/_search-bar.scss
+++ b/assets/src/scss/pages/search/_search-bar.scss
@@ -22,12 +22,11 @@
   }
 
   .search-btn {
-    box-shadow: 0 8px 15px rgba(0, 0, 0, 0.1);
     font-size: $font-size-sm;
     line-height: 2.75;
 
     @include large-and-up {
-      font-size: 1.125rem;
+      margin-top: 2px;
       line-height: 3;
     }
 

--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -473,7 +473,7 @@ class MasterSite extends TimberSite {
 		}
 
 		$context['donatelink']           = $options['donate_button'] ?? '#';
-		$context['donatetext']           = $options['donate_text'] ?? __( 'DONATE', 'planet4-master-theme' );
+		$context['donatetext']           = $options['donate_text'] ?? __( 'Donate', 'planet4-master-theme' );
 		$context['website_navbar_title'] = $options['website_navigation_title'] ?? __( 'International (English)', 'planet4-master-theme' );
 		if ( is_front_page() && isset( $options['donate_btn_visible_on_mobile'] ) && $options['donate_btn_visible_on_mobile'] ) {
 			$context['enhanced_donate_btn_class'] = 'btn-enhanced-donate';

--- a/src/Search.php
+++ b/src/Search.php
@@ -693,7 +693,6 @@ abstract class Search {
 		$context['default_sort']     = self::DEFAULT_SORT;
 		$context['filters']          = $this->filters;
 		$context['found_posts']      = $this->total_matches;
-		$context['source_selection'] = false;
 		$context['page_category']    = 'Search Page';
 		$context['sort_options']     = [
 			'_score'    => [

--- a/src/Search.php
+++ b/src/Search.php
@@ -685,16 +685,16 @@ abstract class Search {
 	protected function set_general_context( &$context ) {
 
 		// Search context.
-		$context['posts']            = $this->posts;
-		$context['paged_posts']      = $this->paged_posts;
-		$context['current_page']     = $this->current_page;
-		$context['search_query']     = $this->search_query;
-		$context['selected_sort']    = $this->selected_sort;
-		$context['default_sort']     = self::DEFAULT_SORT;
-		$context['filters']          = $this->filters;
-		$context['found_posts']      = $this->total_matches;
-		$context['page_category']    = 'Search Page';
-		$context['sort_options']     = [
+		$context['posts']         = $this->posts;
+		$context['paged_posts']   = $this->paged_posts;
+		$context['current_page']  = $this->current_page;
+		$context['search_query']  = $this->search_query;
+		$context['selected_sort'] = $this->selected_sort;
+		$context['default_sort']  = self::DEFAULT_SORT;
+		$context['filters']       = $this->filters;
+		$context['found_posts']   = $this->total_matches;
+		$context['page_category'] = 'Search Page';
+		$context['sort_options']  = [
 			'_score'    => [
 				'name'  => __( 'Most relevant', 'planet4-master-theme' ),
 				'order' => 'DESC',

--- a/src/Search.php
+++ b/src/Search.php
@@ -1071,7 +1071,7 @@ abstract class Search {
 		$this->context['load_more'] = $args ?? [
 			'posts_per_load' => self::POSTS_PER_LOAD,
 			// Translators: %s = number of results per page.
-			'button_text'    => sprintf( __( 'SHOW %s MORE RESULTS', 'planet4-master-theme' ), self::POSTS_PER_LOAD ),
+			'button_text'    => sprintf( __( 'Show %s more results', 'planet4-master-theme' ), self::POSTS_PER_LOAD ),
 			'async'          => true,
 		];
 	}

--- a/templates/author.twig
+++ b/templates/author.twig
@@ -53,7 +53,7 @@
 						data-page="1"
 						data-total="{{ posts.pagination.total }}"
 						data-url="{{ author.path }}"
-						class="load-more-mt btn btn-medium btn-small btn-secondary mb-5"
+						class="load-more-mt btn btn-small btn-secondary mb-5"
 						data-ga-category="Articles List"
 						data-ga-action="Load More Button"
 						data-ga-label="n/a">

--- a/templates/blocks/header.twig
+++ b/templates/blocks/header.twig
@@ -66,7 +66,7 @@
 							{% if ( header_button_link_checkbox ) %}
 								target="_blank"
 							{% endif %}
-								class="btn btn-primary btn-medium page-header-btn"
+								class="btn btn-primary page-header-btn"
 								data-ga-category="Header"
 								data-ga-action="Call to Action"
 								data-ga-label="n/a">

--- a/templates/cookies.twig
+++ b/templates/cookies.twig
@@ -3,6 +3,6 @@
 		<div>
 			{{ cookies.text|e('wp_kses_post')|raw }}
 		</div>
-		<button class="btn p-0" id="hidecookie">{{ __( 'Got it!', 'planet4-master-theme' ) }}</button>
+		<button class="btn btn-secondary p-0" id="hidecookie">{{ __( 'Got it!', 'planet4-master-theme' ) }}</button>
 	</div>
 {% endif %}

--- a/templates/cookies.twig
+++ b/templates/cookies.twig
@@ -3,6 +3,6 @@
 		<div>
 			{{ cookies.text|e('wp_kses_post')|raw }}
 		</div>
-		<button class="btn p-0" id="hidecookie">{{ __( 'GOT IT!', 'planet4-master-theme' ) }}</button>
+		<button class="btn p-0" id="hidecookie">{{ __( 'Got it!', 'planet4-master-theme' ) }}</button>
 	</div>
 {% endif %}

--- a/templates/search.twig
+++ b/templates/search.twig
@@ -366,7 +366,7 @@
 							{% if ( load_more and found_posts > paged_posts|length ) %}
 								<div class="col-lg-12 mb-5 load-more-button-div">
 									<button
-										class="btn btn-small btn-secondary more-btn {{ load_more.async ? 'btn-load-more-async' : '' }} btn-load-more-click-scroll"
+										class="btn btn-secondary more-btn {{ load_more.async ? 'btn-load-more-async' : '' }} btn-load-more-click-scroll"
 										data-current_page="{{ current_page }}"
 										data-total_posts="{{ found_posts }}"
 										data-posts_per_load="{{ load_more.posts_per_load }}"

--- a/templates/search.twig
+++ b/templates/search.twig
@@ -38,15 +38,15 @@
 								{% if ( source_selection ) %}
 									<div class="col-md-4">
 										<div class="btn-group btn-block" role="group" aria-label="" id="search-type">
-											<button type="button" class="btn btn-secondary btn-medium active">{{ __('This Site', 'planet4-master-theme' ) }}</button>
-											<button type="button" class="btn btn-secondary btn-medium">{{ __( 'Archive', 'planet4-master-theme' ) }}</button>
+											<button type="button" class="btn btn-secondary active">{{ __('This Site', 'planet4-master-theme' ) }}</button>
+											<button type="button" class="btn btn-secondary">{{ __( 'Archive', 'planet4-master-theme' ) }}</button>
 										</div>
 									</div>
 								{% endif %}
 								<div class="col-md-3">
 									<button
 										type="submit"
-										class="btn btn-primary btn-medium search-btn btn-block"
+										class="btn btn-primary search-btn btn-block"
 										data-ga-category="Search Page"
 										data-ga-action="Search Button"
 										data-ga-label="n/a" >
@@ -205,8 +205,8 @@
 											</div>
 										</div>
 										<div class="btnact">
-											<button type="button" class="btn btn-action btn-medium btn-small cancelbtn" data-dismiss="modal">{{ __( 'Cancel', 'planet4-master-theme' ) }}</button>
-											<button type="button" class="btn btn-primary btn-medium btn-small applybtn">{{ __( 'Apply Filters', 'planet4-master-theme' ) }}</button>
+											<button type="button" class="btn btn-action btn-small cancelbtn" data-dismiss="modal">{{ __( 'Cancel', 'planet4-master-theme' ) }}</button>
+											<button type="button" class="btn btn-primary btn-small applybtn">{{ __( 'Apply Filters', 'planet4-master-theme' ) }}</button>
 										</div>
 									</div>
 								</div>
@@ -374,7 +374,7 @@
 							{% if ( load_more and found_posts > paged_posts|length ) %}
 								<div class="col-lg-12 mb-5 load-more-button-div">
 									<button
-										class="btn btn-medium btn-small btn-secondary more-btn {{ load_more.async ? 'btn-load-more-async' : '' }} btn-load-more-click-scroll"
+										class="btn btn-small btn-secondary more-btn {{ load_more.async ? 'btn-load-more-async' : '' }} btn-load-more-click-scroll"
 										data-current_page="{{ current_page }}"
 										data-total_posts="{{ found_posts }}"
 										data-posts_per_load="{{ load_more.posts_per_load }}"

--- a/templates/search.twig
+++ b/templates/search.twig
@@ -31,18 +31,10 @@
 					<div class="search-bar">
 						<form id="search_form_inner" role="search" class="form" action="{{ data_nav_bar.home_url }}">
 							<div class="row">
-								<div class="{{ source_selection ? 'col-md-5' : 'col-md-9' }}">
+								<div class="col-md-9">
 									<input type="search" class="form-control mb-2 mb-sm-0" placeholder="{{ search_label }}" value="{{ search_query|e('wp_kses_post')|raw }}" name="s" aria-label="Search">
 									<input type="hidden" name="orderby" value="{{ selected_sort ?? default_sort }}" />
 								</div>
-								{% if ( source_selection ) %}
-									<div class="col-md-4">
-										<div class="btn-group btn-block" role="group" aria-label="" id="search-type">
-											<button type="button" class="btn btn-secondary active">{{ __('This Site', 'planet4-master-theme' ) }}</button>
-											<button type="button" class="btn btn-secondary">{{ __( 'Archive', 'planet4-master-theme' ) }}</button>
-										</div>
-									</div>
-								{% endif %}
 								<div class="col-md-3">
 									<button
 										type="submit"

--- a/templates/taxonomy.twig
+++ b/templates/taxonomy.twig
@@ -35,7 +35,7 @@
 						data-page="1"
 						data-total="{{ posts.pagination.total }}"
 						data-url="{{ fn('get_term_link', taxonomy.term_id ) }}"
-						class="load-more-mt btn btn-medium btn-small btn-secondary mb-5"
+						class="load-more-mt btn btn-small btn-secondary mb-5"
 						data-ga-category="Articles List"
 						data-ga-action="Load More Button"
 						data-ga-label="n/a">

--- a/templates/tease-search.twig
+++ b/templates/tease-search.twig
@@ -117,7 +117,7 @@
 						{%  set link_text = settings['take_action_covers_button_text'] %}
 						<a
 							href="{{ post.link }}"
-							class="btn btn-primary btn-medium btn-small"
+							class="btn btn-primary btn-small"
 							data-ga-category="Search Results"
 							data-ga-action="Call to Action"
 							data-ga-label="{{ ga_page_type }}">


### PR DESCRIPTION
See https://jira.greenpeace.org/browse/PLANET-5501

In order to follow the new "capitalized" buttons, we need to update some default texts:
- Donate button default text: from `DONATE` to `Donate`
- Cookies button text: from `GOT IT!` to `Got it!`
- Search "load more" button text: from `SHOW %s MORE RESULTS` to `Show %s more results`

I also did a bit of clean up:
- Remove `btn-medium` class as it just duplicates the "regular" button styles
- Remove `source_selection` and `btn-secondary` from search bar (no longer relevant)

#### Related PRs
- [styleguide](https://github.com/greenpeace/planet4-styleguide/pull/80)
- [gutenberg-blocks](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/413)