### PR TITLE
Remove preload and line break in href

### DIFF
--- a/templates/google-fonts.twig
+++ b/templates/google-fonts.twig
@@ -1,1 +1,0 @@
-https://fonts.googleapis.com/css?family=Roboto:300,400,500,700,900|Lora:400,400i,700&display=swap&subset=latin-ext

--- a/templates/html-header.twig
+++ b/templates/html-header.twig
@@ -79,8 +79,7 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 	<meta name="robots" content="max-snippet:-1, max-image-preview:large, max-video-preview:-1">
 	<link rel="shortcut icon" type="image/ico" href="{{ theme.uri }}/favicon.ico"/>
-	<link rel="preload" as="style" href="{% include 'google-fonts.twig' %}"/>
-	<link rel="stylesheet" href="{% include 'google-fonts.twig' %}"/>
+	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700,900|Lora:400,400i,700&display=swap&subset=latin-ext"/>
 
 	{% if hreflang %}
 		<!-- hreflang metadata -->


### PR DESCRIPTION
* This line break caused an issue with Cloudflare's APO, which inlines
Google Fonts for better performance. They clearly didn't expect a
newline in there and did a bad request to Google resulting in a 400.
Cloudflare then proceeded to include that 400 response in the page, as
though it was the expected styles. This meant a html document was inside
of a style tag in the head, breaking the site very badly.
* Remove preload as APO doesn't remove it when inlining the google fonts
response.