### PR TITLE
PLANET-6004 Fix pdf link icon (hover) colors

### DIFF
--- a/assets/src/js/external_links.js
+++ b/assets/src/js/external_links.js
@@ -1,7 +1,7 @@
 export const setupExternalLinks = () => {
   const siteURL = window.location.host;
 
-  const linkSelector = ['div.page-template', 'article'].map(sel=>`${sel} a:not(.btn):not(.cover-card-heading):not([href*="${siteURL}"]):not([href*=".pdf"]):not([href^="/"]):not([href^="#"]):not([href^="javascript:"])`).join(', ');
+  const linkSelector = ['div.page-template', 'article'].map(sel=>`${sel} a:not(.btn):not(.cover-card-heading):not(.wp-block-button__link):not([href*="${siteURL}"]):not([href*=".pdf"]):not([href^="/"]):not([href^="#"]):not([href^="javascript:"])`).join(', ');
   const links = [...document.querySelectorAll(linkSelector)];
 
   links.forEach(link => {


### PR DESCRIPTION
### Description

See https://jira.greenpeace.org/browse/PLANET-6004

### Testing

You can see the fixed links & buttons on [this page](https://www-dev.greenpeace.org/test-leda/links-and-buttons-with-icons/) for example.

Note: the issue with the width of the secondary buttons will be solved as part of [PLANET-5980](https://jira.greenpeace.org/browse/PLANET-5980).

### Related PRs
- [styleguide](https://github.com/greenpeace/planet4-styleguide/pull/107)
- [blocks](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/531)