### PR TITLE
PLANET-5055 Pinned the ElasticPress Search algorithm to v3.4

### DIFF
--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -195,6 +195,9 @@ class MasterSite extends TimberSite {
 		add_action( 'admin_notices', [ $this, 'show_dashboard_notice' ] );
 		add_action( 'wp_ajax_dismiss_dashboard_notice', [ $this, 'dismiss_dashboard_notice' ] );
 		add_filter( 'timber/twig', [ $this, 'p4_optimize_img_url' ] );
+
+		// Pin the ElasticPress to v3.4 search algorithm.
+		simple_value_filter( 'ep_search_algorithm_version', '3.4' );
 	}
 
 	/**


### PR DESCRIPTION
[JIRA 5055](https://jira.greenpeace.org/browse/PLANET-5055)

The [ElasticPress v3.5](https://github.com/10up/ElasticPress/releases) version includes a revamp of the search algorithm, which probably breaks the backwards compatibility. 

After discussion with @Inwerpsel , we agree on to pin the EP search algorithm to older version (v3.4) and we will test & evaluate the new algorithm changes in separate ticket.

Related PR # [102](https://github.com/greenpeace/planet4-base-fork/pull/102)