### PR TITLE
PLANET-6034 adjust xxl breakpoint to wider than HD

### DIFF
--- a/assets/src/scss/bootstrap-build.scss
+++ b/assets/src/scss/bootstrap-build.scss
@@ -20,6 +20,7 @@ Text Domain: planet4-master-theme
 
 @import "~bootstrap/scss/functions";
 @import "~bootstrap/scss/variables";
+@import "./bootstrap-variables";
 @import "~bootstrap/scss/mixins";
 @import "~bootstrap/scss/utilities";
 

--- a/assets/src/scss/bootstrap-variables.scss
+++ b/assets/src/scss/bootstrap-variables.scss
@@ -1,0 +1,8 @@
+$grid-breakpoints: (
+  xs: 0,
+  sm: 576px,
+  md: 768px,
+  lg: 992px,
+  xl: 1200px,
+  xxl: 1921px
+);


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6034

---

The XXL breakpoint is breaking some things. We can increase the min-width so that it only matches screens wider than 1920px, which should solve most spacing issues. Removing the breakpoint using the same variable seems to not work.