### PR TITLE
PLANET-6019: Verify Elasticpress activation before adding filters

### DIFF
--- a/src/Search.php
+++ b/src/Search.php
@@ -112,6 +112,10 @@ abstract class Search {
 	 * Add filters that are needed by both the initial page load and subsequent ajax page loads.
 	 */
 	public static function add_general_filters(): void {
+		if ( ! is_plugin_active( 'elasticpress' ) ) {
+			return;
+		}
+
 		// Call apply filters to catch issue in WPML's ElasticPress integration, which uses the wrong filter name.
 		add_filter(
 			'ep_formatted_args',
@@ -386,7 +390,7 @@ abstract class Search {
 			} else {
 				$template_post                = $post;
 				$template_post->id            = $post->ID;
-				$template_post->link          = $post->permalink;
+				$template_post->link          = $post->permalink ?? get_permalink( $post->ID );
 				$template_post->preview       = $post->excerpt;
 				$thumbnail                    = get_the_post_thumbnail_url( $post->ID, 'thumbnail' );
 				$template_post->thumbnail_alt = get_the_post_thumbnail_caption( $post->ID );


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6019
Related to: https://github.com/greenpeace/planet4-docker-compose/pull/85

On local instance, Elasticsearch container is disabled by default.
Elasticpress throws some exceptions when it is activated (no server to connect to), and once deactivated the Search functionality throws some more.

This fixes exceptions thrown when Elasticpress plugin is disabled, and keeps some links working in the result page.

## Test

- Disable Elasticpress 
  `docker-compose exec php-fpm wp plugin deactivate elasticpress`
- Go to a search page
  - on `master` branch, you should get an error 
  - on this branch, the page appears and result links are valid