### PR TITLE
PLANET-6043 Fix search pages image aspect ratios

### DIFF
--- a/templates/tease-author.twig
+++ b/templates/tease-author.twig
@@ -1,4 +1,4 @@
-<li id="result-row-{{ post.ID }}" class="d-flex search-result-list-item">
+<li id="result-row-{{ post.ID }}" class="d-flex align-items-start search-result-list-item">
 	<img
 		class="d-flex search-result-item-image"
 		src="{{ post.thumbnail.src('thumbnail') }}"

--- a/templates/tease-taxonomy-post.twig
+++ b/templates/tease-taxonomy-post.twig
@@ -1,4 +1,4 @@
-<li id="result-row-{{ post.ID }}" class="d-flex search-result-list-item">
+<li id="result-row-{{ post.ID }}" class="d-flex align-items-start search-result-list-item">
 	<img
 		class="d-flex search-result-item-image"
 		src="{{ post.thumbnail.src('thumbnail') ?? dummy_thumbnail }}"


### PR DESCRIPTION
### Description 

See https://jira.greenpeace.org/browse/PLANET-6043

We added this fix to the [search page results](https://github.com/greenpeace/planet4-master-theme/blob/master/templates/tease-search.twig#L19) when upgrading to Bootstrap 5, but forgot to update the other templates that feature search results.
This PR proposes a fix using the new BS 5 classes, but there is [another PR](https://github.com/greenpeace/planet4-master-theme/pull/1354) without the BS 5 classes, which avoids some duplication 🙂