### PR TITLE
PLANET-5842 Remove unused colors

### DIFF
--- a/assets/src/scss/pages/_404.scss
+++ b/assets/src/scss/pages/_404.scss
@@ -8,10 +8,6 @@
       padding-top: 110px;
     }
 
-    .page-header-content {
-      color: #152340;
-    }
-
     .page-header-subtitle {
       margin-top: 150px;
 
@@ -26,11 +22,6 @@
       @include large-and-up {
         margin-top: -30px;
       }
-    }
-
-    .search-form-title {
-      font-weight: bold;
-      color: #152340;
     }
 
     .search-form {

--- a/assets/src/scss/pages/post/_author-block.scss
+++ b/assets/src/scss/pages/post/_author-block.scss
@@ -39,7 +39,6 @@
 .author-block-info-name {
   font-size: 1.0625rem;
   font-weight: bold;
-  color: $crimson;
   margin-bottom: 30px;
 
   a {

--- a/assets/src/scss/pages/search/_filter-sidebar.scss
+++ b/assets/src/scss/pages/search/_filter-sidebar.scss
@@ -88,23 +88,6 @@
       }
     }
 
-    .custom-control-indicator {
-      appearance: none;
-      border: 1px solid $black;
-      background-color: transparent;
-    }
-
-    .p4-custom-control-input:checked {
-      & + .custom-control-indicator {
-        background-color: $faded-jade;
-        border-color: $faded-jade;
-      }
-
-      & ~ .custom-control-description {
-        font-weight: bold;
-      }
-    }
-
     ul {
       li {
         height: 42px;

--- a/assets/src/scss/pages/search/_suggested-terms.scss
+++ b/assets/src/scss/pages/search/_suggested-terms.scss
@@ -32,7 +32,6 @@
     }
 
     a {
-      color: $blue-elm;
       text-decoration: none;
       font-size: 1.125rem;
       line-height: 2.3;


### PR DESCRIPTION
### Description

See https://jira.greenpeace.org/browse/PLANET-5842

- ~~#63bbfd = $blue-60~~
- ~~($grey-60) = $shadow-color~~
- ~~#f6f4e7 = $single-bg~~
- ~~#aed4c7 = $active~~
- ~~#b0d4c8 = $body-bg~~
- ~~#a7e021 = $inch-worm~~
- ~~#e51538 = $crimson~~
- ~~#5c1f10 = $brown-header~~
- ~~#003300 = $green~~
- ~~#264042 = $darkb-blue-text~~
- ~~#004d53 = $heading~~
- ~~#115247 = $search-text-color~~
- ~~#186a70 = $genoa~~
- ~~#017e7a = $percentage-text~~
- #418482 = $faded-jade => actually used in search page for search bar border, will be replaced in https://jira.greenpeace.org/browse/PLANET-5843
- ~~#22938d = $blue-elm~~
- ~~#67b2af = $light-blue~~
- ~~#1bb6d6 = $java~~
- ~~#007799 = $allports~~
- ~~#152340 = (none)~~
- ~~#152431 = $article-heading-color~~
- ~~#1b4a1b = $green-80~~
- ~~#a7a7a7 = $step-number~~
- ~~$blue-top-nav = $dark-blue~~

### Related PRs:
- [gutenberg-blocks](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/492)
- [styleguide](https://github.com/greenpeace/planet4-styleguide/pull/95)