### PR TITLE
PLANET-6087 Refer to beta category in help

### DIFF
--- a/src/Features.php
+++ b/src/Features.php
@@ -95,7 +95,7 @@ class Features {
 			[
 				'name' => __( 'Allow beta blocks in post editor.', 'planet4-master-theme-backend' ),
 				'desc' => __(
-					'If enabled, beta blocks defined in <a href="https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/blob/master/planet4-gutenberg-blocks.php">this file</a>. Not for production use.',
+					'If enabled, you can use early or unstable versions of blocks in the post editor. These will be in the "Planet 4 Blocks - BETA" category.',
 					'planet4-master-theme-backend'
 				),
 				'id'   => self::BETA_BLOCKS,


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6087

---

Now that we moved out blocks that were already used in production from the beta category, it will be hidden behind this toggle from now on. So we can refer to it in the help text.

https://www-dev.greenpeace.org/test-pluto/wp-admin/admin.php?page=planet4_settings_features