### PR TITLE
Use python3 for book-instance

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -256,7 +256,7 @@ jobs:
       - run:
           name: "Book instance"
           command: |
-            JIRA_USERNAME=planet4 python /home/circleci/book-test-instance.py \
+            JIRA_USERNAME=planet4 /home/circleci/book-test-instance.py \
             --pr-url $(cat /tmp/workspace/pr) \
             --results /tmp/workspace/booking.json >/tmp/workspace/test-instance
             echo "https://app.circleci.com/pipelines/github/greenpeace/planet4-test-$(cat /tmp/workspace/test-instance)/"


### PR DESCRIPTION
Removing the python call, since the script is executable and already configured to use python3