### PR TITLE
PLANET-5759 Remove unused img_align script

### DIFF
--- a/assets/src/js/app.js
+++ b/assets/src/js/app.js
@@ -3,7 +3,6 @@ import { setupCommentsAnchor } from './comments_anchor';
 import { setupCountrySelect } from './country_select';
 import { setImageTitlesFromAltText } from './global';
 import { setupHeader } from './header';
-import { setupImageAlign } from './img_align';
 import { setupLoadMore } from './load_more';
 import { setupPDFIcon } from './pdf_icon';
 import { setupSearch } from './search';
@@ -28,7 +27,6 @@ jQuery(function($) {
   setupCountrySelect($);
   setImageTitlesFromAltText($);
   setupHeader($);
-  setupImageAlign($);
   setupLoadMore($);
   setupPDFIcon($);
   setupSearch($);

--- a/assets/src/js/img_align.js
+++ b/assets/src/js/img_align.js
@@ -1,8 +1,0 @@
-export const setupImageAlign = function($) {
-  'use strict';
-
-  $('div.wp-caption[class*="align"]').each( function() {
-    const imgwidth = $(this).find('img').attr('width');
-    $(this).css('cssText', 'width: ' + imgwidth +'px !important;');
-  });
-};


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5759

---

This one seems unused. `wp-caption` was probably a default WP class in the pro-Gutenberg era.