### PR TITLE
PLANET-5959 Add lazy youtube loading

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -65,7 +65,7 @@
     "selector-pseudo-element-case": "lower",
     "selector-type-case": "lower",
     "selector-type-no-unknown": [true, {
-       "ignoreTypes": ["/^--[a-z]\\w*(--?[a-z0-9]+)*--$/"]
+       "ignoreTypes": ["/^--[a-z]\\w*(--?[a-z0-9]+)*--$/", "lite-youtube"]
     }],
     "selector-max-empty-lines": 0,
 

--- a/assets/src/scss/style.scss
+++ b/assets/src/scss/style.scss
@@ -75,6 +75,7 @@ Text Domain: planet4-master-theme
 @import "vendors/fontawesome";
 @import "vendors/usabilla";
 @import "vendors/gtm";
+@import "~lite-youtube-embed";
 
 // Campaign overrides
 @import "campaigns/campaign_cookies";

--- a/package-lock.json
+++ b/package-lock.json
@@ -12163,6 +12163,11 @@
       "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
       "dev": true
     },
+    "lite-youtube-embed": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/lite-youtube-embed/-/lite-youtube-embed-0.1.3.tgz",
+      "integrity": "sha512-Q6J74y9t/69uque79iPUVMH+m9vD+AZHP/wGFk1iWHVMmn0Xj0l3HGxMjUrq1TkQfVahNs5ttMBfmX989uCyYA=="
+    },
     "livereload-js": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/livereload-js/-/livereload-js-2.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "bootstrap": "^4.3.1",
     "classnames": "^2.2.6",
     "jquery": "^3.5.1",
+    "lite-youtube-embed": "^0.1.3",
     "popper.js": "^1.15.0"
   }
 }

--- a/src/Features.php
+++ b/src/Features.php
@@ -16,6 +16,8 @@ class Features {
 
 	public const CLOUDFLARE_DEPLOY_PURGE = 'cloudflare_deploy_purge';
 
+	public const LAZY_YOUTUBE_PLAYER = 'lazy_youtube_player';
+
 	/**
 	 * Get the features options page settings.
 	 *
@@ -64,6 +66,15 @@ class Features {
 					'planet4-master-theme-backend'
 				),
 				'id'   => self::CLOUDFLARE_DEPLOY_PURGE,
+				'type' => 'checkbox',
+			],
+			[
+				'name' => __( 'Lazy YouTube player', 'planet4-master-theme-backend' ),
+				'desc' => __(
+					'Only load the YouTube player after clicking a video.',
+					'planet4-master-theme-backend'
+				),
+				'id'   => self::LAZY_YOUTUBE_PLAYER,
 				'type' => 'checkbox',
 			],
 		];

--- a/src/Migrations/M002EnableLazyYoutube.php
+++ b/src/Migrations/M002EnableLazyYoutube.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace P4\MasterTheme\Migrations;
+
+use P4\MasterTheme\Features;
+use P4\MasterTheme\MigrationRecord;
+use P4\MasterTheme\MigrationScript;
+use P4\MasterTheme\Settings;
+
+/**
+ * Turn on the lazy youtube feature everywhere.
+ */
+class M002EnableLazyYoutube extends MigrationScript {
+
+	/**
+	 * Perform the actual migration.
+	 *
+	 * @param MigrationRecord $record Information on the execution, can be used to add logs.
+	 *
+	 * @return void
+	 */
+	protected static function execute( MigrationRecord $record ): void {
+		$settings = get_option( Settings::KEY, [] );
+
+		$settings[ Features::LAZY_YOUTUBE_PLAYER ] = 'on';
+		update_option( Settings::KEY, $settings );
+	}
+}

--- a/src/Migrator.php
+++ b/src/Migrator.php
@@ -3,6 +3,7 @@
 namespace P4\MasterTheme;
 
 use P4\MasterTheme\Migrations\M001EnableEnFormFeature;
+use P4\MasterTheme\Migrations\M002EnableLazyYoutube;
 
 /**
  * Run any new migration scripts and record results in the log.
@@ -22,6 +23,7 @@ class Migrator {
 		 */
 		$scripts = [
 			M001EnableEnFormFeature::class,
+			M002EnableLazyYoutube::class,
 		];
 
 		// Loop migrations and run those that haven't run yet.

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,6 +14,7 @@ module.exports = {
     style: './assets/src/scss/style.scss',
     bootstrap: './assets/src/scss/bootstrap-build.scss',
     archive_picker: './assets/src/js/archive_picker.js',
+    "lite-yt-embed": './node_modules/lite-youtube-embed/src/lite-yt-embed.js',
   },
   output: {
     filename: '[name].js',


### PR DESCRIPTION
* Add a way to force feature settings using query string. Can be used to
alternate lighthouse tests between both versions so that both are
affected about equally by the run conditions.
* Use srcdoc with an image using YouTube's url schema to avoid loading
the massive player on page load.

Ref: https://jira.greenpeace.org/browse/PLANET-5959
---
