### PR TITLE
PLANET-6153: Revert "PLANET-6019: Verify Elasticpress existence before adding filt…

### DIFF
--- a/src/Search.php
+++ b/src/Search.php
@@ -112,10 +112,6 @@ abstract class Search {
 	 * Add filters that are needed by both the initial page load and subsequent ajax page loads.
 	 */
 	public static function add_general_filters(): void {
-		if ( ! is_plugin_active( 'elasticpress' ) ) {
-			return;
-		}
-
 		// Call apply filters to catch issue in WPML's ElasticPress integration, which uses the wrong filter name.
 		add_filter(
 			'ep_formatted_args',
@@ -390,7 +386,7 @@ abstract class Search {
 			} else {
 				$template_post                = $post;
 				$template_post->id            = $post->ID;
-				$template_post->link          = $post->permalink ?? get_permalink( $post->ID );
+				$template_post->link          = $post->permalink;
 				$template_post->preview       = $post->excerpt;
 				$thumbnail                    = get_the_post_thumbnail_url( $post->ID, 'thumbnail' );
 				$template_post->thumbnail_alt = get_the_post_thumbnail_caption( $post->ID );


### PR DESCRIPTION
…ers"

This reverts commit f0ec043c45a5a6d856344462494fbc77ce9cbf28.

Ref: https://jira.greenpeace.org/browse/PLANET-6153

---

The commit being reverted resulted in our filters not being added when running the ES sync. As a result, the `guid` field did not get synced. Archived posts use this field to store the external link.

We should probably re-index all sites, since there were also other filters that were not being run during the sync. Some of those were to prevent syncing a huge amount of data in ES, so likely our cluster now is having a bad time.