### PR TITLE
PLANET-5983: Properly extract vars from multiple files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1510,6 +1510,61 @@
         }
       }
     },
+    "@greenpeace/planet4-postcss-css-variables": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@greenpeace/planet4-postcss-css-variables/-/planet4-postcss-css-variables-0.2.0.tgz",
+      "integrity": "sha512-n9rzhf9DB8mJk8qH88OtqnRqYg/ZtszQzseqLtagNFKjWSL76XqYNRvyK6Zu5kMSN1H/m1xa4VHb6GpRF6rdIw==",
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "escape-string-regexp": "^1.0.3",
+        "extend": "^3.0.1",
+        "postcss": "^6.0.8",
+        "shallow-equal": "^1.2.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "postcss": {
+          "version": "6.0.23",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+          "requires": {
+            "chalk": "^2.4.1",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.4.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
     "@hapi/address": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.4.tgz",
@@ -4327,8 +4382,7 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "base": {
       "version": "0.11.2",
@@ -5399,7 +5453,6 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -5407,8 +5460,7 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "color-string": {
       "version": "1.5.3",
@@ -6882,8 +6934,7 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "escodegen": {
       "version": "1.14.3",
@@ -7558,8 +7609,7 @@
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "dev": true
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
     "extend-shallow": {
       "version": "3.0.2",
@@ -8531,8 +8581,7 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
     "has-symbols": {
       "version": "1.0.0",
@@ -13867,67 +13916,6 @@
         "postcss-value-parser": "^3.0.0"
       }
     },
-    "postcss-css-variables-extract": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/postcss-css-variables-extract/-/postcss-css-variables-extract-0.1.3.tgz",
-      "integrity": "sha512-OoF40JXG9HK4Wz2/MzlBBe4/7DeDkkwcu7Q9wTWmE8KMDCmlQBIcm+DM0/HENCkDzdAtqDuCcbVewA9ArHNATg==",
-      "dev": true,
-      "requires": {
-        "balanced-match": "^1.0.0",
-        "escape-string-regexp": "^1.0.3",
-        "extend": "^3.0.1",
-        "postcss": "^6.0.8",
-        "shallow-equal": "^1.2.1"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "postcss": {
-          "version": "6.0.23",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.4.1",
-            "source-map": "^0.6.1",
-            "supports-color": "^5.4.0"
-          }
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
-      }
-    },
     "postcss-discard-comments": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-4.0.2.tgz",
@@ -16029,8 +16017,7 @@
     "shallow-equal": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/shallow-equal/-/shallow-equal-1.2.1.tgz",
-      "integrity": "sha512-S4vJDjHHMBaiZuT9NPb616CSmLf618jawtv3sufLl6ivK8WocjAo58cXwbRV1cgqxH0Qbv+iUt6m05eqEa2IRA==",
-      "dev": true
+      "integrity": "sha512-S4vJDjHHMBaiZuT9NPb616CSmLf618jawtv3sufLl6ivK8WocjAo58cXwbRV1cgqxH0Qbv+iUt6m05eqEa2IRA=="
     },
     "shebang-command": {
       "version": "1.2.0",
@@ -19293,6 +19280,12 @@
             }
           }
         },
+        "y18n": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+          "dev": true
+        },
         "yallist": {
           "version": "3.1.1",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
@@ -19775,9 +19768,9 @@
       "dev": true
     },
     "y18n": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
-      "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
       "dev": true
     },
     "yallist": {

--- a/package.json
+++ b/package.json
@@ -26,8 +26,7 @@
     "svg-sprite-loader": "^4.1.6",
     "terser-webpack-plugin": "^2.2.1",
     "webpack": "^4.40.2",
-    "webpack-fix-style-only-entries": "^0.4.0",
-    "postcss-css-variables-extract": "^0.1.3"
+    "webpack-fix-style-only-entries": "^0.4.0"
   },
   "browserslist": [
     "last 2 version",
@@ -35,6 +34,7 @@
     "not dead"
   ],
   "dependencies": {
+    "@greenpeace/planet4-postcss-css-variables": "^0.2.0",
     "bootstrap": "^5.0.0-beta2",
     "classnames": "^2.2.6",
     "jquery": "^3.5.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,12 +6,10 @@ const FixStyleOnlyEntriesPlugin = require("webpack-fix-style-only-entries");
 const RemovePlugin = require('remove-files-webpack-plugin');
 const SpriteLoaderPlugin = require('svg-sprite-loader/plugin');
 const dashDash = require('@greenpeace/dashdash');
-const cssVariables = require( 'postcss-css-variables-extract' );
-const fs = require( 'fs' );
-const collectVarUsages = require( 'postcss-css-variables-extract/lib/scss-var-usages' );
-const mergeVarUsages = require( 'postcss-css-variables-extract/lib/merge-var-usages' );
+const cssVariables = require( '@greenpeace/planet4-postcss-css-variables' );
+const VariableCombinePlugin = require( '@greenpeace/planet4-postcss-css-variables/variableCombinePlugin' )
 
-let allCssVars = {};
+const allCssVars = {};
 module.exports = {
   ...defaultConfig,
   entry: {
@@ -107,25 +105,7 @@ module.exports = {
     new SpriteLoaderPlugin({
       plainSprite: true
     }),
-    {
-      apply: ( compiler ) => {
-        compiler.hooks.done.tap( 'DoneWriteCssVars', ( ) => {
-          // We use postcss to get the selector and resolved default value. For the original file and line number
-          // we use a separate scripts which loops through all scss files. Only variables that are in the final css
-          // are included.
-          const scssUsages = collectVarUsages( './assets/src' );
-          // console.log( 'CSS', allCssVars );
-          // console.log( 'sass', scssUsages );
-          const mergedUsages = mergeVarUsages( allCssVars, scssUsages );
-          fs.writeFile(
-            './assets/build/css-variables.json',
-            JSON.stringify( mergedUsages, null, 2 ),
-            console.log
-          );
-          allCssVars = {};
-        } );
-      }
-    }
+    VariableCombinePlugin({filename: './assets/build/css-variables.json', allCssVars})
   ],
   optimization: {
     ...defaultConfig.optimization,


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5983

---

The previous version of this plugin didn't account for [multiple entrypoints](https://github.com/greenpeace/planet4-master-theme/blob/0c65cee3a83bc760e21a59fed9f6583f7304b4cb/webpack.config.js#L16-L19). To resolve this the new version now writes to a separate key per entrypoint.

The plugin to combine these and write the file is now also included. Before this was in both repos using this package.

This also disables extracting the variables from the source SCSS files. Nothing was done with the result yet, and probably the same can be achieved directly in the postcss plugin by ensuring the rules source is properly set.

This also makes it use [Greenpeace's fork](https://github.com/greenpeace/planet4-postcss-css-variables) and npm package.

Identical plugin PR: https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/548