### PR TITLE
PLANET-5221 Checkout code for forks, instead of composer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,10 +6,8 @@ workflows:
     jobs:
       - php72-tests
       - php73-tests
-      - acceptance-tests:
-          context: org-global
-      - a11y-tests:
-          context: org-global
+      - acceptance-tests
+      - a11y-tests
       - create-release-zip:
           context: org-global
           filters:
@@ -79,6 +77,7 @@ job-references:
         auth: &docker_auth
     working_directory: /home/circleci/
     environment:
+      WP_VERSION: 5.4.2
       APP_HOSTNAME: www.planet4.test
       APP_HOSTPATH:
       CLOUDSQL_INSTANCE: p4-develop-k8s
@@ -94,10 +93,11 @@ commands:
     steps:
       - setup_remote_docker:
           docker_layer_caching: true
+      - checkout:
+          path: /home/circleci/checkout/planet4-master-theme
       - run:
           name: Build - Configure
           command: |
-            activate-gcloud-account.sh
             mkdir -p /tmp/workspace/var
             mkdir -p /tmp/workspace/src
             echo "${CIRCLE_BUILD_NUM}" > /tmp/workspace/var/circle-build-num
@@ -105,12 +105,19 @@ commands:
           name: Build - Build containers
           working_directory: /home/circleci
           command: |
-            echo "Master theme branch is ${CIRCLE_BRANCH}"
-            MASTER_THEME_BRANCH=dev-${CIRCLE_BRANCH} \
+            if [ -n "$CIRCLE_PR_NUMBER" ]; then
+              BRANCH=contrib
+              git --git-dir=/home/circleci/checkout/planet4-master-theme/.git checkout -b contrib
+              echo "Using tmp branch contrib for fork PR $CIRCLE_PR_NUMBER"
+            else
+              BRANCH="${CIRCLE_BRANCH}"
+              echo "Master theme branch is ${CIRCLE_BRANCH}"
+            fi
+            MASTER_THEME_BRANCH=dev-${BRANCH}#${CIRCLE_SHA1} \
             PLUGIN_GUTENBERG_BLOCKS_BRANCH=dev-master \
             MERGE_SOURCE=git@github.com:greenpeace/planet4-base-fork.git \
             MERGE_REF=develop \
-            make
+            make ci
       - run:
           name: Test - Clone planet4-docker-compose
           command: |


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5221

Allow acceptance tests (and a11y tests) to run on forks.

This involved the following changes:

- Remove `org-global` context 
- Remove `activate-gcloud-account.sh`, which depended on the context and was needed only for `make`
- Replace `make` with `make ci`, as `make` pushes the images for which the gcloud account activation is needed, but these images are only used in the job itself, we don't need to push them
- Create a local `contrib` branch after checking out forks. A branch with the same name exists on the repo itself. Composer checks the branches on our GitHub repo, if the branch exists only in the local repository, then composer fails because it doesn't check there. However in the end composer will still use the local branch if it exists in both. Example of how that fails on the other repo, where I created a fork PR before creating the `contrib` branch: https://app.circleci.com/pipelines/github/greenpeace/planet4-plugin-gutenberg-blocks/2758/workflows/0bd2da97-91a6-49c8-ae2e-cb3fe26e5ae2/jobs/7665
- Pass the `WP_VERSION` as an env var to the test jobs. This was previously using the value in `org-global`, removing the context caused the job to use an older version, resulting in many tests failing because of a database upgrade prompt.