### PR TITLE
PLANET-5441 apply url_encode to twitter text

### DIFF
--- a/templates/blocks/meta_fields.twig
+++ b/templates/blocks/meta_fields.twig
@@ -1,0 +1,57 @@
+{% if ((post and (1 != fn('post_password_required', post))) or author is defined) %}
+	{% if (author.description is defined and author.description) %}
+		{% set meta_description = author.description|striptags %}
+	{% elseif (post.post_excerpt is defined and post.post_excerpt) %}
+		{% set meta_description = post.post_excerpt|striptags %}
+	{% else %}
+		{% set meta_description = site.description %}
+	{% endif %}
+
+	{% if (author.name is defined and author.name is not null) %}
+		{% set meta_twitter_creator = author.name %}
+	{% elseif (post.author is defined and post.author is not null) %}
+		{% set meta_twitter_creator = post.author.name %}
+	{% endif %}
+
+	<meta name="description" content="{{ meta_description }}">
+
+	{% if not (og_title is defined) %}
+		{% if (wp_title) %}
+			{% set og_title = wp_title|raw~' - '~site.name %}
+		{% else %}
+			{% set og_title = site.name %}
+		{% endif %}
+	{% endif %}
+	<meta name="title" content="{{ og_title|e('html_attr')|raw }}"/>
+	<meta property="og:title" content="{{ og_title|e('html_attr')|raw }}" />
+	<meta property="og:type" content="article" />
+	<meta property="og:url" content="{{ current_url }}" />
+	{% if (og_description) %}
+		<meta property="og:description" content="{{ og_description|striptags }}" />
+	{% endif %}
+	{% if (og_image_data) %}
+		<meta property="og:image" content="{{ og_image_data['url'] }}" />
+		<meta property="og:image:width" content="{{ og_image_data['width'] }}" />
+		<meta property="og:image:height" content="{{ og_image_data['height'] }}" />
+	{% endif %}
+	<meta property="og:site_name" content="{{ site.name }}" />
+
+	{% if facebook_page_id %}
+		<meta property="fb:pages" content="{{ facebook_page_id }}" />
+	{% endif %}
+
+	<meta name="twitter:card" content="summary_large_image" />
+	<meta name="twitter:site" content="{{ site.name }}" />
+	<meta name="twitter:title" content="{{ og_title|e('html_attr')|url_encode }}">
+	{% if (og_description) %}
+		<meta name="twitter:description" content="{{ og_description|e('html_attr')|raw }}">
+	{% endif %}
+
+	{% if (meta_twitter_creator is defined) %}
+		<meta name="twitter:creator" content="{{ meta_twitter_creator }}">
+	{% endif %}
+
+	{% if (og_image_data) %}
+		<meta name="twitter:image" content="{{ og_image_data['url'] }}" />
+	{% endif %}
+{% endif %}

--- a/templates/blocks/share_buttons.twig
+++ b/templates/blocks/share_buttons.twig
@@ -1,23 +1,30 @@
-<div class="share-buttons float-md-right">
+<div class="share-buttons">
+	<!-- Whatsapp -->
+	<a href="https://wa.me/?text={{ social.link }}"
+		 onclick="dataLayer.push({'event' : 'uaevent', 'eventCategory' : 'Social Share', 'eventAction': 'Whatsapp', 'eventLabel': '{{ social.link }}'});"
+		 target="_blank" class="share-btn whatsapp">
+		{{ 'whatsapp'|svgicon }}
+		<span class="sr-only">{{ __( 'Share on', 'planet4-master-theme' ) }} Whatsapp</span>
+	</a>
 	<!-- Facebook -->
-	<a href="https://www.facebook.com/sharer/sharer.php?u={{ post.link }}"
-		 onclick="dataLayer.push({'event' : 'uaevent', 'eventCategory' : 'Social Share', 'eventAction': 'Facebook', 'eventLabel': '{{ post.link }}'});"
+	<a href="https://www.facebook.com/sharer/sharer.php?u={{ social.link }}"
+		 onclick="dataLayer.push({'event' : 'uaevent', 'eventCategory' : 'Social Share', 'eventAction': 'Facebook', 'eventLabel': '{{ social.link }}'});"
 		 target="_blank" class="share-btn facebook">
-		<i class="fab fa-facebook-f"></i>
-		<span class="sr-only">{{ __( 'Share on' ) }} Facebook</span>
+		{{ 'facebook-f'|svgicon }}
+		<span class="sr-only">{{ __( 'Share on', 'planet4-master-theme' ) }} Facebook</span>
 	</a>
 	<!-- Twitter -->
-	<a href="https://twitter.com/share?url={{ post.link }}&text={{ post.title|raw }} via @{{ social_accounts.twitter }}&related={{ social_accounts.twitter }}"
-		 onclick="dataLayer.push({'event' : 'uaevent', 'eventCategory' : 'Social Share', 'eventAction': 'Twitter', 'eventLabel': '{{ post.link }}'});"
+	<a href="https://twitter.com/share?url={{ social.link }}&text={{ social.title|url_encode }}{% if social.description %} - {{ social.description|striptags }}{% endif %} via @{{ social_accounts.twitter }}&related={{ social_accounts.twitter }}"
+		 onclick="dataLayer.push({'event' : 'uaevent', 'eventCategory' : 'Social Share', 'eventAction': 'Twitter', 'eventLabel': '{{ social.link }}'});"
 		 target="_blank" class="share-btn twitter">
-		<i class="fab fa-twitter"></i>
-		<span class="sr-only">{{ __( 'Share on' ) }} Twitter</span>
+		{{ 'twitter'|svgicon }}
+		<span class="sr-only">{{ __( 'Share on', 'planet4-master-theme' ) }} Twitter</span>
 	</a>
 	<!-- Email -->
-	<a href="mailto:?subject={{ post.title }}&body={{ post.link }}"
-		 onclick="dataLayer.push({'event' : 'uaevent', 'eventCategory' : 'Social Share', 'eventAction': 'Email', 'eventLabel': '{{ post.link }}'});"
+	<a href="mailto:?subject={{ social.title|url_encode }}&body={% if social.description %}{{ social.description|striptags }} {% endif %}{{ social.link }}"
+		 onclick="dataLayer.push({'event' : 'uaevent', 'eventCategory' : 'Social Share', 'eventAction': 'Email', 'eventLabel': '{{ social.link }}'});"
 		 target="_blank" class="share-btn email">
-		<i class="fas fa-envelope"></i>
-		<span class="sr-only">{{ __( 'Share via' ) }} Email</span>
+		{{ 'envelope'|svgicon }}
+		<span class="sr-only">{{ __( 'Share via', 'planet4-master-theme' ) }} Email</span>
 	</a>
 </div>


### PR DESCRIPTION
For https://github.com/greenpeace/planet4/issues/109

url_encode method should convert # to %23
https://twig.symfony.com/doc/3.x/filters/url_encode.html

It would convert the link from [bad link](https://twitter.com/share?url=https://www.greenpeace.org/canada/en/story/41373/why-you-have-to-say-gnlnonmerci-before-september-14/&text=WHY%20YOU%20HAVE%20TO%20SAY%20GNLNonMerci%20BEFORE%20SEPTEMBER%2014%20!%20via%20@GreenpeaceCA&related=GreenpeaceCA) to [correct link](https://twitter.com/intent/tweet?url=https%3A%2F%2Fwww.greenpeace.org%2Fcanada%2Fen%2Fstory%2F41373%2Fwhy-you-have-to-say-gnlnonmerci-before-september-14%2F&text=WHY%20YOU%20HAVE%20TO%20SAY%20%23GNLNonMerci%20BEFORE%20SEPTEMBER%2014%20!%20via%20%40GreenpeaceCA&related=GreenpeaceCA)