### PR TITLE
Always add apps login filter

### DIFF
--- a/src/Cookies.php
+++ b/src/Cookies.php
@@ -6,32 +6,11 @@ namespace P4\MasterTheme;
  * Class Cookies
  */
 class Cookies {
-
-	const COOKIE_NAME = 'greenpeace';
-
 	/**
 	 * Cookies constructor.
 	 */
 	public function __construct() {
-		$this->hooks();
-	}
-
-	/**
-	 * Register actions for WordPress hooks and filters.
-	 */
-	private function hooks() {
-		$options                = get_option( 'planet4_options' );
-		$enforce_cookies_policy = isset( $options['enforce_cookies_policy'] ) ? true : false;
-
-		// Do not add any hook if enforce cookies setting is not set.
-		if ( false === $enforce_cookies_policy ) {
-			return;
-		}
-		// If our cookie is not set then register the following filters.
-		if ( '2' !== $this->read_cookie( self::COOKIE_NAME ) ) {
-
-			add_filter( 'gal_set_login_cookie', [ $this, 'filter_google_login_set_login_cookie' ], 10, 1 );
-		}
+		add_filter( 'gal_set_login_cookie', [ $this, 'filter_google_login_set_login_cookie' ], 10, 1 );
 	}
 
 	/**
@@ -47,23 +26,5 @@ class Cookies {
 		global $pagenow;
 
 		return 'wp-login.php' === $pagenow;
-	}
-
-
-	/**
-	 * Get an entry from $_COOKIE super global
-	 *
-	 * @param string $name Cookie name.
-	 *
-	 * @since 1.9
-	 *
-	 * @return bool Return false if entry does not exist, otherwise return cookie value.
-	 */
-	public function read_cookie( $name = '' ) {
-		if ( isset( $_COOKIE[ $name ] ) ) {
-			return $_COOKIE[ $name ];
-		} else {
-			return false;
-		}
 	}
 }


### PR DESCRIPTION
* This filter is needed to prevent the cookie from being set anywhere
but the login page. If you don't add the filter then the cookie is
always set.
* The checks were in place to prevent other things from setting cookies.
Those things are not there anymore, so we don't need the checks.

Ref: https://jira.greenpeace.org/browse/PLANET-5605
deployed on https://k8s.p4.greenpeace.org/test-iocaste/