### PR TITLE
PLANET-6136 Prepare test instance for themes review

### DIFF
--- a/assets/src/scss/editorOverrides.scss
+++ b/assets/src/scss/editorOverrides.scss
@@ -1,6 +1,10 @@
 // Moved from another repo, for history please see https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/blame/f5c532ed5704738136224cde305e9a0ffe614ceb/assets/src/styles/editorOverrides.scss
 .editor-post-title__block textarea.editor-post-title__input {
-  font-family: var(--headings--font-family, var(--header-primary-font, $roboto));
+  --headings-- {
+    // Not sure if fallback still needed, preserving for now.
+    font-family: var(--header-primary-font, $roboto);
+  }
+
   font-size: $font-size-xl;
   line-height: 1.225;
   margin-bottom: 30px;
@@ -74,14 +78,17 @@
 
 .wp-block-button.is-style-secondary .wp-block-button__link[role="textbox"],
 [class="wp-block-button"] .wp-block-button__link[role="textbox"] {
-  background-color: var(--btn-secondary-background-color, transparentize($white, .7));
-  border-color: var(--btn-secondary-border-color, $dark-blue);
-  color: var(--btn-secondary-color, $dark-blue);
+  --button-secondary-- {
+    background: transparentize($white, .7);
+    border-color: $dark-blue;
+    color: $dark-blue;
+    padding: 2px $n30;
+  }
+
   box-shadow: none;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  padding: 2px $n30;
 
   html[dir="rtl"] & {
     line-height: 2.5;
@@ -89,20 +96,25 @@
 }
 
 .wp-block-button.is-style-cta .wp-block-button__link[role="textbox"] {
-  background-color: var(--btn-primary-background-color, $orange);
-  border-color: var(--btn-secondary-border-color, $orange);
-  color: var(--btn-primary-color, $white);
-  box-shadow: 0 2px 5px rgba(0, 0, 0, .25);
+  --button-primary-- {
+    background: $orange;
+    border-color: $orange;
+    color: $white;
+    box-shadow: 0 2px 5px rgba(0, 0, 0, .25);
+  }
 }
 
 .wp-block-button.is-style-donate .wp-block-button__link[role="textbox"] {
-  background-color: var(--btn-donate-background-color, $aquamarine);
-  color: var(--btn-donate-color, $grey);
+  --button-donate-- {
+    background: $aquamarine;
+    color: $grey;
+    box-shadow: 0 2px 5px rgba(0, 0, 0, .25);
+  }
+
   line-height: 1.65;
   min-width: 180px;
   margin: 0;
   padding: 2px $n30;
-  box-shadow: 0 2px 5px rgba(0, 0, 0, .25);
   transition: color background-color font-weight 100ms;
 
   .editor-styles-wrapper & {
@@ -112,7 +124,7 @@
 }
 
 .editor-rich-text__editable.wp-block-button__link:not([role="textbox"]) {
-  background-color: $white;
+  background: $white;
   border-radius: 0;
   border: none;
   color: $grey-80 !important;
@@ -152,10 +164,14 @@
 
 .edit-post-visual-editor .editor-block-list__block-edit,
 .edit-post-visual-editor {
-  font-family: var(--body-font, "Noto Serif");
+  --body-- {
+    font-family: "Noto Serif", serif;
+  }
 
   h1, h2, h3, h4, h5 {
-    font-family: var(--headings--font-family, var(--header-primary-font, $roboto));
+    --headings-- {
+      font-family: var(--header-primary-font, $roboto);
+    }
   }
 }
 

--- a/assets/src/scss/layout/_page-header.scss
+++ b/assets/src/scss/layout/_page-header.scss
@@ -25,7 +25,9 @@
 .page-header {
   _-- {
     color: $grey-80;
-    padding-top: $n90;
+    background: inherit;
+    padding-top: 90px;
+    padding-bottom: 0;
     margin-bottom: $space-md;
 
     @include medium-and-up {
@@ -107,7 +109,8 @@
   margin: auto;
 }
 
-.page-header-title {
+.page-header-title _-- {
+  text-transform: none;
   max-width: 80%;
   margin-bottom: 10px;
 

--- a/assets/src/scss/layout/_page-header.scss
+++ b/assets/src/scss/layout/_page-header.scss
@@ -23,23 +23,25 @@
 }
 
 .page-header {
-  color: $grey-80;
-  padding-top: $n90;
-  margin-bottom: $space-md;
+  _-- {
+    color: $grey-80;
+    padding-top: $n90;
+    margin-bottom: $space-md;
+
+    @include medium-and-up {
+      padding-top: 104px;
+    }
+
+    @include large-and-up {
+      padding-top: 144px;
+      margin-bottom: $space-lg;
+    }
+
+    @include x-large-and-up {
+      padding-top: 144px;
+    }
+  }
   position: relative;
-
-  @include medium-and-up {
-    padding-top: 104px;
-  }
-
-  @include large-and-up {
-    padding-top: 144px;
-    margin-bottom: $space-lg;
-  }
-
-  @include x-large-and-up {
-    padding-top: 144px;
-  }
 
   &.page-header-hidden {
     padding: 0 !important;
@@ -56,7 +58,7 @@
     }
   }
 
-  h3 {
+  h3 _-- {
     margin-bottom: 20px;
 
     @include medium-and-up {

--- a/src/PostCampaign.php
+++ b/src/PostCampaign.php
@@ -82,7 +82,7 @@ class PostCampaign {
 
 				$orderby = $query->get( 'orderby' );
 
-				if ( $orderby === 'theme' ) {
+				if ( 'theme' === $orderby ) {
 					$query->set( 'meta_key', 'theme' );
 					$query->set( 'orderby', 'meta_value' );
 				}
@@ -416,6 +416,11 @@ class PostCampaign {
 		return $defaults;
 	}
 
+	/**
+	 * Get whether the theme of a campaign is one of the legacy themes.
+	 *
+	 * @return string[] Whether it's legacy.
+	 */
 	public static function get_legacy_themes(): array {
 		return [
 			'default',
@@ -445,14 +450,13 @@ class PostCampaign {
 
 			$new_theme = $themes[ $theme ] ?? [];
 
-			$potential_new_version = str_replace('-new', '', $theme);
+			$potential_new_version = str_replace( '-new', '', $theme );
 			if ( ! in_array( $potential_new_version, self::get_legacy_themes(), true ) ) {
 				return $new_theme;
 			}
-			$theme = $potential_new_version;
+			$theme         = $potential_new_version;
 			$meta['theme'] = $potential_new_version;
 		}
-
 
 		// TODO: Use wp_safe_remote_get?
 		// TODO: Handle errors.
@@ -478,7 +482,7 @@ class PostCampaign {
 
 		$css_vars = array_filter( $css_vars );
 
-		return array_merge($new_theme ?? [], $css_vars);
+		return array_merge( $new_theme ?? [], $css_vars );
 	}
 
 	/**

--- a/src/PostCampaign.php
+++ b/src/PostCampaign.php
@@ -31,6 +31,17 @@ class PostCampaign {
 		'footer_links_color',
 	];
 
+	public const LEGACY_THEMES = [
+		'default',
+		'antarctic',
+		'arctic',
+		'climate',
+		'oceans',
+		'oil',
+		'plastics',
+		'forest',
+	];
+
 	/**
 	 * Taxonomy_Image constructor.
 	 */
@@ -417,24 +428,6 @@ class PostCampaign {
 	}
 
 	/**
-	 * Get whether the theme of a campaign is one of the legacy themes.
-	 *
-	 * @return string[] Whether it's legacy.
-	 */
-	public static function get_legacy_themes(): array {
-		return [
-			'default',
-			'antarctic',
-			'arctic',
-			'climate',
-			'oceans',
-			'oil',
-			'plastics',
-			'forest',
-		];
-	}
-
-	/**
 	 * Determine the css variables for a certain post.
 	 *
 	 * @param array $meta The meta containing the variable values.
@@ -444,14 +437,14 @@ class PostCampaign {
 	public static function css_vars( array $meta ): array {
 		$theme = self::get_theme( $meta );
 
-		$is_new_theme = ! in_array( $theme, self::get_legacy_themes(), true );
+		$is_new_theme = ! in_array( $theme, self::LEGACY_THEMES, true );
 		if ( $is_new_theme ) {
 			$themes = json_decode( get_option( 'planet4_themes', '[]' ), true );
 
 			$new_theme = $themes[ $theme ] ?? [];
 
 			$potential_new_version = str_replace( '-new', '', $theme );
-			if ( ! in_array( $potential_new_version, self::get_legacy_themes(), true ) ) {
+			if ( ! in_array( $potential_new_version, self::LEGACY_THEMES, true ) ) {
 				return $new_theme;
 			}
 			$theme         = $potential_new_version;

--- a/src/PostCampaign.php
+++ b/src/PostCampaign.php
@@ -50,6 +50,44 @@ class PostCampaign {
 
 		add_filter( 'get_user_option_edit_campaign_per_page', [ $this, 'set_default_items_per_page' ], 10, 3 );
 
+		add_filter(
+			'manage_campaign_posts_columns',
+			function ( $columns ) {
+				return array_merge( $columns, [ 'theme' => __( 'Theme', 'planet4-master-theme-backend' ) ] );
+			}
+		);
+
+		add_action(
+			'manage_campaign_posts_custom_column',
+			function ( $column_key, $post_id ) {
+				echo esc_html( get_post_meta( $post_id, 'theme', true ) );
+			},
+			10,
+			2
+		);
+		add_filter(
+			'manage_edit-campaign_sortable_columns',
+			function ( $columns ) {
+				$columns['theme'] = 'theme';
+
+				return $columns;
+			}
+		);
+		add_action(
+			'pre_get_posts',
+			function ( $query ) {
+				if ( ! is_admin() ) {
+					return;
+				}
+
+				$orderby = $query->get( 'orderby' );
+
+				if ( $orderby === 'theme' ) {
+					$query->set( 'meta_key', 'theme' );
+					$query->set( 'orderby', 'meta_value' );
+				}
+			}
+		);
 	}
 
 	/**

--- a/src/PostCampaign.php
+++ b/src/PostCampaign.php
@@ -437,14 +437,22 @@ class PostCampaign {
 	 * @return array The values that will be used for the css variables.
 	 */
 	public static function css_vars( array $meta ): array {
-		$is_new_theme = $meta['theme'] && ! in_array( $meta['theme'], self::get_legacy_themes(), true );
+		$theme = self::get_theme( $meta );
+
+		$is_new_theme = ! in_array( $theme, self::get_legacy_themes(), true );
 		if ( $is_new_theme ) {
 			$themes = json_decode( get_option( 'planet4_themes', '[]' ), true );
 
-			return $themes[ $meta['theme'] ] ?? [];
+			$new_theme = $themes[ $theme ] ?? [];
+
+			$potential_new_version = str_replace('-new', '', $theme);
+			if ( ! in_array( $potential_new_version, self::get_legacy_themes(), true ) ) {
+				return $new_theme;
+			}
+			$theme = $potential_new_version;
+			$meta['theme'] = $potential_new_version;
 		}
 
-		$theme = self::get_theme( $meta );
 
 		// TODO: Use wp_safe_remote_get?
 		// TODO: Handle errors.
@@ -470,7 +478,7 @@ class PostCampaign {
 
 		$css_vars = array_filter( $css_vars );
 
-		return $css_vars;
+		return array_merge($new_theme ?? [], $css_vars);
 	}
 
 	/**
@@ -617,9 +625,8 @@ class PostCampaign {
 	 */
 	public static function get_theme( array $meta ): string {
 		$theme = $meta['theme'] ?? $meta['_campaign_page_template'] ?? null;
-		$theme = $theme ? $theme : 'default';
 
-		return $theme;
+		return $theme ? $theme : 'default';
 	}
 
 	/**

--- a/src/PostCampaign.php
+++ b/src/PostCampaign.php
@@ -17,7 +17,6 @@ class PostCampaign {
 	public const META_FIELDS = [
 		'p4_campaign_name',
 		'theme',
-		'new_theme',
 		'campaign_logo',
 		'campaign_logo_color',
 		'campaign_nav_type',
@@ -417,18 +416,32 @@ class PostCampaign {
 		return $defaults;
 	}
 
+	public static function get_legacy_themes(): array {
+		return [
+			'default',
+			'antarctic',
+			'arctic',
+			'climate',
+			'oceans',
+			'oil',
+			'plastics',
+			'forest',
+		];
+	}
+
 	/**
 	 * Determine the css variables for a certain post.
 	 *
 	 * @param array $meta The meta containing the variable values.
+	 *
 	 * @return array The values that will be used for the css variables.
 	 */
 	public static function css_vars( array $meta ): array {
-		$new_theme = $meta['new_theme'] ?? null;
-		if ( !empty($new_theme) ) {
+		$is_new_theme = $meta['theme'] && ! in_array( $meta['theme'], self::get_legacy_themes(), true );
+		if ( $is_new_theme ) {
 			$themes = json_decode( get_option( 'planet4_themes', '[]' ), true );
 
-			return $themes[ $new_theme ] ?? [];
+			return $themes[ $meta['theme'] ] ?? [];
 		}
 
 		$theme = self::get_theme( $meta );

--- a/src/PostCampaign.php
+++ b/src/PostCampaign.php
@@ -17,6 +17,7 @@ class PostCampaign {
 	public const META_FIELDS = [
 		'p4_campaign_name',
 		'theme',
+		'new_theme',
 		'campaign_logo',
 		'campaign_logo_color',
 		'campaign_nav_type',

--- a/src/PostCampaign.php
+++ b/src/PostCampaign.php
@@ -423,6 +423,13 @@ class PostCampaign {
 	 * @return array The values that will be used for the css variables.
 	 */
 	public static function css_vars( array $meta ): array {
+		$new_theme = $meta['new_theme'] ?? null;
+		if ( !empty($new_theme) ) {
+			$themes = json_decode( get_option( 'planet4_themes', '[]' ), true );
+
+			return $themes[ $new_theme ] ?? [];
+		}
+
 		$theme = self::get_theme( $meta );
 
 		// TODO: Use wp_safe_remote_get?

--- a/templates/css-variables.twig
+++ b/templates/css-variables.twig
@@ -1,7 +1,7 @@
 <style>
 	:root {
 		{% for key, value in css_vars %}
-			--{{ key }}: {{ value }};
+			--{{ key|trim('--', 'left') }}: {{ value }};
 		{% endfor %}
 	}
 </style>

--- a/templates/css-variables.twig
+++ b/templates/css-variables.twig
@@ -1,7 +1,7 @@
 <style>
 	:root {
 		{% for key, value in css_vars %}
-			--{{ key|trim('--', 'left') }}: {{ value }};
+			--{{ key|trim('--', 'left') }}: {{ value|raw }};
 		{% endfor %}
 	}
 </style>

--- a/templates/html-header.twig
+++ b/templates/html-header.twig
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html {{ fn('language_attributes', 'html') }}>
+<html {{ fn('language_attributes', 'html') }} data-base="{% if constant('WP_HOME') is defined %}{{ constant('WP_HOME') }}{% endif %}">
 <head>
 	<meta charset="{{ site.charset }}">
 	{% include 'blocks/title.twig' %}


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6136

---

This branch ended up with various small things. I didn't split them up yet because for now it seems manageable to review. But I can still split it if that works better for the reviewer.

- Add the theme to the campaigns listing and allow sorting on it. See screenshot
- Fix fallbacks in editor styles
- Add a "data-base" attribute so that we can use it to create a namespace in localstorage.
- If a campaign has a new theme selected, it will grab it from the options. Not intended to be used in production, but it shouldn't affect any live content so we can merge it. On production you're not able to select a new theme for a campaign.
- If the stripping `-new` from the theme name results in one of the legacy themes, it will still use the sidebar settings corresponding to that theme. This is because when we switch the new themes will effectively use the same settings.

![Screenshot from 2021-05-25 10-58-11](https://user-images.githubusercontent.com/7604138/119473454-777fe780-bd4b-11eb-8d5f-e17e3ee190f9.png)
