### PR TITLE
PLANET-5606 Center search buttons svg icons

### DIFF
--- a/assets/src/scss/pages/search/_filter-sidebar.scss
+++ b/assets/src/scss/pages/search/_filter-sidebar.scss
@@ -144,6 +144,11 @@
       padding: 0 $n10;
       color: $white;
 
+      svg {
+        margin-right: 4px;
+        vertical-align: baseline;
+      }
+
       &:hover {
         color: $grey-80;
         cursor: pointer;

--- a/assets/src/scss/pages/search/_search-bar.scss
+++ b/assets/src/scss/pages/search/_search-bar.scss
@@ -25,9 +25,25 @@
     font-size: $font-size-sm;
     line-height: 2.75;
 
+    svg {
+      margin-right: 4px;
+      vertical-align: baseline;
+    }
+
+    // We need this margin exception for tablets because otherwise the button moves to 2 lines.
+    @include medium-and-up {
+      svg {
+        margin-right: 0;
+      }
+    }
+
     @include large-and-up {
       margin-top: 2px;
       line-height: 3;
+
+      svg {
+        margin-right: 4px;
+      }
     }
 
     i {


### PR DESCRIPTION
### Description
See https://jira.greenpeace.org/browse/PLANET-5606

In addition to centering the icons, in the comments of the ticket there was also a request to add a 4px margin between the icons and the text.

### Testing
- Broken version: go to [this page](https://www-dev.greenpeace.org/test-jupiter/?s=&orderby=_score) and check the alignment of the icons in the search button and in the filters button (mobile & tablet only)
- Fixed version: go to [this page](https://www-dev.greenpeace.org/test-phoebe/?s=&orderby=_score) and check the alignment of the icons in the search button and in the filters button (mobile & tablet only)

**Note**: on tablets for the search button we need to remove the 4px margin, because otherwise the button is not wide enough and spreads onto 2 lines