### PR TITLE
PLANET-6002 Remove Submenu back to top button

### DIFF
--- a/templates/base.twig
+++ b/templates/base.twig
@@ -18,8 +18,6 @@
 		<li><a href="#content">{{ __( 'Skip to Content', 'planet4-master-theme' ) }}</a></li>
 		<li><a href="#footer">{{ __( 'Skip to Footer', 'planet4-master-theme' ) }}</a></li>
 	</ul>
-	<a class="back-top d-none" title="{{ __('Go to the top of the page.', 'planet4-master-theme') }}"
-	   onclick="window.scrollTo({top: 0})"></a>
 
 	{% if custom_styles.nav_type == 'minimal' %}
 		{% include 'navigation-bar_min.twig' with data_nav_bar %}


### PR DESCRIPTION
### Description

See https://jira.greenpeace.org/browse/PLANET-6002

### Testing

Go to a long page with a Submenu block (for example Copyright or maybe Privacy) and make sure that the button doesn't appear when you scroll down.

#### Related PRs
- https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/584