### PR TITLE
PLANET-5619 Restrict CF plugin

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -114,6 +114,23 @@ add_action(
 	}
 );
 
+// Ensure no actions trigger a purge everything.
+simple_value_filter( 'cloudflare_purge_everything_actions', [] );
+// Remove the menu item to the Cloudflare page.
+add_action(
+	'admin_menu',
+	function () {
+		remove_submenu_page( 'options-general.php', 'cloudflare' );
+	}
+);
+// remove_submenu_page does not prevent accessing the page. Add a higher prio action that dies instead.
+add_action(
+	'settings_page_cloudflare',
+	function () {
+		die( 'This page is blocked to prevent excessive cache purging.' );
+	},
+	1
+);
 
 require_once 'load-class-aliases.php';
 


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5619

* Remove any actions that would trigger a full purge.
* Remove settings page. 1) from the menu 2) because removing from menu
still leaves the page accessible, add a function to the same action with
a higher priority.

Deploying it now on a test instances without the CF plugin first as we'll probably do that for prod too.

I'm currently verifying if the plugin will function correctly by just putting the right credentials into `wp_options` (likely it will).