### PR TITLE
PLANET-6043 Fix search pages image aspect ratios

### DIFF
--- a/assets/src/scss/pages/search/_search-results.scss
+++ b/assets/src/scss/pages/search/_search-results.scss
@@ -28,6 +28,7 @@
       margin: 0 auto 24px;
       border-bottom: 1px solid $grey-20;
       position: relative;
+      align-items: flex-start;
 
       .search-result-item-image,
       .blank-block {

--- a/templates/tease-search.twig
+++ b/templates/tease-search.twig
@@ -16,7 +16,7 @@
 {% elseif ( first_of_the_page and loop.index0 is divisible by(5) ) %}
 	<div class="search-results-load row-hidden" style="display: none;">
 {% endif %}
-		<li id="result-row-{{ post.ID }}" class="d-flex align-items-start search-result-list-item">
+		<li id="result-row-{{ post.ID }}" class="d-flex search-result-list-item">
 
 		<img
 			class="d-flex search-result-item-image"


### PR DESCRIPTION
### Description 

See https://jira.greenpeace.org/browse/PLANET-6043

We added this fix to the [search page results](https://github.com/greenpeace/planet4-master-theme/blob/master/templates/tease-search.twig#L19) when upgrading to Bootstrap 5, but forgot to update the other templates that feature search results. 
There is already a [PR open](https://github.com/greenpeace/planet4-master-theme/pull/1353) for that issue using the new BS 5 classes, but this PR gives another solution without using the BS 5 classes, which avoids some duplication 🙂 