### PR TITLE
test against version we use

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ job-references:
           command: |
             mkdir -p /tmp/test-results/phpunit
             rm -rf $WP_TESTS_DIR $WP_CORE_DIR
-            bash bin/install-wp-tests.sh wordpress_test root '' 127.0.0.1 latest
+            bash bin/install-wp-tests.sh wordpress_test root '' 127.0.0.1
             XDEBUG_MODE=coverage vendor/bin/phpunit --log-junit /tmp/test-results/phpunit/$CIRCLE_STAGE.xml --coverage-html /tmp/coverage-report --coverage-text
       - store_test_results:
           path: /tmp/test-results

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -9,7 +9,7 @@ DB_NAME=$1
 DB_USER=$2
 DB_PASS=$3
 DB_HOST=${4-localhost}
-WP_VERSION=${5-latest}
+WP_VERSION=${5-"5.4"}
 SKIP_DB_CREATE=${6-false}
 
 TMPDIR=${TMPDIR-/tmp}


### PR DESCRIPTION
Ref: <!-- Please add a url to the ticket this change is addressing. -->

---

Our tests are running against the latest version of WP, not against the one we use in production. This came up by a new issue in 5.7 that broke a test.

Could need more changes than just the WP version since it's still failing.