### PR TITLE
PLANET-5939: Image as first block separated from navbar

### DIFF
--- a/assets/src/scss/pages/_page.scss
+++ b/assets/src/scss/pages/_page.scss
@@ -61,6 +61,10 @@ div.page-template {
       }
     }
 
+    & > .wp-block-image:first-child {
+      margin-top: 0;
+    }
+
     .navigation-bar_min ~ & {
       padding-top: $min-height;
     }


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5939
Goes with: https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/501

Last fix https://github.com/greenpeace/planet4-master-theme/pull/1293 introduced a change that separated image from navbar on campaigns relying on an image as first block.

_Expected layout:_
![Screenshot from 2021-02-16 08-56-34](https://user-images.githubusercontent.com/617346/108033936-0b4b6480-7035-11eb-847c-dd7c199147b5.png)

_Layout after https://github.com/greenpeace/planet4-master-theme/pull/1293_
![Screenshot from 2021-02-16 08-56-53](https://user-images.githubusercontent.com/617346/108033942-0dadbe80-7035-11eb-910f-47d00082e4c7.png)

This is because some campaigns have a fixed margin applied to header (solved in https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/501), and image blocks also have a fixed margin.

## Fix

Add a specific margin for first image block, like we previously gave to the first paragraph.

