### PR TITLE
PLANET-5848 Remove blue caption from classic editor images

### DIFF
--- a/assets/src/scss/pages/post/_article-content.scss
+++ b/assets/src/scss/pages/post/_article-content.scss
@@ -285,7 +285,7 @@
 .wp-caption {
   position: relative;
   display: inline-block;
-  width: auto !important;
+  width: auto;
   max-width: 100%;
 
   &.alignnone {
@@ -323,25 +323,12 @@
   }
 
   .wp-caption-text {
-    font-size: 0.8125rem;
-    margin: 0;
-    line-height: 1.4;
-    color: $white;
+    font-size: $font-size-xxs;
     font-family: $roboto;
-    width: 100%;
-    max-width: 100%;
-    background: linear-gradient(210deg, transparentize($dark-blue, .8) 0%, $dark-blue 100%);
-    padding: $n10 $n20;
-
-    @include medium-and-up {
-      position: absolute;
-      left: 0;
-      bottom: 0;
-      padding: $n20 $n30;
-    }
-
-    @include large-and-up {
-      padding: $n20 $n30;
-    }
+    line-height: 1.4;
+    margin-bottom: 0;
+    padding-top: $n10;
+    color: $grey-60;
+    text-align: center;
   }
 }


### PR DESCRIPTION
### Description

See https://jira.greenpeace.org/browse/PLANET-5848

### Testing
- [Old version](https://www-dev.greenpeace.org/test-jupiter/explore/ships/arctic-sunrise/) with the blue caption overlay
- [New version](https://www-dev.greenpeace.org/test-tavros/explore/ships/arctic-sunrise/) with the regular caption styles