### PR TITLE
PLANET-5820 Anti flicker selector insteadof toggle

### DIFF
--- a/assets/src/scss/vendors/_gtm.scss
+++ b/assets/src/scss/vendors/_gtm.scss
@@ -1,3 +1,4 @@
-.async-hide {
+// Hide elements that will be AB-tested until the test is ready.
+.google-optimize-loading .ab-hide {
   opacity: 0 !important;
 }

--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -470,7 +470,7 @@ class MasterSite extends TimberSite {
 		// Do not embed google tag manager js if 'greenpeace' cookie is not set or enforce_cookies_policy setting is not enabled.
 		$context['enforce_cookies_policy'] = isset( $options['enforce_cookies_policy'] ) ? true : false;
 		$context['google_tag_value']       = $options['google_tag_manager_identifier'] ?? '';
-		$context['google_optimizer']       = isset( $options['google_optimizer'] ) ? true : false;
+		$context['ab_hide_selector']       = $options['ab_hide_selector'] ?? null;
 		$context['facebook_page_id']       = $options['facebook_page_id'] ?? '';
 		$context['preconnect_domains']     = [];
 

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -347,6 +347,15 @@ class Settings {
 						'type' => 'checkbox',
 					],
 					[
+						'name' => __( 'AB Hide Selector', 'planet4-master-theme-backend' ),
+						'desc' => __(
+							'When running an AB test it is possible that the original is shown for a short while (called flicker). If this happens you can enter a CSS selector here and matching elements will be hidden until the test is fully loaded.',
+							'planet4-master-theme-backend'
+						),
+						'id'   => 'ab_hide_selector',
+						'type' => 'text',
+					],
+					[
 						'name' => __( 'Local Projects Smartsheet ID', 'planet4-master-theme-backend' ),
 						'desc' => __( 'The smartsheet that is used to get analytics values from local(NRO) smartsheet.', 'planet4-master-theme-backend' ),
 						'id'   => 'analytics_local_smartsheet_id',

--- a/templates/html-header.twig
+++ b/templates/html-header.twig
@@ -7,6 +7,13 @@
 	{% include 'blocks/meta_fields.twig' %}
 
 	{% if google_tag_value %}
+		{% if ab_hide_selector %}
+		<style>
+			.google-optimize-loading {{ ab_hide_selector }} {
+				opacity: 0 !important;
+			}
+		</style>
+		{% endif %}
 		<script>
 			var google_tag_value = '{{ google_tag_value }}';
 
@@ -20,15 +27,11 @@
 				'gPlatform': 'Planet 4'
 			});
 
-			// Needed anti-flicker snippet if Optimizer is enabled
-			var google_optimizer = '{{ google_optimizer }}';
-			if (google_optimizer) {
-				(function(a,s,y,n,c,h,i,d,e){s.className+=' '+y;h.start=1*new Date;
-				h.end=i=function(){s.className=s.className.replace(RegExp(' ?'+y),'')};
-				(a[n]=a[n]||[]).hide=h;setTimeout(function(){i();h.end=null},c);h.timeout=c;
-				})(window,document.documentElement,'async-hide','dataLayer',4000,
-				{'{{ google_tag_value }}':true});
-			}
+			(function(a,s,y,n,c,h,i,d,e){s.className+=' '+y;h.start=1*new Date;
+			h.end=i=function(){s.className=s.className.replace(RegExp(' ?'+y),'')};
+			(a[n]=a[n]||[]).hide=h;setTimeout(function(){i();h.end=null},c);h.timeout=c;
+			})(window,document.documentElement,'google-optimize-loading','dataLayer',4000,
+			{'{{ google_tag_value }}':true});
 
 			{% if not post.password_required %}
 				var cf_campaign_name = '{% if cf_campaign_name is defined and cf_campaign_name is not null %}{{ cf_campaign_name|raw }}{% endif %}';


### PR DESCRIPTION
* The toggle controlled whether to hide everything before the test is
applied, which harmed performance.
* Instead provide an option for a selector that will be hidden before
the test is ready.
* Always run the snippet since we're not hiding anything unless
specifically configured.
* Rename `.async-hide` class to something more accurate.
* Provide `.ab-hide` class which will be hidden while loading.

Ref: https://jira.greenpeace.org/browse/PLANET-5820

Tested and UAT approved on https://www-dev.greenpeace.org/test-deimos . It's set up there with the take action boxout selector, and Julia confirmed that the tests ran succesfully.