### PR TITLE
PLANET-6021 Hide core upgrade notice

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -132,6 +132,16 @@ add_action(
 	1
 );
 
+/**
+ * Hide core updates notification in the dashboard, to avoid confusion while an upgrade is already in progress.
+ */
+function hide_wp_update_nag() {
+	remove_action( 'admin_notices', 'update_nag', 3 );
+	remove_filter( 'update_footer', 'core_update_footer' );
+}
+
+add_action( 'admin_menu', 'hide_wp_update_nag' );
+
 require_once 'load-class-aliases.php';
 
 Loader::get_instance();


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6021

---

We already watch for new releases, so this notice only causes confusion to users.
To test: confirm that the notice is not shown at the top of every admin page.