### PR TITLE
remove bullet from breadcrumbs styling

### DIFF
--- a/assets/src/scss/layout/_breadcrumbs.scss
+++ b/assets/src/scss/layout/_breadcrumbs.scss
@@ -23,7 +23,6 @@
   .tag-wrap-bullet {
     pointer-events: none;
     display: inline-block;
-    color: $link-color;
     font-weight: 400;
     margin-left: -12px;
     margin-right: 8px;

--- a/assets/src/scss/layout/_breadcrumbs.scss
+++ b/assets/src/scss/layout/_breadcrumbs.scss
@@ -20,19 +20,17 @@
     position: relative;
   }
 
-  .tag-item--main + .tag-wrap,
-  .tag-wrap + .tag-wrap {
-    &:before {
-      content: "\2022";
-      pointer-events: none;
-      display: inline-block;
-      margin-left: -12px;
-      margin-right: 8px;
+  .tag-wrap-bullet {
+    pointer-events: none;
+    display: inline-block;
+    color: $link-color;
+    font-weight: 400;
+    margin-left: -12px;
+    margin-right: 8px;
 
-      html[dir="rtl"] & {
-        margin-right: -12px;
-        margin-left: 8px;
-      }
+    html[dir="rtl"] & {
+      margin-right: -12px;
+      margin-left: 8px;
     }
   }
 

--- a/templates/blocks/header.twig
+++ b/templates/blocks/header.twig
@@ -29,6 +29,10 @@
 						</div>
 					{% endif %}
 
+					{% if ( post.issues_nav_data and campaigns ) %}
+						<span class="tag-wrap-bullet" aria-hidden="true">&#8226;</span>
+					{% endif %}
+
 					{% if ( campaigns ) %}
 						<div class="tag-wrap issues">
 							{% for campaign in campaigns %}

--- a/templates/single.twig
+++ b/templates/single.twig
@@ -24,6 +24,10 @@
 						</a>
 					{% endif %}
 
+					{% if ( page_type and post.issues_nav_data ) %}
+						<span class="tag-wrap-bullet" aria-hidden="true">&#8226;</span>
+					{% endif %}
+
 					{% if ( post.issues_nav_data ) %}
 						<div class="tag-wrap issues">
 							{% for issue in post.issues_nav_data %}

--- a/templates/single.twig
+++ b/templates/single.twig
@@ -43,6 +43,10 @@
 						</div>
 					{% endif %}
 
+					{% if ( post.issues_nav_data and post.tags ) %}
+						<span class="tag-wrap-bullet" aria-hidden="true">&#8226;</span>
+					{% endif %}
+
 					{% if (post.tags) %}
 						<div class="tag-wrap tags">
 							{% for tag in post.tags %}

--- a/templates/tease-author.twig
+++ b/templates/tease-author.twig
@@ -20,6 +20,10 @@
 				</a>
 			{% endfor %}
 
+			{% if ( post.get_custom_terms and post.tags ) %}
+				<span class="tag-wrap-bullet" aria-hidden="true">&#8226;</span>
+			{% endif %}
+
 			{% if (post.tags) %}
 				<div class="tag-wrap tags">
 					{% for tag in post.tags %}

--- a/templates/tease-search.twig
+++ b/templates/tease-search.twig
@@ -53,6 +53,10 @@
 							</a>
 						{% endfor %}
 
+						{% if ( post.p4_page_types and post.tags ) %}
+							<span class="tag-wrap-bullet" aria-hidden="true">&#8226;</span>
+						{% endif %}
+
 						{% if (post.tags) %}
 							<div class="tag-wrap tags">
 								{% for tag in post.tags %}

--- a/templates/tease-taxonomy-post.twig
+++ b/templates/tease-taxonomy-post.twig
@@ -20,6 +20,11 @@
 						{{ post.get_page_types.0.name|e('wp_kses_post')|raw }}
 				</a>
 			{% endif %}
+
+			{% if ( (post.page_types is not empty) and post.tags ) %}
+				<span class="tag-wrap-bullet" aria-hidden="true">&#8226;</span>
+			{% endif %}
+
 			{% if (post.tags) %}
 				<div class="tag-wrap tags">
 					{% for tag in post.tags %}


### PR DESCRIPTION
Ref: 1/2 of https://github.com/greenpeace/planet4/issues/114

Sibling PR: https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/560

## Description
This will remove the bullet applied via css `content: "\2022";` as there is not a clean way to hide the bullet from the screenreader when the bullet is added through css like this.

## Potential Issues
After taking a quick look, and noticing that we are updating a file that seems more general than the component we are touching (`_breadcrumbs.scss`) I am a little worried that this might break other functionality by hiding bullets in other places of the website. I would definitely like some 👀 on this PR with that in mind. Thank you ❤️ 

---

<!--
Please provide a brief summary of the change introduced to make review process easier.

Ideally this should also be part of the commit summary.
-->
