### PR TITLE
PLANET-5523 Add Beta Blocks option

### DIFF
--- a/src/Features.php
+++ b/src/Features.php
@@ -22,6 +22,8 @@ class Features {
 
 	public const THEME_EDITOR_NON_LOGGED_IN = 'theme_editor_non_logged_in';
 
+	public const BETA_BLOCKS = 'beta_blocks';
+
 	/**
 	 * Get the features options page settings.
 	 *
@@ -88,6 +90,15 @@ class Features {
 					'planet4-master-theme-backend'
 				),
 				'id'   => self::THEME_EDITOR,
+				'type' => 'checkbox',
+			],
+			[
+				'name' => __( 'Allow beta blocks in post editor.', 'planet4-master-theme-backend' ),
+				'desc' => __(
+					'If enabled, beta blocks defined in <a href="https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/blob/master/planet4-gutenberg-blocks.php">this file</a>. Not for production use.',
+					'planet4-master-theme-backend'
+				),
+				'id'   => self::BETA_BLOCKS,
 				'type' => 'checkbox',
 			],
 		];

--- a/tag.php
+++ b/tag.php
@@ -11,7 +11,6 @@
 
 use P4\MasterTheme\TaxonomyCampaign;
 use Timber\Timber;
-use P4GBKS\Blocks\Covers;
 use P4GBKS\Blocks\Articles;
 use P4GBKS\Blocks\HappyPoint;
 
@@ -68,7 +67,7 @@ if ( is_tag() ) {
 		$campaign = new TaxonomyCampaign( $templates, $context );
 
 		$campaign->add_block(
-			Covers::BLOCK_NAME,
+			'covers',
 			[
 				'title'       => __( 'Things you can do', 'planet4-master-theme' ),
 				'description' => __( 'We want you to take action because together we\'re strong.', 'planet4-master-theme' ),
@@ -109,11 +108,11 @@ if ( is_tag() ) {
 			}
 		}
 
-		$campaign->add_block( Covers::BLOCK_NAME, $cfc_args );
+		$campaign->add_block( 'covers', $cfc_args );
 
 		// Convert old CampaignThumbnail block to Covers block[Campaign covers].
 		$campaign->add_block(
-			Covers::BLOCK_NAME,
+			'covers',
 			[
 				'title'       => __( 'Related Campaigns', 'planet4-master-theme' ),
 				'category_id' => $category->term_id ?? __( 'This Campaign is not assigned to an Issue', 'planet4-master-theme' ),


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5523

---

This adds the feature toggle for beta blocks used in by the plugin.

Also makes `tag.php` use a string literal instead of the class constant from the other repo, to avoid hassle when we change the old version name to `OldCovers`.