### PR TITLE
Add custom selector config

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -64,7 +64,9 @@
     "selector-pseudo-class-case": "lower",
     "selector-pseudo-element-case": "lower",
     "selector-type-case": "lower",
-    "selector-type-no-unknown": true,
+    "selector-type-no-unknown": [true, {
+       "ignoreTypes": ["/^--[a-z]\\w*(--?[a-z0-9]+)*--$/"]
+    }],
     "selector-max-empty-lines": 0,
 
     "rule-empty-line-before": ["always", {"except": ["first-nested", "after-single-line-comment"]}],


### PR DESCRIPTION
Forgot to include this in the previous PR, like in the blocks plugin https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/410/files#diff-a3f38f2cae79a3819f93ff1a9d4cd281cbe8f95696e14a29864f08796d3dc568R67