### PR TITLE
Planet 5481 - Improve Image Archive UI

### DIFF
--- a/admin/css/picker.css
+++ b/admin/css/picker.css
@@ -1,22 +1,32 @@
 /* Todo: Change to scss, separate styles that are essential to the ImagePicker component to work (if there are any)
      from ArchivePicker styles*/
 
-.archive-picker-search input[type=submit] {
-  display: inline-block;
+.archive-picker-search {
+  margin-top: 20px;
+}
+
+.archive-picker-search input {
+  margin-right: 10px;
 }
 
 .picker-list {
   max-width: 60%;
   max-height: 75vh;
   overflow-y: scroll;
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0 10px;
+}
+
+@media (min-width: 768px) {
+  .picker-list {
+    grid-template-columns: repeat(3, 1fr);
+  }
 }
 
 .image-picker li {
-  display: inline-block !important;
+  display: inline-block;
   position: relative;
-  border: 2px solid transparent;
 }
 
 .image-picker li[data-wordpress-id]:after {
@@ -29,12 +39,16 @@
 }
 
 .image-picker li img {
-  margin: 2px 4px 0 0;
+  margin: 0;
+  border: 2px solid transparent;
+  box-sizing: border-box;
+  width: 100%;
+  object-fit: cover;
+  cursor: pointer;
 }
 
-li.picker-selected {
+.image-picker li img.picker-selected {
   border-color: yellow;
-  box-sizing: border-box;
 }
 
 .picker-sidebar-fields {
@@ -42,6 +56,7 @@ li.picker-selected {
   flex-direction: column;
   max-height: 100%;
   overflow: auto;
+  margin-top: 0;
 }
 
 .picker-sidebar-fields dd {
@@ -58,21 +73,26 @@ li.picker-selected {
   background: white;
   padding: 48px 8px 8px;
   border-left: 3px solid black;
+  overflow-y: auto;
   display: flex;
   flex-direction: column;
 }
 
-.picker-sidebar-single img {
+.picker-sidebar img {
   object-fit: cover;
   width: 100%;
+  margin-bottom: 10px;
+}
+
+.picker-sidebar-single .sidebar-action {
+  width: fit-content;
+  align-self: center;
+  margin-bottom: 10px;
 }
 
 .archive-picker-loading {
-  background: lightgrey;
-  border: 2px solid black;
-  border-radius: 4px;
   position: fixed;
-  bottom: 0;
-  padding: 5px;
-  left: 24%;
+  bottom: 20px;
+  text-align: center;
+  width: 50%;
 }

--- a/assets/src/js/Components/ArchivePicker.js
+++ b/assets/src/js/Components/ArchivePicker.js
@@ -50,7 +50,7 @@ const ArchivePicker = () => {
 
   return <Fragment>
     <form
-      className={'archive-picker-search'}
+      className='archive-picker-search'
       onSubmit={event => {
         event.preventDefault();
         if (!loading) {
@@ -64,10 +64,14 @@ const ArchivePicker = () => {
         type='text'
         disabled={loading}
       />
-      <input type='submit' value={__('Search', 'planet4-master-theme-backend')} />
+      <button
+        disabled={loading}
+        type='submit'
+        className='button'
+      >{__('Search', 'planet4-master-theme-backend')}</button>
     </form>
     {loading && (
-      <div className={'archive-picker-loading'}> loading...</div>
+      <div className='archive-picker-loading'>{__('Loading...', 'planet4-master-theme-backend')}</div>
     )}
     {!!error && (
       <div>
@@ -75,9 +79,9 @@ const ArchivePicker = () => {
         <p> {error.message} </p>
       </div>
     )}
-    <div className={'image-picker'}>
+    <div className='image-picker'>
       <ul
-        className={'picker-list'}
+        className='picker-list'
         onScroll={event => {
           if (!loading && isNearScrollEnd(event)) {
             setCurrentPage(currentPage + 1);

--- a/assets/src/js/Components/archivePicker/ArchivePickerList.js
+++ b/assets/src/js/Components/archivePicker/ArchivePickerList.js
@@ -22,9 +22,9 @@ export const ArchivePickerList = ({
 
       return <li
         key={id}
-        data-wordpress-id={wordpress_id}
-        className={classNames({ 'picker-selected': isSelected(image) })}>
+        data-wordpress-id={wordpress_id}>
         <img
+          className={classNames({ 'picker-selected': isSelected(image) })}
           srcSet={toSrcSet(sizes, { maxWidth: 900 })}
           title={`${title}`}
           alt={alt}

--- a/assets/src/js/Components/archivePicker/MultiSidebar.js
+++ b/assets/src/js/Components/archivePicker/MultiSidebar.js
@@ -6,20 +6,15 @@ const { __ } = wp.i18n;
 export const MultiSidebar = ({ selectedImages, toggleMultiSelection }) => (
   <Fragment>
     <p>{selectedImages.length} {__('images selected', 'planet4-master-theme-backend')}</p>
-    <ul>
-      {selectedImages.map(selected => (
-        <li
-          key={selected.id}
-        >
-          <img
-            srcSet={toSrcSet(selected.sizes, { maxWidth: 700 })}
-            title={selected.title}
-            alt={selected.title}
-            width={80}
-            onClick={() => toggleMultiSelection(selected)}
-          />
-        </li>
-      ))}
-    </ul>
+    {selectedImages.map(selected => (
+      <img
+        srcSet={toSrcSet(selected.sizes, { maxWidth: 700 })}
+        title={selected.title}
+        alt={selected.title}
+        key={selected.id}
+        width={80}
+        onClick={() => toggleMultiSelection(selected)}
+      />
+    ))}
   </Fragment>
 );

--- a/assets/src/js/Components/archivePicker/SingleSidebar.js
+++ b/assets/src/js/Components/archivePicker/SingleSidebar.js
@@ -45,7 +45,6 @@ export const SingleSidebar = ({ image, processingError, processingImages, includ
       )}
       {image.wordpress_id ? (
         <a
-          target='_blank'
           href={wpImageLink(image.wordpress_id)}
         >Wordpress image #{ image.wordpress_id}</a>
       ) : (

--- a/assets/src/js/Components/archivePicker/SingleSidebar.js
+++ b/assets/src/js/Components/archivePicker/SingleSidebar.js
@@ -16,23 +16,14 @@ const renderDefinition = (key, value) => (
 
 export const SingleSidebar = ({ image, processingError, processingImages, includeInWp }) => {
   const original = image ? image.original : {};
-  const aspectRatio = original.height / original.width;
 
   const renderImage = () => (
-    <div
-      style={{ maxHeight: '10vh', position: 'relative', width: '100%', paddingTop: `${aspectRatio * 100}%`, }}
-    >
-      <div
-        style={{ position: 'absolute', top: 0, bottom: 0, left: 0, right: 0, }}
-      >
-        <img
-          key={original.url}
-          srcSet={toSrcSet(image.sizes, { maxWidth: PREVIEW_MAX_SIZE })}
-          title={image.title}
-          alt={image.title}
-        />
-      </div>
-    </div>
+    <img
+      key={original.url}
+      srcSet={toSrcSet(image.sizes, { maxWidth: PREVIEW_MAX_SIZE })}
+      title={image.title}
+      alt={image.title}
+    />
   );
 
   return (
@@ -45,10 +36,12 @@ export const SingleSidebar = ({ image, processingError, processingImages, includ
       )}
       {image.wordpress_id ? (
         <a
+          className="sidebar-action"
           href={wpImageLink(image.wordpress_id)}
         >Wordpress image #{ image.wordpress_id}</a>
       ) : (
         <button
+          className="button sidebar-action"
           onClick={async () => {
             await includeInWp([image.id]);
           }}

--- a/src/ImageArchive/UiIntegration.php
+++ b/src/ImageArchive/UiIntegration.php
@@ -64,6 +64,14 @@ class UiIntegration {
 			'dashicons-format-image',
 			11
 		);
+
+		add_submenu_page(
+			'gpi-image-picker',
+			__( 'Image Archive', 'planet4-master-theme-backend' ),
+			__( 'Library', 'planet4-master-theme-backend' ),
+			Capability::USE_IMAGE_ARCHIVE_PICKER,
+			'gpi-image-picker'
+		);
 	}
 
 	/**
@@ -76,8 +84,7 @@ class UiIntegration {
 			__( 'API info', 'planet4-master-theme-backend' ),
 			Capability::USE_IMAGE_ARCHIVE_PICKER,
 			'media-api-info',
-			[ self::class, 'api_info' ],
-			11
+			[ self::class, 'api_info' ]
 		);
 	}
 

--- a/src/ImageArchive/UiIntegration.php
+++ b/src/ImageArchive/UiIntegration.php
@@ -61,7 +61,7 @@ class UiIntegration {
 			Capability::USE_IMAGE_ARCHIVE_PICKER,
 			'gpi-image-picker',
 			[ self::class, 'output_picker' ],
-			P4ML_ADMIN_DIR . 'images/logo_menu_page_16x16.png',
+			'dashicons-format-image',
 			3
 		);
 	}

--- a/src/ImageArchive/UiIntegration.php
+++ b/src/ImageArchive/UiIntegration.php
@@ -56,8 +56,8 @@ class UiIntegration {
 		}
 
 		add_menu_page(
-			__( 'GPI Image Archive', 'planet4-master-theme-backend' ),
-			__( 'GPI Image Archive', 'planet4-master-theme-backend' ),
+			__( 'Image Archive', 'planet4-master-theme-backend' ),
+			__( 'Image Archive', 'planet4-master-theme-backend' ),
 			Capability::USE_IMAGE_ARCHIVE_PICKER,
 			'gpi-image-picker',
 			[ self::class, 'output_picker' ],

--- a/src/ImageArchive/UiIntegration.php
+++ b/src/ImageArchive/UiIntegration.php
@@ -62,7 +62,7 @@ class UiIntegration {
 			'gpi-image-picker',
 			[ self::class, 'output_picker' ],
 			'dashicons-format-image',
-			3
+			11
 		);
 	}
 
@@ -77,7 +77,7 @@ class UiIntegration {
 			Capability::USE_IMAGE_ARCHIVE_PICKER,
 			'media-api-info',
 			[ self::class, 'api_info' ],
-			3
+			11
 		);
 	}
 


### PR DESCRIPTION
See https://jira.greenpeace.org/browse/PLANET-5481

- [x] Use a dashicon (eg. https://developer.wordpress.org/resource/dashicons/#format-image)
- [x] Push the menu right after the Media (maybe remove "GPI" to make it shorter)
- [x] Rename the first submenu item to "Library"
- [x] Use same UI elements for the search bar and the buttons as the rest of wp-admin
- [x] Use grid instead of flexbox for displaying the image, to have them use the same dimensions (similar to the current medialibrary plugin)
- [x] Image link after importing should open on the same window

You can see the improved UI version [here](https://www-dev.greenpeace.org/test-iocaste/wp-admin/admin.php?page=gpi-image-picker)!