### PR TITLE
PLANET-5660 Revert twitter card title url encoding

### DIFF
--- a/templates/blocks/meta_fields.twig
+++ b/templates/blocks/meta_fields.twig
@@ -42,7 +42,7 @@
 
 	<meta name="twitter:card" content="summary_large_image" />
 	<meta name="twitter:site" content="{{ site.name }}" />
-	<meta name="twitter:title" content="{{ og_title|e('html_attr')|url_encode }}">
+	<meta name="twitter:title" content="{{ og_title|e('html_attr')|raw }}">
 	{% if (og_description) %}
 		<meta name="twitter:description" content="{{ og_description|e('html_attr')|raw }}">
 	{% endif %}


### PR DESCRIPTION
[JIRA 5660](https://jira.greenpeace.org/browse/PLANET-5660)

The URL encoding function was added on twitter card title during fixing the [PLANET-5441 ](https://jira.greenpeace.org/browse/PLANET-5441)ticket, but it breaks the twitter cards view and display encoded text as it is.