### PR TITLE
PLANET-5773: CSL iframe not loading on posts

### DIFF
--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -595,7 +595,9 @@ class MasterSite extends TimberSite {
 		];
 
 		$allowedposttags['script'] = [
-			'src' => true,
+			'src'    => true,
+			'id'     => true,
+			'data-*' => true,
 		];
 
 		// Allow source tag for WordPress audio shortcode to function.


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5773

> it seems as though CSL iframes work fine on page but not on posts.

## Problem

[ControlShiftLabs iframe script](https://support.controlshiftlabs.com/hc/en-us/articles/204104308-Embeddable-Petition-Signature-Forms) relies on attributes `id` and `data-petition-url` to insert its form, as seen in its minified version: `function loadIframe(){var e=document.getElementById("controlsfhift-embed-sign-form-script")`.

We [filter a post content](https://github.com/greenpeace/planet4-master-theme/blob/700bf73ff32d472f578556491459c22599379a04/templates/single.twig#L95) before display in a certain way, that is [not applied to pages](https://github.com/greenpeace/planet4-master-theme/blob/700bf73ff32d472f578556491459c22599379a04/templates/page.twig#L5), and strips those attrributes.

Allowlisting those attributes will make CSL script work.

## Fix

- Adding `id` and `data-*` to the list of attributes allowed for a `script` tag

## Test

- Insert an HTML block with the following content:
```html
<script src="https://demo.controlshiftlabs.com/assets/embed_sign_form.js" id="controlsfhift-embed-sign-form-script" data-petition-url="https://gpfood.controlshiftlabs.com/petitions/save-the-sea-turtles/embed"></script>
```
- On a page it works, on a post it generates a console error, attributes are stripped.
- On this branch, the code works for pages and posts.
