### PR TITLE
Split fonts as CF crashes on combined url

### DIFF
--- a/templates/html-header.twig
+++ b/templates/html-header.twig
@@ -79,7 +79,8 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 	<meta name="robots" content="max-snippet:-1, max-image-preview:large, max-video-preview:-1">
 	<link rel="shortcut icon" type="image/ico" href="{{ theme.uri }}/favicon.ico"/>
-	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700,900|Lora:400,400i,700&display=swap&subset=latin-ext"/>
+	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700,900&display=swap&subset=latin-ext"/>
+	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lora:400,400i,700&display=swap&subset=latin-ext"/>
 
 	{% if hreflang %}
 		<!-- hreflang metadata -->


### PR DESCRIPTION
Turns out the line break was not the culprit. Instead APO is not handling google fonts links that specify multiple fonts in a single request correctly. We can split these up as they will be inlined anyway, instead of waiting for their fix.