### PR TITLE
PLANET-5983: Add variables

### DIFF
--- a/assets/src/scss/base/_body.scss
+++ b/assets/src/scss/base/_body.scss
@@ -6,11 +6,13 @@ body {
 }
 
 body {
-  color: $grey-80;
-  font-family: $lora;
+  _-- {
+    color: $grey-80;
+    font-family: $lora;
+    background-color: $white;
+  }
   position: relative;
   overflow-y: hidden;
-  background-color: var(--body-background-color, $white);
 
   &.search {
     font-family: $roboto;

--- a/assets/src/scss/base/_typography.scss
+++ b/assets/src/scss/base/_typography.scss
@@ -18,12 +18,15 @@ html {
 p,
 li {
   hyphens: none;
-  font-size: $font-size-sm;
-  line-height: 1.6rem;
 
-  @include x-large-and-up {
-    font-size: $font-size-md;
-    line-height: 1.75rem;
+  --text-- {
+    font-size: $font-size-sm;
+    line-height: 1.6rem;
+
+    @include x-large-and-up {
+      font-size: $font-size-md;
+      line-height: 1.75rem;
+    }
   }
 }
 
@@ -46,8 +49,10 @@ h3,
 h4,
 h5,
 h6 {
-  font-family: $roboto;
-  font-weight: bold;
+  --headings-- {
+    font-family: $roboto;
+    font-weight: bold;
+  }
 
   &.has-text-align-center,
   &.has-text-align-right,
@@ -126,12 +131,12 @@ h6 {
 // :hover     - hovered state
 //
 // Styleguide Style.typography.links
-a {
-  color: var(--link--color, $link-color);
+a --link-- {
+  color: $link-color;
   text-decoration: none;
 
   &:hover {
-    color: var(--link-hover--color, $link-color);
+    color: $link-color;
     text-decoration: underline;
   }
 }

--- a/assets/src/scss/components/_buttons.scss
+++ b/assets/src/scss/components/_buttons.scss
@@ -12,23 +12,25 @@
 .btn,
 .wp-block-button a,
 .wp-block-file .wp-block-file__button {
+  --button-- {
+    font-family: $roboto;
+    text-align: center;
+    font-weight: bold;
+    border-radius: 4px;
+    padding: 0 30px;
+    transition-property: color, background-color, border-color;
+    transition-duration: 150ms;
+    transition-timing-function: linear;
+  }
   display: inline-block;
   position: relative;
-  font-family: $roboto;
   font-size: $font-size-sm;
-  text-align: center;
   text-decoration: none;
   color: $white;
-  font-weight: bold;
-  border-radius: 4px;
   border: 1px solid transparent;
   cursor: pointer;
   line-height: 3;
-  padding: 0 $n30;
   appearance: none;
-  transition-property: color, background-color, border-color;
-  transition-duration: 150ms;
-  transition-timing-function: linear;
 
   &:hover,
   &:focus,
@@ -70,23 +72,32 @@
   line-height: 3.1;
 }
 
+$primary-button-box-shadow: 0 2px 5px rgba(0, 0, 0, .25);
+
 .btn-primary,
 .wp-block-button.is-style-cta a {
-  background-color: $orange;
-  color: var(--btn-primary-color, $white);
-  box-shadow: 0 2px 5px rgba(0, 0, 0, .25);
+  --button-primary-- {
+    background: $orange;
+    color: $white;
+    // Adding this here so that the variable exists, though technically not needed.
+    // This allows for the hover variable to be previewed.
+    border-color: transparent;
+    box-shadow: $primary-button-box-shadow;
 
-  &:hover,
-  &:focus,
-  &:active {
-    background-color: $orange-hover;
-    border-color: $orange-hover;
-  }
+    &:hover,
+    &:focus,
+    &:active {
+      background: $orange-hover;
+      color: $white;
+      border-color: $orange-hover;
+      box-shadow: $primary-button-box-shadow;
+    }
 
-  &:disabled,
-  &.disabled,
-  &[disabled] {
-    background-color: $orange;
+    &:disabled,
+    &.disabled,
+    &[disabled] {
+      background: $orange;
+    }
   }
 }
 
@@ -94,36 +105,39 @@
 .wp-block-button.is-style-secondary a,
 [class="wp-block-button"] a,
 .wp-block-file .wp-block-file__button {
-  background-color: transparentize($white, .7);
-  border-color: $dark-blue;
-  color: $dark-blue;
-  box-shadow: none;
+  --button-secondary-- {
+    background: transparentize($white, .7);
+    border-color: $dark-blue;
+    color: $dark-blue;
+    box-shadow: none;
+
+    &:visited {
+      color: $dark-blue;
+    }
+
+    &:hover,
+    &:focus {
+      background: $dark-blue;
+      border-color: $dark-blue;
+      color: $white;
+    }
+
+    &:active {
+      background: $active-blue;
+      border-color: $active-blue;
+    }
+
+    &:disabled,
+    &.disabled,
+    &[disabled] {
+      background: $white;
+      color: $dark-blue;
+    }
+  }
+
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-
-  &:visited {
-    color: $dark-blue;
-  }
-
-  &:hover,
-  &:focus {
-    background-color: $dark-blue;
-    border-color: $dark-blue;
-    color: $white;
-  }
-
-  &:active {
-    background-color: $active-blue;
-    border-color: $active-blue;
-  }
-
-  &:disabled,
-  &.disabled,
-  &[disabled] {
-    background-color: $white;
-    color: $dark-blue;
-  }
 }
 
 // The new core buttons block wrap in "wp-block-buttons" class which apply
@@ -151,21 +165,29 @@
   }
 }
 
+$donate-button-box-shadow: 0 2px 5px rgba(0, 0, 0, .25);
+
 .btn-donate,
 .wp-block-button.is-style-donate a {
-  background-color: var(--btn-donate-background-color, $aquamarine);
-  color: var(--btn-donate-color, $grey-80);
-  line-height: 1.65;
-  min-width: 180px;
-  margin: 0;
-  padding: 2px $n30;
-  box-shadow: 0 2px 5px rgba(0, 0, 0, .25);
-  text-transform: none;
+  --button-donate-- {
+    background: $aquamarine;
+    color: $grey-80;
+    min-width: 180px;
+    padding: 2px 30px;
+    box-shadow: $donate-button-box-shadow;
+    border-width: 1px;
+    border-color: transparent;
 
-  &:hover,
-  &:focus {
-    color: transparentize($grey-80, 0.2);
+    &:hover,
+    &:focus {
+      background: $aquamarine;
+      color: transparentize($grey-80, 0.2);
+      box-shadow: $donate-button-box-shadow;
+    }
   }
+  line-height: 1.65;
+  margin: 0;
+  text-transform: none;
 
   @include large-and-up {
     font-size: $font-size-md;

--- a/assets/src/scss/layout/_breadcrumbs.scss
+++ b/assets/src/scss/layout/_breadcrumbs.scss
@@ -31,7 +31,6 @@
   .tag-wrap {
     display: inline;
     position: relative;
-    color: $link-color;
   }
 
   .tag-item--main + .tag-wrap,
@@ -51,8 +50,10 @@
   }
 
   .tag-item {
-    color: $link-color;
-    font-weight: 400;
+    _-- {
+      color: $link-color;
+      font-weight: 400;
+    }
     display: inline-block;
 
     @include x-large-and-up {
@@ -79,7 +80,9 @@
   }
 
   .tag-item--main {
-    font-weight: 500;
+    _-- {
+      font-weight: 500;
+    }
 
     &.page-type {
       text-transform: uppercase;

--- a/assets/src/scss/layout/_footer.scss
+++ b/assets/src/scss/layout/_footer.scss
@@ -42,9 +42,11 @@
 //
 // Styleguide Layout.footer
 .site-footer {
-  font-family: $roboto;
+  --footer-- {
+    font-family: $roboto;
+    background: $dark-blue;
+  }
   padding: 45px 0 $n25;
-  background: var(--footer_color, $dark-blue);
   position: relative;
   z-index: 2;
   text-align: center;
@@ -60,15 +62,11 @@
     padding: 55px 0 $n25;
   }
 
-  p {
-    font-family: $roboto;
-  }
-
-  a {
-    color: var(--footer_links_color, inherit);
+  a --footer--links-- {
+    color: inherit;
 
     &:hover {
-      color: var(--footer_links_color, $white);
+      color: $white;
     }
   }
 
@@ -78,7 +76,9 @@
 }
 
 .footer-social-media {
-  color: var(--footer_links_color, $grey-20);
+  _-- {
+    color: $grey-20;
+  }
   font-size: $font-size-xl;
   margin: auto;
   text-align: center;
@@ -112,10 +112,12 @@
   }
 
   a {
-    transition: color 100ms linear;
+    --footer-social-media--link-- {
+      transition: color 100ms linear;
 
-    &:hover {
-      color: $white;
+      &:hover {
+        color: $white;
+      }
     }
   }
 }
@@ -147,10 +149,12 @@
 }
 
 .footer-links {
-  color: var(--footer_links_color, $white);
-  font-weight: bold;
-  text-transform: uppercase;
-  margin-bottom: 16px;
+  --footer-menu-- {
+    color: $white;
+    font-weight: bold;
+    text-transform: uppercase;
+    margin-bottom: 16px;
+  }
 
   li {
     font-size: $font-size-md;
@@ -167,9 +171,11 @@
 }
 
 .footer-links-secondary {
-  color: var(--footer_links_color, $grey-10);
-  text-transform: uppercase;
-  margin-bottom: 30px;
+  --footer-menu-secondary-- {
+    color: $grey-10;
+    text-transform: uppercase;
+    margin-bottom: 30px;
+  }
 
   @include medium-and-up {
     font-size: $font-size-xxs;
@@ -181,7 +187,9 @@
 }
 
 .copyright-text {
-  color: var(--footer_links_color, $grey-10);
+  --footer--copyright-- {
+    color: $grey-10;
+  }
   font: $font-size-xxs;
   line-height: 1.3;
   margin-left: auto;
@@ -207,13 +215,15 @@
     }
   }
 
-  a {
-    color: var(--footer_links_color, $white);
+  a --footer--copyright--link-- {
+    color: $white;
   }
 }
 
 .gp-year {
-  color: var(--footer_links_color, $white);
+  --footer--copyright--year-- {
+    color: $white;
+  }
   font-size: $font-size-xxs;
   text-transform: none;
 
@@ -235,7 +245,6 @@
   line-height: 1;
 
   .footer-social-media {
-    color: var(--footer_links_color, $grey-20);
     font-size: $font-size-xl;
     margin: 0 auto $space-md auto;
     text-align: center;
@@ -255,10 +264,6 @@
 
     a {
       transition: color 100ms linear;
-
-      &:hover {
-        color: $grey-20;
-      }
     }
 
     .list-unstyled {
@@ -267,13 +272,12 @@
   }
 
   .gp-year {
-    color: var(--footer_links_color, $white);
     font-size: $font-size-xxs;
     font-family: $lora;
     margin: 40px 0 30px 0;
   }
 
-  .icon {
-    fill: var(--footer_links_color, $white);
+  .icon _-- {
+    fill: $white;
   }
 }

--- a/assets/src/scss/layout/_navbar.scss
+++ b/assets/src/scss/layout/_navbar.scss
@@ -70,6 +70,14 @@ $min-height: 40px;
 $navbar-default-height: 60px;
 
 .top-navigation {
+  _-- {
+    background: transparentize($dark-blue, 0.2);
+    border-bottom-width: 0;
+    border-bottom-color: transparent;
+    box-shadow: none;
+  }
+
+  border-bottom-style: solid;
   position: fixed;
   width: 100%;
   top: 0;
@@ -80,7 +88,6 @@ $navbar-default-height: 60px;
   flex-direction: row;
   justify-content: space-between;
   align-items: normal;
-  background: var(--campaign_nav_color, transparentize($dark-blue, 0.2));
   height: $menu-height-small;
   font-family: $roboto;
 
@@ -96,8 +103,12 @@ $navbar-default-height: 60px;
     align-items: center;
   }
 
-  a.nav-link {
-    color: var(--nav-link-color, $white);
+  a.nav-link --nav-link-- {
+    color: $white;
+
+    &:hover {
+      color: $white;
+    }
   }
 
   .donate-nav-item {
@@ -455,19 +466,24 @@ $navbar-default-height: 60px;
 
     .nav-link {
       padding: 0;
-      min-width: 20%;
       text-align: center;
-      border-bottom: var(--nav-link-border-width, 2px) solid transparent;
+      border-bottom-style: solid;
 
-      &:hover,
-      &:focus,
-      &:active {
-        border-bottom: var(--nav-link-border-width, 2px) solid var(--nav-link-hover-border-color, $white);
+      --nav-link-- {
+        border-bottom-width: 2px;
+        border-bottom-color: transparent;
+        min-width: 20%;
+
+        &:hover,
+        &:focus,
+        &:active {
+          border-bottom-color: $white;
+        }
       }
     }
 
-    .active .nav-link {
-      border-bottom: var(--nav-link-border-width, 2px) solid var(--nav-link-active-border-color, $white);
+    .active .nav-link --nav-link-active-- {
+      border-bottom-color: $white;
     }
   }
 
@@ -616,10 +632,12 @@ $navbar-default-height: 60px;
 }
 
 .country-list {
+  _-- {
+    background: $x-dark-blue;
+    line-height: 1.5;
+  }
   display: none;
   text-transform: none;
-  background: $x-dark-blue;
-  line-height: 1.5;
   padding: 1.4em 0;
   overflow-y: hidden;
   top: $navbar-default-height;
@@ -631,7 +649,10 @@ $navbar-default-height: 60px;
 
   a {
     display: block;
-    color: $white;
+
+    _-- {
+      color: $white;
+    }
   }
 
   .active a {
@@ -639,11 +660,13 @@ $navbar-default-height: 60px;
   }
 
   .country-group-letter {
-    font-size: $font-size-sm;
+    _-- {
+      font-size: $font-size-sm;
+      font-weight: bold;
+      color: $grey-40;
+    }
     position: absolute;
     line-height: 1.5;
-    font-weight: bold;
-    color: $grey-40;
     @include margin($left: -$n25);
 
     html[dir="rtl"] & {
@@ -709,14 +732,15 @@ $navbar-default-height: 60px;
   }
 
   @include large-and-up {
+    --country-list-- {
+      height: 344px;
+      width: 80%;
+      left: 10%;
+    }
+    max-height: calc(100vh - #{$menu-height-large});
     position: absolute;
-    height: 344px;
-    width: 80%;
-    left: 10%;
     overflow-x: hidden;
     overflow-y: hidden !important;
-    max-height: 344px;
-    max-height: calc(100vh - #{$menu-height-large});
     padding: 2em 4em 4em;
 
     .admin-bar & {
@@ -771,7 +795,9 @@ $navbar-default-height: 60px;
 }
 
 .navigation-bar_min {
-  height: $min-height;
+  --top-navigation-min-- {
+    height: $min-height;
+  }
   align-items: baseline;
   justify-content: start;
 

--- a/assets/src/scss/layout/_skewed-overlay.scss
+++ b/assets/src/scss/layout/_skewed-overlay.scss
@@ -1,4 +1,8 @@
 .skewed-overlay {
+  _-- {
+    display: block;
+  }
+
   pointer-events: none;
   height: 200vh;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1443,9 +1443,9 @@
       "dev": true
     },
     "@greenpeace/dashdash": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@greenpeace/dashdash/-/dashdash-1.0.3.tgz",
-      "integrity": "sha512-aS85RTkLbSM2LBok43wC1+8TPz/vz19RE5BlJfOSx5Z14EuDlKHRl9uF72qJXrsHyZsWuDcbRpcOOd2O6BvAhA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@greenpeace/dashdash/-/dashdash-1.1.1.tgz",
+      "integrity": "sha512-bFMEtgXBxFTj5Ls3A2GqYn5lu8Cbb+RaN0cIIHv6mgEHcZ1HRDJROud6dHGhcIkdPN+M2cAymr+4MC4t2Q7MVg==",
       "dev": true,
       "requires": {
         "postcss": "^7.0.32"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint:css": "wp-scripts lint-style"
   },
   "devDependencies": {
-    "@greenpeace/dashdash": "^1.0.3",
+    "@greenpeace/dashdash": "^1.1.1",
     "@wordpress/components": "^8.3.2",
     "@wordpress/scripts": "3.3.0",
     "autoprefixer": "^9.6.1",

--- a/src/PostCampaign.php
+++ b/src/PostCampaign.php
@@ -467,6 +467,7 @@ class PostCampaign {
 	 */
 	private static function migrate_old_vars( array $css_vars ): array {
 		if ( isset( $css_vars['footer_links_color'] ) ) {
+			$css_vars['footer--background']   = $css_vars['footer_color'];
 			$css_vars['footer--links--color'] = $css_vars['footer_links_color'];
 			// This one already existed separately, maybe we can just remove but keeping it for now.
 			$css_vars['footer-links--color']               = $css_vars['footer_links_color'];
@@ -482,7 +483,7 @@ class PostCampaign {
 			$css_vars['body--background-color'] = $css_vars['body-background-color'];
 		}
 		if ( isset( $css_vars['header-primary-font'] ) ) {
-			$css_vars['headers--font-family'] = $css_vars['header-primary-font'];
+			$css_vars['headings--font-family'] = $css_vars['header-primary-font'];
 		}
 		if ( isset( $css_vars['campaign_nav_color'] ) ) {
 			$css_vars['top-navigation--background'] = $css_vars['campaign_nav_color'];

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -52,7 +52,7 @@ module.exports = {
             options: {
               ident: 'postcss',
               plugins: () => [
-                dashDash({ mediaQueryAliases, mediaQueryAtStart: true }),
+                dashDash({ mediaQueryAliases, mediaQueryAtStart: false }),
                 cssVariables({ preserve: true, exportVarUsagesTo: allCssVars }),
                 require('autoprefixer'),
               ],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,6 +10,14 @@ const cssVariables = require( '@greenpeace/planet4-postcss-css-variables' );
 const VariableCombinePlugin = require( '@greenpeace/planet4-postcss-css-variables/variableCombinePlugin' )
 
 const allCssVars = {};
+const mediaQueryAliases = {
+  '(max-width: 576px)': 'mobile-only',
+  '(min-width: 576px)': 'small-and-up',
+  '(min-width: 768px)': 'medium-and-up',
+  '(min-width: 992px)': 'large-and-up',
+  '(min-width: 1200px)': 'x-large-and-up',
+};
+
 module.exports = {
   ...defaultConfig,
   entry: {
@@ -44,9 +52,9 @@ module.exports = {
             options: {
               ident: 'postcss',
               plugins: () => [
-                dashDash(),
-                 cssVariables( { preserve: true, exportVarUsagesTo: allCssVars } ),
-                 require('autoprefixer'),
+                dashDash({ mediaQueryAliases, mediaQueryAtStart: true }),
+                cssVariables({ preserve: true, exportVarUsagesTo: allCssVars }),
+                require('autoprefixer'),
               ],
               sourceMap: true,
             }


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5983

---

Easiest to review with whitespace changes hidden: https://github.com/greenpeace/planet4-master-theme/pull/1325/files?diff=split&w=1

Current proposed migration path:
* Add all variables needed to recreate the campaign themes (CSS overrides living under https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/tree/d90243cf861c5e5909db59c546516bc6f58315cb/assets/src/styles/campaigns, as well as the sidebar options.
* Recreate the themes (either by adding a JSON/CSS file for each one in our code, or by allowing themes to be created and saved in the database without code change)
* Switch all existing campaigns to use these instead of the CSS overrides.
* Remove the old override based code.

In this PR (might split up further):
* Add variables unless adding them has a significant risk for regressions (e.g. have to change our CSS logic to make the variable work, only had to make minor changes which seem safe).
* I removed some declarations that are not used or not needed, when they also prevented variables from working. Also some minor modifications. I added explanatory comments for most of these in the PR.
* In some cases I needed to add hover properties that weren't present because they are the same as the non-hover property in our theme, but were being customized in campaign themes. e.g. https://github.com/greenpeace/planet4-master-theme/pull/1325/files#diff-2bc1c6e089a7a01997bb250bca7b661343c35a1512e49d22a11b1f00ef03b783R183

The test instance has data from GPI, so we can test all current campaigns if they still look the same with these changes. https://www-dev.greenpeace.org/test-nix/?s=&orderby=_score&f%5Bctype%5D%5BCampaign%5D=4

Note that if a campaign uses one of the campaign themes, the experimental theme editor will not work. This is not a problem since we intend to replace those themes altogether.