### PR TITLE
PLANET-5748 Add password validation message on password protected page

### DIFF
--- a/assets/src/scss/pages/_page.scss
+++ b/assets/src/scss/pages/_page.scss
@@ -84,3 +84,13 @@ div.page-template {
     }
   }
 }
+
+.error-message {
+  color: $orange-hover;
+}
+
+.password-field {
+  padding-top: $space-xs;
+  padding-bottom: $space-xs;
+  margin-bottom: $space-xs;
+}

--- a/page.php
+++ b/page.php
@@ -70,6 +70,9 @@ $context['custom_body_classes'] = 'brown-bg ';
 
 if ( post_password_required( $post->ID ) ) {
 
+	// Password protected form validation.
+	$context['is_password_valid'] = $post->is_password_valid();
+
 	// Hide the page title from links to the extra feeds.
 	remove_action( 'wp_head', 'feed_links_extra', 3 );
 

--- a/single-campaign.php
+++ b/single-campaign.php
@@ -117,6 +117,9 @@ foreach ( range( 1, 5 ) as $i ) {
 
 if ( post_password_required( $post->ID ) ) {
 
+	// Password protected form validation.
+	$context['is_password_valid'] = $post->is_password_valid();
+
 	// Hide the campaign title from links to the extra feeds.
 	remove_action( 'wp_head', 'feed_links_extra', 3 );
 

--- a/single.php
+++ b/single.php
@@ -130,6 +130,9 @@ $context['post_comments_count'] = get_comments(
 
 if ( post_password_required( $post->ID ) ) {
 
+	// Password protected form validation.
+	$context['is_password_valid'] = $post->is_password_valid();
+
 	// Hide the post title from links to the extra feeds.
 	remove_action( 'wp_head', 'feed_links_extra', 3 );
 

--- a/templates/single-page.twig
+++ b/templates/single-page.twig
@@ -5,15 +5,19 @@
 		<div class="page-header-background"></div>
 	</div>
 
-	<div class="page-template {% if hide_page_title_checkbox == 'on' %}no-page-title{% endif %}">
+	<div class="page-template">
 
-		<form id="password-form" class="mb-5" action="{{login_url}}?action=postpass" method="post">
-			<div class="form-group">
-				<label for="pwbox-{{post.ID}}"><h6>{{ __( 'To see the content of this page, please enter your password  below', 'planet4-master-theme' ) }}</h6></label>
-				<input class="form-control" name="post_password" id="pwbox-{{post.ID}}" type="password" size="20" maxlength="20">
+		<form id="password-form" class="" action="{{login_url}}?action=postpass" method="post">
+			<div class="mb-3">
+				<label for="pwbox-{{post.ID}}" class="form-label"><h6>{{ __( 'To see the content of this page, please enter your password  below', 'planet4-master-theme' ) }}</h6></label>
+				<div class="col-sm-8">
+					<input class="form-control password-field" name="post_password" id="pwbox-{{post.ID}}" type="password">
+				</div>
+				{% if not is_password_valid %} <span class="error-message">{{ __( 'Sorry, Invalid password.', 'planet4-master-theme' ) }}</span> {% endif %}
 			</div>
-			<button class="btn btn-primary" type="submit">{{ __( 'Submit', 'planet4-master-theme' ) }}</button>
+			<div class="mb-3">
+				<button class="btn btn-primary" type="submit">{{ __( 'Submit', 'planet4-master-theme' ) }}</button>
+			</div>
 		</form>
-
 	</div>
 {% endblock %}

--- a/templates/single-password.twig
+++ b/templates/single-password.twig
@@ -10,17 +10,18 @@
 
 		<div class="container">
 			<div class="post-content">
-				<div class="post-content-lead">
-
-					<form id="password-form" class="mb-5" action="{{login_url}}?action=postpass" method="post">
-						<div class="form-group">
-							<label for="pwbox-{{post.ID}}"><h6>{{ __( 'To see the content of this page, please enter your password  below', 'planet4-master-theme' ) }}</h6></label>
-							<input class="form-control" name="post_password" id="pwbox-{{post.ID}}" type="password" size="20" maxlength="20">
+				<form id="password-form" action="{{login_url}}?action=postpass" method="post">
+					<div class="mb-3">
+						<label for="pwbox-{{post.ID}}" class="form-label"><h6>{{ __( 'To see the content of this page, please enter your password  below', 'planet4-master-theme' ) }}</h6></label>
+						<div class="col-sm-8">
+							<input class="form-control password-field" name="post_password" id="pwbox-{{post.ID}}" type="password">
 						</div>
+						{% if not is_password_valid %} <span class="error-message">{{ __( 'Sorry, Invalid password.', 'planet4-master-theme' ) }}</span> {% endif %}
+					</div>
+					<div class="mb-3">
 						<button class="btn btn-primary" type="submit">{{ __( 'Submit', 'planet4-master-theme' ) }}</button>
-					</form>
-
-				</div>
+					</div>
+				</form>
 			</div>
 		</div>
 


### PR DESCRIPTION
Ref: [JIRA 5748](https://jira.greenpeace.org/browse/PLANET-5748)

---

**Testing steps:**
- Add a page with password protected visibility
- Go to the page on frontend, add wrong password
- It should show wrong password message

**Summary:**
Here I didn’t find a better way than the below one -
- When visitor open a password protected page, check if page url have  a unique hash token? If no add one in URL and redirect to url with hash token
- This token is use to uniquely identify visitor, store and access old cookie password hash from transient cache

In wordpress core, the latest entered password is stored as a secure hash in a cookie named 'wp-postpass_' . COOKIEHASH.
When the password form is called, that cookie has been validated internally by WordPress.

The form validation flow is as per below -

```
<?php
…
$old_cookie = get_transient( 'p4-postpass_' . $custom_hash );
if ( false === $old_cookie ) {
	if ( isset( $_COOKIE[ 'wp-postpass_' . COOKIEHASH ] ) ) {
		$current_cookie = wp_unslash( $_COOKIE[ 'wp-postpass_' . COOKIEHASH ] );
		set_transient( 'p4-postpass_' . $custom_hash, $current_cookie, $expiration = 60 * 5 ); // Transient cache expires in 5 mins.
	}
} else {
	if ( isset( $_COOKIE[ 'wp-postpass_' . COOKIEHASH ] ) ) {
		$current_cookie = wp_unslash( $_COOKIE[ 'wp-postpass_' . COOKIEHASH ] );
		set_transient( 'p4-postpass_' . $custom_hash, $current_cookie, $expiration = 60 * 5 );
		if ( $current_cookie !== $old_cookie ) {
			$context['validation_error'] = __( 'Sorry, Invalide password.', 'planet4-master-theme' );
		}
	}
}
…
?>
```

Previously I also considered different solutions like , 
- Use of new cookie to save old password hash, but that approach fail in some scenario.
- Use session variable to save a old password hash
- Etc.
