### PR TITLE
PLANET-5654: WP_Block_Type_Registry::register was called incorrectly

### DIFF
--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -195,7 +195,7 @@ class MasterSite extends TimberSite {
 		add_action( 'init', [ $this, 'login_redirect' ], 1 );
 		add_filter( 'attachment_fields_to_edit', [ $this, 'add_image_attachment_fields_to_edit' ], 10, 2 );
 		add_filter( 'attachment_fields_to_save', [ $this, 'add_image_attachment_fields_to_save' ], 10, 2 );
-		add_action( 'init', [ $this, 'p4_register_core_image_block' ] );
+		add_filter( 'register_block_type_args', [ $this, 'register_core_blocks_callback' ] );
 		add_action( 'admin_notices', [ $this, 'show_dashboard_notice' ] );
 		add_action( 'wp_ajax_dismiss_dashboard_notice', [ $this, 'dismiss_dashboard_notice' ] );
 
@@ -1122,12 +1122,17 @@ class MasterSite extends TimberSite {
 
 	/**
 	 * Add callback function to Gutenberg core/image block.
+	 *
+	 * @param array $args Parameters given during block register.
+	 *
+	 * @return array Parameters of the block.
 	 */
-	public function p4_register_core_image_block() {
-		register_block_type(
-			'core/image',
-			[ 'render_callback' => [ $this, 'p4_core_image_block_render' ] ]
-		);
+	public function register_core_blocks_callback( array $args ): array {
+		if ( 'core/image' === $args['name'] ) {
+			$args['render_callback'] = [ $this, 'p4_core_image_block_render' ];
+		}
+
+		return $args;
 	}
 
 	/**

--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -195,7 +195,9 @@ class MasterSite extends TimberSite {
 		add_action( 'init', [ $this, 'login_redirect' ], 1 );
 		add_filter( 'attachment_fields_to_edit', [ $this, 'add_image_attachment_fields_to_edit' ], 10, 2 );
 		add_filter( 'attachment_fields_to_save', [ $this, 'add_image_attachment_fields_to_save' ], 10, 2 );
-		add_filter( 'register_block_type_args', [ $this, 'register_core_blocks_callback' ] );
+		version_compare( get_bloginfo( 'version' ), '5.5', '<' )
+			? add_action( 'init', [ $this, 'p4_register_core_image_block' ] )
+			: add_filter( 'register_block_type_args', [ $this, 'register_core_blocks_callback' ] );
 		add_action( 'admin_notices', [ $this, 'show_dashboard_notice' ] );
 		add_action( 'wp_ajax_dismiss_dashboard_notice', [ $this, 'dismiss_dashboard_notice' ] );
 
@@ -1118,6 +1120,16 @@ class MasterSite extends TimberSite {
 		}
 
 		return $content;
+	}
+
+	/**
+	 * Add callback function to Gutenberg core/image block.
+	 */
+	public function p4_register_core_image_block() {
+		register_block_type(
+			'core/image',
+			[ 'render_callback' => [ $this, 'p4_core_image_block_render' ] ]
+		);
 	}
 
 	/**


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5654

## Problem

`register_block_type('core/image')` is called twice, first by WP, then by us to add a render callback. This triggers an error WP >= 5.5.

## Fix

Fix by hooking to the `register_block_type_args` which allows to modify block type args at register, including `render_callback`.
~The fix also works for WP < 5.5~ <sub>no it does not</sub> 
Added a version compare to use this fix only on versions >= 5.5

## Test

The render callback we add is used to add credits to images caption.
- Add an image in a post. The image has to have something in the _Credit_ field of the Attachment details.
- The credit appears at the end of the image caption on the frontend.

![Screenshot from 2020-12-10 20-11-15](https://user-images.githubusercontent.com/617346/101889060-42b61480-3b9f-11eb-9bfc-9460221d0527.png)

