### PR TITLE
PLANET-5035 Make sure author image is full height

### DIFF
--- a/assets/src/scss/pages/post/_author-block.scss
+++ b/assets/src/scss/pages/post/_author-block.scss
@@ -69,6 +69,7 @@
   @include large-and-up {
     img {
       width: auto;
+      height: 100%;
     }
   }
 }


### PR DESCRIPTION
### Description

See [PLANET-5035](https://jira.greenpeace.org/browse/PLANET-5035): this is an old ticket that was closed but apparently the issue comes back from time to time in very specific cases (probably due to the author image dimensions?) This fix should solve it for good. 😬 