### PR TITLE
PLANET-5501 Update clear search filters button styles

### DIFF
--- a/assets/src/scss/pages/search/_filter-sidebar.scss
+++ b/assets/src/scss/pages/search/_filter-sidebar.scss
@@ -177,20 +177,21 @@
       border-bottom: 1px solid $grey-20;
       padding-bottom: 10px;
 
-      .activefilter-tag,
-      .clearall {
+      .activefilter-tag {
         font-size: 1.125rem;
-        font-style: normal;
-        color: $dark-blue;
         border: 1px solid $dark-blue;
         padding: 0 $n40 0 $n20;
         display: inline-block;
-        margin-right: 8px;
         margin-bottom: 16px;
         line-height: 42px;
         text-decoration: none;
         position: relative;
+        cursor: pointer;
+        background-color: transparent;
+        color: $dark-blue;
+        margin-inline-end: 8px;
         min-width: 40%;
+        text-align: left;
       }
 
       .icon-cross {
@@ -201,19 +202,10 @@
         margin-right: $n15;
       }
 
-      .activefilter-tag {
-        background-color: transparent;
-        cursor: pointer;
-        text-align: left;
-      }
-
       .clearall {
-        text-align: center;
         width: 100%;
         background: $dark-blue;
         color: $white;
-        text-transform: uppercase;
-        cursor: pointer;
       }
     }
   }

--- a/templates/search.twig
+++ b/templates/search.twig
@@ -216,7 +216,7 @@
 												</button>
 											{% endfor %}
 										{% endfor %}
-										<button class="clearall">{{ __( 'Clear all', 'planet4-master-theme' ) }} <i class="icon-cross"></i></button>
+										<button class="btn clearall">{{ __( 'Clear all', 'planet4-master-theme' ) }} <i class="icon-cross"></i></button>
 									</div>
 								</div>
 							{% endif %}


### PR DESCRIPTION
### Description

When updating the button styles for [PLANET-5501](https://jira.greenpeace.org/browse/PLANET-5501) we forgot the one to clear search filters 😬 We probably missed it because it didn't have the `btn` class so I added it, which also avoids some duplicate code

<img width="333" alt="Screenshot 2021-03-09 at 09 42 24" src="https://user-images.githubusercontent.com/6949075/110450039-1ab54f00-80c3-11eb-9c08-3d0fb8d3a3b5.png">

### Testing

You can see the updated button [here](https://www-dev.greenpeace.org/test-umbriel/?s=&orderby=_score&f%5Bcat%5D%5BNature%5D=3) for instance