### PR TITLE
PLANET-5622: Skewed overlay changes position when page length changes

### DIFF
--- a/assets/src/scss/styleguide/src/layout/_skewed-overlay.scss
+++ b/assets/src/scss/styleguide/src/layout/_skewed-overlay.scss
@@ -1,6 +1,6 @@
 .skewed-overlay {
   pointer-events: none;
-  height: 100%;
+  height: 200vh;
 
   width: 100%;
   position: absolute;


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5622

This recreates the original styleguide PR since the styleguide was moved to the master theme: https://github.com/greenpeace/planet4-styleguide/pull/90

(previously approved by @mleray)