### PR TITLE
PLANET-4861 Adjust search sorting options

### DIFF
--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -78,13 +78,17 @@ class MasterSite extends TimberSite {
 		$this->theme_dir        = get_template_directory_uri();
 		$this->theme_images_dir = $this->theme_dir . '/images/';
 		$this->sort_options     = [
-			'_score'    => [
+			'_score'        => [
 				'name'  => __( 'Most relevant', 'planet4-master-theme' ),
 				'order' => 'DESC',
 			],
-			'post_date' => [
-				'name'  => __( 'Most recent', 'planet4-master-theme' ),
+			'post_date'     => [
+				'name'  => __( 'Newest', 'planet4-master-theme' ),
 				'order' => 'DESC',
+			],
+			'post_date_asc' => [
+				'name'  => __( 'Oldest', 'planet4-master-theme' ),
+				'order' => 'ASC',
 			],
 		];
 	}

--- a/src/Search.php
+++ b/src/Search.php
@@ -509,7 +509,8 @@ abstract class Search {
 
 		if ( $selected_sort && self::DEFAULT_SORT !== $selected_sort ) {
 			$args['orderby'] = 'date';
-			$args['order']   = 'desc';
+			// Order by post_date = Newest[desc]/Oldest[asc].
+			$args['order'] = 'post_date' === $selected_sort ? 'desc' : 'asc';
 		}
 
 		$args['search_fields'] = [
@@ -695,13 +696,17 @@ abstract class Search {
 		$context['found_posts']   = $this->total_matches;
 		$context['page_category'] = 'Search Page';
 		$context['sort_options']  = [
-			'_score'    => [
+			'_score'        => [
 				'name'  => __( 'Most relevant', 'planet4-master-theme' ),
 				'order' => 'DESC',
 			],
-			'post_date' => [
-				'name'  => __( 'Most recent', 'planet4-master-theme' ),
+			'post_date'     => [
+				'name'  => __( 'Newest', 'planet4-master-theme' ),
 				'order' => 'DESC',
+			],
+			'post_date_asc' => [
+				'name'  => __( 'Oldest', 'planet4-master-theme' ),
+				'order' => 'ASC',
 			],
 		];
 

--- a/templates/search.twig
+++ b/templates/search.twig
@@ -341,12 +341,12 @@
 										name="select_order"
 										data-ga-category="Search Page"
 										data-ga-action="Sort By Filter"
-										data-ga-label="{{ ( selected_sort == '_score' ) ? 'Most Recent' : 'Most Relevant' }}">
+										data-ga-label="{% if selected_sort == '_score' %}Most Relevant{% elseif selected_sort == 'post_date' %}Newest{% else %}Oldest{% endif %}">
 									{% for key, sort_option in sort_options %}
 										{% if key == selected_sort %}
 											<option value="{{ key }}" {{ not search_query and key == '_score' ? 'disabled' : 'selected' }}>{{ __( sort_option.name, 'planet4-master-theme' ) }}</option>
 										{% else %}
-											<option value="{{ key }}">{{ __( sort_option.name, 'planet4-master-theme' ) }}</option>
+											<option value="{{ key }}" {{ not search_query and key == '_score' ? 'disabled' : '' }}>{{ __( sort_option.name, 'planet4-master-theme' ) }}</option>
 										{% endif %}
 									{% endfor %}
 								</select>


### PR DESCRIPTION
[JIRA 4861](https://jira.greenpeace.org/browse/PLANET-4861)

Tasks : 
- Added a new sort option called "Oldest"
- Renamed option "Most recent" as "Newest"
- Make new sort option translatable
- Make sure that archived content should be sorted

Testing :
- Open [P4 search page](https://www.planet4.test/?s=&orderby=_score)
- Toggle between new sort options in "Sort by" dropdown
- The content will be sort as per newly added sort options( Oldest = Sort by post_date ASC, Newest = Sort by post_date DESC)
- To test the archived content, make sure the "Include archived content in search for" setting is enabled from backend(Admin >> Planet4 >> Search content)
