### PR TITLE
PLANET-5983 Ensure theme fonts are loaded, add page section header variables

### DIFF
--- a/assets/src/scss/layout/_page-section.scss
+++ b/assets/src/scss/layout/_page-section.scss
@@ -1,4 +1,8 @@
-.page-section-header {
+.page-section-header _-- {
+  text-transform: none;
+  color: inherit;
+  font-weight: var(--headings--font-weight, bold);
+  font-size: 2.5rem;
   margin-bottom: $space-md;
 }
 

--- a/single-campaign.php
+++ b/single-campaign.php
@@ -100,15 +100,13 @@ $context['post_tags']       = implode( ', ', $post->tags() );
 $context['custom_styles']   = $custom_styles;
 $context['css_vars']        = PostCampaign::css_vars( $campaign_meta );
 
-if ( $theme_name && 'default' !== $theme_name ) {
-	$context['custom_font_families'] = [
-		'Montserrat:300,400,500,600,700,800',
-		'Kanit:400,500,600,800',
-		'Open+Sans:400,500,600,800',
-		'Anton:400,500,600,800',
-		'Amiko:400,500,600,800',
-	];
-}
+$context['custom_font_families'] = [
+	'Montserrat:300,400,500,600,700,800',
+	'Kanit:400,500,600,800',
+	'Open+Sans:400,500,600,800',
+	'Anton:400,500,600,800',
+	'Amiko:400,500,600,800',
+];
 
 // Social footer link overrides.
 $context['social_overrides'] = [];

--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -466,6 +466,7 @@ class MasterSite extends TimberSite {
 		$context['cookies']      = [
 			'text' => planet4_get_option( 'cookies_field' ),
 		];
+		$context['theme_uri']    = $this->theme_dir;
 		$context['data_nav_bar'] = [
 			'images'                  => $this->theme_images_dir,
 			'home_url'                => home_url( '/' ),

--- a/templates/head/google_fonts.twig
+++ b/templates/head/google_fonts.twig
@@ -1,5 +1,51 @@
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700,900&display=swap&subset=latin-ext"/>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lora:400,400i,700&display=swap&subset=latin-ext"/>
+{% if  custom_font_families %}
+	<style>
+		@font-face {
+			font-family: Sanctuary;
+			src: url("{{ theme_uri }}/public/fonts/SanctuaryLC-Regular.otf");
+			font-display: swap;
+		}
+
+		@font-face {
+			font-family: "Save the Arctic";
+			src: url("{{ theme_uri }}/public/fonts/save-the-arctic.otf");
+		}
+
+		@font-face {
+			font-family: Jost;
+			src: url("{{ theme_uri }}/public/fonts/Jost-Book.woff") format("woff");
+			font-weight: normal;
+			font-style: normal;
+			font-display: swap;
+		}
+
+		@font-face {
+			font-family: Jost;
+			src: url("{{ theme_uri }}/public/fonts/Jost-BookItalic.woff") format("woff");
+			font-weight: normal;
+			font-style: italic;
+			font-display: swap;
+		}
+
+		@font-face {
+			font-family: Jost;
+			src: url("{{ theme_uri }}/public/fonts/Jost-Black.woff") format("woff");
+			font-weight: bold;
+			font-style: normal;
+			font-display: swap;
+		}
+
+		@font-face {
+			font-family: Jost;
+			src: url("{{ theme_uri }}/public/fonts/Jost-BlackItalic.woff") format("woff");
+			font-weight: bold;
+			font-style: italic;
+			font-display: swap;
+		}
+	</style>
+{% endif %}
 {% for font_family in custom_font_families %}
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family={{ font_family }}&display=swap"/>
 {% endfor %}

--- a/templates/html-header.twig
+++ b/templates/html-header.twig
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html {{ fn('language_attributes', 'html') }} data-base="{% if constant('WP_HOME') is defined %}{{ constant('WP_HOME') }}{% endif %}">
+<html {{ fn('language_attributes', 'html') }} data-base="{{ data_nav_bar.home_url }}">
 <head>
 	<meta charset="{{ site.charset }}">
 	{% include 'blocks/title.twig' %}
@@ -38,7 +38,7 @@
 	{% endif %}
 
 	{% if custom_styles %}
-		<style type="text/css">
+		<style>
 			{% for style in custom_styles.css %}{{ style|raw }}{% endfor %}
 		</style>
 	{% endif %}


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5983

---

While adding variables to the blocks CSS I find that some need more variables in master theme.

We also need to include the custom fonts for the default theme as well.

Also included a commit to use an existing variable in the twig template instead of a constant. These don't throw errors when undefined.