### PR TITLE
PLANET-5990 Restrict max-width on floated elements

### DIFF
--- a/assets/src/scss/pages/post/_article-content.scss
+++ b/assets/src/scss/pages/post/_article-content.scss
@@ -123,6 +123,7 @@
       float: left;
       margin: 0 $n10 $n10 0;
       padding-top: 6px;
+      max-width: 100%;
     }
   }
 
@@ -131,6 +132,7 @@
       float: right;
       margin: 0 0 $n10 $n10;
       padding-top: 6px;
+      max-width: 100%;
     }
   }
 


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5990

---

On images this has no effect, since they already have `max-width`,
but other elements can expand outside of the post container when floating.

> _[Test post](https://www-dev.greenpeace.org/test-proteus/story/1007/social-media-test/)_

Required for greenpeace/planet4-plugin-gutenberg-blocks#524