### PR TITLE
PLANET-5939: Campaign text hidden by navbar

### DIFF
--- a/assets/src/scss/pages/_page.scss
+++ b/assets/src/scss/pages/_page.scss
@@ -33,6 +33,38 @@ div.page-template {
     max-width: 100%;
     height: auto;
   }
+
+  .page-header-hidden + &.no-page-title {
+    padding-top: $menu-height-small;
+
+    @include medium-and-up {
+      padding-top: $menu-height-large;
+    }
+
+    & > p:first-child {
+      padding-top: $space-xs;
+
+      @include small-and-up {
+        padding-top: $space-sm;
+      }
+
+      @include medium-and-up {
+        padding-top: $space-md;
+      }
+
+      @include large-and-up {
+        padding-top: $space-lg;
+      }
+
+      @include x-large-and-up {
+        padding-top: $space-xl;
+      }
+    }
+
+    .navigation-bar_min ~ & {
+      padding-top: $min-height;
+    }
+  }
 }
 
 .single-campaign {

--- a/templates/page.twig
+++ b/templates/page.twig
@@ -1,7 +1,7 @@
 {% extends "base.twig" %}
 
 {% block content %}
-	<div class="page-template">
+	<div class="page-template {% if hide_page_title_checkbox == 'on' %}no-page-title{% endif %}">
 		{{ post.content|raw }}
 	</div>
 {% endblock %}

--- a/templates/single-page.twig
+++ b/templates/single-page.twig
@@ -5,7 +5,7 @@
 		<div class="page-header-background"></div>
 	</div>
 
-	<div class="page-template">
+	<div class="page-template {% if hide_page_title_checkbox == 'on' %}no-page-title{% endif %}">
 
 		<form id="password-form" class="mb-5" action="{{login_url}}?action=postpass" method="post">
 			<div class="form-group">


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5939

On a campaign page with title hidden and no subtitle or description, the text is on top of the page and gets hidden by the navbar.

![Screenshot from 2021-02-09 16-57-13](https://user-images.githubusercontent.com/617346/107390477-08fa7f00-6af8-11eb-8ad2-a65bec9aa78b.png)

The div `.page-header` has a padding that largely compensate the navbar height, but it is not always visible. When the title is hidden (option "Hide page title" in Campaign and Page) and there's no subtitle or description, it shrinks as `.page-header-hidden` and the main container has no padding-top.  
The padding has to be precise, so that when we add an EN form as first block, it doesn't look weird or has no white empty bar at the top.

The problem also exists on Pages. Solution has to be tested on:

| | Page type | Title visible* | First block |
| --- | --- | --- | --- |
| Minimal navigation |
| | Campaign | no title | <ul><li>[x] paragraph</li><li>[x] EN form</li></ul> |
| | Campaign | title | <ul><li>[x] paragraph</li><li>[x] EN form</li></ul> |
| Main navigation |
| | Campaign | no title | <ul><li>[x] paragraph</li><li>[x] EN form</li></ul> |
| | Campaign | title | <ul><li>[x] paragraph</li><li>[x] EN form</li></ul> |
| | Page | no title | <ul><li>[x] paragraph</li><li>[x] EN form</li></ul> |
| | Page | title | <ul><li>[x] paragraph</li><li>[x] EN form</li></ul> |

_***title visible** can be header title, subtitle or description, each of those will make the div `page-header` appear, and this div has its own padding._

## Fix 
Assigning a padding-top the height of the current navbar, in this context only (header hidden, no title).  
Padding is different according to main nav or minimal nav.

## Test

Any of those situations should work.  
Test instance has 3 campaigns pages to check: 
- https://www-dev.greenpeace.org/test-pluto/campaign/campaign-with-title/
- https://www-dev.greenpeace.org/test-pluto/campaign/campaign-no-title/
- https://www-dev.greenpeace.org/test-pluto/campaign/campaign-no-title-en-form/
- https://www-dev.greenpeace.org/test-pluto/page-no-title/