### PR TITLE
Prevent unneeded prefixes, we autoprefix

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -87,6 +87,7 @@
     "no-unknown-animations": true,
     "no-invalid-double-slash-comments": true,
     "no-missing-end-of-source-newline": true,
-    "max-empty-lines": 1
+    "max-empty-lines": 1,
+    "property-no-vendor-prefix": true
   }
 }

--- a/assets/src/scss/pages/post/_author-block.scss
+++ b/assets/src/scss/pages/post/_author-block.scss
@@ -53,7 +53,11 @@
 
   @supports (display: -webkit-box) {
     display: -webkit-box;
+    /* stylelint-disable property-no-vendor-prefix */
+    /*! autoprefixer: off */
     -webkit-box-orient: vertical;
+    /*! autoprefixer: on */
+    /* stylelint-enable property-no-vendor-prefix */
     max-height: none;
   }
 }

--- a/assets/src/scss/pages/post/_post.scss
+++ b/assets/src/scss/pages/post/_post.scss
@@ -2,7 +2,6 @@
 .single-idea {
   .skewed-overlay {
     mask-image: none;
-    -webkit-mask-image: none;
   }
 
   .page-header {


### PR DESCRIPTION
Ref: no ticket for now

---

Since we use autoprefixer, we can use a stylelintrule to detect any prefixes in our source that would be added during build anyway. This adds the rule and fixes violations, except `-webkit-box-orient` which is buggy.
