### PR TITLE
PLANET-5870: Cache clear command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -259,6 +259,7 @@ jobs:
             JIRA_USERNAME=planet4 python /home/circleci/book-test-instance.py \
             --pr-url $(cat /tmp/workspace/pr) \
             --results /tmp/workspace/booking.json >/tmp/workspace/test-instance
+            echo "https://app.circleci.com/pipelines/github/greenpeace/planet4-test-$(cat /tmp/workspace/test-instance)/"
       - run: activate-gcloud-account.sh
       - run:
           name: "Put zip in cloud storage"

--- a/src/Commands.php
+++ b/src/Commands.php
@@ -33,7 +33,7 @@ class Commands {
 		 * Put the CF API key into the options table, where the CF plugin uses it from.
 		 */
 		$put_cf_key_in_db = static function ( $args ) {
-			$hostname = $args[0];
+			$hostname = $args[0] ?? null;
 			if ( empty( $hostname ) ) {
 				WP_CLI::error( 'Please specify the hostname.' );
 			}
@@ -65,7 +65,7 @@ class Commands {
 
 			if ( isset( $assoc_args['urls'] ) ) {
 				$urls = explode( ',', $assoc_args['urls'] );
-			} elseif ( $assoc_args['all'] ) {
+			} elseif ( isset( $assoc_args['all'] ) ) {
 				$post_types = isset( $assoc_args['post-types'] )
 					? explode( ',', $assoc_args['post-types'] )
 					: [

--- a/src/Commands.php
+++ b/src/Commands.php
@@ -1,10 +1,25 @@
 <?php
+/**
+ * Commands.
+ */
 
 namespace P4\MasterTheme;
 
+use CF\Integration\DefaultConfig;
+use CF\Integration\DefaultIntegration;
+use CF\Integration\DefaultLogger;
+use CF\WordPress\DataStore;
+use CF\WordPress\WordPressAPI;
+use CF\WordPress\WordPressClientAPI;
 use WP_CLI;
 
+/**
+ * Class with a static function just because PHP can't autoload functions.
+ */
 class Commands {
+	/**
+	 * Add some WP_CLI commands if we're in CLI.
+	 */
 	public static function load() {
 		if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
 			return;
@@ -35,5 +50,63 @@ class Commands {
 			update_option( 'cloudflare_cached_domain_name', $root_domain );
 		};
 		WP_CLI::add_command( 'p4-cf-key-in-db', $put_cf_key_in_db );
+
+		$purge_urls = static function ( $args, $assoc_args ) {
+			if ( ! defined( 'CLOUDFLARE_PLUGIN_DIR' ) ) {
+				define( 'CLOUDFLARE_PLUGIN_DIR', WP_PLUGIN_DIR . '/cloudflare/' );
+			}
+			require_once CLOUDFLARE_PLUGIN_DIR . 'vendor/autoload.php';
+
+			if ( isset( $assoc_args['urls'] ) ) {
+				$urls = explode( ',', $assoc_args['urls'] );
+			} elseif ( $assoc_args['all'] ) {
+				$post_types = isset( $assoc_args['post-types'] )
+					? explode( ',', $assoc_args['post-types'] )
+					: [
+						'post',
+						'page',
+						'campaign',
+					];
+				$query_args = [
+					'post_type'           => $post_types,
+					'posts_per_page'      => - 1,
+					'post_status'         => 'publish',
+					'ignore_sticky_posts' => 1,
+					'fields'              => 'ids',
+				];
+				$ids        = get_posts( $query_args );
+				$urls       = array_map( 'get_permalink', $ids );
+				WP_CLI::log( 'About to purge ' . count( $urls ) . ' urls.' );
+			} else {
+				WP_CLI::error( 'Please provide either --urls, or purge all urls with --all.' );
+			}
+
+			// The following is just a copy of the plugin's dependency chain, can probably be improved.
+			$config          = new DefaultConfig( file_get_contents( CLOUDFLARE_PLUGIN_DIR . 'config.json', true ) );
+			$logger          = new DefaultLogger( $config->getValue( 'debug' ) );
+			$data_store      = new DataStore( $logger );
+			$integration_api = new WordPressAPI( $data_store );
+			$integration     = new DefaultIntegration( $config, $integration_api, $data_store, $logger );
+			$api             = new WordPressClientAPI( $integration );
+
+			$zone_id = $api->getZoneTag( get_option( 'cloudflare_cached_domain_name' ) );
+
+			// 30 is Cloudflare's purge api limit.
+			$chunks = array_chunk( $urls, 30 );
+			foreach ( $chunks as $i => $chunk ) {
+				// We only use $i to be human readable, increment it immediately.
+				++ $i;
+
+				$ok = $api->zonePurgeFiles( $zone_id, $chunk );
+				// It's unlikely that only some of the chunks will fail, as Cloudflare's API responds with success
+				// for any url, even if on non-existent domains. Giving a warning per chunk anyway, just in case.
+				if ( ! $ok ) {
+					$joined = implode( $chunk, "\n" );
+					WP_CLI::warning( "Chunk $i failed, one or more of these didn't work out: \n$joined" );
+				}
+			}
+		};
+
+		WP_CLI::add_command( 'p4-cf-purge', $purge_urls );
 	}
 }

--- a/src/Commands.php
+++ b/src/Commands.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace P4\MasterTheme;
+
+use WP_CLI;
+
+class Commands {
+	public static function load() {
+		if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
+			return;
+		}
+		$activator_command = static function ( $args, $assoc_args ) {
+			Activator::run();
+		};
+		WP_CLI::add_command( 'p4-run-activator', $activator_command );
+
+		/**
+		 * Put the CF API key into the options table, where the CF plugin uses it from.
+		 */
+		$put_cf_key_in_db = static function ( $args ) {
+			$hostname = $args[0];
+			if ( empty( $hostname ) ) {
+				WP_CLI::error( 'Please specify the hostname.' );
+			}
+
+			if ( ! defined( 'CLOUDFLARE_API_KEY' ) || empty( CLOUDFLARE_API_KEY ) ) {
+				WP_CLI::error( 'CLOUDFLARE_API_KEY constant is not set.' );
+			}
+
+			$domain_parts = explode( '.', $hostname );
+
+			$root_domain = implode( '.', array_slice( $domain_parts, - 2 ) );
+			update_option( 'cloudflare_api_key', CLOUDFLARE_API_KEY );
+			update_option( 'automatic_platform_optimization', [ 'value' => 1 ] );
+			update_option( 'cloudflare_cached_domain_name', $root_domain );
+		};
+		WP_CLI::add_command( 'p4-cf-key-in-db', $put_cf_key_in_db );
+	}
+}

--- a/src/Commands.php
+++ b/src/Commands.php
@@ -5,13 +5,9 @@
 
 namespace P4\MasterTheme;
 
-use CF\Integration\DefaultConfig;
-use CF\Integration\DefaultIntegration;
-use CF\Integration\DefaultLogger;
-use CF\WordPress\DataStore;
-use CF\WordPress\WordPressAPI;
-use CF\WordPress\WordPressClientAPI;
-use WP_CLI;
+use P4\MasterTheme\Commands\CloudflarePurge;
+use P4\MasterTheme\Commands\RunActivator;
+use P4\MasterTheme\Commands\SaveCloudflareKey;
 
 /**
  * Class with a static function just because PHP can't autoload functions.
@@ -24,95 +20,8 @@ class Commands {
 		if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
 			return;
 		}
-		$activator_command = static function ( $args, $assoc_args ) {
-			Activator::run();
-		};
-		WP_CLI::add_command( 'p4-run-activator', $activator_command );
-
-		/**
-		 * Put the CF API key into the options table, where the CF plugin uses it from.
-		 */
-		$put_cf_key_in_db = static function ( $args ) {
-			$hostname = $args[0] ?? null;
-			if ( empty( $hostname ) ) {
-				WP_CLI::error( 'Please specify the hostname.' );
-			}
-
-			if ( ! defined( 'CLOUDFLARE_API_KEY' ) || empty( CLOUDFLARE_API_KEY ) ) {
-				WP_CLI::error( 'CLOUDFLARE_API_KEY constant is not set.' );
-			}
-
-			$domain_parts = explode( '.', $hostname );
-
-			$root_domain = implode( '.', array_slice( $domain_parts, - 2 ) );
-			update_option( 'cloudflare_api_key', CLOUDFLARE_API_KEY );
-			update_option( 'automatic_platform_optimization', [ 'value' => 1 ] );
-			update_option( 'cloudflare_cached_domain_name', $root_domain );
-		};
-		WP_CLI::add_command( 'p4-cf-key-in-db', $put_cf_key_in_db );
-
-		$purge_urls = static function ( $args, $assoc_args ) {
-			if ( ! Features::is_active( Features::CLOUDFLARE_DEPLOY_PURGE ) ) {
-				WP_CLI::warning( 'Purge on deploy is not enabled, not purging.' );
-
-				return;
-			}
-
-			if ( ! defined( 'CLOUDFLARE_PLUGIN_DIR' ) ) {
-				define( 'CLOUDFLARE_PLUGIN_DIR', WP_PLUGIN_DIR . '/cloudflare/' );
-			}
-			require_once CLOUDFLARE_PLUGIN_DIR . 'vendor/autoload.php';
-
-			if ( isset( $assoc_args['urls'] ) ) {
-				$urls = explode( ',', $assoc_args['urls'] );
-			} elseif ( isset( $assoc_args['all'] ) ) {
-				$post_types = isset( $assoc_args['post-types'] )
-					? explode( ',', $assoc_args['post-types'] )
-					: [
-						'post',
-						'page',
-						'campaign',
-					];
-				$query_args = [
-					'post_type'           => $post_types,
-					'posts_per_page'      => - 1,
-					'post_status'         => 'publish',
-					'ignore_sticky_posts' => 1,
-					'fields'              => 'ids',
-				];
-				$ids        = get_posts( $query_args );
-				$urls       = array_map( 'get_permalink', $ids );
-				WP_CLI::log( 'About to purge ' . count( $urls ) . ' urls.' );
-			} else {
-				WP_CLI::error( 'Please provide either --urls, or purge all urls with --all.' );
-			}
-
-			// The following is just a copy of the plugin's dependency chain, can probably be improved.
-			$config          = new DefaultConfig( file_get_contents( CLOUDFLARE_PLUGIN_DIR . 'config.json', true ) );
-			$logger          = new DefaultLogger( $config->getValue( 'debug' ) );
-			$data_store      = new DataStore( $logger );
-			$integration_api = new WordPressAPI( $data_store );
-			$integration     = new DefaultIntegration( $config, $integration_api, $data_store, $logger );
-			$api             = new WordPressClientAPI( $integration );
-
-			$zone_id = $api->getZoneTag( get_option( 'cloudflare_cached_domain_name' ) );
-
-			// 30 is Cloudflare's purge api limit.
-			$chunks = array_chunk( $urls, 30 );
-			foreach ( $chunks as $i => $chunk ) {
-				// We only use $i to be human readable, increment it immediately.
-				++ $i;
-
-				$ok = $api->zonePurgeFiles( $zone_id, $chunk );
-				// It's unlikely that only some of the chunks will fail, as Cloudflare's API responds with success
-				// for any url, even if on non-existent domains. Giving a warning per chunk anyway, just in case.
-				if ( ! $ok ) {
-					$joined = implode( $chunk, "\n" );
-					WP_CLI::warning( "Chunk $i failed, one or more of these didn't work out: \n$joined" );
-				}
-			}
-		};
-
-		WP_CLI::add_command( 'p4-cf-purge', $purge_urls );
+		RunActivator::register();
+		SaveCloudflareKey::register();
+		CloudflarePurge::register();
 	}
 }

--- a/src/Commands.php
+++ b/src/Commands.php
@@ -52,6 +52,12 @@ class Commands {
 		WP_CLI::add_command( 'p4-cf-key-in-db', $put_cf_key_in_db );
 
 		$purge_urls = static function ( $args, $assoc_args ) {
+			if ( ! Features::is_active( Features::CLOUDFLARE_DEPLOY_PURGE ) ) {
+				WP_CLI::warning( 'Purge on deploy is not enabled, not purging.' );
+
+				return;
+			}
+
 			if ( ! defined( 'CLOUDFLARE_PLUGIN_DIR' ) ) {
 				define( 'CLOUDFLARE_PLUGIN_DIR', WP_PLUGIN_DIR . '/cloudflare/' );
 			}

--- a/src/Commands/CloudflarePurge.php
+++ b/src/Commands/CloudflarePurge.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace P4\MasterTheme\Commands;
+
+use CF\Integration\DefaultConfig;
+use CF\Integration\DefaultIntegration;
+use CF\Integration\DefaultLogger;
+use CF\WordPress\DataStore;
+use CF\WordPress\WordPressAPI;
+use CF\WordPress\WordPressClientAPI;
+use P4\MasterTheme\Features;
+use WP_CLI;
+
+/**
+ * Class CloudflarePurge
+ */
+class CloudflarePurge extends Command {
+
+	/**
+	 * The name to access the command.
+	 *
+	 * @return string The command name.
+	 */
+	protected static function get_name(): string {
+		return 'p4-cf-purge';
+	}
+
+	/**
+	 * The logic of the command. Has WP_CLI command signature.
+	 *
+	 * @param array|null $args Positional arguments.
+	 * @param array|null $assoc_args Named arguments.
+	 */
+	public static function execute( ?array $args, ?array $assoc_args ): void {
+		if ( ! Features::is_active( Features::CLOUDFLARE_DEPLOY_PURGE ) ) {
+			WP_CLI::warning( 'Purge on deploy is not enabled, not purging.' );
+
+			return;
+		}
+
+		if ( ! defined( 'CLOUDFLARE_PLUGIN_DIR' ) ) {
+			define( 'CLOUDFLARE_PLUGIN_DIR', WP_PLUGIN_DIR . '/cloudflare/' );
+		}
+		require_once CLOUDFLARE_PLUGIN_DIR . 'vendor/autoload.php';
+
+		// The following is just a copy of the plugin's dependency chain, can probably be improved.
+		$config          = new DefaultConfig( file_get_contents( CLOUDFLARE_PLUGIN_DIR . 'config.json', true ) );
+		$logger          = new DefaultLogger( $config->getValue( 'debug' ) );
+		$data_store      = new DataStore( $logger );
+		$integration_api = new WordPressAPI( $data_store );
+		$integration     = new DefaultIntegration( $config, $integration_api, $data_store, $logger );
+		$api             = new WordPressClientAPI( $integration );
+
+		$zone_id = $api->getZoneTag( get_option( 'cloudflare_cached_domain_name' ) );
+
+		$urls = self::get_urls( $assoc_args );
+		WP_CLI::log( 'About to purge ' . count( $urls ) . ' urls.' );
+
+		// 30 is Cloudflare's purge api limit.
+		$chunks = array_chunk( $urls, 30 );
+
+		foreach ( $chunks as $i => $chunk ) {
+			// We only use $i to be human readable, increment it immediately.
+			++ $i;
+
+			$ok = $api->zonePurgeFiles( $zone_id, $chunk );
+			// It's unlikely that only some of the chunks will fail, as Cloudflare's API responds with success
+			// for any url, even if on non-existent domains. Giving a warning per chunk anyway, just in case.
+			if ( ! $ok ) {
+				$joined = implode( $chunk, "\n" );
+				WP_CLI::warning( "Chunk $i failed, one or more of these didn't work out: \n$joined" );
+			}
+		}
+	}
+
+	/**
+	 * Determine which urls to purge. Throws error if right args were not passed.
+	 *
+	 * @param array|null $assoc_args The named args passed to the command.
+	 *
+	 * @throws \RuntimeException If you don't provide the right args.
+	 *
+	 * @return array The urls to purge
+	 */
+	private static function get_urls( ?array $assoc_args ): array {
+		if ( isset( $assoc_args['urls'] ) ) {
+			return explode( ',', $assoc_args['urls'] );
+		}
+
+		if ( isset( $assoc_args['all'] ) ) {
+			$post_types = isset( $assoc_args['post-types'] )
+				? explode( ',', $assoc_args['post-types'] )
+				: [
+					'post',
+					'page',
+					'campaign',
+				];
+			$query_args = [
+				'post_type'           => $post_types,
+				'posts_per_page'      => - 1,
+				'post_status'         => 'publish',
+				'ignore_sticky_posts' => 1,
+				'fields'              => 'ids',
+			];
+
+			$ids = get_posts( $query_args );
+
+			return array_map( 'get_permalink', $ids );
+		}
+
+		throw new \RuntimeException( 'Please provide either --urls, or purge all urls with --all.' );
+	}
+}

--- a/src/Commands/CloudflarePurge.php
+++ b/src/Commands/CloudflarePurge.php
@@ -26,6 +26,15 @@ class CloudflarePurge extends Command {
 	}
 
 	/**
+	 * The description shown in the argument's help.
+	 *
+	 * @return string The description text.
+	 */
+	protected static function get_short_description(): string {
+		return 'Purge urls from Cloudflare cache';
+	}
+
+	/**
 	 * The logic of the command. Has WP_CLI command signature.
 	 *
 	 * @param array|null $args Positional arguments.

--- a/src/Commands/Command.php
+++ b/src/Commands/Command.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace P4\MasterTheme\Commands;
+
+use WP_CLI;
+
+/**
+ * Base class for WP_CLI commands.
+ */
+abstract class Command {
+	/**
+	 * Registers the command.
+	 *
+	 * @throws \Exception If WP_CLI doesn't like what we register.
+	 */
+	public static function register(): void {
+		WP_CLI::add_command( static::get_name(), [ static::class, 'execute' ] );
+	}
+
+	/**
+	 * The name to access the command.
+	 *
+	 * @return string The command name.
+	 */
+	abstract protected static function get_name(): string;
+
+	/**
+	 * The logic of the command. Has WP_CLI command signature.
+	 *
+	 * @param array|null $args Positional arguments.
+	 * @param array|null $assoc_args Named arguments.
+	 */
+	abstract public static function execute( ?array $args, ?array $assoc_args ): void;
+}

--- a/src/Commands/Command.php
+++ b/src/Commands/Command.php
@@ -14,7 +14,13 @@ abstract class Command {
 	 * @throws \Exception If WP_CLI doesn't like what we register.
 	 */
 	public static function register(): void {
-		WP_CLI::add_command( static::get_name(), [ static::class, 'execute' ] );
+		WP_CLI::add_command(
+			static::get_name(),
+			[ static::class, 'execute' ],
+			[
+				'shortdesc' => static::get_short_description(),
+			]
+		);
 	}
 
 	/**
@@ -23,6 +29,13 @@ abstract class Command {
 	 * @return string The command name.
 	 */
 	abstract protected static function get_name(): string;
+
+	/**
+	 * The description shown in the argument's help.
+	 *
+	 * @return string The description text.
+	 */
+	abstract protected static function get_short_description(): string;
 
 	/**
 	 * The logic of the command. Has WP_CLI command signature.

--- a/src/Commands/RunActivator.php
+++ b/src/Commands/RunActivator.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace P4\MasterTheme\Commands;
+
+use P4\MasterTheme\Activator;
+
+/**
+ * Class RunActivator
+ */
+class RunActivator extends Command {
+
+	/**
+	 * The name to access the command.
+	 *
+	 * @return string The command name.
+	 */
+	protected static function get_name(): string {
+		return 'p4-run-activator';
+	}
+
+	/**
+	 * The logic of the command. Has WP_CLI command signature.
+	 *
+	 * @param array|null $args Positional arguments.
+	 * @param array|null $assoc_args Named arguments.
+	 */
+	public static function execute( ?array $args, ?array $assoc_args ): void {
+		Activator::run();
+	}
+}

--- a/src/Commands/RunActivator.php
+++ b/src/Commands/RunActivator.php
@@ -19,6 +19,15 @@ class RunActivator extends Command {
 	}
 
 	/**
+	 * The description shown in the argument's help.
+	 *
+	 * @return string The description text.
+	 */
+	protected static function get_short_description(): string {
+		return 'Update roles in DB and run migrations scripts';
+	}
+
+	/**
 	 * The logic of the command. Has WP_CLI command signature.
 	 *
 	 * @param array|null $args Positional arguments.

--- a/src/Commands/SaveCloudflareKey.php
+++ b/src/Commands/SaveCloudflareKey.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace P4\MasterTheme\Commands;
+
+use WP_CLI;
+
+/**
+ * Class SaveCloudflareKey
+ */
+class SaveCloudflareKey extends Command {
+
+	/**
+	 * The name to access the command.
+	 *
+	 * @return string The command name.
+	 */
+	protected static function get_name(): string {
+		return 'p4-cf-key-in-db';
+	}
+
+	/**
+	 * The logic of the command. Has WP_CLI command signature.
+	 *
+	 * @param array|null $args Positional arguments.
+	 * @param array|null $assoc_args Named arguments.
+	 *
+	 * @throws WP_CLI\ExitException If no hostname or Cloudflare key is not present.
+	 */
+	public static function execute( ?array $args, ?array $assoc_args ): void {
+		$hostname = $args[0] ?? null;
+		if ( empty( $hostname ) ) {
+			WP_CLI::error( 'Please specify the hostname.' );
+		}
+
+		if ( ! defined( 'CLOUDFLARE_API_KEY' ) || empty( CLOUDFLARE_API_KEY ) ) {
+			WP_CLI::error( 'CLOUDFLARE_API_KEY constant is not set.' );
+		}
+
+		$domain_parts = explode( '.', $hostname );
+
+		$root_domain = implode( '.', array_slice( $domain_parts, - 2 ) );
+		update_option( 'cloudflare_api_key', CLOUDFLARE_API_KEY );
+		update_option( 'automatic_platform_optimization', [ 'value' => 1 ] );
+		update_option( 'cloudflare_cached_domain_name', $root_domain );
+	}
+}

--- a/src/Commands/SaveCloudflareKey.php
+++ b/src/Commands/SaveCloudflareKey.php
@@ -19,6 +19,15 @@ class SaveCloudflareKey extends Command {
 	}
 
 	/**
+	 * The description shown in the argument's help.
+	 *
+	 * @return string The description text.
+	 */
+	protected static function get_short_description(): string {
+		return 'Put Cloudflare key in DB from config file';
+	}
+
+	/**
 	 * The logic of the command. Has WP_CLI command signature.
 	 *
 	 * @param array|null $args Positional arguments.

--- a/src/Features.php
+++ b/src/Features.php
@@ -14,6 +14,8 @@ class Features {
 
 	public const ENGAGING_NETWORKS = 'feature_engaging_networks';
 
+	public const CLOUDFLARE_DEPLOY_PURGE = 'cloudflare_deploy_purge';
+
 	/**
 	 * Get the features options page settings.
 	 *
@@ -53,6 +55,15 @@ class Features {
 					'planet4-master-theme-backend'
 				),
 				'id'   => self::ENGAGING_NETWORKS,
+				'type' => 'checkbox',
+			],
+			[
+				'name' => __( 'Purge HTML from Cloudflare on deploy.', 'planet4-master-theme-backend' ),
+				'desc' => __(
+					'WARNING: Do not change this setting without checking with Planet4 team. This will purge all URLs from Cloudflare after a deploy. We are still experimenting with the effects of that on Cloudflare performance.',
+					'planet4-master-theme-backend'
+				),
+				'id'   => self::CLOUDFLARE_DEPLOY_PURGE,
 				'type' => 'checkbox',
 			],
 		];

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -3,7 +3,6 @@
 namespace P4\MasterTheme;
 
 use RuntimeException;
-use WP_CLI;
 
 /**
  * Class Loader.
@@ -52,7 +51,7 @@ final class Loader {
 	private function __construct( $services ) {
 		$this->load_services( $services );
 		$this->add_filters();
-		$this->load_commands();
+		Commands::load();
 	}
 
 	/**
@@ -144,42 +143,6 @@ final class Loader {
 	 */
 	private function add_filters(): void {
 		add_filter( 'pre_delete_post', [ $this, 'do_not_delete_autosave' ], 1, 3 );
-	}
-
-	/**
-	 * Registers WP_CLI commands.
-	 */
-	public function load_commands() {
-		if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
-			return;
-		}
-
-		$activator_command = static function ( $args, $assoc_args ) {
-			Activator::run();
-		};
-		WP_CLI::add_command( 'p4-run-activator', $activator_command );
-
-		/**
-		 * Put the CF API key into the options table, where the CF plugin uses it from.
-		 */
-		$put_cf_key_in_db = static function ( $args ) {
-			$hostname = $args[0];
-			if ( empty( $hostname ) ) {
-				WP_CLI::error( 'Please specify the hostname.' );
-			}
-
-			if ( ! defined( 'CLOUDFLARE_API_KEY' ) || empty( CLOUDFLARE_API_KEY ) ) {
-				WP_CLI::error( 'CLOUDFLARE_API_KEY constant is not set.' );
-			}
-
-			$domain_parts = explode( '.', $hostname );
-
-			$root_domain = implode( '.', array_slice( $domain_parts, - 2 ) );
-			update_option( 'cloudflare_api_key', CLOUDFLARE_API_KEY );
-			update_option( 'automatic_platform_optimization', [ 'value' => 1 ] );
-			update_option( 'cloudflare_cached_domain_name', $root_domain );
-		};
-		WP_CLI::add_command( 'p4-cf-key-in-db', $put_cf_key_in_db );
 	}
 
 	/**


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5870

Adding this as a command first so that we can make it a post-deploy step for test instances. We can start that way and observe if purging all html on each deployment causes any issues. Then we can set it up for a few production NROs and see how it goes. If it doesn't cause issues (e.g. Cloudflare deciding to evict us from cache more frequently once they pick up these entries usually don't live long), we could do this for all sites on each deploy.

I added a feature flag for this, so that we're not blocked to use it on production by needing more code changes. Tested off and on behavior on https://app.circleci.com/pipelines/github/greenpeace/planet4-test-janus/37/workflows/a3b88549-3fb8-4d73-926b-2e42e61b34ad/jobs/199