### PR TITLE
PLANET-5774 Replace OG description field type from wysiwyg to textarea, strip OG desc

### DIFF
--- a/src/MetaboxRegister.php
+++ b/src/MetaboxRegister.php
@@ -236,14 +236,10 @@ class MetaboxRegister {
 
 		$p4_open_graph->add_field(
 			[
-				'name'    => __( 'Description', 'planet4-master-theme-backend' ),
-				'desc'    => __( 'Enter description if you want to override the open graph description', 'planet4-master-theme-backend' ),
-				'id'      => 'p4_og_description',
-				'type'    => 'wysiwyg',
-				'options' => [
-					'media_buttons' => false,
-					'textarea_rows' => 5,
-				],
+				'name' => __( 'Description', 'planet4-master-theme-backend' ),
+				'desc' => __( 'Enter description if you want to override the open graph description', 'planet4-master-theme-backend' ),
+				'id'   => 'p4_og_description',
+				'type' => 'textarea_small',
 			]
 		);
 

--- a/src/Post.php
+++ b/src/Post.php
@@ -313,7 +313,7 @@ class Post extends TimberPost {
 			return $this->post_excerpt;
 		}
 
-		return $og_desc;
+		return wp_strip_all_tags( $og_desc );
 	}
 
 	/**
@@ -363,7 +363,7 @@ class Post extends TimberPost {
 
 		return [
 			'title'       => $og_title,
-			'description' => $og_description,
+			'description' => wp_strip_all_tags( $og_description ),
 			'link'        => $link,
 		];
 	}

--- a/tests/test-open-graph.php
+++ b/tests/test-open-graph.php
@@ -53,7 +53,7 @@ class OpenGraphTest extends P4_TestCase {
 		$this->assertHasElementWithAttributes(
 			[
 				'property' => 'og:description',
-				'content'  => $post_data['meta_input']['p4_og_description'],
+				'content'  => wp_strip_all_tags( $post_data['meta_input']['p4_og_description'] ),
 			],
 			$output,
 			'Did not find og:description meta.'
@@ -158,7 +158,20 @@ class OpenGraphTest extends P4_TestCase {
 				],
 				'page.php',
 			],
-
+			// Test html tags in OG description.
+			[
+				[
+					'post_type'    => 'page',
+					'post_title'   => 'The name of the place is Babylon',
+					'post_name'    => 'test-social-url',
+					'post_content' => 'test content',
+					'meta_input'   => [
+						'p4_og_title'       => 'Custom open graph title',
+						'p4_og_description' => '<p>Custom open graph description</p>',
+					],
+				],
+				'page.php',
+			],
 		];
 	}
 


### PR DESCRIPTION

Ref: [JIRA 5774](https://jira.greenpeace.org/browse/PLANET-5774)

---

**Task:**
- Strip OG description field data
- Replace the OG description field type in backend from TinyMEC to textarea
- Update open graph unit test for strip tags

**Testing:**
- Login to [nix-test](https://www-dev.greenpeace.org/test-nix/admin) instance
- Add/edit page/post/campaign, the OG description field on page will display as textarea
- Check OG description field in page source, if the existing content have a html tags in description field, that will be strip before display on frontend.

eg. https://www-dev.greenpeace.org/test-nix/campaign/beskidt-palmeolie-truer-regnskoven/

Related PR : https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/466