### PR TITLE
PLANET-6015: add field here so it can be used in editor

### DIFF
--- a/src/PostCampaign.php
+++ b/src/PostCampaign.php
@@ -15,6 +15,7 @@ class PostCampaign {
 	const DEFAULT_NAVBAR_THEME = 'planet4';
 
 	public const META_FIELDS = [
+		'p4_campaign_name',
 		'theme',
 		'campaign_logo',
 		'campaign_logo_color',


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6015

---

The block editor validation relied on reading the meta from the input field that is separate from the other data flow in the editor. This adds it to the "campaign fields", which results in it being registered for the API so it can be used in the editor.

This PR needs to be merged before the tests on https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/537 can pass. Adding just the field here should only mean it is registered for the REST API so that it's returned by `wp.data.select('core/editor').getEditedPostAttribute('meta')`. So this seems a safe change.