### PR TITLE
Remove jquery from load_more component

### DIFF
--- a/assets/src/js/load_more.js
+++ b/assets/src/js/load_more.js
@@ -1,28 +1,31 @@
-export const setupLoadMore = function($) {
-  const load_more = $('button.load-more-mt');
+export const setupLoadMore = function() {
+  const load_more = document.querySelectorAll('button.load-more-mt');
 
-  load_more.off('mousedown touchstart').on('mousedown touchstart', function (e) {
-    e.preventDefault();
-
-    const $content = $( this.dataset.content );
-    const next_page = parseInt(this.dataset.page) + 1;
-    const total_pages = parseInt(this.dataset.total);
-    const url = this.dataset.url + `?page=${ next_page }`;
-    this.dataset.page = next_page;
-
-    $.ajax({
-      url: url,
-      type: 'GET',
-      dataType: 'html'
-    }).done(function ( response ) {
-      // Append the response at the bottom of the results and then show it.
-      $content.append( response );
-
-      if (next_page === total_pages) {
-        load_more.fadeOut();
-      }
-    }).fail(function ( jqXHR, textStatus, errorThrown ) {
-      console.log(errorThrown); //eslint-disable-line no-console
-    });
+  load_more.forEach(elt => {
+    elt.addEventListener( 'mousedown', handler );
+    elt.addEventListener( 'touchstart', handler );
   });
 };
+
+function handler(e) {
+  e.preventDefault();
+  const load_more_elt = e.currentTarget;
+
+  const content_elt = document.querySelector( this.dataset.content );
+  const next_page = parseInt( this.dataset.page, 10 ) + 1;
+  const total_pages = parseInt( this.dataset.total, 10 );
+  const url = this.dataset.url + `?page=${ next_page }`;
+  this.dataset.page = next_page;
+
+  fetch(url)
+    .then(response => response.text())
+    .then(html => {
+      content_elt.innerHTML += html;
+      if (next_page === total_pages) {
+        load_more_elt.classList.add( 'hide-load-more' );
+      }
+    })
+    .catch(err => {
+      console.log(err); //eslint-disable-line no-console
+    });
+}

--- a/assets/src/scss/components/_buttons.scss
+++ b/assets/src/scss/components/_buttons.scss
@@ -245,3 +245,10 @@ $donate-button-box-shadow: 0 2px 5px rgba(0, 0, 0, .25);
     outline: none;
   }
 }
+
+button.load-more-mt {
+  &.hide-load-more {
+    opacity: 0;
+    transition: opacity 400ms;
+  }
+}


### PR DESCRIPTION
This replaces all jquery references in the component to using
raw DOM APIs instead. Note that this uses the `fetch` api,
which may not be available in older browsers. I am not sure
if we need to support browsers that do not have fetch in it.

Fixes https://github.com/greenpeace/planet4/issues/134

Please let me know a good way to test this out.
