### PR TITLE
PLANET-6028 explicitly define bootstrap as dep of parent-style

### DIFF
--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -739,7 +739,12 @@ class MasterSite extends TimberSite {
 		);
 
 		// This loads a linked style file since the relative images paths are outside the build directory.
-		wp_enqueue_style( 'parent-style', $this->theme_dir . '/assets/build/style.min.css', [], $css_creation );
+		wp_enqueue_style(
+			'parent-style',
+			$this->theme_dir . '/assets/build/style.min.css',
+			[ 'bootstrap' ],
+			$css_creation
+		);
 
 		$jquery_should_wait = is_plugin_active( 'planet4-plugin-gutenberg-blocks/planet4-gutenberg-blocks.php' ) && ! is_user_logged_in();
 


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6028

---

We didn't define this earlier but it didn't cause any issues. However since last deploy the Japanese child theme is now loading bootstrap after the master theme CSS, which changes the order of CSS and so causes most `a` tags to be underlined (and likely more issues). Could be it was already loading like this before but it only started causing issues with Bootstrap 5 upgrade.