### PR TITLE
PLANET-5981 Updates for Bootstrap 5

### DIFF
--- a/assets/src/js/header.js
+++ b/assets/src/js/header.js
@@ -38,7 +38,7 @@ export const setupHeader = function($) {
     const clickedElement = evt.target;
     $('button[aria-expanded="true"]').each(function(i, button) {
       const $button = $(button);
-      const buttonTarget = $($button.data('target')).get( 0 );
+      const buttonTarget = $($button.data('bs-target')).get( 0 );
       if (buttonTarget && ! $.contains(buttonTarget, clickedElement)) {
         // Spoof a click on the open menu's toggle to close that menu.
         $button.trigger('click');

--- a/assets/src/js/header.js
+++ b/assets/src/js/header.js
@@ -10,16 +10,16 @@ export const setupHeader = function($) {
     evt.stopPropagation();
 
     const $button = $(this);
-    const target = $button.data('target');
+    const target = $button.data('bs-target');
     if (!target) {
-      throw new Error('Missing `data-target` attribute: specify the container to be toggled');
+      throw new Error('Missing `data-bs-target` attribute: specify the container to be toggled');
     }
-    const toggleClass = $button.data('toggle');
+    const toggleClass = $button.data('bs-toggle');
     if (!toggleClass) {
-      throw new Error('Missing `data-toggle` attribute: specify the class to toggle');
+      throw new Error('Missing `data-bs-toggle` attribute: specify the class to toggle');
     }
 
-    // Toggle visibility of the target specified via data-target.
+    // Toggle visibility of the target specified via data-bs-target.
     $(target).toggleClass(toggleClass);
     $(this).toggleClass(toggleClass);
 

--- a/assets/src/scss/pages/_404.scss
+++ b/assets/src/scss/pages/_404.scss
@@ -26,14 +26,15 @@
 
     .search-form {
       padding-top: 10px;
+      position: relative;
 
       .search-form-btn {
         background: none;
         border: none;
         font-size: 20px;
         position: absolute;
-        right: 15px;
-        top: 38px;
+        right: 6px;
+        top: 13px;
       }
     }
 

--- a/assets/src/scss/pages/_page.scss
+++ b/assets/src/scss/pages/_page.scss
@@ -19,6 +19,10 @@ div.page-template {
     width: 1140px;
   }
 
+  @media (min-width: 1400px) {
+    width: 1320px;
+  }
+
   .container {
     padding-left: 0;
     padding-right: 0;

--- a/assets/src/scss/pages/search/_filter-sidebar.scss
+++ b/assets/src/scss/pages/search/_filter-sidebar.scss
@@ -115,6 +115,11 @@
     margin-top: 29px;
     z-index: 2;
 
+    html[dir="rtl"] & {
+      right: 0;
+      left: auto;
+    }
+
     @include small-and-up {
       margin-top: -14px;
     }

--- a/assets/src/scss/pages/search/_search-results.scss
+++ b/assets/src/scss/pages/search/_search-results.scss
@@ -37,6 +37,7 @@
 
         @include small-and-up {
           width: 25%;
+          min-width: 25%;
           margin: 0 32px 0 0;
           visibility: visible;
 

--- a/assets/src/scss/pages/search/_sort-filter.scss
+++ b/assets/src/scss/pages/search/_sort-filter.scss
@@ -14,19 +14,37 @@ div.search-filter-results {
 .sort-filter {
   width: 50%;
   float: right;
+  text-align: right;
+
+  html[dir="rtl"] & {
+    float: left;
+    text-align: left;
+  }
 
   @include small-and-up {
     width: 100%;
     float: none;
+
+    html[dir="rtl"] & {
+      float: none;
+    }
+  }
+
+  .select-container {
+    margin-top: -7px;
+
+    @include small-and-up {
+      margin-top: -14px;
+    }
   }
 
   label {
     font-size: 1.125rem;
-    margin-right: 90px;
+    margin-inline-end: 90px;
     font-weight: bold;
 
     @include small-and-up {
-      margin-right: 0;
+      margin-inline-end: 0.5rem;
     }
 
     @include large-and-up {
@@ -52,15 +70,6 @@ div.search-filter-results {
 
     @include large-and-up {
       width: 270px;
-    }
-  }
-
-  div {
-    text-align: right;
-    margin-top: -7px;
-
-    @include small-and-up {
-      text-align: inherit;
     }
   }
 }

--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -646,11 +646,11 @@ class MasterSite extends TimberSite {
 		];
 
 		// Allow below tags for carousel slider.
-		$allowedposttags['div']['data-ride']    = true;
-		$allowedposttags['li']['data-target']   = true;
-		$allowedposttags['li']['data-slide-to'] = true;
-		$allowedposttags['a']['data-slide']     = true;
-		$allowedposttags['span']['aria-hidden'] = true;
+		$allowedposttags['div']['data-bs-ride']    = true;
+		$allowedposttags['li']['data-bs-target']   = true;
+		$allowedposttags['li']['data-bs-slide-to'] = true;
+		$allowedposttags['a']['data-bs-slide']     = true;
+		$allowedposttags['span']['aria-hidden']    = true;
 
 		// Allow below tags for spreadsheet block.
 		$allowedposttags['input'] = [

--- a/templates/author.twig
+++ b/templates/author.twig
@@ -45,7 +45,7 @@
 			<div class="row">
 				<div class="col-md-12 col-lg-5 col-xl-5 mt-3">
 					<button
-						data-content=".multiple-search-result .list-unstyled"
+						data-bs-content=".multiple-search-result .list-unstyled"
 						data-page="1"
 						data-total="{{ posts.pagination.total }}"
 						data-url="{{ author.path }}"

--- a/templates/navigation-bar.twig
+++ b/templates/navigation-bar.twig
@@ -25,7 +25,7 @@
 					data-ga-action="Close Menu"
 					data-ga-label="{{ page_category }}">
 						<span
-							class="screen-reader-text"
+							class="visually-hidden"
 							data-ga-category="Menu Navigation"
 							data-ga-action="Close Menu"
 							data-ga-label="{{ page_category }}">
@@ -41,8 +41,8 @@
 					data-ga-category="Menu Navigation"
 					data-ga-action="Open Country Selector"
 					data-ga-label="{{ page_category }}">
-						<span class="screen-reader-text">{{ __( 'Selected', 'planet4-master-theme' ) }}:</span> {{ website_navbar_title }}
-						<span class="screen-reader-text">{{ __( 'Change Country', 'planet4-master-theme' ) }}</span>
+						<span class="visually-hidden">{{ __( 'Selected', 'planet4-master-theme' ) }}:</span> {{ website_navbar_title }}
+						<span class="visually-hidden">{{ __( 'Change Country', 'planet4-master-theme' ) }}</span>
 				</button>
 			</li>
 			{% for key,item in navbar_menu.get_items %}
@@ -94,7 +94,7 @@
 			data-ga-category="Menu Navigation"
 			data-ga-action="Open Search"
 			data-ga-label="{{ page_category }}">
-				<span class="screen-reader-text">{{ __( 'Toggle search form', 'planet4-master-theme' ) }}</span>
+				<span class="visually-hidden">{{ __( 'Toggle search form', 'planet4-master-theme' ) }}</span>
 		</button>
 		<form id="search_form" action="{{ data_nav_bar.home_url }}" class="form nav-item nav-search-wrap">
 			<input id="search_input" type="search" class="form-control" placeholder="{{ search_label }}"
@@ -111,7 +111,7 @@
 					{% set data_ga_attrs = 'data-ga-category="Menu Navigation" data-ga-action="Search" data-ga-label="' ~ page_category ~ '"' %}
 					{{ search_icon|replace({'<svg': "<svg " ~ data_ga_attrs })|raw }}
 				<span
-					class="screen-reader-text"
+					class="visually-hidden"
 					data-ga-category="Menu Navigation"
 					data-ga-action="Search"
 					data-ga-label="{{ page_category }}">

--- a/templates/navigation-bar.twig
+++ b/templates/navigation-bar.twig
@@ -7,8 +7,8 @@
 		{% set search_label = __( 'Search', 'planet4-master-theme' ) %}
 		<button
 			class="btn btn-navbar-toggle navbar-dropdown-toggle"
-			data-toggle="open"
-			data-target="#navbar-dropdown"
+			data-bs-toggle="open"
+			data-bs-target="#navbar-dropdown"
 			aria-expanded="false"
 			aria-label="{{ toggle_label }}">
 			<span
@@ -34,8 +34,8 @@
 				</button>
 				<button
 					class="country-dropdown-toggle"
-					data-toggle="open"
-					data-target="#country-list"
+					data-bs-toggle="open"
+					data-bs-target="#country-list"
 					aria-expanded="false"
 					aria-label="{{ data_nav_bar.country_dropdown_toggle }}"
 					data-ga-category="Menu Navigation"
@@ -87,8 +87,8 @@
 		</ul>
 		<button
 			class="navbar-search-toggle"
-			data-toggle="open"
-			data-target="#search_form"
+			data-bs-toggle="open"
+			data-bs-target="#search_form"
 			aria-expanded="false"
 			aria-label="{{ data_nav_bar.navbar_search_toggle }}"
 			data-ga-category="Menu Navigation"

--- a/templates/search.twig
+++ b/templates/search.twig
@@ -333,8 +333,8 @@
 				<div class="col-lg-8">
 					<div class="result-area">
 						<div class="sort-filter clearfix">
-							<div class="float-end">
-								<label class="me-sm-2" for="select_order">{{ __('Sort by', 'planet4-master-theme' ) }}</label>
+							<div class="select-container">
+								<label for="select_order">{{ __('Sort by', 'planet4-master-theme' ) }}</label>
 								<select
 										id="select_order"
 										class="form-select"

--- a/templates/search.twig
+++ b/templates/search.twig
@@ -68,7 +68,7 @@
 												<h4 class="modal-title">{{ __( 'Refine your search', 'planet4-master-theme' ) }}</h4>
 											</div>
 											<div class="col-3 text-right">
-												<button type="button" class="closebtn" data-dismiss="modal">
+												<button type="button" class="closebtn" data-bs-dismiss="modal">
 													{{ 'times'|svgicon }}
 												</button>
 											</div>
@@ -78,7 +78,7 @@
 												<div id="filter-sidebar-options-modal">
 													{% if ( categories|length > 0 ) %}
 														<div class="filteritem">
-															<a data-toggle="collapse" href="#item-modal-issue" aria-expanded="true">
+															<a data-bs-toggle="collapse" href="#item-modal-issue" aria-expanded="true">
 																{{ __( 'ISSUE', 'planet4-master-theme' ) }} <span></span>
 															</a>
 															<div id="item-modal-issue" class="collapse show" role="tabpanel">
@@ -107,7 +107,7 @@
 													{% endif %}
 													{% if ( page_types|length > 0 ) %}
 														<div class="filteritem">
-															<a data-toggle="collapse" href="#item-modal-category" aria-expanded="true">
+															<a data-bs-toggle="collapse" href="#item-modal-category" aria-expanded="true">
 																{{ __( 'CATEGORY', 'planet4-master-theme' ) }} <span></span>
 															</a>
 															<div id="item-modal-category" class="collapse show" role="tabpanel">
@@ -136,7 +136,7 @@
 													{% endif %}
 													{% if ( content_types|length > 0 ) %}
 														<div class="filteritem">
-															<a data-toggle="collapse" href="#item-modal-content" aria-expanded="true">
+															<a data-bs-toggle="collapse" href="#item-modal-content" aria-expanded="true">
 																{{ __( 'CONTENT TYPES', 'planet4-master-theme' ) }} <span></span>
 															</a>
 															<div id="item-modal-content" class="collapse show" role="tabpanel">
@@ -168,7 +168,7 @@
 											<div class="col-md-6">
 												{% if ( tags|length > 0 ) %}
 													<div class="filteritem">
-														<a data-toggle="collapse" href="#item-modal-campaign" aria-expanded="true">
+														<a data-bs-toggle="collapse" href="#item-modal-campaign" aria-expanded="true">
 															{{ __( 'CAMPAIGN', 'planet4-master-theme' ) }} <span></span>
 														</a>
 														<div id="item-modal-campaign" class="collapse show" role="tabpanel">
@@ -196,7 +196,7 @@
 											</div>
 										</div>
 										<div class="btnact">
-											<button type="button" class="btn btn-action btn-small cancelbtn" data-dismiss="modal">{{ __( 'Cancel', 'planet4-master-theme' ) }}</button>
+											<button type="button" class="btn btn-action btn-small cancelbtn" data-bs-dismiss="modal">{{ __( 'Cancel', 'planet4-master-theme' ) }}</button>
 											<button type="button" class="btn btn-primary btn-small applybtn">{{ __( 'Apply filters', 'planet4-master-theme' ) }}</button>
 										</div>
 									</div>
@@ -222,7 +222,7 @@
 							{% endif %}
 							{% if ( categories|length > 0 ) %}
 								<div class="filteritem">
-									<a data-toggle="collapse" href="#item-issue" aria-expanded="true">
+									<a data-bs-toggle="collapse" href="#item-issue" aria-expanded="true">
 										{{ __( 'Issue', 'planet4-master-theme' ) }} <span></span>
 									</a>
 									<div id="item-issue" class="collapse show" role="tabpanel">
@@ -249,7 +249,7 @@
 							{% endif %}
 							{% if ( tags|length > 0 ) %}
 								<div class="filteritem">
-									<a data-toggle="collapse" href="#item-campaign" class="{{ collapsed }}" aria-expanded="{{ expanded }}">
+									<a data-bs-toggle="collapse" href="#item-campaign" class="{{ collapsed }}" aria-expanded="{{ expanded }}">
 										{{ __( 'Campaign', 'planet4-master-theme' ) }} <span></span>
 									</a>
 									<div id="item-campaign" class="collapse {{ show }}" role="tabpanel">
@@ -275,7 +275,7 @@
 							{% endif %}
 							{% if ( page_types|length > 0 ) %}
 								<div class="filteritem">
-									<a data-toggle="collapse" href="#item-category" class="{{ collapsed }}" aria-expanded="{{ expanded }}">
+									<a data-bs-toggle="collapse" href="#item-category" class="{{ collapsed }}" aria-expanded="{{ expanded }}">
 										{{ __( 'Category', 'planet4-master-theme' ) }} <span></span>
 									</a>
 									<div id="item-category" class="collapse {{ show }}" role="tabpanel">
@@ -302,7 +302,7 @@
 							{% endif %}
 							{% if ( content_types|length > 0 ) %}
 								<div class="filteritem">
-									<a data-toggle="collapse" href="#item-content" class="{{ collapsed }}" aria-expanded="{{ expanded }}">
+									<a data-bs-toggle="collapse" href="#item-content" class="{{ collapsed }}" aria-expanded="{{ expanded }}">
 										{{ __( 'Content type', 'planet4-master-theme' ) }} <span></span>
 									</a>
 									<div id="item-content" class="collapse {{ show }}" role="tabpanel">

--- a/templates/search.twig
+++ b/templates/search.twig
@@ -334,10 +334,10 @@
 					<div class="result-area">
 						<div class="sort-filter clearfix">
 							<div class="float-end">
-								<label class="mr-sm-2" for="select_order">{{ __('Sort by', 'planet4-master-theme' ) }}</label>
+								<label class="me-sm-2" for="select_order">{{ __('Sort by', 'planet4-master-theme' ) }}</label>
 								<select
 										id="select_order"
-										class="form-control"
+										class="form-select"
 										name="select_order"
 										data-ga-category="Search Page"
 										data-ga-action="Sort By Filter"

--- a/templates/search.twig
+++ b/templates/search.twig
@@ -67,7 +67,7 @@
 											<div class="col-9">
 												<h4 class="modal-title">{{ __( 'Refine your search', 'planet4-master-theme' ) }}</h4>
 											</div>
-											<div class="col-3 text-right">
+											<div class="col-3 text-end">
 												<button type="button" class="closebtn" data-bs-dismiss="modal">
 													{{ 'times'|svgicon }}
 												</button>

--- a/templates/search.twig
+++ b/templates/search.twig
@@ -333,7 +333,7 @@
 				<div class="col-lg-8">
 					<div class="result-area">
 						<div class="sort-filter clearfix">
-							<div class="float-right">
+							<div class="float-end">
 								<label class="mr-sm-2" for="select_order">{{ __('Sort by', 'planet4-master-theme' ) }}</label>
 								<select
 										id="select_order"

--- a/templates/taxonomy.twig
+++ b/templates/taxonomy.twig
@@ -31,7 +31,7 @@
 			<div class="row">
 				<div class="col-md-12 col-lg-5 col-xl-5 mt-3">
 					<button
-						data-content=".multiple-search-result .list-unstyled"
+						data-bs-content=".multiple-search-result .list-unstyled"
 						data-page="1"
 						data-total="{{ posts.pagination.total }}"
 						data-url="{{ fn('get_term_link', taxonomy.term_id ) }}"

--- a/templates/tease-search.twig
+++ b/templates/tease-search.twig
@@ -16,7 +16,7 @@
 {% elseif ( first_of_the_page and loop.index0 is divisible by(5) ) %}
 	<div class="search-results-load row-hidden" style="display: none;">
 {% endif %}
-		<li id="result-row-{{ post.ID }}" class="d-flex search-result-list-item">
+		<li id="result-row-{{ post.ID }}" class="d-flex align-items-start search-result-list-item">
 
 		<img
 			class="d-flex search-result-item-image"


### PR DESCRIPTION
### Description

See https://jira.greenpeace.org/browse/PLANET-5981

Changes made to comply with the [migration doc](https://getbootstrap.com/docs/5.0/migration/):
- Rename all Bootstrap attributes' prefixes from `data-` to `data-bs-`
- Rename `float-right` to `float-end`
- Add `form-select` to select components instead of `form-control` (which now has the `appearance: none;` hiding the select's arrow)
- Remove `mr-sm-2` class
- Rename `text-right` to `text-end`
- Update page-template width for xxl screens (new breakpoint added as of Bootstrap 5)
- Remove `screen-reader-text` class to use Bootstrap's `visually-hidden` instead
- Add `align-items-start` class to search results
- Fix search for rtl direction

### Testing

You can check the changes on [this test instance](https://www-dev.greenpeace.org/test-janus/), basically everything should look/behave the same as it does in the current sites 🙂 

### Related PRs

- [styleguide](https://github.com/greenpeace/planet4-styleguide/pull/104)
- [gutenberg-blocks](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/521)