### PR TITLE
Fix stylelint recursive path

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,7 +179,7 @@ jobs:
       - checkout
       - run:
           name: Lint CSS
-          command: stylelint assets/**/*.scss
+          command: stylelint "assets/src/scss/**/*.scss"
       - run:
           name: Install eslint react plugin
           command: PUPPETEER_SKIP_DOWNLOAD=true PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true npm install eslint-plugin-react


### PR DESCRIPTION
stylelint needs a double-quoted path, otherwise it doesn't make a recursive lookup.

Counterpart of greenpeace/planet4-plugin-gutenberg-blocks#510. In this case no scss code needed fixing.