### PR TITLE
PLANET-5782: Restore the P4 message board after the Holiday party announcement

### DIFF
--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -2,6 +2,7 @@
 
 namespace P4\MasterTheme;
 
+use DateTimeImmutable;
 use Timber\Timber;
 use Timber\Site as TimberSite;
 use Timber\Menu as TimberMenu;
@@ -1195,21 +1196,50 @@ class MasterSite extends TimberSite {
 	 * Version number DASHBOARD_MESSAGE_VERSION has to be incremented
 	 * each time we add a new message.
 	 *
+	 * @todo Remove party message after over_date (PLANET-5782).
+	 *
 	 * @return string
 	 */
 	private function p4_message(): string {
-		return '<style>#p4-notice li { list-style: disc; margin-left: 3em; }</style>
-		<h2>Time for the P4 Community to PAAARTTYYYY 🥳 🥳 🥳</h2>
-		<p>There’s already an invite in your calendars for <b>Friday, December 18th</b>
-		   at 3pm GMT / 4pm CET / 10pm Bangkok / 12am Tokyo / 9am Mexico DF / 10 am NY / 12pm Sao Paulo - B. Aires,
-		   but please shout in <a href="https://greenpeace.slack.com/archives/C014UMRC4AJ" target="_blank">#p4-general</a> if you did not get the invite!</p>
-		<p>Please join us (and invite others in your NRO/team) with your favourite drinks for games, dances and laughs (but <em>no work talks</em>)
-			<ul>
-				<li>🧞‍♀️🧞‍♂️ Dressing up is encouraged! Most awesome costumes will get prizes</li>
-				<li>🎶 <a href="https://www.youtube.com/playlist?list=PLRWtdTW6NaMUAxoBmV1baj7CStIIhuXtc&jct=DoU-zKSovfpKY5InMOOQTOiYwM6p7g" target="_blank">Here\'s a YouTube playlist for everyone to add their favourite songs</a></li>
-			</ul>
-		</p>
-		<p>☮️  🥂 💚</p>';
+		$now           = new \DateTimeImmutable();
+		$over_date     = new \DateTimeImmutable( '2020-12-19' );
+		$party_is_over = $now >= $over_date;
+
+		if ( ! $party_is_over ) {
+			return '<style>#p4-notice li { list-style: disc; margin-left: 3em; }</style>
+				<h2>Time for the P4 Community to PAAARTTYYYY 🥳 🥳 🥳</h2>
+				<p>There’s already an invite in your calendars for <b>Friday, December 18th</b>
+				at 3pm GMT / 4pm CET / 10pm Bangkok / 12am Tokyo / 9am Mexico DF / 10 am NY / 12pm Sao Paulo - B. Aires,
+				but please shout in <a href="https://greenpeace.slack.com/archives/C014UMRC4AJ" target="_blank">#p4-general</a> if you did not get the invite!</p>
+				<p>Please join us (and invite others in your NRO/team) with your favourite drinks for games, dances and laughs (but <em>no work talks</em>)
+					<ul>
+						<li>🧞‍♀️🧞‍♂️ Dressing up is encouraged! Most awesome costumes will get prizes</li>
+						<li>🎶 <a href="https://www.youtube.com/playlist?list=PLRWtdTW6NaMUAxoBmV1baj7CStIIhuXtc&jct=DoU-zKSovfpKY5InMOOQTOiYwM6p7g" target="_blank">Here\'s a YouTube playlist for everyone to add their favourite songs</a></li>
+					</ul>
+				</p>
+				<p>☮️  🥂 💚</p>';
+		}
+
+		return '<h2>Welcome to the new P4 message board!</h2>
+			<p>Did you already join the community on Slack? Here\'s the Planet 4 channels waiting for you in the Global Workspace 👇
+				<ul>
+					<li><span style="margin-right: 3px;">
+						<a href="https://greenpeace.slack.com/archives/C014UMRC4AJ">#p4-general</a> 🌏</span>
+						to learn, ask and share about P4, connect with the community and stay on top of all P4 news</li>
+					<li><span style="margin-right: 3px;">
+						<a href="https://greenpeace.slack.com/archives/C0151L0KKNX">#p4-dev</a> 🚀</span>
+						for all coders, engineers and techies</li>
+					<li><span style="margin-right: 3px;">
+						<a href="https://greenpeace.slack.com/archives/C015E2TGLCR">#p4-design</a> 🎨</span>
+						for all artists, creatives and visual wonders</li>
+					<li><span style="margin-right: 3px;">
+						<a href="https://greenpeace.slack.com/archives/C01672QUA0Z">#web-analytics</a> 📊</span>
+						for all data ninjas</li>
+					<li><span style="margin-right: 3px;">
+						<a href="https://greenpeace.slack.com/archives/C014UMRD3T8">#p4-infra</a> ⚙️</span>
+						for all Matrix architects</li>
+				</ul>
+			</p>';
 	}
 
 	/**


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5782

> Once the Holiday party is over (December 18th), we should put back the original message  (well, slightly adjusted)

## Fix 

Made the message time dependent, as we might not deploy anything during the holidays.

## Test

You can play with the `over_date` locally to see the dashboard message change, if `over_date` is in the past.

- Before `over_date`: Party message
- Starting on `over_date`: Regular slack message
