### PR TITLE
Fix Finland localized name

### DIFF
--- a/templates/countries.json
+++ b/templates/countries.json
@@ -231,7 +231,7 @@
       "codes": ["FI"],
       "lang": [
         {
-          "name": "Suomea",
+          "name": "Suomi",
           "url": "https://www.greenpeace.org/finland",
           "locale": ["fi-FI"]
         }


### PR DESCRIPTION
This came as a request from GP Nordic. It turns out we had it wrong all along.