### PR TITLE
PLANET-5726 Hide password protected content on post listing & search page

### DIFF
--- a/author.php
+++ b/author.php
@@ -22,6 +22,7 @@ $post_args = [
 	'paged'          => 1,
 	'meta_key'       => 'p4_author_override',
 	'meta_compare'   => 'NOT EXISTS',
+	'has_password'   => false,  // Skip password protected content.
 ];
 
 if ( isset( $wp_query->query_vars['author'] ) ) {

--- a/category.php
+++ b/category.php
@@ -22,6 +22,7 @@ $post_args = [
 	'posts_per_page' => 10,
 	'post_type'      => 'post',
 	'paged'          => 1,
+	'has_password'   => false,  // Skip password protected content.
 ];
 
 $context['dummy_thumbnail'] = get_template_directory_uri() . '/images/dummy-thumbnail.png';

--- a/src/Search.php
+++ b/src/Search.php
@@ -450,6 +450,7 @@ abstract class Search {
 			'no_found_rows'  => true,
 			'post_type'      => self::get_post_types(),
 			'post_status'    => [ 'publish', 'inherit' ],
+			'has_password'   => false,  // Skip password protected content.
 		];
 
 		if ( $paged > 1 ) {

--- a/src/Search.php
+++ b/src/Search.php
@@ -236,6 +236,12 @@ abstract class Search {
 			10,
 			1
 		);
+		add_filter(
+			'ep_post_query_db_args',
+			[ self::class, 'hide_password_protected_content' ],
+			10,
+			1
+		);
 	}
 
 
@@ -1134,6 +1140,19 @@ abstract class Search {
 		);
 
 		$args['post__not_in'] = $unwanted_attachment_ids;
+
+		return $args;
+	}
+
+	/**
+	 * Exclude password protected content from ElasticPress sync.
+	 *
+	 * @param mixed[] $args The args ElasticPress will use to fetch the ids of posts that will be synced.
+	 *
+	 * @return mixed The args with exclusion of password protected content.
+	 */
+	public static function hide_password_protected_content( $args ) {
+		$args['has_password'] = false;
 
 		return $args;
 	}

--- a/taxonomy.php
+++ b/taxonomy.php
@@ -24,6 +24,7 @@ $post_args = [
 	'post_type'      => 'post',
 	'paged'          => 1,
 	'p4-page-type'   => $context['taxonomy']->slug,
+	'has_password'   => false,  // Skip password protected content.
 ];
 
 $context['page_category']   = 'Post Type Page';


### PR DESCRIPTION
[JIRA 5726](https://jira.greenpeace.org/browse/PLANET-5726)

**Task** -
- Hide password protected content from post listing pages like taxonomy, author, p4 post type pages etc
- Hide password protected content from search result page

**Blocker** -
 - ~~The elasticPress plugin won’t provide option/support to hide password protected content from search result(quite surprising)~~

I found some discussion and open PR which offer the solution , but it will take time to get approval and merging -
- https://github.com/10up/ElasticPress/pull/1789
- https://github.com/10up/ElasticPress/pull/1913

~~Till the time we could consider some temporary solution-~~
- ~~We already have a meta field check which skip the posts from search result ( `p4_do_not_index` [meta field](https://github.com/greenpeace/planet4-master-theme/blob/master/src/Search.php#L463))~~

~~Any suggestions or if I miss something~~

The solution suggested by @Inwerpsel works like a charm. Thanks 🚀 



