### PR TITLE
PLANET-5619 Command to update CF key from config

### DIFF
--- a/src/Loader.php
+++ b/src/Loader.php
@@ -154,11 +154,32 @@ final class Loader {
 			return;
 		}
 
-		$command = static function ( $args, $assoc_args ) {
+		$activator_command = static function ( $args, $assoc_args ) {
 			Activator::run();
 		};
+		WP_CLI::add_command( 'p4-run-activator', $activator_command );
 
-		WP_CLI::add_command( 'p4-run-activator', $command );
+		/**
+		 * Put the CF API key into the options table, where the CF plugin uses it from.
+		 */
+		$put_cf_key_in_db = static function ( $args ) {
+			$hostname = $args[0];
+			if ( empty( $hostname ) ) {
+				WP_CLI::error( 'Please specify the hostname.' );
+			}
+
+			if ( ! defined( 'CLOUDFLARE_API_KEY' ) || empty( CLOUDFLARE_API_KEY ) ) {
+				WP_CLI::error( 'CLOUDFLARE_API_KEY constant is not set.' );
+			}
+
+			$domain_parts = explode( '.', $hostname );
+
+			$root_domain = implode( '.', array_slice( $domain_parts, - 2 ) );
+			update_option( 'cloudflare_api_key', CLOUDFLARE_API_KEY );
+			update_option( 'automatic_platform_optimization', [ 'value' => 1 ] );
+			update_option( 'cloudflare_cached_domain_name', $root_domain );
+		};
+		WP_CLI::add_command( 'p4-cf-key-in-db', $put_cf_key_in_db );
 	}
 
 	/**


### PR DESCRIPTION
The Cloudflare plugin uses this key from the db. We'll put it in wp-config during deploy (https://github.com/greenpeace/planet4-builder/pull/62 https://github.com/greenpeace/planet4-helm-wordpress/pull/13/files), so that it can be put into the db in a post deploy script (https://github.com/greenpeace/planet4-base-fork/pull/104/files) which uses the command introduced in this PR.