### PR TITLE
PLANET-6080 Add fonts in HTML head for campaigns

### DIFF
--- a/single-campaign.php
+++ b/single-campaign.php
@@ -100,6 +100,16 @@ $context['post_tags']       = implode( ', ', $post->tags() );
 $context['custom_styles']   = $custom_styles;
 $context['css_vars']        = PostCampaign::css_vars( $campaign_meta );
 
+if ( $theme_name && 'default' !== $theme_name ) {
+	$context['custom_font_families'] = [
+		'Montserrat:300,400,500,600,700,800',
+		'Kanit:400,500,600,800',
+		'Open+Sans:400,500,600,800',
+		'Anton:400,500,600,800',
+		'Amiko:400,500,600,800',
+	];
+}
+
 // Social footer link overrides.
 $context['social_overrides'] = [];
 

--- a/templates/head/google_fonts.twig
+++ b/templates/head/google_fonts.twig
@@ -1,0 +1,5 @@
+<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700,900&display=swap&subset=latin-ext"/>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lora:400,400i,700&display=swap&subset=latin-ext"/>
+{% for font_family in custom_font_families %}
+	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family={{ font_family }}&display=swap"/>
+{% endfor %}

--- a/templates/html-header.twig
+++ b/templates/html-header.twig
@@ -14,8 +14,7 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 	<meta name="robots" content="max-snippet:-1, max-image-preview:large, max-video-preview:-1">
 	<link rel="shortcut icon" type="image/ico" href="{{ theme.uri }}/favicon.ico"/>
-	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700,900&display=swap&subset=latin-ext"/>
-	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lora:400,400i,700&display=swap&subset=latin-ext"/>
+	{% include 'head/google_fonts.twig' %}
 
 	{% if hreflang %}
 		<!-- hreflang metadata -->


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6080

---

These fonts were loaded with an `import` in the stylesheet, which is being removed in https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/556. This PR adds them to the HTML so that Cloudflare APO can optimize them.

Both should be merged at the same time. This one should go first so we don't end up in a state where there are no fonts.

I moved the new code and existing fonts into a new template part.
