### PR TITLE
PLANET-5162 Fix author override value in RSS feed

### DIFF
--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -201,6 +201,21 @@ class MasterSite extends TimberSite {
 
 		// Pin the ElasticPress to v3.4 search algorithm.
 		simple_value_filter( 'ep_search_algorithm_version', '3.4' );
+
+		// Update P4 author override value in RSS feed.
+		add_filter(
+			'the_author',
+			function ( $post_author ) {
+				if ( is_feed() ) {
+					global $post;
+					$author_override = get_post_meta( $post->ID, 'p4_author_override', true );
+					if ( '' !== $author_override ) {
+						$post_author = $author_override;
+					}
+				}
+				return $post_author;
+			}
+		);
 	}
 
 	/**


### PR DESCRIPTION
Ref: [JIRA 5162](https://jira.greenpeace.org/browse/PLANET-5162)

---
**Issue :**
- The RSS feed not showing the author override value in place of author name (`dc:creator`) in RSS feed.

**Testing:**
- Add post with author override value
- After checkout of this branch goto RSS feed link(https://www.planet4.test/feed/)
- The post feed will show the author override value at author name