### PR TITLE
PLANET-5325 Take Action boxout A/B test

### DIFF
--- a/assets/src/js/external_links.js
+++ b/assets/src/js/external_links.js
@@ -10,7 +10,7 @@ export const setupExternalLinks = function($) {
       </g>
   </svg>`;
 
-  $('div.page-template a:not(.btn):not(.cover-card-heading), article a:not(.btn)').each(function () {
+  $('div.page-template a:not(.btn):not(.cover-card-heading), article a:not(.btn):not(.cover-card-heading)').each(function () {
     let href = undefined === $(this).attr('href') ? '' : $(this).attr('href');
     if (href != '' && href.indexOf(siteURL) <= -1 && href.length > 0) {
       if ($(this).text().trim().length == 0) {

--- a/assets/src/scss/pages/post/_article-content.scss
+++ b/assets/src/scss/pages/post/_article-content.scss
@@ -1,6 +1,7 @@
 .post-content {
   color: $grey-80;
   margin-bottom: 0;
+  z-index: 3;
 
   .cover-card {
     width: auto;


### PR DESCRIPTION
### Description

See https://jira.greenpeace.org/browse/PLANET-5325

- **Remove external link markup**: we don't want to show the external link markup in Take Action covers, including Take Action boxouts. In order to achieve this, we need to update the selector as Take Action boxouts are only in posts (that don't have the `page-template` class).
- **Update post content z-index value**: this is to prevent the Take Action boxout going under the author block and comment form on mobile (scrolling version)

Related gutenberg-blocks PR: https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/364