### PR TITLE
PLANET-5386 Force only related videos of channel

### DIFF
--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -1019,14 +1019,20 @@ class MasterSite extends TimberSite {
 	 * @see https://developer.wordpress.org/reference/hooks/embed_oembed_html/
 	 *
 	 * @param mixed  $cache The cached HTML result, stored in post meta.
-	 * @param string $url   The attempted embed URL.
+	 * @param string $url The attempted embed URL.
 	 *
 	 * @return mixed
 	 */
 	public function filter_youtube_oembed_nocookie( $cache, $url ) {
 		if ( ! empty( $url ) ) {
 			if ( strpos( $url, 'youtube.com' ) !== false || strpos( $url, 'youtu.be' ) !== false ) {
-				$cache = str_replace( 'youtube.com', 'youtube-nocookie.com', $cache );
+
+				$replacements = [
+					'youtube.com'    => 'youtube-nocookie.com',
+					'feature=oembed' => 'feature=oembed&rel=0',
+				];
+
+				$cache = str_replace( array_keys( $replacements ), array_values( $replacements ), $cache );
 			}
 		}
 


### PR DESCRIPTION
We need to add `rel=0` query parameter to the iframe url. This is done in the same way as the youtube-nocookie, on the embed html response.

For now this uses a somewhat shaky method of adding this, by relying on the `feature=oembed`query parameter being there. Checking if there is a better way, but I guess there's no risk proceeding with this in the meanwhile if it turns out to be tricky?

Ref: https://jira.greenpeace.org/browse/PLANET-5386