### PR TITLE
PLANET-5971 Fix blocks js loading when logged in

### DIFF
--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -717,7 +717,9 @@ class MasterSite extends TimberSite {
 		// This loads a linked style file since the relative images paths are outside the build directory.
 		wp_enqueue_style( 'parent-style', $this->theme_dir . '/assets/build/style.min.css', [], $css_creation );
 
-		$jquery_deps = is_plugin_active( 'planet4-plugin-gutenberg-blocks/planet4-gutenberg-blocks.php' ) ? [ 'planet4-blocks-frontend' ] : [];
+		$jquery_should_wait = is_plugin_active( 'planet4-plugin-gutenberg-blocks/planet4-gutenberg-blocks.php' ) && ! is_user_logged_in();
+
+		$jquery_deps = $jquery_should_wait ? [ 'planet4-blocks-frontend' ] : [];
 
 		// JS files.
 		wp_deregister_script( 'jquery' );


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5971

---

* By not making jquery depend on it when logged in, since in that case
WordPress enqueues jquery in the head.
