### PR TITLE
PLANET-5897: Add HTTP Header class that sends CSP and X-Frame headers

### DIFF
--- a/src/HttpHeaders.php
+++ b/src/HttpHeaders.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace P4\MasterTheme;
+
+/**
+ * Class HttpHeaders
+ */
+class HttpHeaders {
+	/**
+	 * Headers constructor.
+	 */
+	public function __construct() {
+		add_action( 'wp_headers', [ $this, 'send_content_security_policy_header' ], 10, 1 );
+	}
+
+
+	/**
+	 * Send Content Security Policy (CSP) HTTP headers.
+	 */
+	public function send_content_security_policy_header() {
+		$allowed_frame_ancestors = array( '\'self\'' );
+
+		// Filter hook to allow modification of trusted frame ancestors.
+		$modified_allowed_frame_ancestors = apply_filters( 'planet4_csp_allowed_frame_ancestors', $allowed_frame_ancestors );
+
+		if ( ! is_array( $modified_allowed_frame_ancestors ) ) {
+			$modified_allowed_frame_ancestors = $allowed_frame_ancestors;
+		}
+
+		$directives = array(
+			'frame-ancestors' => 'frame-ancestors ' . implode( ' ', $modified_allowed_frame_ancestors )
+		);
+
+		$csp_header = 'Content-Security-Policy: ' . implode( '; ', $directives );
+		$csp_header = preg_replace( "/\r|\n/", "", $csp_header );
+
+		header( $csp_header );
+
+		// In addition, send the "X-Frame-Options" header when no other trusted frame ancestors were added through the filter.
+		if ( $modified_allowed_frame_ancestors === $allowed_frame_ancestors ) {
+			header( 'X-Frame-Options: SAMEORIGIN' );
+		}
+	}
+}

--- a/src/HttpHeaders.php
+++ b/src/HttpHeaders.php
@@ -17,7 +17,7 @@ class HttpHeaders {
 	/**
 	 * Send Content Security Policy (CSP) HTTP headers.
 	 */
-	public function send_content_security_policy_header() {
+	public function send_content_security_policy_header( $headers ): array {
 		$default_allowed_frame_ancestors = [ '\'self\'' ];
 
 		/**
@@ -36,14 +36,16 @@ class HttpHeaders {
 			'frame-ancestors ' . implode( ' ', $allowed_frame_ancestors ),
 		];
 
-		$csp_header = 'Content-Security-Policy: ' . implode( '; ', $directives );
+		$csp_header = implode( '; ', $directives );
 		$csp_header = preg_replace( "/\r|\n/", '', $csp_header );
 
-		header( $csp_header );
+		$headers[ 'Content-Security-Policy' ] = $csp_header;
 
 		// In addition, send the "X-Frame-Options" header when no other trusted frame ancestors were added through the filter.
 		if ( $allowed_frame_ancestors === $default_allowed_frame_ancestors ) {
-			header( 'X-Frame-Options: SAMEORIGIN' );
+			$headers[ 'X-Frame-Options' ] = 'SAMEORIGIN';
 		}
+
+		return $headers;
 	}
 }

--- a/src/HttpHeaders.php
+++ b/src/HttpHeaders.php
@@ -23,7 +23,7 @@ class HttpHeaders {
 		// Filter hook to allow adding trusted frame ancestors.
 		$additional_allowed_frame_ancestors = apply_filters( 'planet4_csp_allowed_frame_ancestors', [] );
 
-		$allowed_frame_ancestors = array_merge($default_allowed_frame_ancestors, (array)$additional_allowed_frame_ancestors);
+		$allowed_frame_ancestors = array_merge( $default_allowed_frame_ancestors, (array) $additional_allowed_frame_ancestors );
 
 		$directives = [
 			'default-src *',

--- a/src/HttpHeaders.php
+++ b/src/HttpHeaders.php
@@ -23,7 +23,9 @@ class HttpHeaders {
 		// Filter hook to allow adding trusted frame ancestors.
 		$additional_allowed_frame_ancestors = apply_filters( 'planet4_csp_allowed_frame_ancestors', [] );
 
-		$allowed_frame_ancestors = array_merge( $default_allowed_frame_ancestors, (array) $additional_allowed_frame_ancestors );
+		if ( is_array( $additional_allowed_frame_ancestors ) ) {
+			$allowed_frame_ancestors = array_merge( $default_allowed_frame_ancestors, $additional_allowed_frame_ancestors );
+		}
 
 		$directives = [
 			'default-src * \'self\' data: \'unsafe-inline\' \'unsafe-eval\'',

--- a/src/HttpHeaders.php
+++ b/src/HttpHeaders.php
@@ -18,14 +18,12 @@ class HttpHeaders {
 	 * Send Content Security Policy (CSP) HTTP headers.
 	 */
 	public function send_content_security_policy_header() {
-		$allowed_frame_ancestors = [ '\'self\'' ];
+		$default_allowed_frame_ancestors = [ '\'self\'' ];
 
-		// Filter hook to allow modification of trusted frame ancestors.
-		$modified_allowed_frame_ancestors = apply_filters( 'planet4_csp_allowed_frame_ancestors', $allowed_frame_ancestors );
+		// Filter hook to allow adding trusted frame ancestors.
+		$additional_allowed_frame_ancestors = apply_filters( 'planet4_csp_allowed_frame_ancestors', [] );
 
-		if ( ! is_array( $modified_allowed_frame_ancestors ) ) {
-			$modified_allowed_frame_ancestors = $allowed_frame_ancestors;
-		}
+		$allowed_frame_ancestors = array_merge($default_allowed_frame_ancestors, (array)$additional_allowed_frame_ancestors);
 
 		$directives = [
 			'default-src *',
@@ -38,7 +36,7 @@ class HttpHeaders {
 		header( $csp_header );
 
 		// In addition, send the "X-Frame-Options" header when no other trusted frame ancestors were added through the filter.
-		if ( $modified_allowed_frame_ancestors === $allowed_frame_ancestors ) {
+		if ( $allowed_frame_ancestors === $default_allowed_frame_ancestors ) {
 			header( 'X-Frame-Options: SAMEORIGIN' );
 		}
 	}

--- a/src/HttpHeaders.php
+++ b/src/HttpHeaders.php
@@ -16,6 +16,8 @@ class HttpHeaders {
 
 	/**
 	 * Send Content Security Policy (CSP) HTTP headers.
+	 *
+	 * @param string[] $headers Associative array of headers to be sent.
 	 */
 	public function send_content_security_policy_header( $headers ): array {
 		$default_allowed_frame_ancestors = [ '\'self\'' ];
@@ -39,11 +41,11 @@ class HttpHeaders {
 		$csp_header = implode( '; ', $directives );
 		$csp_header = preg_replace( "/\r|\n/", '', $csp_header );
 
-		$headers[ 'Content-Security-Policy' ] = $csp_header;
+		$headers['Content-Security-Policy'] = $csp_header;
 
 		// In addition, send the "X-Frame-Options" header when no other trusted frame ancestors were added through the filter.
 		if ( $allowed_frame_ancestors === $default_allowed_frame_ancestors ) {
-			$headers[ 'X-Frame-Options' ] = 'SAMEORIGIN';
+			$headers['X-Frame-Options'] = 'SAMEORIGIN';
 		}
 
 		return $headers;

--- a/src/HttpHeaders.php
+++ b/src/HttpHeaders.php
@@ -26,7 +26,7 @@ class HttpHeaders {
 		$allowed_frame_ancestors = array_merge( $default_allowed_frame_ancestors, (array) $additional_allowed_frame_ancestors );
 
 		$directives = [
-			'default-src *',
+			'default-src * \'self\' data: \'unsafe-inline\' \'unsafe-eval\'',
 			'frame-ancestors ' . implode( ' ', $allowed_frame_ancestors ),
 		];
 

--- a/src/HttpHeaders.php
+++ b/src/HttpHeaders.php
@@ -18,7 +18,7 @@ class HttpHeaders {
 	 * Send Content Security Policy (CSP) HTTP headers.
 	 */
 	public function send_content_security_policy_header() {
-		$allowed_frame_ancestors = array( '\'self\'' );
+		$allowed_frame_ancestors = [ '\'self\'' ];
 
 		// Filter hook to allow modification of trusted frame ancestors.
 		$modified_allowed_frame_ancestors = apply_filters( 'planet4_csp_allowed_frame_ancestors', $allowed_frame_ancestors );
@@ -27,12 +27,12 @@ class HttpHeaders {
 			$modified_allowed_frame_ancestors = $allowed_frame_ancestors;
 		}
 
-		$directives = array(
-			'frame-ancestors' => 'frame-ancestors ' . implode( ' ', $modified_allowed_frame_ancestors )
-		);
+		$directives = [
+			'frame-ancestors' => 'frame-ancestors ' . implode( ' ', $modified_allowed_frame_ancestors ),
+		];
 
 		$csp_header = 'Content-Security-Policy: ' . implode( '; ', $directives );
-		$csp_header = preg_replace( "/\r|\n/", "", $csp_header );
+		$csp_header = preg_replace( "/\r|\n/", '', $csp_header );
 
 		header( $csp_header );
 

--- a/src/HttpHeaders.php
+++ b/src/HttpHeaders.php
@@ -20,7 +20,11 @@ class HttpHeaders {
 	public function send_content_security_policy_header() {
 		$default_allowed_frame_ancestors = [ '\'self\'' ];
 
-		// Filter hook to allow adding trusted frame ancestors.
+		/**
+		 * Filter hook to add trusted frame ancestors to the Content Security Policy.
+		 *
+		 * @param array $additional_allowed_frame_ancestors Array of domains to whitelist as frame ancestors.
+		 */
 		$additional_allowed_frame_ancestors = apply_filters( 'planet4_csp_allowed_frame_ancestors', [] );
 
 		if ( is_array( $additional_allowed_frame_ancestors ) ) {

--- a/src/HttpHeaders.php
+++ b/src/HttpHeaders.php
@@ -28,7 +28,8 @@ class HttpHeaders {
 		}
 
 		$directives = [
-			'frame-ancestors' => 'frame-ancestors ' . implode( ' ', $modified_allowed_frame_ancestors ),
+			'default-src *',
+			'frame-ancestors ' . implode( ' ', $allowed_frame_ancestors ),
 		];
 
 		$csp_header = 'Content-Security-Policy: ' . implode( '; ', $directives );

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -71,6 +71,7 @@ final class Loader {
 			Cookies::class,
 			DevReport::class,
 			MasterSite::class,
+			HttpHeaders::class,
 		];
 
 		if ( is_admin() ) {


### PR DESCRIPTION
Ref: https://github.com/greenpeace/planet4/issues/132

Adds an HTTP Header class that sends two headers by default:
`Content-Security-Policy: frame-ancestors 'self'`
`X-Frame-Options: SAMEORIGIN`

In addition, it contains a filter hook to allow modification of the allowed frame ancestors list in the `Content-Security-Policy` header. In practice, the filter can be used to whitelist domains of 3rd party websites to embed Planet4 content.
When the filter is used to add allowed frame ancestors, the `X-Frame-Options` header is not sent. 

This PR is intended to replace sending of the `X-Frame-Options: SAMEORIGIN` header [directly from NGINX](https://github.com/greenpeace/planet4-docker/blob/develop/src/planet-4-151612/openresty/etc/nginx/conf.d/security.conf#L8). The config for NGINX has to be altered separately.
