### PR TITLE
Combine g fonts

### DIFF
--- a/templates/google-fonts.twig
+++ b/templates/google-fonts.twig
@@ -1,0 +1,1 @@
+https://fonts.googleapis.com/css?family=Roboto:300,400,500,700,900|Lora:400,400i,700&display=swap&subset=latin-ext

--- a/templates/html-header.twig
+++ b/templates/html-header.twig
@@ -79,10 +79,8 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 	<meta name="robots" content="max-snippet:-1, max-image-preview:large, max-video-preview:-1">
 	<link rel="shortcut icon" type="image/ico" href="{{ theme.uri }}/favicon.ico"/>
-	<link rel="preload" as="style" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700,900&display=swap"/>
-	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700,900&display=swap"/>
-	<link rel="preload" as="style" href="https://fonts.googleapis.com/css?family=Lora:400,400i,700&subset=latin-ext&display=swap"/>
-	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lora:400,400i,700&subset=latin-ext&display=swap"/>
+	<link rel="preload" as="style" href="{% include 'google-fonts.twig' %}"/>
+	<link rel="stylesheet" href="{% include 'google-fonts.twig' %}"/>
 
 	{% if hreflang %}
 		<!-- hreflang metadata -->


### PR DESCRIPTION
Quick win is to combine both requests, which should produce the same result.

~~I'm still sorting out whether we need the `?subset=latin-ext` query parameter, which was only on one of the two fonts.~~ It's ignored for most browsers, they get all subsets anyway as they're able to figure out which one they need to fetch. But for browsers without that capability it is still needed, Google fonts then will only serve the subset. see https://github.com/google/fonts/issues/113