### PR TITLE
PLANET-5850 Remove CSS vars ponyfill

### DIFF
--- a/assets/src/js/app.js
+++ b/assets/src/js/app.js
@@ -6,7 +6,6 @@ import { setupLoadMore } from './load_more';
 import { setupPDFIcon } from './pdf_icon';
 import { setupSearch } from './search';
 import { setupExternalLinks } from './external_links';
-import { setupCSSVarsPonyfill } from './cssvarsponyfill';
 import { setupEnhancedDonateButton } from './enhancedDonateButton';
 
 import 'bootstrap';
@@ -28,6 +27,5 @@ jQuery(function($) {
   setupPDFIcon($);
   setupSearch($);
   setupExternalLinks($);
-  setupCSSVarsPonyfill();
   setupEnhancedDonateButton();
 });

--- a/assets/src/js/cssvarsponyfill.js
+++ b/assets/src/js/cssvarsponyfill.js
@@ -1,4 +1,0 @@
-/* global cssVars */
-export const setupCSSVarsPonyfill = () => {
-  cssVars();
-};

--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -712,7 +712,6 @@ class MasterSite extends TimberSite {
 
 		// JS files.
 		wp_register_script( 'jquery', 'https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js', [], '3.3.1', true );
-		wp_register_script( 'cssvarsponyfill', 'https://cdnjs.cloudflare.com/ajax/libs/css-vars-ponyfill/2.3.1/css-vars-ponyfill.min.js', [], '2', false );
 
 		// Variables reflected from PHP to the JS side.
 		$localized_variables = [
@@ -722,7 +721,7 @@ class MasterSite extends TimberSite {
 			'show_scroll_times' => Search::SHOW_SCROLL_TIMES,
 		];
 
-		wp_register_script( 'main', $this->theme_dir . '/assets/build/index.js', [ 'jquery', 'cssvarsponyfill' ], $js_creation, true );
+		wp_register_script( 'main', $this->theme_dir . '/assets/build/index.js', [ 'jquery' ], $js_creation, true );
 		wp_localize_script( 'main', 'localizations', $localized_variables );
 		wp_enqueue_script( 'main' );
 	}


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5850

After doing some testing I noticed that the ponyfill has a large impact on performance. I don't know yet exactly what causes this impact, it could be the additional domain for a blocking resource, or the ponyfill might interfere with render by accessing style attributes. Normally it should not have to do anything for browsers that do support CSS variables, but maybe just checking for support affects page load.

I [temporarily put a commit on this branch](https://github.com/greenpeace/planet4-master-theme/commit/77faaca03c024f9f80b747d8fca8453efe0b8d12) that has a toggle for the removal so I could test both scenarios. The difference for the test instance was quite massive, without the ponyfill it was getting just under 70, with the ponyfill this dropped to under 50. It seems that this increase is due to total blocking time.
