### PR TITLE
PLANET-5983: Move in styleguide

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "assets/src/scss/styleguide"]
-	path = assets/src/scss/styleguide
-	url = https://github.com/greenpeace/planet4-styleguide.git

--- a/assets/src/scss/pages/_page.scss
+++ b/assets/src/scss/pages/_page.scss
@@ -157,4 +157,3 @@ div.page-template {
     }
   }
 }
-

--- a/assets/src/scss/pages/_page.scss
+++ b/assets/src/scss/pages/_page.scss
@@ -90,21 +90,21 @@ div.page-template {
 }
 
 .password-form {
-  .input-text{
-    font-size:16px;
-    line-height:1.6;
-    font-weight:400;
-    margin-bottom:16px;
-    position:relative;
+  .input-text {
+    font-size: 16px;
+    line-height: 1.6;
+    font-weight: 400;
+    margin-bottom: 16px;
+    position: relative;
   }
 
-  .input-text input{
-    border:1px solid $grey-20;
-    border-radius:4px;
-    display:inline-block;
-    font-size:16px;
-    padding:15px 14px 8px;
-    min-width:400px;
+  .input-text input {
+    border: 1px solid $grey-20;
+    border-radius: 4px;
+    display: inline-block;
+    font-size: 16px;
+    padding: 15px 14px 8px;
+    min-width: 400px;
 
     &.is-invalid {
       border-color: $dark-orange;
@@ -116,13 +116,13 @@ div.page-template {
     }
   }
 
-  .input-text input:hover{
-    border:1px solid $grey-40;
+  .input-text input:hover {
+    border: 1px solid $grey-40;
   }
 
-  .input-text input:focus{
-    border-color:rgba(0,109,253,0.75);
-    outline:0 none;
+  .input-text input:focus {
+    border-color: rgba(0, 109, 253, 0.75);
+    outline: 0 none;
   }
 
   .invalid-pw-feedback {

--- a/assets/src/scss/styleguide/src/base/_body.scss
+++ b/assets/src/scss/styleguide/src/base/_body.scss
@@ -1,0 +1,27 @@
+html,
+body {
+  overflow-x: hidden;
+  scroll-behavior: smooth;
+  scroll-padding-top: 4rem;
+}
+
+body {
+  color: $grey-80;
+  font-family: $lora;
+  position: relative;
+  overflow-y: hidden;
+  background-color: var(--body-background-color, $white);
+
+  &.search {
+    font-family: $roboto;
+  }
+
+  .mejs-container {
+    clear: initial;
+  }
+}
+
+.container > * {
+  position: relative;
+  z-index: 2;
+}

--- a/assets/src/scss/styleguide/src/base/_colors.scss
+++ b/assets/src/scss/styleguide/src/base/_colors.scss
@@ -1,0 +1,141 @@
+// Colors
+//
+// Styleguide Style.colors
+
+// Primary
+//
+// $white - #fff;
+//
+// Styleguide Style.colors.primary
+$white: #fff;
+
+// Grey
+//
+// $grey-80: #020202;
+// $grey: #23292d;
+// $grey-60: #45494c;
+// $grey-40: #6f7376;
+// $grey-20: #a3a5a7;
+// $grey-10: #ececec;
+// $grey-05: #f5f7f8;
+//
+// Styleguide Style.colors.grey
+$grey-80: #020202;
+$grey: #23292d;
+$grey-60: #45494c;
+$grey-40: #6f7376;
+$grey-20: #a3a5a7;
+$grey-10: #ececec;
+$grey-05: #f5f7f8;
+
+// Green
+//
+// $gp-green - #66cc00; used only on the GP wordmark
+// $gp-green-80 - #8bcc49;
+// $gp-green-20 - #e3f2d3;
+//
+// Styleguide Style.colors.grey
+$gp-green: #66cc00;
+$gp-green-80: #8bcc49;
+$gp-green-20: #e3f2d3;
+
+// Blue
+//
+// $blue - #2077bf;
+//
+// Styleguide Style.colors.blue
+$blue: #2077bf;
+
+// Link color
+$link-color: #006dfd;
+
+// Yellow
+//
+// $yellow - #ffd204;
+//
+// Styleguide Style.colors.yellow
+$yellow: #ffd204;
+$yellow-20: #fff6cd;
+
+// Orange
+//
+// $orange - #f36d3a;
+// $dark-orange - #f75848;
+// $orange-hover - #ee562d;
+//
+// Styleguide Style.colors.orange
+$orange: #f36b35;
+$dark-orange: #f75848;
+$orange-hover: #ee562d;
+
+// Various blues:
+$x-dark-blue:  #042233;
+$dark-blue:    #074365;
+$active-blue:  #05324c;
+$aquamarine:   #68dfde;
+$comment-block:#e7ecf0;
+$comment-text: #d1dce2;
+
+// Various reds:
+$peach:       #eaccbb;
+
+// Social buttons
+$facebook: #4267b2;
+$twitter:  #55acee;
+$email:    #8a49de;
+$whatsapp: #25d366;
+
+// Used colors
+$light-blue-bg:         #d6e6f2;
+
+// Colors to be fixed/addressed:
+$carousel-indi-color:   #8bcc49;
+$cookie-bkg:            #c0dbe2;
+
+// Table/spreadsheet colors
+$table-font-color: #020202;
+
+// Background colors
+// Grey variant (default)
+$table-header-grey: #45494c;
+$table-odd-row-grey: #ececec;
+$table-even-row-grey: #f5f7f8;
+$table-footer-grey: #e0e4e7;
+
+// Green variant
+$table-header-green: #073d14;
+$table-odd-row-green: #d0fac9;
+$table-even-row-green: #eafee7;
+$table-footer-green: #d1e8cd;
+
+// Blue variant
+$table-header-blue: $dark-blue;
+$table-odd-row-blue: #c9e7fa;
+$table-even-row-blue: #e7f5fe;
+$table-footer-blue: #c3d7e2;
+
+// Allower colors for blocks palette
+$palette: (
+  "grey-80": $grey-80,
+  "grey-60": $grey-60,
+  "grey-40": $grey-40,
+  "grey-20": $grey-20,
+  "grey-10": $grey-10,
+  "grey": $grey,
+  "gp-green": $gp-green,
+  "x-dark-blue": $x-dark-blue,
+  "dark-blue": $dark-blue,
+  "blue": $blue,
+  "orange-hover": $orange-hover,
+  "yellow": $yellow
+);
+
+@each $name, $color in $palette {
+  .has-#{$name}-color {
+    color: $color;
+  }
+
+  .has-#{$name}-background-color {
+    background-color: $color;
+  }
+}

--- a/assets/src/scss/styleguide/src/base/_fonts.scss
+++ b/assets/src/scss/styleguide/src/base/_fonts.scss
@@ -1,0 +1,12 @@
+$font-base-size: 16px;
+
+$font-size-xxxs: 0.75rem;
+$font-size-xxs: 0.875rem;
+$font-size-xs: 0.9375rem;
+$font-size-sm: 1rem;
+$font-size-md: 1.25rem;
+$font-size-lg: 1.375rem;
+$font-size-xl: 1.75rem;
+$font-size-xxl: 2.5rem;
+$font-size-xxxl: 3rem;
+$font-size-xxxxl: 4rem;

--- a/assets/src/scss/styleguide/src/base/_functions.scss
+++ b/assets/src/scss/styleguide/src/base/_functions.scss
@@ -1,0 +1,42 @@
+/**
+* Test if `$value` is a valid direction
+*
+* @param {*} $value - Value to test
+* @return {Bool}
+*/
+@function is-direction($value) {
+  $is-keyword: index((to top, to top right, to right top, to right, to bottom right, to right bottom, to bottom, to bottom left, to left bottom, to left, to left top, to top left), $value);
+  $is-angle: type-of($value) == "number" and index("deg" "grad" "turn" "rad", unit($value));
+
+  @return $is-keyword or $is-angle;
+}
+
+/**
+* Convert a direction to legacy syntax
+*
+* @param {Keyword | Angle} $value - Value to convert
+* @require {function} is-direction
+* @require {function} convert-angle
+*/
+@function legacy-direction($value) {
+  $conversion-map: (
+    to top : bottom,
+    to top right : bottom left,
+    to right top : left bottom,
+    to right : left,
+    to bottom right : top left,
+    to right bottom : left top,
+    to bottom : top,
+    to bottom left : top right,
+    to left bottom : right top,
+    to left : right,
+    to left top : right bottom,
+    to top left : bottom right
+  );
+
+  @if map-has-key($conversion-map, $value) {
+    @return map-get($conversion-map, $value);
+  }
+
+  @return 90deg - $value;
+}

--- a/assets/src/scss/styleguide/src/base/_icons.scss
+++ b/assets/src/scss/styleguide/src/base/_icons.scss
@@ -1,0 +1,153 @@
+.icon {
+  position: relative;
+  top: .125em;
+  flex-shrink: 0;
+  height: 1em;
+  width: 1em;
+  fill: currentColor;
+  transition: fill .3s;
+}
+
+a.pdf-link {
+  display: inline-block;
+
+  &::before {
+    content: "";
+    background-image: url("../../images/file-pdf.svg"), url("../../public/images/file-pdf.svg");
+    background-position: center;
+    background-repeat: no-repeat;
+    height: 1rem;
+    width: 1rem;
+    margin-bottom: -2px;
+    margin-inline-end: 2px;
+    display: inline-block;
+  }
+}
+
+a.external-link {
+  display: inline-block;
+
+  &::after {
+    content: "";
+    display: inline-block;
+    background-image: url("../../images/external-link.svg"), url("../../public/images/external-link.svg");
+    height: .55rem;
+    width: .55rem;
+    margin-inline-start: .3rem;
+    margin-inline-end: .4rem;
+    background-size: contain;
+    background-repeat: no-repeat;
+  }
+}
+
+@supports (mask-repeat: no-repeat) {
+  a.pdf-link {
+    &::before {
+      background-image: none;
+      background-color: var(--link--color, $link-color);
+      mask-image: url("../../images/file-pdf.svg"), url("../../public/images/file-pdf.svg");
+      mask-repeat: no-repeat;
+      mask-position: center;
+    }
+
+    &:hover::before {
+      background-color: var(--link-hover--color, $link-color);
+    }
+
+    // Primary buttons
+    &.btn-primary {
+      &::before {
+        background-color: $white;
+      }
+
+      &:hover::before {
+        background-color: $white;
+      }
+    }
+
+    // Secondary buttons
+    &.btn-secondary {
+      &::before {
+        background-color: $dark-blue;
+      }
+
+      &:hover::before {
+        background-color: var(--secondary--link--hover--color, $white);
+      }
+    }
+
+    // Donate button
+    &.btn-donate {
+      &::before {
+        background-color: $grey-80;
+      }
+
+      &:hover::before {
+        background-color: transparentize($grey-80, 0.2);
+      }
+    }
+  }
+
+  // Button block, primary style
+  .wp-block-button.is-style-cta a.pdf-link {
+    &::before,
+    &:hover::before {
+      background-color: $white;
+    }
+  }
+
+  // Button block, secondary style
+  [class="wp-block-button"],
+  .wp-block-button.is-style-secondary {
+    a.pdf-link {
+      &::before {
+        background-color: $dark-blue;
+      }
+
+      &:hover::before {
+        background-color: var(--secondary--link--hover--color, $white);
+      }
+    }
+  }
+
+  // Button block, donate style
+  .wp-block-button.is-style-donate a.pdf-link {
+    &::before {
+      background-color: $grey-80;
+    }
+
+    &:hover::before {
+      background-color: transparentize($grey-80, 0.2);
+    }
+  }
+
+  // Button block, text color manually set
+  .wp-block-button a.has-text-color.pdf-link {
+    &::before,
+    &:hover::before {
+      background-color: $white;
+    }
+
+    &.has-grey-80-color {
+      &::before,
+      &:hover::before {
+        background-color: $grey-80;
+      }
+    }
+  }
+
+  a.external-link {
+    &::after {
+      background-image: none;
+      background-color: var(--link--color, $link-color);
+      mask-image: url("../../images/external-link.svg"), url("../../public/images/external-link.svg");
+      mask-repeat: no-repeat;
+      mask-position: center;
+      mask-size: contain;
+    }
+
+    &:hover::after {
+      background-color: var(--link-hover--color, $link-color);
+    }
+  }
+}

--- a/assets/src/scss/styleguide/src/base/_mixins.scss
+++ b/assets/src/scss/styleguide/src/base/_mixins.scss
@@ -1,0 +1,209 @@
+// Mobile-only (up to 576px)
+@mixin mobile-only {
+  @media (max-width: #{$small-width}) {
+    @content;
+  }
+}
+
+// Mobile & Up (greater than to 576px)
+@mixin small-and-up {
+  @media (min-width: #{$small-width}) {
+    @content;
+  }
+}
+
+// Tablet & Up (greater than 768px)
+@mixin medium-and-up {
+  @media (min-width: #{$medium-width}) {
+    @content;
+  }
+}
+
+// Large Tablet & Up (greater than 992px)
+@mixin large-and-up {
+  @media (min-width: #{$large-width}) {
+    @content;
+  }
+}
+
+// Large Desktop & Up (greater than 1200px)
+@mixin x-large-and-up {
+  @media (min-width: #{$extra-large-width}) {
+    @content;
+  }
+}
+
+// Margins and padding. Use to consistently apply gutters
+// use like this: @include padding($left: $n15, $right: $n15); wich will be compiled as padding-left: 15px; padding-right: 15px;
+
+// To use as negative numbers interpolate these as follows...
+// @include margin($top: -#{$n10}, $right: $n20, $bottom: $n10, $left: 0); which will be compiled as margin: -10, 20px 10px 0px;
+
+@mixin padding($top: null, $right: null, $bottom: null, $left: null) {
+  padding-top: $top;
+  padding-right: $right;
+  padding-bottom: $bottom;
+  padding-left: $left;
+}
+
+@mixin margin($top: null, $right: null, $bottom: null, $left: null) {
+  margin-top: $top;
+  margin-right: $right;
+  margin-bottom: $bottom;
+  margin-left: $left;
+}
+
+// Usage: @include transition(all 0.2s ease-in-out);
+@mixin transition($transition...) {
+  // defining prefixes so we can use them in mixins below
+  $prefixes: ("-webkit-", "" );
+  @each $prefix in $prefixes {
+    #{$prefix}transition: $transition;
+  }
+}
+
+// Cause an element to match the size of its stacking context parent.
+@mixin fill-container() {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+}
+
+// Build a linear gradient with a direction and any number of color stops.
+@mixin linear-gradient($direction, $color-stops...) {
+  background: nth(nth($color-stops, 1), 1); /* Old browsers */
+  background: -moz-linear-gradient(legacy-direction($direction), $color-stops); /* FF3.6-15 */
+  background: -webkit-linear-gradient(legacy-direction($direction), $color-stops); /* Chrome10-25,Safari5.1-6 */
+  background: linear-gradient($direction, $color-stops); /* W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+ */
+}
+
+// Create a gradient with hard stops that lines up. Colors layout from top-right to bottom-left.
+@mixin skewed-gradient($color1, $color2, $color3, $color4, $color5, $angle: 245deg) {
+  @include linear-gradient(
+    $angle,
+    #{$color1} 6%,
+    #{$color2} 6%,
+    #{$color2} 35%,
+    #{$color3} 35%,
+    #{$color3} 80%,
+    #{$color4} 80%,
+    #{$color4} 95%,
+    #{$color5} 95%
+  );
+
+  @include large-and-up {
+    @include linear-gradient(
+      $angle,
+      #{$color1} 15%,
+      #{$color2} 15%,
+      #{$color2} 45%,
+      #{$color3} 45%,
+      #{$color3} 80%,
+      #{$color4} 80%,
+      #{$color4} 90%,
+      #{$color5} 90%
+    );
+  }
+}
+
+@mixin detailed-skewed-gradient($color1, $color2, $color3, $color4, $color5, $color6, $color7, $color8, $angle: 245deg) {
+  @include linear-gradient(
+    $angle,
+    #{$color1} 6%,
+    #{$color2} 6%,
+    #{$color3} 35%,
+    #{$color4} 35%,
+    #{$color5} 80%,
+    #{$color6} 80%,
+    #{$color7} 95%,
+    #{$color8} 95%
+  );
+
+  @include large-and-up {
+    @include linear-gradient(
+      $angle,
+      #{$color1} 15%,
+      #{$color2} 15%,
+      #{$color3} 45%,
+      #{$color4} 45%,
+      #{$color5} 80%,
+      #{$color6} 80%,
+      #{$color7} 90%,
+      #{$color8} 90%
+    );
+  }
+}
+
+@mixin clearfix() {
+  &::after {
+    display: block;
+    content: "";
+    clear: both;
+  }
+}
+
+@mixin background-before-opacity($color, $opacity: 0.6) {
+  &:before {
+    content: "";
+    background: ($color);
+    position: absolute;
+    left: 0;
+    top: 0;
+    height: 100%;
+    width: 100%;
+    opacity: $opacity;
+  }
+}
+
+@mixin background($imgpath, $position: center, $repeat: no-repeat, $size: cover) {
+  background: {
+    image: url($imgpath);
+    position: $position;
+    repeat: $repeat;
+    size: $size;
+  }
+}
+
+// Skew mixin
+@mixin skew($side: right, $deg: -20deg, $right: -15px, $left: -15px, $width: 30px, $bg: $white) {
+  position: relative;
+
+  &:before {
+    z-index: -1;
+    content: "";
+    position: absolute;
+    top: 0;
+    bottom: 0;
+
+    @if $side == right {
+      right: $right;
+    }
+    @else if $side == left {
+      left: $left;
+    }
+
+    display: block;
+    width: $width;
+    background: $bg;
+    -webkit-transform: skew($deg);
+    -ms-transform: skew($deg);
+    transform: skew($deg);
+  }
+}
+
+/* Generates mutilevel nested comments
+level-1 is the first level comment with a margin of 50px
+level-2 is the first level comment with a margin of 100px
+and so on...
+*/
+$comment-nest-level: 6;
+$nested-comment-left-margin: 50px;
+@mixin comment-level {
+  @for $i from 1 through $comment-nest-level {
+    .comment-level-#{$i} {
+      margin-left: $nested-comment-left-margin * $i !important;
+    }
+  }
+}

--- a/assets/src/scss/styleguide/src/base/_mixins.scss
+++ b/assets/src/scss/styleguide/src/base/_mixins.scss
@@ -187,8 +187,6 @@
     display: block;
     width: $width;
     background: $bg;
-    -webkit-transform: skew($deg);
-    -ms-transform: skew($deg);
     transform: skew($deg);
   }
 }

--- a/assets/src/scss/styleguide/src/base/_rtl.scss
+++ b/assets/src/scss/styleguide/src/base/_rtl.scss
@@ -1,0 +1,22 @@
+html[dir="rtl"] body {
+  text-transform: lowercase;
+  text-align: right;
+
+  button,
+  .btn {
+    text-transform: lowercase;
+  }
+
+  @include large-and-up {
+    .offset-lg-1 {
+      margin-left: 0;
+      margin-right: 8.333333%;
+    }
+  }
+
+  .list-unstyled {
+    .custom-control {
+      padding-right: 1.5rem;
+    }
+  }
+}

--- a/assets/src/scss/styleguide/src/base/_shame.scss
+++ b/assets/src/scss/styleguide/src/base/_shame.scss
@@ -1,0 +1,6 @@
+// Keep the admin bar fixed on mobile screens for consistency.
+@media screen and (max-width: 600px) {
+  #wpadminbar {
+    position: fixed;
+  }
+}

--- a/assets/src/scss/styleguide/src/base/_typography.scss
+++ b/assets/src/scss/styleguide/src/base/_typography.scss
@@ -1,0 +1,137 @@
+// Typography
+//
+// Styleguide Style.typography
+html {
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+// Paragraphs
+//
+// All plain text elements use Lora font.
+//
+// Markup:
+// <p>The quick brown fox jumps over the lazy dog</p>
+//
+// Styleguide Style.typography.paragraphs
+p,
+li {
+  hyphens: none;
+  font-size: $font-size-sm;
+  line-height: 1.6rem;
+
+  @include x-large-and-up {
+    font-size: $font-size-md;
+    line-height: 1.75rem;
+  }
+}
+
+// Headings
+//
+// Heading elements `<h1> <h6>`. All headings use Roboto font.
+//
+// Markup:
+// <h1>The quick brown fox jumps over the lazy dog</h1>
+// <h2>The quick brown fox jumps over the lazy dog</h2>
+// <h3>The quick brown fox jumps over the lazy dog</h3>
+// <h4>The quick brown fox jumps over the lazy dog</h4>
+// <h5>The quick brown fox jumps over the lazy dog</h5>
+// <h6>The quick brown fox jumps over the lazy dog</h6>
+//
+// Styleguide Style.typography.headings
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-family: $roboto;
+  font-weight: bold;
+
+  &.has-text-align-center,
+  &.has-text-align-right,
+  &.has-text-align-left {
+    width: 100%;
+  }
+}
+
+h1 {
+  line-height: 1.225;
+  margin-bottom: 30px;
+  font-size: $font-size-xxl;
+
+  @include medium-and-up {
+    font-size: $font-size-xxxxl;
+  }
+
+  @include large-and-up {
+    margin-bottom: 48px;
+  }
+}
+
+h2 {
+  line-height: 1.38;
+  margin-bottom: 5px;
+  font-size: $font-size-xl;
+
+  @include medium-and-up {
+    font-size: $font-size-xxl;
+  }
+
+  @include x-large-and-up {
+    margin-bottom: 24px;
+  }
+}
+
+h3 {
+  font-size: $font-size-lg;
+
+  @include medium-and-up {
+    font-size: $font-size-xl;
+  }
+}
+
+h4 {
+  font-size: $font-size-md;
+
+  @include medium-and-up {
+    font-size: $font-size-lg;
+  }
+}
+
+h5 {
+  font-size: $font-size-sm;
+
+  @include medium-and-up {
+    font-size: $font-size-md;
+  }
+}
+
+h6 {
+  font-size: $font-size-sm;
+}
+
+.white-text {
+  color: $white;
+}
+
+// Links
+//
+// Link elements `<a>`.
+//
+// Markup:
+// <a href="#">The quick brown fox jumps over the lazy dog</a>
+//
+// :hover     - hovered state
+//
+// Styleguide Style.typography.links
+a {
+  color: var(--link--color, $link-color);
+  text-decoration: none;
+
+  &:hover {
+    color: var(--link-hover--color, $link-color);
+    text-decoration: underline;
+  }
+}

--- a/assets/src/scss/styleguide/src/base/_variables.scss
+++ b/assets/src/scss/styleguide/src/base/_variables.scss
@@ -1,0 +1,47 @@
+// Fonts
+$roboto:     "Roboto", sans-serif;
+$lora:       "Lora", serif;
+
+// Media queries
+$extra-small-width:  320px;
+$small-width:        576px;
+$medium-width:       768px;
+$large-width:        992px;
+$extra-large-width:  1200px;
+
+// Units:
+$au: auto;
+$n5: 5px;
+$n10: 10px;
+$n15: 15px;
+$n20: 20px;
+$n25: 25px;
+$n30: 30px;
+$n35: 35px;
+$n40: 40px;
+$n50: 50px;
+$n60: 60px;
+$n70: 70px;
+$n80: 80px;
+$n90: 90px;
+$n100: 100px;
+
+// Spacing
+//
+// Variables that define certain margin values to be used mostly
+// for vertical spacing between and inside blocks.
+//
+// Markup:
+// <div class="block">
+//   this is a block with <code>margin-top: $space-md</code>
+//   and <code>margin-bottom: $space-xl</code> on large screens.
+// </div>
+//
+// Styleguide Layout.spacing
+$space-xxs: 4px;
+$space-xs:  8px;
+$space-sm:  12px;
+$space-md:  16px;
+$space-lg:  32px;
+$space-xl:  48px;
+$space-xxl: 64px;

--- a/assets/src/scss/styleguide/src/components/_blockquote.scss
+++ b/assets/src/scss/styleguide/src/components/_blockquote.scss
@@ -1,0 +1,57 @@
+// Blockquote
+//
+// Markup:
+// <blockquote>
+//   “You have to treat ice with respect, otherwise it breaks. We should do the same with nature.”
+// </blockquote>
+//
+// Styleguide Components.blockquote
+
+@mixin blockquote {
+  font-size: $font-size-lg;
+  line-height: 1.4;
+  font-style: italic;
+
+  @include medium-and-up {
+    font-size: $font-size-xxl;
+  }
+
+  @include large-and-up {
+    max-width: 80%;
+  }
+
+  @include x-large-and-up {
+    font-size: $font-size-xxl;
+  }
+}
+
+blockquote,
+blockquote > p {
+  @include blockquote;
+}
+
+blockquote > h5 {
+  @include blockquote;
+  font-family: $lora;
+  color: $grey-80;
+  font-size: $font-size-xxl;
+
+  @include medium-and-up {
+    font-size: $font-size-xxl;
+  }
+}
+
+blockquote > h6 {
+  @include blockquote;
+  font-family: $lora;
+  color: $grey-80;
+  font-size: $font-size-xl;
+
+  @include medium-and-up {
+    font-size: $font-size-xl;
+  }
+
+  @include x-large-and-up {
+    font-size: $font-size-xl;
+  }
+}

--- a/assets/src/scss/styleguide/src/components/_buttons.scss
+++ b/assets/src/scss/styleguide/src/components/_buttons.scss
@@ -1,0 +1,236 @@
+// Buttons
+//
+// Markup:
+// <div class="mb-2">
+//   <a href="/international/act/protect-the-oceans/" class="btn {{modifier_class}}">Protect our seas</a>
+// </div>
+//
+// .btn-primary - Primary button
+// .btn-secondary - Secondary button
+//
+// Styleguide Components.buttons
+.btn,
+.wp-block-button a,
+.wp-block-file .wp-block-file__button {
+  display: inline-block;
+  position: relative;
+  font-family: $roboto;
+  font-size: $font-size-sm;
+  text-align: center;
+  text-decoration: none;
+  color: $white;
+  font-weight: bold;
+  border-radius: 4px;
+  border: 1px solid transparent;
+  cursor: pointer;
+  line-height: 3;
+  padding: 0 $n30;
+  appearance: none;
+  transition-property: color, background-color, border-color;
+  transition-duration: 150ms;
+  transition-timing-function: linear;
+
+  &:hover,
+  &:focus,
+  &:active {
+    color: $white;
+    text-decoration: none;
+    outline: none;
+  }
+
+  &:disabled,
+  &.disabled,
+  &[disabled] {
+    opacity: .5;
+    cursor: default;
+  }
+
+  &.has-background {
+    border-color: transparent !important;
+  }
+
+  &.has-grey-80-color {
+    color: $grey-80 !important;
+
+    &:hover,
+    &:focus,
+    &:active {
+      color: $grey-80 !important;
+    }
+  }
+}
+
+.btn-small {
+  font-size: $font-size-xxs;
+  line-height: 2.8;
+}
+
+.btn-large {
+  font-size: $font-size-md;
+  line-height: 3.1;
+}
+
+.btn-primary,
+.wp-block-button.is-style-cta a {
+  background-color: $orange;
+  color: var(--btn-primary-color, $white);
+  box-shadow: 0 2px 5px rgba(0, 0, 0, .25);
+
+  &:hover,
+  &:focus,
+  &:active {
+    background-color: $orange-hover;
+    border-color: $orange-hover;
+  }
+
+  &:disabled,
+  &.disabled,
+  &[disabled] {
+    background-color: $orange;
+  }
+}
+
+.btn-secondary,
+.wp-block-button.is-style-secondary a,
+[class="wp-block-button"] a,
+.wp-block-file .wp-block-file__button {
+  background-color: transparentize($white, .7);
+  border-color: $dark-blue;
+  color: $dark-blue;
+  box-shadow: none;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+
+  &:visited {
+    color: $dark-blue;
+  }
+
+  &:hover,
+  &:focus {
+    background-color: $dark-blue;
+    border-color: $dark-blue;
+    color: $white;
+  }
+
+  &:active {
+    background-color: $active-blue;
+    border-color: $active-blue;
+  }
+
+  &:disabled,
+  &.disabled,
+  &[disabled] {
+    background-color: $white;
+    color: $dark-blue;
+  }
+}
+
+// The new core buttons block wrap in "wp-block-buttons" class which apply
+// extra css properties which break old button block UI.
+.wp-block-buttons .wp-block-button {
+  display: block !important;
+  margin-left: unset;
+  margin-right: unset;
+}
+
+.btn-action {
+  background-color: transparentize($white, .8);
+  border-color: $white;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, .25);
+
+  &:hover,
+  &:focus {
+    background-color: $orange;
+    border-color: $orange;
+  }
+
+  &:active {
+    background-color: $orange-hover;
+    border-color: $orange-hover;
+  }
+}
+
+.btn-donate,
+.wp-block-button.is-style-donate a {
+  background-color: var(--btn-donate-background-color, $aquamarine);
+  color: var(--btn-donate-color, $grey-80);
+  line-height: 1.65;
+  min-width: 180px;
+  margin: 0;
+  padding: 2px $n30;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, .25);
+  text-transform: none;
+
+  &:hover,
+  &:focus {
+    color: transparentize($grey-80, 0.2);
+  }
+
+  @include large-and-up {
+    font-size: $font-size-md;
+  }
+}
+
+.btn-navbar-toggle {
+  cursor: pointer;
+  color: $gp-green;
+  background-color: transparent;
+  transition: background-color color font-weight 100ms;
+  display: inline-block;
+
+  &:hover,
+  &:focus,
+  &:active {
+    color: $white;
+    box-shadow: none;
+    background-color: $x-dark-blue;
+    border: 1px solid transparent;
+  }
+
+  @include small-and-up {
+    background-color: $dark-blue;
+    border-radius: 0;
+    border: 1px solid transparent;
+    box-shadow: 0 2px 5px rgba(0, 0, 0, .25);
+  }
+}
+
+.btn-filter-item {
+  background-color: transparent;
+  border-color: $dark-blue;
+  color: $dark-blue;
+  padding: 0 $n50 0 $n30;
+  position: relative;
+  font-weight: 400;
+
+  &:hover,
+  &:focus {
+    background-color: $dark-blue;
+    border-color: $dark-blue;
+  }
+
+  &:active {
+    background-color: $grey-80;
+    border-color: $grey-80;
+  }
+
+  i {
+    position: absolute;
+    font-size: $font-size-xxs;
+    right: 10px;
+    top: 50%;
+    transform: translate(0, -40%);
+  }
+}
+
+.no-btn {
+  background: transparent;
+  border: transparent;
+  padding: 0;
+  cursor: pointer;
+
+  &:focus {
+    outline: none;
+  }
+}

--- a/assets/src/scss/styleguide/src/components/_share-buttons.scss
+++ b/assets/src/scss/styleguide/src/components/_share-buttons.scss
@@ -1,0 +1,100 @@
+// Share buttons
+//
+// Markup:
+// <div class="share-buttons">
+//   <!-- Facebook -->
+//   <a href="#" class="share-btn facebook">
+//     <svg viewBox="0 0 32 32" class="icon"><use xlink:href="images/symbol/svg/sprite.symbol.svg#facebook-f"></use></svg>
+//     <span class="visually-hidden">Share on Facebook</span>
+//   </a>
+//   <!-- Twitter -->
+//   <a href="#" class="share-btn twitter">
+//     <svg viewBox="0 0 32 32" class="icon"><use xlink:href="images/symbol/svg/sprite.symbol.svg#twitter"></use></svg>
+//     <span class="visually-hidden">Share on Twitter</span>
+//   </a>
+//   <!-- Email -->
+//   <a href="#" class="share-btn email">
+//     <svg viewBox="0 0 32 32" class="icon"><use xlink:href="images/symbol/svg/sprite.symbol.svg#envelope"></use></svg>
+//     <span class="visually-hidden">Share via Email</span>
+//   </a>
+// </div>
+//
+// Styleguide Components.share_buttons
+.share-buttons {
+  margin: 0 0 $n10 0;
+
+  @include medium-and-up {
+    margin: 0;
+    float: right;
+
+    html[dir="rtl"] & {
+      float: left;
+    }
+  }
+
+  .single-post & {
+    @include medium-and-up {
+      margin: -10px 0 0 0;
+    }
+
+    @include large-and-up {
+      margin: -20px 0 0 0;
+    }
+
+    @include x-large-and-up {
+      margin: -10px 0 0 0;
+    }
+  }
+
+  .share-btn {
+    border: none;
+    box-shadow: 0 2px 0 0 rgba(0, 0, 0, 0.2);
+    color: $white;
+    cursor: pointer;
+    display: inline-block;
+    font-size: $font-size-md;
+    opacity: 0.9;
+    outline: none;
+    width: 4rem;
+    text-align: center;
+    line-height: 2.7rem;
+    height: 2.7rem;
+    border-radius: 4px;
+
+    .icon {
+      top: -2px;
+    }
+
+    &:hover {
+      color: $grey-10;
+    }
+
+    &:active {
+      position: relative;
+      top: 2px;
+      box-shadow: none;
+      color: $grey-10;
+      outline: none;
+    }
+  }
+
+  .twitter {
+    background: $twitter none repeat scroll 0 0;
+  }
+
+  .facebook {
+    background: $facebook none repeat scroll 0 0;
+  }
+
+  .email {
+    background: $email none repeat scroll 0 0;
+  }
+
+  .whatsapp {
+    background: $whatsapp none repeat scroll 0 0;
+
+    .icon {
+      font-size: 1.5rem;
+    }
+  }
+}

--- a/assets/src/scss/styleguide/src/components/_skip-links.scss
+++ b/assets/src/scss/styleguide/src/components/_skip-links.scss
@@ -1,0 +1,28 @@
+// Skip to... links
+//
+// Markup:
+// <ul class="skip-links">
+//   <li><a href="#header">Skip to Navigation</a></li>
+//   <li><a href="#content">Skip to Content</a></li>
+//   <li><a href="#footer">Skip to Footer</a></li>
+// </ul>
+//
+// .skip-links - Skip to... links
+//
+// Styleguide Components.skip-links
+.skip-links {
+  margin: 0 !important;
+  padding: 0 !important;
+  list-style-type: none;
+
+  a {
+    position: absolute;
+    top: -50px;
+    left: 15px;
+    z-index: 100;
+
+    &:focus {
+      top: 60px;
+    }
+  }
+}

--- a/assets/src/scss/styleguide/src/components/_spinner.scss
+++ b/assets/src/scss/styleguide/src/components/_spinner.scss
@@ -1,0 +1,29 @@
+// Spinner
+//
+// Markup:
+// <div class="three-quarters en-spinner">...</div>
+//
+// Styleguide Components.spinner
+@keyframes three-quarters {
+  0% {
+    transform: rotate(0deg);
+  }
+
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+.three-quarters:not(:required) {
+  animation: three-quarters 1250ms infinite linear;
+  border: 8px solid $white;
+  border-right-color: transparent;
+  border-radius: 16px;
+  box-sizing: border-box;
+  display: inline-block;
+  position: relative;
+  overflow: hidden;
+  text-indent: -9999px;
+  width: 32px;
+  height: 32px;
+}

--- a/assets/src/scss/styleguide/src/components/_tweet-block.scss
+++ b/assets/src/scss/styleguide/src/components/_tweet-block.scss
@@ -1,0 +1,30 @@
+blockquote.twitter-tweet {
+  margin: $n60 0;
+  padding-left: 30px;
+  border-left: 4px solid $grey-20;
+  display: inline-block;
+
+  @include medium-and-up {
+    padding-left: 70px;
+  }
+
+  p {
+    font-size: $font-size-lg;
+    line-height: 1.6;
+    margin: 0;
+
+    &:first-child {
+      margin-bottom: 10px;
+    }
+  }
+
+  a {
+    text-decoration: none;
+    outline: 0 none;
+
+    &:hover,
+    &:focus {
+      text-decoration: underline;
+    }
+  }
+}

--- a/assets/src/scss/styleguide/src/layout/_blocks.scss
+++ b/assets/src/scss/styleguide/src/layout/_blocks.scss
@@ -1,0 +1,29 @@
+.block {
+  display: inline-block;
+  width: 100%;
+  margin-top: $space-xs;
+  margin-bottom: $space-md;
+
+  @include large-and-up {
+    margin-top: $space-md;
+    margin-bottom: $space-lg;
+  }
+}
+
+.block-header {
+  margin-top: 0;
+  margin-bottom: $space-md;
+
+  @include large-and-up {
+    margin-bottom: $space-lg;
+  }
+}
+
+.block-footer {
+  margin-top: $space-xs;
+  margin-bottom: 0;
+
+  @include large-and-up {
+    margin-top: $space-md;
+  }
+}

--- a/assets/src/scss/styleguide/src/layout/_breadcrumbs.scss
+++ b/assets/src/scss/styleguide/src/layout/_breadcrumbs.scss
@@ -1,0 +1,102 @@
+// Breadcrumbs
+//
+// Markup:
+// <div class="top-page-tags">
+//   <a class="tag-item tag-item--main page-type" href="#">Press Release</a>
+//   <div class="tag-wrap tags">
+//     <a class="tag-item" href="#">#Climate</a>
+//     <a class="tag-item" href="#">#Oceans</a>
+//     <a class="tag-item" href="#">#Oil</a>
+//   </div>
+// </div>
+//
+// Styleguide Layout.breadcrumbs
+.top-page-tags {
+  font-size: $font-size-xxs;
+  margin-bottom: $space-xs;
+  font-family: $roboto;
+
+  @include medium-and-up {
+    font-size: $font-size-sm;
+  }
+
+  a {
+    font-size: $font-size-xxs;
+
+    @include medium-and-up {
+      font-size: $font-size-sm;
+    }
+  }
+
+  .tag-wrap {
+    display: inline;
+    position: relative;
+    color: $link-color;
+  }
+
+  .tag-item--main + .tag-wrap,
+  .tag-wrap + .tag-wrap {
+    &:before {
+      content: "\2022";
+      pointer-events: none;
+      display: inline-block;
+      margin-left: -12px;
+      margin-right: 8px;
+
+      html[dir="rtl"] & {
+        margin-right: -12px;
+        margin-left: 8px;
+      }
+    }
+  }
+
+  .tag-item {
+    color: $link-color;
+    font-weight: 400;
+    display: inline-block;
+
+    @include x-large-and-up {
+      font-size: $font-size-sm;
+    }
+
+    &:not(:only-child):not(:last-child) {
+      margin-right: 7px;
+
+      html[dir="rtl"] & {
+        margin-right: 0;
+        margin-left: 7px;
+      }
+
+      &.page-type {
+        margin-right: 20px;
+
+        html[dir="rtl"] & {
+          margin-right: 0;
+          margin-left: 20px;
+        }
+      }
+    }
+  }
+
+  .tag-item--main {
+    font-weight: 500;
+
+    &.page-type {
+      text-transform: uppercase;
+
+      html[dir="rtl"] & {
+        text-transform: lowercase;
+        margin-right: 0;
+      }
+    }
+  }
+
+  .issues {
+    margin-right: 20px;
+
+    html[dir="rtl"] & {
+      margin-right: 0;
+      margin-left: 20px;
+    }
+  }
+}

--- a/assets/src/scss/styleguide/src/layout/_cookies.scss
+++ b/assets/src/scss/styleguide/src/layout/_cookies.scss
@@ -1,0 +1,95 @@
+// Cookie Notice
+//
+// Markup:
+// <div class="cookie-notice" id="set-cookie" style="display: block;">
+//   <div class="row m-0">
+//     <div class="col-sm-9 col-md-10">
+//       We use cookies to enhance your experience. By clicking “Got it!” you agree to our <a href="http://www.greenpeace.org/international/privacy/">Privacy &amp; Cookies Policy</a>. You can <a href="https://www.greenpeace.org/international/privacy/#change-your-cookies-preferences">change your cookies settings anytime</a>.
+//     </div>
+//     <div class="col-sm-3 col-md-2">
+//       <button class="btn btn-secondary p-0" id="hidecookie">GOT IT!</button>
+//     </div>
+//   </div>
+// </div>
+//
+// Styleguide Layout.cookie-notice
+.cookie-notice {
+  z-index: 100;
+  display: flex;
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  background: $cookie-bkg url("../../images/cookie-right-gradient-sm.png") no-repeat right;
+  min-height: 80px;
+  flex-direction: column;
+  padding: 36px;
+  background-size: cover;
+  visibility: hidden;
+  opacity: 0;
+  transition: visibility 0.5s, opacity 0.5s linear;
+
+  &.shown {
+    opacity: 1;
+    visibility: visible;
+  }
+
+  @include medium-and-up {
+    flex-direction: row;
+    padding: 24px 36px;
+    background-size: auto;
+  }
+
+  > div {
+    font-size: $font-size-xxs;
+    margin-bottom: 10px;
+    font-weight: 500;
+    color: $dark-blue;
+    text-align: left;
+    font-family: $roboto;
+    line-height: 1.5rem;
+    width: 100%;
+    padding-right: $space-md;
+    display: block;
+
+    html[dir="rtl"] & {
+      padding-right: 0;
+      padding-left: $space-md;
+      text-align: right;
+    }
+
+    @include medium-and-up {
+      font-size: $font-size-xs;
+      margin-bottom: 0;
+      vertical-align: middle;
+    }
+    @include large-and-up {
+      font-size: $font-size-xxs;
+    }
+    @include x-large-and-up {
+      font-size: $font-size-xxs;
+    }
+  }
+
+  a {
+    color: $dark-blue;
+    text-decoration: underline;
+
+    &:hover {
+      text-decoration: none;
+    }
+  }
+
+  .btn {
+    height: 32px;
+    line-height: 32px;
+    font-size: $font-size-xs;
+    width: 100%;
+    box-shadow: 0 8px 15px rgba(0, 0, 0, 0.1);
+    margin-bottom: 0;
+
+    @include medium-and-up {
+      width: 150px;
+    }
+  }
+}

--- a/assets/src/scss/styleguide/src/layout/_footer.scss
+++ b/assets/src/scss/styleguide/src/layout/_footer.scss
@@ -1,0 +1,279 @@
+// Footer
+//
+// Markup:
+// <footer class="site-footer" id="footer">
+//   <div class="container">
+//     <ul class="footer-social-media list-unstyled col-md-8 col-lg-5">
+//       <li>
+//         <a href="#">
+//           <svg viewBox="0 0 32 32" class="icon"><use xlink:href="images/symbol/svg/sprite.symbol.svg#facebook-f"></use></svg>
+//         </a>
+//       </li>
+//       <li>
+//         <a href="#">
+//           <svg viewBox="0 0 32 32" class="icon"><use xlink:href="images/symbol/svg/sprite.symbol.svg#twitter"></use></svg>
+//         </a>
+//       </li>
+//       <li>
+//         <a href="#">
+//           <svg viewBox="0 0 32 32" class="icon"><use xlink:href="images/symbol/svg/sprite.symbol.svg#instagram"></use></svg>
+//         </a>
+//       </li>
+//     </ul>
+//     <ul class="list-unstyled footer-links">
+//       <li><a href="#">Primary Link 1</a></li>
+//       <li><a href="#">Primary Link 2</a></li>
+//       <li><a href="#">Primary Link 3</a></li>
+//     </ul>
+//     <ul class="list-unstyled footer-links-secondary">
+//       <li><a href="#">Secondary Link 1</a></li>
+//       <li><a href="#">Secondary Link 2</a></li>
+//       <li><a href="#">Secondary Link 3</a></li>
+//     </ul>
+//     <p class="copyright-text col-md-8">
+//       Copyright Line 1
+//     </p>
+//     <p class="gp-year">
+//       <svg viewBox="0 0 32 32" class="icon"><use xlink:href="/kss-assets/img/sprite.symbol.svg#creative-commons"></use></svg>
+//       Copyright Line 2 - 2019
+//     </p>
+//   </div>
+// </footer>
+//
+// Styleguide Layout.footer
+.site-footer {
+  font-family: $roboto;
+  padding: 45px 0 $n25;
+  background: var(--footer_color, $dark-blue);
+  position: relative;
+  z-index: 2;
+  text-align: center;
+  transition: margin 1s;
+  clear: both;
+  line-height: 0;
+
+  @include medium-and-up {
+    padding: $n25 0 $n20;
+  }
+
+  @include large-and-up {
+    padding: 55px 0 $n25;
+  }
+
+  p {
+    font-family: $roboto;
+  }
+
+  a {
+    color: var(--footer_links_color, inherit);
+
+    &:hover {
+      color: var(--footer_links_color, $white);
+    }
+  }
+
+  li {
+    line-height: 1;
+  }
+}
+
+.footer-social-media {
+  color: var(--footer_links_color, $grey-20);
+  font-size: $font-size-xl;
+  margin: auto;
+  text-align: center;
+  width: max-content;
+  margin-bottom: 32px;
+  padding: 0;
+
+  .icon {
+    width: 2rem;
+    height: 2rem;
+  }
+
+  @include small-and-up {
+    font-size: $font-size-xxxl;
+  }
+
+  @supports (justify-content: space-between) {
+    & {
+      display: flex;
+      justify-content: space-between;
+    }
+  }
+
+  li {
+    display: inline-block;
+    font-size: $font-size-xl;
+
+    &:not(:last-child) {
+      margin-inline-end: 16px;
+    }
+  }
+
+  a {
+    transition: color 100ms linear;
+
+    &:hover {
+      color: $white;
+    }
+  }
+}
+
+.footer-links,
+.footer-links-secondary {
+  li {
+    line-height: 2rem;
+    @include medium-and-up {
+      display: inline-block;
+
+      &:after {
+        content: "\002F";
+        display: inline-block;
+        margin: 0 16px;
+      }
+
+      &:last-of-type:after {
+        display: none;
+      }
+    }
+
+    @include large-and-up {
+      &:after {
+        margin: 0 24px 0;
+      }
+    }
+  }
+}
+
+.footer-links {
+  color: var(--footer_links_color, $white);
+  font-weight: bold;
+  text-transform: uppercase;
+  margin-bottom: 16px;
+
+  li {
+    font-size: $font-size-md;
+  }
+
+  @include medium-and-up {
+    font-size: $font-size-sm;
+    margin-bottom: 16px;
+  }
+
+  @include large-and-up {
+    font-size: $font-size-md;
+  }
+}
+
+.footer-links-secondary {
+  color: var(--footer_links_color, $grey-10);
+  text-transform: uppercase;
+  margin-bottom: 30px;
+
+  @include medium-and-up {
+    font-size: $font-size-xxs;
+  }
+
+  @include large-and-up {
+    font-size: $font-size-sm;
+  }
+}
+
+.copyright-text {
+  color: var(--footer_links_color, $grey-10);
+  font: $font-size-xxs;
+  line-height: 1.3;
+  margin-left: auto;
+  margin-right: auto;
+  word-break: keep-all;
+  width: 80%;
+  padding: 0;
+
+  @include medium-and-up {
+    line-height: 1;
+  }
+
+  i {
+    display: block;
+    font-size: $font-size-xl;
+    margin-bottom: 10px;
+
+    @include medium-and-up {
+      display: inline-block;
+      position: relative;
+      bottom: -.15em;
+      margin-right: 5px;
+    }
+  }
+
+  a {
+    color: var(--footer_links_color, $white);
+  }
+}
+
+.gp-year {
+  color: var(--footer_links_color, $white);
+  font-size: $font-size-xxs;
+  text-transform: none;
+
+  .icon {
+    top: -.125em;
+  }
+
+  @include medium-and-up {
+    font-size: $font-size-xxs;
+  }
+
+  @include medium-and-up {
+    margin-top: 15px;
+  }
+}
+
+.site-footer_min {
+  padding: 40px 0;
+  line-height: 1;
+
+  .footer-social-media {
+    color: var(--footer_links_color, $grey-20);
+    font-size: $font-size-xl;
+    margin: 0 auto $space-md auto;
+    text-align: center;
+    width: max-content;
+
+    @supports (justify-content: space-between) {
+      & {
+        display: flex;
+        justify-content: space-between;
+      }
+    }
+
+    li {
+      display: inline-block;
+      margin: 0 16px 0 0;
+    }
+
+    a {
+      transition: color 100ms linear;
+
+      &:hover {
+        color: $grey-20;
+      }
+    }
+
+    .list-unstyled {
+      width: 200px;
+    }
+  }
+
+  .gp-year {
+    color: var(--footer_links_color, $white);
+    font-size: $font-size-xxs;
+    font-family: $lora;
+    margin: 40px 0 30px 0;
+  }
+
+  .icon {
+    fill: var(--footer_links_color, $white);
+  }
+}

--- a/assets/src/scss/styleguide/src/layout/_forms.scss
+++ b/assets/src/scss/styleguide/src/layout/_forms.scss
@@ -1,0 +1,229 @@
+// Forms
+//
+// Markup:
+// <label class="custom-control">
+//   <input type="checkbox" name="checkbox_name" />
+//   <span class="custom-control-description">Check me</span>
+// </label>
+// <label class="custom-control">
+//   <input type="radio" name="radio_name" value="1" />
+//   <span class="custom-control-description">Select me</span>
+// </label>
+// <label class="custom-control">
+//   <input type="radio" name="radio_name" value="2" />
+//   <span class="custom-control-description">Or me</span>
+// </label>
+//
+// Styleguide Layout.forms
+.custom-control {
+  input[type="checkbox"] {
+    position: absolute;
+    opacity: 0;
+    pointer-events: none;
+
+    &:not(:disabled) + .custom-control-description:hover:before {
+      border-color: $grey-80;
+    }
+
+    & + .custom-control-description {
+      position: relative;
+      cursor: pointer;
+      font-family: $roboto;
+      font-size: $font-size-xxxs;
+      line-height: 1rem;
+      color: $grey-80;
+      display: inline-block;
+      padding-inline-start: 36px;
+
+      a {
+        color: $grey-80;
+        font-weight: bold;
+      }
+
+      &:before {
+        content: "";
+        width: 20px;
+        height: 20px;
+        background: $white;
+        border: 1px solid $grey-20;
+        border-radius: 2px;
+        left: 0;
+        position: absolute;
+        top: calc((100% - 20px) / 2);
+
+        html[dir="rtl"] & {
+          right: 0;
+          left: auto;
+        }
+      }
+    }
+
+    &:checked + .custom-control-description {
+      &:before {
+        border-color: $grey-80;
+      }
+
+      &:after {
+        content: "";
+        position: absolute;
+        -moz-transform: rotate(-45deg) scale(-1, 1);
+        -webkit-transform: rotate(-45deg) scale(-1, 1);
+        -o-transform: rotate(-45deg) scale(-1, 1);
+        -ms-transform: rotate(-45deg) scale(-1, 1);
+        transform: rotate(-45deg) scale(-1, 1);
+        border-bottom: 2px solid $grey-80;
+        border-right: 2px solid $grey-80;
+        top: calc(((100% - 20px) / 2) + 5px);
+        left: 4px;
+        height: 8px;
+        width: 12px;
+
+        html[dir="rtl"] & {
+          left: auto;
+          right: 4px;
+        }
+      }
+    }
+
+    &:disabled + .custom-control-description {
+      cursor: auto;
+
+      &:before {
+        opacity: 0.5;
+      }
+    }
+  }
+
+  input[type="radio"] {
+    position: absolute;
+    pointer-events: none;
+    opacity: 0;
+
+    &:not(:disabled) + .custom-control-description:hover:before {
+      border-color: $grey-80;
+    }
+
+    & + .custom-control-description {
+      position: relative;
+      cursor: pointer;
+      font-family: $roboto;
+      font-size: $font-size-sm;
+      line-height: 1.25rem;
+      color: $grey-80;
+      padding-inline-start: 36px;
+
+      a {
+        color: $grey-80;
+        font-weight: bold;
+      }
+
+      &:before {
+        content: "";
+        width: 20px;
+        height: 20px;
+        background: $white;
+        border: 1px solid $grey-20;
+        border-radius: 50%;
+        left: 0;
+        position: absolute;
+        top: calc((100% - 20px) / 2);
+
+        html[dir="rtl"] & {
+          right: 0;
+          left: auto;
+        }
+      }
+    }
+
+    &:checked + .custom-control-description:before {
+      background: $grey-80;
+      box-shadow: inset 0 0 0 2px $white;
+      border-color: $grey-80;
+    }
+  }
+}
+
+.form-control,
+.form-select {
+  border-radius: 4px;
+  font-family: $roboto;
+  background-color: $white;
+  border: 1px solid $grey-20;
+  color: $grey-80;
+  padding: 0 16px;
+  font-size: $font-size-sm;
+
+  &::placeholder,
+  &::-webkit-input-placeholder,
+  &::-ms-input-placeholder {
+    color: $grey-40;
+  }
+
+  &:hover {
+    border-color: $grey-40;
+  }
+
+  &:focus {
+    box-shadow: 0 0 0 2px rgba(0, 109, 253, 0.4);
+    color: $grey-80;
+    border-color: transparent;
+  }
+}
+
+input[type="text"].form-control,
+input[type="email"].form-control {
+  height: auto;
+  padding: 11px 16px;
+}
+
+.form-select {
+  height: 48px;
+
+  html[dir="rtl"] & {
+    background-position: left 0.75rem center;
+  }
+
+  &:invalid {
+    color: $grey-40;
+  }
+
+  option[value=""][disabled] {
+    display: none;
+  }
+}
+
+textarea.form-control {
+  padding: 12px 16px;
+  resize: none;
+}
+
+.form-group {
+  margin-bottom: 1rem;
+
+  &.animated-label {
+    position: relative;
+
+    label {
+      position: absolute;
+      left: 0;
+      top: 16px;
+      font-weight: 500;
+      color: $grey-40;
+      padding-inline-start: 16px;
+      font-size: 11px;
+      font-family: $roboto;
+      opacity: 0;
+      transition: all .3s ease;
+      margin-bottom: 0;
+    }
+
+    .form-control:not(:placeholder-shown) {
+      padding: 18px 16px 4px 16px;
+
+      & ~ label {
+        transform: translateY(-10px);
+        opacity: 1;
+      }
+    }
+  }
+}

--- a/assets/src/scss/styleguide/src/layout/_forms.scss
+++ b/assets/src/scss/styleguide/src/layout/_forms.scss
@@ -66,10 +66,6 @@
       &:after {
         content: "";
         position: absolute;
-        -moz-transform: rotate(-45deg) scale(-1, 1);
-        -webkit-transform: rotate(-45deg) scale(-1, 1);
-        -o-transform: rotate(-45deg) scale(-1, 1);
-        -ms-transform: rotate(-45deg) scale(-1, 1);
         transform: rotate(-45deg) scale(-1, 1);
         border-bottom: 2px solid $grey-80;
         border-right: 2px solid $grey-80;

--- a/assets/src/scss/styleguide/src/layout/_navbar.scss
+++ b/assets/src/scss/styleguide/src/layout/_navbar.scss
@@ -1,0 +1,872 @@
+// Navbar
+//
+// Adds a navigation bar to the top of the site.
+//
+// Markup:
+// <nav id="header" class="top-navigation navbar">
+// <a class="site-logo" href="#">
+//   <img src="https://www.greenpeace.org/international/wp-content/themes/planet4-master-theme/images/gp-logo.svg" alt="Greenpeace">
+// </a>
+// <button
+//     class="btn btn-navbar-toggle navbar-dropdown-toggle"
+//     data-toggle="open"
+//     data-target="#navbar-dropdown"
+//     aria-expanded="false"
+//     aria-label="{{ toggle_label }}"
+// >
+//   <span>Menu</span>
+// </button>
+// <ul id="navbar-dropdown" class="navbar-dropdown list-unstyled">
+//   <li class="nav-item" id="country-select">
+//     <button class="close-navbar-dropdown">
+//       <span class="screen-reader-text">Close Menu</span>
+//     </button>
+//     <button
+//         class="country-dropdown-toggle"
+//         data-toggle="open"
+//         data-target="#country-list"
+//         aria-expanded="false"
+//         aria-label="#"
+//     >
+//       <span class="screen-reader-text">...:</span> Navbar title
+//       <span class="screen-reader-text">...</span>
+//     </button>
+//   </li>
+//   <li class="nav-item wpml-ls-item">
+//     <a class="nav-link" href="#">EN</a>
+//     <a class="nav-link" href="#">NL</a>
+//   </li>
+//   <li class="nav-item">
+//     <a class="nav-link" href="#">ABOUT US</a>
+//   </li>
+//   <li class="nav-item">
+//     <a class="btn btn-donate" href="#">Donate</a>
+//   </li>
+// </ul>
+// <button
+//     class="navbar-search-toggle"
+//     data-toggle="open"
+//     data-target="#search_form"
+//     aria-expanded="false"
+//     aria-label="{{ data_nav_bar.navbar_search_toggle }}"
+// >
+//   <span class="screen-reader-text">Toggle search form</span>
+// </button>
+// <form id="search_form" action="#" class="form nav-item nav-search-wrap">
+//   <input id="search_input" type="search" class="form-control" placeholder="Search"
+//        value="" name="s" aria-label="Search">
+//   <input id="orderby" type="hidden" name="orderby" value=""/>
+//   <button class="top-nav-search-btn" type="submit">
+//     <svg viewBox="0 0 32 32" class="icon"><use xlink:href="images/symbol/svg/sprite.symbol.svg#search"></use></svg>
+//     <span class="screen-reader-text">Search</span>
+//   </button>
+// </form>
+// </nav>
+//
+// Styleguide Layout.navbar
+$menu-height-small: 3.375rem;
+$menu-height-large: 3.75rem;
+$min-height: 40px;
+$navbar-default-height: 60px;
+
+.top-navigation {
+  position: fixed;
+  width: 100%;
+  top: 0;
+  z-index: 5;
+  padding: 0;
+  text-transform: uppercase;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: normal;
+  background: var(--campaign_nav_color, transparentize($dark-blue, 0.2));
+  height: $menu-height-small;
+  font-family: $roboto;
+
+  html[dir="rtl"] & {
+    text-transform: lowercase;
+  }
+
+  @include medium-and-up {
+    height: $menu-height-large;
+  }
+
+  @include large-and-up {
+    align-items: center;
+  }
+
+  a.nav-link {
+    color: var(--nav-link-color, $white);
+  }
+
+  .donate-nav-item {
+    line-height: 1;
+    height: $navbar-default-height;
+  }
+
+  .btn-donate {
+    margin-top: 10px;
+    height: 40px;
+  }
+
+  // Move header down when WordPress Admin Bar is present
+  .admin-bar & {
+    top: 46px;
+
+    @media screen and (min-width: 783px) {
+      top: 32px;
+    }
+  }
+}
+
+.site-logo,
+.btn-navbar-toggle,
+.navbar-search-toggle,
+.country-dropdown-toggle,
+.nav-item,
+.nav-link {
+  line-height: $menu-height-small;
+  @include padding(0, $n15, 0, $n15);
+
+  @include medium-and-up {
+    line-height: $menu-height-large;
+    font-size: $font-size-md;
+  }
+}
+
+.btn-navbar-toggle,
+.country-dropdown-toggle,
+.nav-link {
+  &.active,
+  &:hover,
+  &:focus,
+  &:active {
+    text-decoration: none;
+    box-shadow: none;
+    outline: 0;
+  }
+}
+
+.navbar-search-toggle,
+.btn-navbar-toggle {
+  line-height: 2rem;
+  margin: 11px;
+  color: $white;
+  z-index: 1;
+
+  .icon {
+    font-size: $font-size-md;
+  }
+}
+
+.navbar-dropdown-toggle {
+  order: -1;
+
+  // When menu is open, turn the button into the background overlay
+  &[aria-expanded="true"] {
+    z-index: 2;
+    background: transparentize($grey-80, 0.5);
+    position: fixed;
+    width: 100%;
+    height: 100%;
+    top: 0;
+    left: 0;
+    outline: 0;
+    border: 0;
+    box-shadow: none;
+    padding: 0;
+    margin: 0;
+  }
+
+  @include large-and-up {
+    display: none;
+  }
+}
+
+.navbar-search-toggle {
+  cursor: pointer;
+  border: 0;
+  background: url("../../images/search.svg") center center no-repeat;
+  background-size: 28px;
+  margin-left: auto;
+
+  &.open {
+    outline: 0;
+    background: url("../../images/close-icon.svg") center center no-repeat;
+  }
+
+  html[dir="rtl"] & {
+    margin-left: 11px;
+    margin-right: auto;
+  }
+
+  @include large-and-up {
+    display: none;
+  }
+}
+
+// Logo
+//
+// Greenpeace logo.
+//
+// Markup:
+// <a class="site-logo" href="#">
+//   <img src="https://www.greenpeace.org/international/wp-content/themes/planet4-master-theme/images/gp-logo.svg" alt="Greenpeace">
+// </a>
+//
+// Styleguide Style.logo
+.site-logo {
+  position: absolute;
+  width: 100%;
+  text-align: center;
+
+  @include large-and-up {
+    position: static;
+    width: auto;
+    text-align: left;
+    line-height: 1;
+  }
+
+  &:focus {
+    box-shadow: none;
+  }
+
+  img {
+    height: 1.25rem;
+
+    @include small-and-up {
+      height: 1.5rem;
+    }
+
+    @include large-and-up {
+      height: 1.875rem;
+    }
+  }
+}
+
+.navbar-dropdown {
+  display: none;
+  margin: 0;
+  list-style-type: none;
+  height: 100vh;
+  width: 300px;
+  background-position: right $menu-height-small;
+
+  html[dir="rtl"] & {
+    left: auto;
+    right: 0;
+
+    .country-dropdown-toggle {
+      text-transform: none;
+    }
+  }
+
+  @include small-and-up {
+    height: 100vh;
+    width: 375px;
+  }
+
+  @include medium-and-up {
+    width: 400px;
+    background-position: right $menu-height-large;
+  }
+
+  @include large-and-up {
+    height: auto;
+    width: auto;
+    background-position: 0% 0%;
+  }
+
+  &.open {
+    display: flex;
+  }
+
+  li:first-child {
+    z-index: 10;
+
+    @include medium-and-up {
+      z-index: 0;
+    }
+  }
+
+  ::-webkit-scrollbar {
+    width: 9px;
+  }
+
+  ::-webkit-scrollbar-track {
+    -webkit-border-radius: 5px;
+    border-radius: 5px;
+    background: rgba(255, 255, 255, 0.1);
+  }
+
+  ::-webkit-scrollbar-thumb {
+    -webkit-border-radius: 5px;
+    border-radius: 5px;
+    background: rgba(255, 255, 255, 0.2);
+  }
+
+  ::-webkit-scrollbar-thumb:hover {
+    background: rgba(255, 255, 255, 0.4);
+  }
+
+  ::-webkit-scrollbar-thumb:window-inactive {
+    background: rgba(255, 255, 255, 0.05);
+  }
+
+  // All other dropdown styles - This special rule has a 1px offset as it uses max-width instead of min-width
+  @media (max-width: #{$large-width - 1}) {
+    box-sizing: border-box;
+    flex-direction: column;
+    justify-content: space-between;
+    position: absolute;
+    top: 0;
+    left: 0;
+    background: $dark-blue url("../../images/dropdown-gradient.svg") no-repeat;
+    overflow-y: auto;
+    overflow-x: hidden;
+    z-index: 2;
+
+    .close-navbar-dropdown {
+      cursor: pointer;
+      position: absolute;
+      right: 0;
+      height: $menu-height-small;
+      width: $menu-height-small;
+      background: url("../../images/close-icon.svg") center center no-repeat;
+      z-index: 2;
+      border: 0;
+
+      html[dir="rtl"] & {
+        right: auto;
+        left: 0;
+      }
+
+      @include medium-and-up {
+        height: $menu-height-large;
+      }
+
+      &:focus,
+      &:hover {
+        border: 1px dotted transparentize($white, 0.5);
+      }
+    }
+
+    &::before {
+      content: "";
+      position: absolute;
+      left: 0;
+      top: 0;
+      bottom: 0;
+      width: 8px;
+      background: transparentize($grey-80, 0.9);
+      z-index: 0;
+    }
+
+    .country-dropdown-toggle {
+      box-sizing: border-box;
+      width: 100%;
+      text-align: left;
+      padding: 0 $n70 0 67px;
+
+      html[dir="rtl"] & {
+        text-align: right;
+        padding: 0 67px 0 $n70;
+      }
+
+      &:before {
+        content: "";
+        position: absolute;
+        top: 13px;
+        left: 0;
+        height: 1.75em;
+        width: 50px;
+        display: inline-block;
+        background: url("../../images/country-icon.svg") center center no-repeat;
+        border-right: 1px solid transparentize($white, 0.9);
+        background-size: contain;
+
+        html[dir="rtl"] & {
+          left: auto;
+          right: 0;
+          border-right: none;
+          border-left: 1px solid rgba(255, 255, 255, .1);
+        }
+
+        @include medium-and-up {
+          top: 17px;
+        }
+      }
+    }
+
+    .nav-item {
+      z-index: 1;
+
+      &:last-child {
+        flex-basis: 100%;
+      }
+    }
+
+    .nav-link {
+      padding: 0 $n40 0 $n50;
+      display: block;
+      line-height: 2.8125rem;
+      font-size: $font-size-sm;
+      margin: 0.5em 0;
+
+      html[dir="rtl"] & {
+        padding: 0 $n50 0 $n40;
+      }
+    }
+
+    .active .nav-link,
+    .nav-link:focus,
+    .nav-link:hover {
+      position: relative;
+      z-index: 2;
+    }
+
+    .active .nav-link::before {
+      content: "";
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      background: $white;
+      width: 8px;
+      margin-left: -50px;
+      z-index: 2;
+    }
+
+    .btn-donate {
+      display: block;
+      min-width: 200px;
+      margin: 1.5em auto;
+      padding: $n5 $n30;
+    }
+  }
+
+  @include large-and-up {
+    display: flex;
+    flex-grow: 1;
+    justify-content: space-between;
+    padding: 0;
+
+    .close-navbar-dropdown {
+      display: none;
+    }
+
+    .nav-link {
+      padding: 0;
+      min-width: 20%;
+      text-align: center;
+      border-bottom: var(--nav-link-border-width, 2px) solid transparent;
+
+      &:hover,
+      &:focus,
+      &:active {
+        border-bottom: var(--nav-link-border-width, 2px) solid var(--nav-link-hover-border-color, $white);
+      }
+    }
+
+    .active .nav-link {
+      border-bottom: var(--nav-link-border-width, 2px) solid var(--nav-link-active-border-color, $white);
+    }
+  }
+
+  @include x-large-and-up {
+    padding: 0 15px;
+  }
+
+  .nav-item {
+    margin: 0;
+    padding: 0;
+  }
+
+  .wpml-ls-current-language {
+    display: list-item;
+  }
+}
+
+.nav-search-wrap {
+  display: none;
+  position: absolute;
+  top: 100%;
+  right: 0;
+  width: 300px;
+  padding: 11px;
+  max-width: 80%;
+  background: transparentize($dark-blue, 0.2);
+
+  html[dir="rtl"] & {
+    right: auto;
+    left: 0;
+  }
+
+  &.open {
+    display: block;
+  }
+
+  @include large-and-up {
+    height: $navbar-default-height;
+    position: relative;
+    max-width: 20%;
+    width: 400px;
+    display: inline-block;
+    padding: 0 15px;
+    background: none;
+    top: auto;
+    right: auto;
+
+    html[dir="rtl"] & {
+      left: auto;
+    }
+  }
+
+  input::placeholder {
+    color: $grey-40;
+
+    html[dir="rtl"] & {
+      text-transform: lowercase;
+    }
+  }
+
+  .top-nav-search-btn {
+    background-color: $white;
+    border: none;
+    position: absolute;
+    right: 12px;
+    font-size: $font-size-md;
+    line-height: 26px;
+    color: $dark-blue;
+    top: 11px;
+    border-radius: 4px;
+
+    html[dir="rtl"] & {
+      left: 12px;
+      right: auto;
+    }
+
+    .icon {
+      vertical-align: middle;
+      font-size: $font-size-lg;
+      top: 5px;
+    }
+
+    @include large-and-up {
+      right: 16px;
+      top: 9px;
+
+      html[dir="rtl"] & {
+        left: 16px;
+        right: auto;
+      }
+    }
+  }
+
+  input.form-control {
+    height: 40px;
+    border: none;
+    padding: $n5 $n10;
+
+    @include large-and-up {
+      margin-top: 9px;
+    }
+
+    &:not(:placeholder-shown):focus ~ .top-nav-search-btn {
+      display: none;
+    }
+  }
+}
+
+.country-dropdown-toggle {
+  cursor: pointer;
+  font-size: $font-size-sm;
+  border: 0;
+  color: transparentize($white, 0.2);
+  background: transparent;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  transition: color 100ms;
+
+  background-color: $x-dark-blue;
+  @include large-and-up {
+    background-color: transparent;
+  }
+
+  &::after {
+    content: "";
+    width: 8px;
+    height: 8px;
+    background: url("../../images/down-arrow-white.svg") no-repeat center center;
+    background-size: contain;
+    display: inline-block;
+    margin-left: 10px;
+    transition: transform 300ms linear;
+  }
+
+  &:focus,
+  &:hover {
+    color: $white;
+  }
+
+  &[aria-expanded="true"] {
+    &::after {
+      transform: rotate(180deg);
+    }
+  }
+}
+
+.country-list {
+  display: none;
+  text-transform: none;
+  background: $x-dark-blue;
+  line-height: 1.5;
+  padding: 1.4em 0;
+  overflow-y: hidden;
+  top: $navbar-default-height;
+
+  &.open {
+    display: block;
+    overflow-y: scroll !important;
+  }
+
+  a {
+    display: block;
+    color: $white;
+  }
+
+  .active a {
+    text-decoration: underline;
+  }
+
+  .country-group-letter {
+    font-size: $font-size-sm;
+    position: absolute;
+    line-height: 1.5;
+    font-weight: bold;
+    color: $grey-40;
+    @include margin($left: -$n25);
+
+    html[dir="rtl"] & {
+      @include margin($left: 0, $right: -$n25);
+      text-transform: lowercase;
+    }
+
+    @include large-and-up {
+      margin-left: -#{$n25};
+
+      html[dir="rtl"] & {
+        margin-left: 0;
+        margin-right: -#{$n25};
+      }
+    }
+  }
+
+  > ul {
+    padding: 0 0 2em;
+    margin-top: 1.5em;
+  }
+
+  > a,
+  li {
+    position: relative;
+    list-style: none;
+    padding-left: 50px;
+    font-size: $font-size-sm;
+    break-inside: avoid;
+
+    html[dir="rtl"] & {
+      padding-left: 0;
+      padding-right: 50px;
+    }
+
+    @include large-and-up {
+      padding-left: 2em;
+
+      html[dir="rtl"] & {
+        padding-right: 2em;
+        padding-left: 0;
+      }
+    }
+
+    ul {
+      break-inside: avoid;
+      padding: 0;
+      margin: 0 1em 1.2em 0;
+
+      html[dir="rtl"] & {
+        margin: 0 0 1.2em 1em;
+      }
+    }
+
+    li {
+      padding-left: 0;
+      list-style: none;
+
+      html[dir="rtl"] & {
+        padding-right: 0;
+      }
+    }
+  }
+
+  @include large-and-up {
+    position: absolute;
+    height: 344px;
+    width: 80%;
+    left: 10%;
+    overflow-x: hidden;
+    overflow-y: hidden !important;
+    max-height: 344px;
+    max-height: calc(100vh - #{$menu-height-large});
+    padding: 2em 4em 4em;
+
+    .admin-bar & {
+      max-height: calc(100vh - #{$menu-height-large} - 32px);
+    }
+
+    > ul {
+      column-count: 3;
+    }
+  }
+}
+
+.nav-item.wpml-ls-item {
+  @include large-and-up {
+    margin-left: -20px;
+  }
+
+  @include x-large-and-up {
+    margin-left: -60px;
+  }
+
+  .nav-link {
+    display: inline;
+    font-size: $font-size-xxs;
+    padding: 0;
+
+    html[dir="rtl"] & {
+      padding: 0;
+    }
+
+    &:first-child {
+      padding-left: 50px;
+
+      html[dir="rtl"] & {
+        padding-left: 0;
+        padding-right: 50px;
+      }
+
+      @include large-and-up {
+        padding-left: 0;
+
+        html[dir="rtl"] & {
+          padding-right: 0;
+        }
+      }
+    }
+
+    &:not(:last-child)::after {
+      content: " | ";
+    }
+  }
+}
+
+.navigation-bar_min {
+  height: $min-height;
+  align-items: baseline;
+  justify-content: start;
+
+  .nav-item.wpml-ls-item {
+    list-style: none;
+    padding: 0;
+    margin: 0 0 0 $space-lg;
+    line-height: 1rem;
+
+    .nav-link {
+      margin: 0;
+    }
+  }
+
+  .language-selector-min {
+    position: absolute;
+    top: 0;
+    right: $space-lg;
+    @include medium-and-up {
+      position: relative;
+    }
+  }
+
+  .site-logo,
+  .btn-navbar-toggle,
+  .navbar-search-toggle,
+  .country-dropdown-toggle,
+  .nav-item,
+  .nav-link {
+    line-height: 2.25rem;
+    @include padding(0, 0, 0, 0);
+
+    @include medium-and-up {
+      line-height: 2.25rem;
+      font-size: $font-size-md;
+    }
+
+    @include large-and-up {
+      margin-left: 10px;
+    }
+
+    @include x-large-and-up {
+      margin-left: 36px;
+    }
+  }
+
+  .site-logo {
+    position: absolute;
+    width: 100%;
+    text-align: center;
+
+    @include large-and-up {
+      position: static;
+      width: auto;
+      text-align: left;
+    }
+
+    &:focus {
+      box-shadow: none;
+    }
+
+    img {
+      height: 1.1rem;
+    }
+  }
+}
+
+// Enhanced mobile Donate button
+.btn-donate {
+  &.btn-donate-top {
+    position: fixed;
+    left: 0;
+    z-index: 4;
+    width: 100%;
+    height: 3.3rem;
+    line-height: 3.3rem;
+    top: 3.3rem;
+    transition: top .2s;
+
+    .admin-bar & {
+      top: 6.2rem;
+    }
+  }
+
+  &.btn-donate-top-hide {
+    top: -3.3rem;
+
+    .admin-bar & {
+      top: -6.2rem;
+    }
+  }
+}
+
+body.with-donate-on-top {
+  padding-top: 3.3rem;
+}

--- a/assets/src/scss/styleguide/src/layout/_navbar.scss
+++ b/assets/src/scss/styleguide/src/layout/_navbar.scss
@@ -295,13 +295,11 @@ $navbar-default-height: 60px;
   }
 
   ::-webkit-scrollbar-track {
-    -webkit-border-radius: 5px;
     border-radius: 5px;
     background: rgba(255, 255, 255, 0.1);
   }
 
   ::-webkit-scrollbar-thumb {
-    -webkit-border-radius: 5px;
     border-radius: 5px;
     background: rgba(255, 255, 255, 0.2);
   }

--- a/assets/src/scss/styleguide/src/layout/_page-header.scss
+++ b/assets/src/scss/styleguide/src/layout/_page-header.scss
@@ -1,0 +1,208 @@
+// Page Header
+//
+// Creates a page header with tags, post title, authorship data and comments.
+//
+// Markup:
+// <header class="page-header">
+//   <div class="page-header-background">
+//   </div>
+//   <div class="container">
+//     <div class="top-page-tags">
+//       <a class="tag-item tag-item--main page-type" href="#">A page tag</a>
+//       <div class="tag-wrap issues">
+//         <a class="tag-item tag-item--main" href="#">Some issue</a>
+//       </div>
+//       <div class="tag-wrap tags">
+//         <a class="tag-item tag" href="#">#tag</a>
+//       </div>
+//     </div>
+//     <h1 class="page-header-title">The post title</h1>
+//   </div>
+//   <div class="row">
+//     <div class="col-md-6">
+//       <div class="single-post-meta">
+//         <address class="single-post-author">
+//           by <a href="#">Jane Doe</a>
+//         </address>
+//         <time class="single-post-time" pubdate>June 6th, 2019</time>
+//           <span class="separator">|</span>
+//           <span id="comments-link" class="comment-link">
+//             <img src="/images/icons/speech_bubble.svg">
+//             <a class="quantity"> 11 <span class="display-text">Comments</span> </a>
+//           </span>
+//       </div>
+//     </div>
+//     <div class="col-md-6">
+//       (share buttons)
+//     </div>
+//   </div>
+// </header>
+//
+// Styleguide Layout.page-header
+.breadcrumbs {
+  padding-top: 40px;
+
+  li {
+    display: inline-block;
+    list-style-type: none;
+    position: relative;
+
+    &:not(:first-child) {
+      margin-left: 1.5em;
+
+      a:before {
+        content: ">";
+        position: absolute;
+        left: -1em;
+      }
+    }
+  }
+}
+
+.header-wrapper {
+  height: 0;
+}
+
+.page-header {
+  color: $grey-80;
+  padding-top: $n90;
+  margin-bottom: $space-md;
+  position: relative;
+
+  @include medium-and-up {
+    padding-top: 104px;
+  }
+
+  @include large-and-up {
+    padding-top: 144px;
+    margin-bottom: $space-lg;
+  }
+
+  @include x-large-and-up {
+    padding-top: 144px;
+  }
+
+  &.page-header-hidden {
+    padding: 0 !important;
+    margin: 0;
+  }
+
+  .container > *:not(.row) {
+    @include medium-and-up {
+      max-width: 80%;
+    }
+
+    @include x-large-and-up {
+      max-width: 60%;
+    }
+  }
+
+  h3 {
+    margin-bottom: 20px;
+
+    @include medium-and-up {
+      line-height: 1.2;
+    }
+
+    @include large-and-up {
+      width: 60%;
+    }
+
+    @include x-large-and-up {
+      margin-bottom: 30px;
+      line-height: 1.1;
+    }
+  }
+}
+
+.page-header-background {
+  position: absolute;
+  z-index: 0;
+  top: 0;
+  right: 0;
+  left: 0;
+
+  &:after {
+    content: "";
+    display: block;
+    position: absolute;
+    z-index: 0;
+    height: 75%;
+    bottom: -.5%;
+    left: 0;
+    right: 0;
+    @include linear-gradient(360deg, $white 0%, transparent 100%);
+  }
+
+  img {
+    width: 100%;
+    height: auto;
+  }
+}
+
+.page-header-image {
+  max-width: 100%;
+  display: block;
+  margin: auto;
+}
+
+.page-header-title {
+  max-width: 80%;
+  margin-bottom: 10px;
+
+  @include medium-and-up {
+    margin-bottom: 12px;
+  }
+
+  @include large-and-up {
+    margin-bottom: 20px;
+  }
+
+  @include x-large-and-up {
+    line-height: 1.1;
+    margin-bottom: 20px;
+  }
+}
+
+.page-header-subtitle {
+  line-height: 1.3;
+  max-width: 80%;
+  margin: 0;
+
+  @include medium-and-up {
+    margin: 0 0 22px 0;
+  }
+}
+
+.page-header-btn {
+  display: inline-block;
+  width: 100%;
+  margin-top: 40px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+
+  @include medium-and-up {
+    margin-top: 24px;
+    width: auto;
+    min-width: 300px;
+  }
+
+  @include large-and-up {
+    margin-top: 24px;
+  }
+
+  @include x-large-and-up {
+    margin-top: 36px;
+  }
+}
+
+.page-header-content {
+  display: none;
+  margin-top: 0;
+
+  @include medium-and-up {
+    display: block;
+    margin-bottom: 0;
+  }
+}

--- a/assets/src/scss/styleguide/src/layout/_page-section.scss
+++ b/assets/src/scss/styleguide/src/layout/_page-section.scss
@@ -1,0 +1,28 @@
+// Page Section
+//
+// Describes **title** and **description** of each block.
+//
+// Markup:
+// <header>
+//   <h2 class="page-section-header">Block Title</h2>
+// </header>
+// <div class="page-section-description">Description Text</div>
+//
+// Styleguide Layout.page-section
+.page-section-header {
+  margin-bottom: $space-md;
+}
+
+.page-section-description {
+  margin-bottom: $space-xl;
+
+  @include medium-and-up {
+    width: 100%;
+  }
+
+  @include x-large-and-up {
+    .row & {
+      margin-top: 0;
+    }
+  }
+}

--- a/assets/src/scss/styleguide/src/layout/_skewed-overlay.scss
+++ b/assets/src/scss/styleguide/src/layout/_skewed-overlay.scss
@@ -1,0 +1,45 @@
+.skewed-overlay {
+  pointer-events: none;
+  height: 100%;
+
+  width: 100%;
+  position: absolute;
+  z-index: 1;
+  overflow: hidden;
+  mask-image: linear-gradient(170deg, rgba(0, 0, 0, 1), rgba(0, 0, 0, 1), rgba(226, 119, 119, 0.2), rgba(0, 0, 0, 0));
+  -webkit-mask-image: linear-gradient(170deg, rgba(0, 0, 0, 1), rgba(0, 0, 0, 1), rgba(226, 119, 119, 0.2), rgba(0, 0, 0, 0));
+  mask-size: 100%;
+  mask-repeat: no-repeat;
+  mask-position: left top;
+
+  &:before {
+    content: "";
+    display: block;
+    width: 100%;
+    height: 100%;
+    @include detailed-skewed-gradient(
+      transparent,
+      rgba(255, 255, 255, 0.2),
+      rgba(255, 255, 255, 1),
+      rgba(255, 255, 255, 0.85),
+      rgba(255, 255, 255, 0.3),
+      rgba(255, 255, 255, 0.9),
+      rgba(255, 255, 255, 0.9),
+      rgba(255, 255, 255, 0.95)
+    );
+
+    html[dir="rtl"] & {
+      @include detailed-skewed-gradient(
+        transparent,
+        rgba(255, 255, 255, 0.2),
+        rgba(255, 255, 255, 1),
+        rgba(255, 255, 255, 0.85),
+        rgba(255, 255, 255, 0.3),
+        rgba(255, 255, 255, 0.9),
+        rgba(255, 255, 255, 0.9),
+        rgba(255, 255, 255, 0.95),
+        -245deg
+      );
+    }
+  }
+}

--- a/assets/src/scss/styleguide/src/layout/_skewed-overlay.scss
+++ b/assets/src/scss/styleguide/src/layout/_skewed-overlay.scss
@@ -7,7 +7,6 @@
   z-index: 1;
   overflow: hidden;
   mask-image: linear-gradient(170deg, rgba(0, 0, 0, 1), rgba(0, 0, 0, 1), rgba(226, 119, 119, 0.2), rgba(0, 0, 0, 0));
-  -webkit-mask-image: linear-gradient(170deg, rgba(0, 0, 0, 1), rgba(0, 0, 0, 1), rgba(226, 119, 119, 0.2), rgba(0, 0, 0, 0));
   mask-size: 100%;
   mask-repeat: no-repeat;
   mask-position: left top;

--- a/assets/src/scss/styleguide/src/layout/_tables.scss
+++ b/assets/src/scss/styleguide/src/layout/_tables.scss
@@ -1,0 +1,61 @@
+@mixin table {
+  .wp-block-table {
+    margin-top: $space-xs;
+    margin-bottom: $space-md;
+
+    @include large-and-up {
+      margin-top: $space-md;
+      margin-bottom: $space-lg;
+    }
+  }
+
+  table {
+    margin-bottom: 15px;
+    font-family: $roboto;
+    width: 100%;
+
+    @include mobile-only {
+      display: block;
+      overflow: auto;
+    }
+
+    thead,
+    tfoot,
+    th,
+    td {
+      border: none;
+    }
+
+    th {
+      color: $white;
+      height: 36px;
+      font-size: $font-size-xs;
+      padding: 6px $n20;
+      box-sizing: border-box;
+      @include x-large-and-up {
+        font-size: $font-size-md;
+      }
+    }
+
+    td {
+      min-height: 120px;
+      font-size: $font-size-xs;
+      padding: $n20;
+      vertical-align: top;
+      color: $table-font-color;
+
+      @include mobile-only {
+        min-width: 300px;
+      }
+
+      @include x-large-and-up {
+        font-size: $font-size-md;
+      }
+    }
+  }
+}
+
+.post-content,
+.page-template {
+  @include table;
+}


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5983

---

This should move in the entire styleguide repo (except parts only relevant to the styleguide repo itself). It's moved to the location it already was in the theme.

Other repos that used the styleguide can be switched to use master theme as a submodule instead after this PR is merged.

I also needed to fix some code style issues in the styleguide, and also one in master theme before I could make the test pass. These are the commits starting from https://github.com/greenpeace/planet4-master-theme/pull/1344/commits/b489975a0008c90871f8562c92212a891a63b987