### PR TITLE
PLANET-5503 Remove hammer and slick CSS and JS resources

### DIFF
--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -691,7 +691,6 @@ class MasterSite extends TimberSite {
 		wp_enqueue_script( 'main' );
 
 		wp_enqueue_script( 'slick', 'https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.9.0/slick.min.js', [], '1.9.0', true );
-		wp_enqueue_script( 'hammer', 'https://cdnjs.cloudflare.com/ajax/libs/hammer.js/2.0.8/hammer.min.js', [], '2.0.8', true );
 	}
 
 	/**

--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -669,7 +669,6 @@ class MasterSite extends TimberSite {
 			[],
 			Loader::theme_file_ver( 'assets/build/bootstrap.min.css' )
 		);
-		wp_enqueue_style( 'slick', 'https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.9.0/slick.min.css', [], '1.9.0' );
 
 		// This loads a linked style file since the relative images paths are outside the build directory.
 		wp_enqueue_style( 'parent-style', $this->theme_dir . '/assets/build/style.min.css', [], $css_creation );
@@ -689,8 +688,6 @@ class MasterSite extends TimberSite {
 		wp_register_script( 'main', $this->theme_dir . '/assets/build/index.js', [ 'jquery', 'cssvarsponyfill' ], $js_creation, true );
 		wp_localize_script( 'main', 'localizations', $localized_variables );
 		wp_enqueue_script( 'main' );
-
-		wp_enqueue_script( 'slick', 'https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.9.0/slick.min.js', [], '1.9.0', true );
 	}
 
 	/**


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5503

* Hammer is only used by a block which also performs this enqueue. (We do need to check if none of the NRO code relies on it being there.)
* Slick is added as a dependency by the blocks plugin, but the only usage it has is currently not working. So we can remove both CSS and JS files of it until we have fixed the usage. We need to merge https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/434 first for that, to remove the dependency. (currently causes failing tests anyway)