### PR TITLE
PLANET-5964: make depend on blocks

### DIFF
--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -711,7 +711,14 @@ class MasterSite extends TimberSite {
 		wp_enqueue_style( 'parent-style', $this->theme_dir . '/assets/build/style.min.css', [], $css_creation );
 
 		// JS files.
-		wp_register_script( 'jquery', 'https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js', [], '3.3.1', true );
+		wp_deregister_script( 'jquery' );
+		wp_register_script(
+			'jquery',
+			'https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js',
+			[ 'planet4-blocks-frontend' ],
+			'3.3.1',
+			true
+		);
 
 		// Variables reflected from PHP to the JS side.
 		$localized_variables = [


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5964

---

This also makes us use jquery 3 instead of 1 on the front end, and consequently we won't be loading jquery-migrate. Add the blocks index script as a dependency so that jquery doesn't block it. That script is rendering a large portion of the page.