### PR TITLE
PLANET-6062 Hide Menu text when main menu is open on small screens

### DIFF
--- a/assets/src/scss/layout/_navbar.scss
+++ b/assets/src/scss/layout/_navbar.scss
@@ -174,7 +174,7 @@ $navbar-default-height: 60px;
 .navbar-dropdown-toggle {
   order: -1;
 
-  // When menu is open, turn the button into the background overlay
+  // When menu is open, turn the button into the background overlay and hide the text
   &[aria-expanded="true"] {
     z-index: 2;
     background: transparentize($grey-80, 0.5);
@@ -188,6 +188,10 @@ $navbar-default-height: 60px;
     box-shadow: none;
     padding: 0;
     margin: 0;
+
+    span {
+      display: none;
+    }
   }
 
   @include large-and-up {


### PR DESCRIPTION
### Description

See https://jira.greenpeace.org/browse/PLANET-6062

### Testing
You'll need to resize your screen, for me on Chrome I could see the issue at 768px width.
- Broken: 
<img width="810" alt="Screenshot 2021-04-15 at 09 53 04" src="https://user-images.githubusercontent.com/6949075/114833965-664cce00-9dd0-11eb-9fe7-93c112e80cf2.png">

- Fixed:
<img width="818" alt="Screenshot 2021-04-15 at 09 52 47" src="https://user-images.githubusercontent.com/6949075/114833988-6cdb4580-9dd0-11eb-91ca-6a996d6a860b.png">
