### PR TITLE
PLANET-6053 Remove inline-block from icon links to properly wrap

### DIFF
--- a/assets/src/scss/styleguide/src/base/_icons.scss
+++ b/assets/src/scss/styleguide/src/base/_icons.scss
@@ -9,8 +9,6 @@
 }
 
 a.pdf-link {
-  display: inline-block;
-
   &::before {
     content: "";
     background-image: url("../../images/file-pdf.svg"), url("../../public/images/file-pdf.svg");
@@ -25,8 +23,6 @@ a.pdf-link {
 }
 
 a.external-link {
-  display: inline-block;
-
   &::after {
     content: "";
     display: inline-block;

--- a/tests/acceptance/CustomTaxonomyPageCept.php
+++ b/tests/acceptance/CustomTaxonomyPageCept.php
@@ -6,11 +6,11 @@ $I->amOnPage('/story');
 
 $I->see('Story', 'h1');
 
-$I->click('Lilian Reyes');
+$I->click('Nikos');
 
-$I->amOnPage('/author/lreyes');
+$I->amOnPage('/author/nroussos');
 
-$I->see('Lilian Reyes', 'h1');
+$I->see('Nikos', 'h1');
 
 // Create a new post and override the author
 $slug = $I->generateRandomSlug();


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6053

---

`inline-block` forces links with long text to try to fit on the same line causing weird white space on paragraphs.

Not sure why we had that initially. It looks these were added when we removed `jQuery` from the js part of these links.