### PR TITLE
PLANET-5906: Migrate to Bootstrap 5

### DIFF
--- a/assets/src/scss/bootstrap-build.scss
+++ b/assets/src/scss/bootstrap-build.scss
@@ -20,9 +20,9 @@ Text Domain: planet4-master-theme
 
 // Required
 // See: https://getbootstrap.com/docs/4.3/getting-started/theming/#importing
-@import "~bootstrap/scss/functions";
-@import "~bootstrap/scss/variables";
-@import "~bootstrap/scss/mixins";
+// @import "~bootstrap/scss/functions";
+// @import "~bootstrap/scss/variables";
+// @import "~bootstrap/scss/mixins";
 
 // TODO: Add variable overrides for the 16px grid here.
 
@@ -50,7 +50,7 @@ Text Domain: planet4-master-theme
 // @import "~bootstrap/scss/_input-group.scss";
 // @import "~bootstrap/scss/_jumbotron.scss";
 // @import "~bootstrap/scss/_list-group.scss";
-@import "~bootstrap/scss/_media.scss";
+// @import "~bootstrap/scss/_media.scss";
 // @import "~bootstrap/scss/_mixins.scss";
 @import "~bootstrap/scss/_modal.scss";
 // @import "~bootstrap/scss/_nav.scss";

--- a/assets/src/scss/bootstrap-build.scss
+++ b/assets/src/scss/bootstrap-build.scss
@@ -12,57 +12,50 @@ Tags: light, accessibility-ready
 Text Domain: planet4-master-theme
 */
 
-// Full bootstrap:
-// @import "~bootstrap/scss/bootstrap";
+// This file includes commented-out depedencies to make it easier
+// to track what we are excluding from the original file:
+// https://github.com/twbs/bootstrap/blob/main/scss/bootstrap.scss
 
-@import "~bootstrap/scss/bootstrap-grid.scss";
-@import "~bootstrap/scss/bootstrap-reboot.scss";
+// Configuration
 
-// Required
-// See: https://getbootstrap.com/docs/4.3/getting-started/theming/#importing
-// @import "~bootstrap/scss/functions";
-// @import "~bootstrap/scss/variables";
-// @import "~bootstrap/scss/mixins";
+@import "~bootstrap/scss/functions";
+@import "~bootstrap/scss/variables";
+@import "~bootstrap/scss/mixins";
+@import "~bootstrap/scss/utilities";
 
-// TODO: Add variable overrides for the 16px grid here.
+// Layout & components
+@import "~bootstrap/scss/root";
+@import "~bootstrap/scss/reboot";
+@import "~bootstrap/scss/type";
+@import "~bootstrap/scss/images";
+@import "~bootstrap/scss/containers";
+@import "~bootstrap/scss/grid";
+// @import "~bootstrap/scss/tables";
+@import "~bootstrap/scss/forms";
+// @import "~bootstrap/scss/buttons";
+@import "~bootstrap/scss/transitions";
+// @import "~bootstrap/scss/dropdown";
+// @import "~bootstrap/scss/button-group";
+// @import "~bootstrap/scss/nav";
+// @import "~bootstrap/scss/navbar";
+@import "~bootstrap/scss/card";
+// @import "~bootstrap/scss/accordion";
+// @import "~bootstrap/scss/breadcrumb";
+// @import "~bootstrap/scss/pagination";
+// @import "~bootstrap/scss/badge";
+// @import "~bootstrap/scss/alert";
+// @import "~bootstrap/scss/progress";
+// @import "~bootstrap/scss/list-group";
+// @import "~bootstrap/scss/close";
+// @import "~bootstrap/scss/toasts";
+@import "~bootstrap/scss/modal";
+// @import "~bootstrap/scss/tooltip";
+// @import "~bootstrap/scss/popover";
+@import "~bootstrap/scss/carousel";
+// @import "~bootstrap/scss/spinners";
 
-// Optional
-// @import "~bootstrap/scss/reboot";
-// @import "~bootstrap/scss/type";
-// @import "~bootstrap/scss/images";
-// @import "~bootstrap/scss/code";
-// @import "~bootstrap/scss/grid";
-// @import "~bootstrap/scss/_alert.scss";
-// @import "~bootstrap/scss/_badge.scss";
-// @import "~bootstrap/scss/_breadcrumb.scss";
-// @import "~bootstrap/scss/_button-group.scss";
-// @import "~bootstrap/scss/_buttons.scss";
-@import "~bootstrap/scss/_card.scss";
-@import "~bootstrap/scss/_carousel.scss";
-// @import "~bootstrap/scss/_close.scss";
-// @import "~bootstrap/scss/_code.scss";
-// @import "~bootstrap/scss/_custom-forms.scss";
-// @import "~bootstrap/scss/_dropdown.scss";
-@import "~bootstrap/scss/_forms.scss";
-// @import "~bootstrap/scss/_functions.scss";
-// @import "~bootstrap/scss/_grid.scss";
-// @import "~bootstrap/scss/_images.scss";
-// @import "~bootstrap/scss/_input-group.scss";
-// @import "~bootstrap/scss/_jumbotron.scss";
-// @import "~bootstrap/scss/_list-group.scss";
-// @import "~bootstrap/scss/_media.scss";
-// @import "~bootstrap/scss/_mixins.scss";
-@import "~bootstrap/scss/_modal.scss";
-// @import "~bootstrap/scss/_nav.scss";
-// @import "~bootstrap/scss/_navbar.scss";
-// @import "~bootstrap/scss/_pagination.scss";
-// @import "~bootstrap/scss/_popover.scss";
-// @import "~bootstrap/scss/_print.scss";
-// @import "~bootstrap/scss/_progress.scss";
-// @import "~bootstrap/scss/_reboot.scss";
-// @import "~bootstrap/scss/_root.scss";
-// @import "~bootstrap/scss/_tables.scss";
-// @import "~bootstrap/scss/_tooltip.scss";
-@import "~bootstrap/scss/_transitions.scss";
-@import "~bootstrap/scss/_type.scss";
-@import "~bootstrap/scss/_utilities.scss";
+// Helpers
+@import "~bootstrap/scss/helpers";
+
+// Utilities
+@import "~bootstrap/scss/utilities/api";

--- a/package-lock.json
+++ b/package-lock.json
@@ -4539,9 +4539,9 @@
       "dev": true
     },
     "bootstrap": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.3.1.tgz",
-      "integrity": "sha512-rXqOmH1VilAt2DyPzluTi2blhk17bO7ef+zLLPlWvG494pDxcM234pJ8wTc/6R40UWizAIIMgxjvxZg5kmsbag=="
+      "version": "5.0.0-beta2",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.0.0-beta2.tgz",
+      "integrity": "sha512-e+uPbPHqTQWKyCX435uVlOmgH9tUt0xtjvyOC7knhKgOS643BrQKuTo+KecGpPV7qlmOyZgCfaM4xxPWtDEN/g=="
     },
     "brace-expansion": {
       "version": "1.1.11",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "not dead"
   ],
   "dependencies": {
-    "bootstrap": "^4.3.1",
+    "bootstrap": "^5.0.0-beta2",
     "classnames": "^2.2.6",
     "jquery": "^3.5.1",
     "lite-youtube-embed": "^0.1.3",

--- a/templates/blocks/share_buttons.twig
+++ b/templates/blocks/share_buttons.twig
@@ -4,27 +4,27 @@
 		 onclick="dataLayer.push({'event' : 'uaevent', 'eventCategory' : 'Social Share', 'eventAction': 'Whatsapp', 'eventLabel': '{{ social.link }}'});"
 		 target="_blank" class="share-btn whatsapp">
 		{{ 'whatsapp'|svgicon }}
-		<span class="sr-only">{{ __( 'Share on', 'planet4-master-theme' ) }} Whatsapp</span>
+		<span class="visually-hidden">{{ __( 'Share on', 'planet4-master-theme' ) }} Whatsapp</span>
 	</a>
 	<!-- Facebook -->
 	<a href="https://www.facebook.com/sharer/sharer.php?u={{ social.link }}"
 		 onclick="dataLayer.push({'event' : 'uaevent', 'eventCategory' : 'Social Share', 'eventAction': 'Facebook', 'eventLabel': '{{ social.link }}'});"
 		 target="_blank" class="share-btn facebook">
 		{{ 'facebook-f'|svgicon }}
-		<span class="sr-only">{{ __( 'Share on', 'planet4-master-theme' ) }} Facebook</span>
+		<span class="visually-hidden">{{ __( 'Share on', 'planet4-master-theme' ) }} Facebook</span>
 	</a>
 	<!-- Twitter -->
 	<a href="https://twitter.com/share?url={{ social.link }}&text={{ social.title|url_encode }}{% if social.description %} - {{ social.description|striptags }}{% endif %} via @{{ social_accounts.twitter }}&related={{ social_accounts.twitter }}"
 		 onclick="dataLayer.push({'event' : 'uaevent', 'eventCategory' : 'Social Share', 'eventAction': 'Twitter', 'eventLabel': '{{ social.link }}'});"
 		 target="_blank" class="share-btn twitter">
 		{{ 'twitter'|svgicon }}
-		<span class="sr-only">{{ __( 'Share on', 'planet4-master-theme' ) }} Twitter</span>
+		<span class="visually-hidden">{{ __( 'Share on', 'planet4-master-theme' ) }} Twitter</span>
 	</a>
 	<!-- Email -->
 	<a href="mailto:?subject={{ social.title|url_encode }}&body={% if social.description %}{{ social.description|striptags }} {% endif %}{{ social.link }}"
 		 onclick="dataLayer.push({'event' : 'uaevent', 'eventCategory' : 'Social Share', 'eventAction': 'Email', 'eventLabel': '{{ social.link }}'});"
 		 target="_blank" class="share-btn email">
 		{{ 'envelope'|svgicon }}
-		<span class="sr-only">{{ __( 'Share via', 'planet4-master-theme' ) }} Email</span>
+		<span class="visually-hidden">{{ __( 'Share via', 'planet4-master-theme' ) }} Email</span>
 	</a>
 </div>

--- a/templates/footer.twig
+++ b/templates/footer.twig
@@ -9,7 +9,7 @@
 						   data-ga-action="Social Icons"
 						   data-ga-label="{{ social.icon }}">
 							{{ social.icon|svgicon }}
-							<span class="sr-only">{{ social.icon }}</span>
+							<span class="visually-hidden">{{ social.icon }}</span>
 						</a>
 					</li>
 				{% endfor %}
@@ -30,7 +30,7 @@
 						   data-ga-action="Social Icons"
 						   data-ga-label="{{ social.title }}">
 							{{ name|svgicon }}
-							<span class="sr-only">{{ social.title }}</span>
+							<span class="visually-hidden">{{ social.title }}</span>
 						</a>
 					</li>
 				{% endfor %}

--- a/templates/footer_min.twig
+++ b/templates/footer_min.twig
@@ -6,7 +6,7 @@
 					<li>
 						<a href="{{ social.url }}">
 							{{ social.icon|svgicon }}
-							<span class="sr-only">{{ social.icon }}</span>
+							<span class="visually-hidden">{{ social.icon }}</span>
 						</a>
 					</li>
 				{% endfor %}
@@ -24,7 +24,7 @@
 						{% set social_url = social.url %}
 						<a href="{{ social_url }}">
 							{{ name|svgicon }}
-							<span class="sr-only">{{ social.title }}</span>
+							<span class="visually-hidden">{{ social.title }}</span>
 						</a>
 					</li>
 				{% endfor %}

--- a/templates/tease-author.twig
+++ b/templates/tease-author.twig
@@ -1,4 +1,4 @@
-<li id="result-row-{{ post.ID }}" class="media search-result-list-item">
+<li id="result-row-{{ post.ID }}" class="d-flex search-result-list-item">
 	<img
 		class="d-flex search-result-item-image"
 		src="{{ post.thumbnail.src('thumbnail') }}"
@@ -7,7 +7,7 @@
 		data-ga-action="Image"
 		data-ga-label="n/a" />
 
-	<div id="tease-{{ post.ID }}" class="media-body search-result-item-body tease tease-{{ post.post_type }}">
+	<div id="tease-{{ post.ID }}" class="search-result-item-body tease tease-{{ post.post_type }}">
 		<div class="search-result-tags top-page-tags">
 			{% for page_type in post.get_custom_terms %}
 				<a

--- a/templates/tease-search.twig
+++ b/templates/tease-search.twig
@@ -16,7 +16,7 @@
 {% elseif ( first_of_the_page and loop.index0 is divisible by(5) ) %}
 	<div class="search-results-load row-hidden" style="display: none;">
 {% endif %}
-		<li id="result-row-{{ post.ID }}" class="media search-result-list-item">
+		<li id="result-row-{{ post.ID }}" class="d-flex search-result-list-item">
 
 		<img
 			class="d-flex search-result-item-image"
@@ -27,7 +27,7 @@
 			data-ga-action="Image"
 			data-ga-label="{{ ga_page_type }}" />
 
-		<div id="tease-{{ post.ID }}" class="media-body search-result-item-body tease tease-{{ post.post_type }}">
+		<div id="tease-{{ post.ID }}" class="search-result-item-body tease tease-{{ post.post_type }}">
 			<div class="search-result-item-flex-title">
 				<div>
 					{% if ( is_archive or is_campaign ) %}

--- a/templates/tease-taxonomy-post.twig
+++ b/templates/tease-taxonomy-post.twig
@@ -1,4 +1,4 @@
-<li id="result-row-{{ post.ID }}" class="media search-result-list-item">
+<li id="result-row-{{ post.ID }}" class="d-flex search-result-list-item">
 	<img
 		class="d-flex search-result-item-image"
 		src="{{ post.thumbnail.src('thumbnail') ?? dummy_thumbnail }}"
@@ -8,7 +8,7 @@
 		data-ga-action="Image"
 		data-ga-label="n/a" />
 
-	<div id="tease-{{ post.ID }}" class="media-body search-result-item-body tease tease-{{ post.post_type }}">
+	<div id="tease-{{ post.ID }}" class="search-result-item-body tease tease-{{ post.post_type }}">
 		<div class="search-result-tags top-page-tags">
 			{% if (post.page_types is not empty) %}
 				<a


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5906

Migrate to Bootstrap 5.

Changes:
* [_media.scss](https://github.com/twbs/bootstrap/blob/v4.6.0/scss/_media.scss) no longer exists, but it can be replaced with the `d-flex` utility.
* `sr-only` is now `visually-hidden`

Also check the [styleguide PR](https://github.com/greenpeace/planet4-styleguide/pull/98) and the [blocks PR](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/505).

---

<!--
Please provide a brief summary of the change introduced to make review process easier.

Ideally this should also be part of the commit summary.
-->
