### PR TITLE
No ticket - Update admin login button styles

### DIFF
--- a/admin/css/login.css
+++ b/admin/css/login.css
@@ -51,14 +51,21 @@ body.login #login_error, body.login .message, body.login .success {
 }
 
 body.login div#login form#loginform p.submit input#wp-submit {
-  background: #f36d3a;
-  box-shadow: none;
+  background: #f36b35;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, .25);
   text-shadow: none;
-  text-transform: uppercase;
   height: auto;
   border: none;
   color: white;
   padding: 0.5em 40px;
   line-height: 1;
-  border-radius: 0;
+  border-radius: 4px;
+}
+
+body.login div#login form#loginform p.submit input#wp-submit:hover {
+  background: #ee562d;
+}
+
+body.login div#login form#loginform p.submit input#wp-submit:active {
+  background: #dd4a22;
 }


### PR DESCRIPTION
When updating the button styles to make them more consistent with [PLANET-5501](https://jira.greenpeace.org/browse/PLANET-5501) and then [PLANET-5644](https://jira.greenpeace.org/browse/PLANET-5644), we forgot this button in the admin login page 😬 I've also added hover and active styles.

#### Old version:
<img width="337" alt="Screenshot 2020-11-12 at 10 10 40" src="https://user-images.githubusercontent.com/6949075/98919854-a4675e00-24cf-11eb-92a8-26627d3ce6bd.png">

#### New version:
<img width="332" alt="Screenshot 2020-11-12 at 10 35 12" src="https://user-images.githubusercontent.com/6949075/98922478-c6aeab00-24d2-11eb-8581-10a49bcfc724.png">
