### PR TITLE
Fix "Load more" function on author and taxonomy

### DIFF
--- a/templates/author.twig
+++ b/templates/author.twig
@@ -45,7 +45,7 @@
 			<div class="row">
 				<div class="col-md-12 col-lg-5 col-xl-5 mt-3">
 					<button
-						data-bs-content=".multiple-search-result .list-unstyled"
+						data-content=".multiple-search-result .list-unstyled"
 						data-page="1"
 						data-total="{{ posts.pagination.total }}"
 						data-url="{{ author.path }}"

--- a/templates/taxonomy.twig
+++ b/templates/taxonomy.twig
@@ -31,7 +31,7 @@
 			<div class="row">
 				<div class="col-md-12 col-lg-5 col-xl-5 mt-3">
 					<button
-						data-bs-content=".multiple-search-result .list-unstyled"
+						data-content=".multiple-search-result .list-unstyled"
 						data-page="1"
 						data-total="{{ posts.pagination.total }}"
 						data-url="{{ fn('get_term_link', taxonomy.term_id ) }}"


### PR DESCRIPTION
Related to: https://jira.greenpeace.org/browse/PLANET-5981

"Load More" button doesn't work on author and taxonomy pages.

## Description

Data attribute `data-bs-content` in templates is not the one expected by the `load_more.js` script; the "Load More" button does a request but doesn't display anything.
This reverts the data-content attribute changes from https://github.com/greenpeace/planet4-master-theme/pull/1323 

## Test

You can check the issue on this page https://www.greenpeace.org/international/story/ - the "Load More" button doesn't display more stories, despite sending a GET request and getting a response. You can make it work by changing the `data-bs-content` attribute to `data-content`.  

Locally:
- Create a few posts (use the clone function, quick edit to change title and publish)
- For convenience you can change the `posts_per_page` property in `author.php` to make the button appear with fewer posts
- Check the author page http://www.planet4.test/author/admin/
  - On `master` branch, the "Load More" button doesn't work
  - On this branch, it displays your posts properly