### PR TITLE
Bump dashdash, whitelist shorthand

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -65,7 +65,7 @@
     "selector-pseudo-element-case": "lower",
     "selector-type-case": "lower",
     "selector-type-no-unknown": [true, {
-       "ignoreTypes": ["/^--[a-z]\\w*(--?[a-z0-9]+)*--$/", "lite-youtube"]
+	  "ignoreTypes": ["/^--[a-z]\\w*(--?[a-z0-9]+)*--$/", "_--", "lite-youtube"]
     }],
     "selector-max-empty-lines": 0,
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1443,9 +1443,9 @@
       "dev": true
     },
     "@greenpeace/dashdash": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@greenpeace/dashdash/-/dashdash-1.0.2.tgz",
-      "integrity": "sha512-QIsCb2OVBFKM998Akj2LPDoG4tmBGpmCW+ZCWCdRTOdcU84VPLczHauhEHlYdVnlAYBbG1mGxFObn4FsJWuMzg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@greenpeace/dashdash/-/dashdash-1.0.3.tgz",
+      "integrity": "sha512-aS85RTkLbSM2LBok43wC1+8TPz/vz19RE5BlJfOSx5Z14EuDlKHRl9uF72qJXrsHyZsWuDcbRpcOOd2O6BvAhA==",
       "dev": true,
       "requires": {
         "postcss": "^7.0.32"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint:css": "wp-scripts lint-style"
   },
   "devDependencies": {
-    "@greenpeace/dashdash": "^1.0.2",
+    "@greenpeace/dashdash": "^1.0.3",
     "@wordpress/components": "^8.3.2",
     "@wordpress/scripts": "3.3.0",
     "autoprefixer": "^9.6.1",


### PR DESCRIPTION
Ref: no ticket, just a bump to match the same bump in https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/495

---

This bumps dashdash to the latest version, which supports a shorthand to generate variable names from the selector.
```
.foo-bar {
  _-- {
    color: green;
    background-color: yellow;
  }
}
```
produces the same result as
```
.foo-bar {
  --foo-bar-- {
    color: green;
    background-color: yellow;
  }
}
```
which is the same as
```
.foo-bar {
  color: var(--foo-bar--color, green);
  background-color: var(--foo-bar--background-color, yellow);
}
```