### PR TITLE
PLANET-4535: Match change in plugin's script handle

### DIFF
--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -748,7 +748,7 @@ class MasterSite extends TimberSite {
 
 		$jquery_should_wait = is_plugin_active( 'planet4-plugin-gutenberg-blocks/planet4-gutenberg-blocks.php' ) && ! is_user_logged_in();
 
-		$jquery_deps = $jquery_should_wait ? [ 'planet4-blocks-frontend' ] : [];
+		$jquery_deps = $jquery_should_wait ? [ 'planet4-blocks-script' ] : [];
 
 		// JS files.
 		wp_deregister_script( 'jquery' );


### PR DESCRIPTION
This update is to match the changes in the blocks plugin repo, see:
https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/508/files#diff-4baaf0cfa9f65dafcc2bed33ae43cbc221e00364aaa33ec6b6c71b49e56ea5c0R402

Ref: https://jira.greenpeace.org/browse/PLANET-4535


---

<!--
Please provide a brief summary of the change introduced to make review process easier.

Ideally this should also be part of the commit summary.
-->
