### PR TITLE
PLANET-6035 Restore embed block iframe heights

### DIFF
--- a/assets/src/scss/editorOverrides.scss
+++ b/assets/src/scss/editorOverrides.scss
@@ -199,12 +199,6 @@ input.describe[type=text][data-setting=caption] {
   color: red;
 }
 
-.wp-embed-responsive .block-editor {
-  .wp-block-embed.wp-has-aspect-ratio .wp-block-embed__wrapper::before {
-    content: none;
-  }
-}
-
 // Sidebar help texts
 .components-base-control__help,
 .components-form-token-field__help,


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6035

---

We made a fix for `iframe` heights a while back which worked, but in 5.5 or 5.6 a change was done (possibly to address the same issue) that together with our fix causes the iframe in the embed block to have no height. I couldn't reproduce the original issue (that youtube videos overlap the next block in the editor) after removing the CSS, so I guess it's fixed in core.

Tested on https://www-dev.greenpeace.org/test-pandora/wp-admin/post.php?post=29036&action=edit

original issue: https://jira.greenpeace.org/browse/PLANET-5344
PR (same code was previously in blocks): https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/361