### PR TITLE
PLANET-4590: Error on saving post content due to meta field registration too wide

### DIFF
--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -915,8 +915,8 @@ class MasterSite extends TimberSite {
 	 */
 	private function register_meta_fields(): void {
 		// Credit for images, used in image caption.
-		\register_meta(
-			'post',
+		\register_post_meta(
+			'attachment',
 			self::CREDIT_META_FIELD,
 			[
 				'show_in_rest' => true,


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-4590
Fixes: https://github.com/greenpeace/planet4-master-theme/pull/1259

The meta field `_credit_text` is used in the API response to gather information on an attachment to generate a caption with credits.  
Current code registers this meta key a bit too widely, which makes saving a campaign content fail.

## Fix

- Restrict the availability of meta key  `_credit_key` to attachments only

## Test

- Create a campaign and try to save the draft
  - On master branch, saving process fails, mentioning in the API response `Sorry, you are not allowed to edit the _credit_text custom field.` If it doesn't fail, check in the browser console that `wp.data.select('core/editor').getCurrentPost().meta['_credit_text']` returns an empty string.
  - On this branch, the saving process works, and `wp.data.select('core/editor').getCurrentPost().meta['_credit_text']` returns `undefined`
  - Reload the page when you switch branches, so that the meta field is registered as the code dictates