### PR TITLE
PLANET-6237 Slack notifications

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,9 @@
       "vendor/plugins/{$name}/": ["type:wordpress-plugin"]
     }
   },
-  "require": {},
+  "require": {
+    "alek13/slack": "^2.0"
+  },
   "require-dev": {
     "squizlabs/php_codesniffer": "^3.5.8",
     "wp-coding-standards/wpcs": "^2.2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,458 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "15cfac644b19501d06c1dde63bc78dd5",
-    "packages": [],
+    "content-hash": "e8a2cd2eb209cae0089f625520eee193",
+    "packages": [
+        {
+            "name": "alek13/slack",
+            "version": "2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-slack/slack.git",
+                "reference": "eec88af852b83a2eb992c61299ca2d92e805fb77"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-slack/slack/zipball/eec88af852b83a2eb992c61299ca2d92e805fb77",
+                "reference": "eec88af852b83a2eb992c61299ca2d92e805fb77",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "guzzlehttp/guzzle": "~7.0|~6.0|~5.0|~4.0",
+                "php": "^7.1|^8.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.0",
+                "phpunit/phpunit": ">=7.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Maknz\\Slack\\": "src/",
+                    "Slack\\Tests\\": "tests/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "maknz",
+                    "email": "github@mak.geek.nz"
+                },
+                {
+                    "name": "Alexander Chibrikin",
+                    "email": "alek13.me@gmail.com"
+                }
+            ],
+            "description": "A simple PHP package (fork of maknz/slack) for sending messages to Slack, with a focus on ease of use and elegant syntax.",
+            "keywords": [
+                "laravel",
+                "slack"
+            ],
+            "support": {
+                "issues": "https://github.com/php-slack/slack/issues",
+                "source": "https://github.com/php-slack/slack/tree/2.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://donorbox.org/php-slack",
+                    "type": "custom"
+                }
+            ],
+            "time": "2021-06-09T21:46:34+00:00"
+        },
+        {
+            "name": "guzzlehttp/guzzle",
+            "version": "7.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/guzzle.git",
+                "reference": "7008573787b430c1c1f650e3722d9bba59967628"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/7008573787b430c1c1f650e3722d9bba59967628",
+                "reference": "7008573787b430c1c1f650e3722d9bba59967628",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "guzzlehttp/promises": "^1.4",
+                "guzzlehttp/psr7": "^1.7 || ^2.0",
+                "php": "^7.2.5 || ^8.0",
+                "psr/http-client": "^1.0"
+            },
+            "provide": {
+                "psr/http-client-implementation": "1.0"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.4.1",
+                "ext-curl": "*",
+                "php-http/client-integration-tests": "^3.0",
+                "phpunit/phpunit": "^8.5.5 || ^9.3.5",
+                "psr/log": "^1.1"
+            },
+            "suggest": {
+                "ext-curl": "Required for CURL handler support",
+                "ext-intl": "Required for Internationalized Domain Name (IDN) support",
+                "psr/log": "Required for using the Log middleware"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "7.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com",
+                    "homepage": "https://sagikazarmark.hu"
+                }
+            ],
+            "description": "Guzzle is a PHP HTTP client library",
+            "homepage": "http://guzzlephp.org/",
+            "keywords": [
+                "client",
+                "curl",
+                "framework",
+                "http",
+                "http client",
+                "psr-18",
+                "psr-7",
+                "rest",
+                "web service"
+            ],
+            "support": {
+                "issues": "https://github.com/guzzle/guzzle/issues",
+                "source": "https://github.com/guzzle/guzzle/tree/7.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/Nyholm",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/alexeyshockov",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/gmponos",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-03-23T11:33:13+00:00"
+        },
+        {
+            "name": "guzzlehttp/promises",
+            "version": "1.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/promises.git",
+                "reference": "8e7d04f1f6450fef59366c399cfad4b9383aa30d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/8e7d04f1f6450fef59366c399cfad4b9383aa30d",
+                "reference": "8e7d04f1f6450fef59366c399cfad4b9383aa30d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "symfony/phpunit-bridge": "^4.4 || ^5.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Promise\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Guzzle promises library",
+            "keywords": [
+                "promise"
+            ],
+            "support": {
+                "issues": "https://github.com/guzzle/promises/issues",
+                "source": "https://github.com/guzzle/promises/tree/1.4.1"
+            },
+            "time": "2021-03-07T09:25:29+00:00"
+        },
+        {
+            "name": "guzzlehttp/psr7",
+            "version": "1.8.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/psr7.git",
+                "reference": "dc960a912984efb74d0a90222870c72c87f10c91"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/dc960a912984efb74d0a90222870c72c87f10c91",
+                "reference": "dc960a912984efb74d0a90222870c72c87f10c91",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0",
+                "psr/http-message": "~1.0",
+                "ralouphie/getallheaders": "^2.0.5 || ^3.0.0"
+            },
+            "provide": {
+                "psr/http-message-implementation": "1.0"
+            },
+            "require-dev": {
+                "ext-zlib": "*",
+                "phpunit/phpunit": "~4.8.36 || ^5.7.27 || ^6.5.14 || ^7.5.20 || ^8.5.8 || ^9.3.10"
+            },
+            "suggest": {
+                "laminas/laminas-httphandlerrunner": "Emit PSR-7 responses"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Psr7\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "Tobias Schultze",
+                    "homepage": "https://github.com/Tobion"
+                }
+            ],
+            "description": "PSR-7 message implementation that also provides common utility methods",
+            "keywords": [
+                "http",
+                "message",
+                "psr-7",
+                "request",
+                "response",
+                "stream",
+                "uri",
+                "url"
+            ],
+            "support": {
+                "issues": "https://github.com/guzzle/psr7/issues",
+                "source": "https://github.com/guzzle/psr7/tree/1.8.2"
+            },
+            "time": "2021-04-26T09:17:50+00:00"
+        },
+        {
+            "name": "psr/http-client",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-client.git",
+                "reference": "2dfb5f6c5eff0e91e20e913f8c5452ed95b86621"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-client/zipball/2dfb5f6c5eff0e91e20e913f8c5452ed95b86621",
+                "reference": "2dfb5f6c5eff0e91e20e913f8c5452ed95b86621",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0 || ^8.0",
+                "psr/http-message": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Client\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP clients",
+            "homepage": "https://github.com/php-fig/http-client",
+            "keywords": [
+                "http",
+                "http-client",
+                "psr",
+                "psr-18"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-client/tree/master"
+            },
+            "time": "2020-06-29T06:28:15+00:00"
+        },
+        {
+            "name": "psr/http-message",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP messages",
+            "homepage": "https://github.com/php-fig/http-message",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-message/tree/master"
+            },
+            "time": "2016-08-06T14:39:51+00:00"
+        },
+        {
+            "name": "ralouphie/getallheaders",
+            "version": "3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ralouphie/getallheaders.git",
+                "reference": "120b605dfeb996808c31b6477290a714d356e822"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ralouphie/getallheaders/zipball/120b605dfeb996808c31b6477290a714d356e822",
+                "reference": "120b605dfeb996808c31b6477290a714d356e822",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "require-dev": {
+                "php-coveralls/php-coveralls": "^2.1",
+                "phpunit/phpunit": "^5 || ^6.5"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/getallheaders.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ralph Khattar",
+                    "email": "ralph.khattar@gmail.com"
+                }
+            ],
+            "description": "A polyfill for getallheaders.",
+            "support": {
+                "issues": "https://github.com/ralouphie/getallheaders/issues",
+                "source": "https://github.com/ralouphie/getallheaders/tree/develop"
+            },
+            "time": "2019-03-08T08:55:37+00:00"
+        }
+    ],
     "packages-dev": [
         {
             "name": "composer/installers",

--- a/functions.php
+++ b/functions.php
@@ -78,6 +78,7 @@ function planet4_get_option( $key = '', $default = null ) {
 
 use P4\MasterTheme\ImageArchive\Rest;
 use P4\MasterTheme\Loader;
+use P4\MasterTheme\Notifications\Slack;
 use Timber\Timber;
 
 if ( ! class_exists( 'Timber' ) ) {
@@ -145,3 +146,11 @@ add_action( 'admin_menu', 'hide_wp_update_nag' );
 require_once 'load-class-aliases.php';
 
 Loader::get_instance();
+
+add_action(
+	'notification/elements',
+	static function () {
+		notification_register_carrier( new Slack( 'slack', 'Slack' ) );
+	}
+);
+

--- a/src/Features.php
+++ b/src/Features.php
@@ -24,8 +24,6 @@ class Features {
 
 	public const BETA_BLOCKS = 'beta_blocks';
 
-	public const SLACK_WEBHOOK = 'slack_webhook';
-
 	/**
 	 * Get the features options page settings.
 	 *
@@ -102,15 +100,6 @@ class Features {
 				),
 				'id'   => self::BETA_BLOCKS,
 				'type' => 'checkbox',
-			],
-			[
-				'name' => __( 'Slack webhook URL', 'planet4-master-theme-backend' ),
-				'desc' => __(
-					'TMP',
-					'planet4-master-theme-backend'
-				),
-				'id'   => self::SLACK_WEBHOOK,
-				'type' => 'text',
 			],
 		];
 

--- a/src/Features.php
+++ b/src/Features.php
@@ -24,6 +24,8 @@ class Features {
 
 	public const BETA_BLOCKS = 'beta_blocks';
 
+	public const SLACK_WEBHOOK = 'slack_webhook';
+
 	/**
 	 * Get the features options page settings.
 	 *
@@ -100,6 +102,15 @@ class Features {
 				),
 				'id'   => self::BETA_BLOCKS,
 				'type' => 'checkbox',
+			],
+			[
+				'name' => __( 'Slack webhook URL', 'planet4-master-theme-backend' ),
+				'desc' => __(
+					'TMP',
+					'planet4-master-theme-backend'
+				),
+				'id'   => self::SLACK_WEBHOOK,
+				'type' => 'text',
 			],
 		];
 

--- a/src/Notifications/MrkDwnField.php
+++ b/src/Notifications/MrkDwnField.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace P4\MasterTheme\Notifications;
+
+use BracketSpace\Notification\Defaults\Field\CodeEditorField;
+
+/**
+ * In order to use mrkdwn, we need to disable html sanitization on the code editor field.
+ */
+class MrkDwnField extends CodeEditorField {
+	/**
+	 * Disable sanitization since we're not dealing with HTML. We're sending this to Slack and it's interpreted as
+	 * mrkdwn, which should provide a safe environment.
+	 *
+	 * @param mixed $value The mrkdwn content.
+	 *
+	 * @return mixed The mrkdwn content.
+	 */
+	public function sanitize( $value ) {
+		return $value;
+	}
+}

--- a/src/Notifications/Slack.php
+++ b/src/Notifications/Slack.php
@@ -55,7 +55,7 @@ class Slack extends Abstracts\Carrier {
 	 */
 	public function send( Triggerable $trigger ) {
 		$webhook = planet4_get_option( Features::SLACK_WEBHOOK );
-		$client  = new Client( $webhook );
+		$client  = new Client( $webhook, [ 'link_names' => true ] );
 		$message = $this->get_message( $trigger );
 		$client->to( '#experiment-p4-slack-notifications' )->send( $message );
 	}

--- a/src/Notifications/Slack.php
+++ b/src/Notifications/Slack.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Slack Carrier.
+ */
+
+namespace P4\MasterTheme\Notifications;
+
+use BracketSpace\Notification\Interfaces\Triggerable;
+use BracketSpace\Notification\Abstracts;
+use BracketSpace\Notification\Defaults\Field;
+use Maknz\Slack\Client;
+use P4\MasterTheme\Features;
+
+/**
+ * Slack Carrier.
+ */
+class Slack extends Abstracts\Carrier {
+
+	/**
+	 * Carrier icon.
+	 *
+	 * @var string SVG.
+	 */
+	public $icon = '<svg enable-background="new 0 0 2447.6 2452.5" viewBox="0 0 2447.6 2452.5" xmlns="http://www.w3.org/2000/svg"><g clip-rule="evenodd" fill-rule="evenodd"><path d="m897.4 0c-135.3.1-244.8 109.9-244.7 245.2-.1 135.3 109.5 245.1 244.8 245.2h244.8v-245.1c.1-135.3-109.5-245.1-244.9-245.3.1 0 .1 0 0 0m0 654h-652.6c-135.3.1-244.9 109.9-244.8 245.2-.2 135.3 109.4 245.1 244.7 245.3h652.7c135.3-.1 244.9-109.9 244.8-245.2.1-135.4-109.5-245.2-244.8-245.3z" fill="#36c5f0"/><path d="m2447.6 899.2c.1-135.3-109.5-245.1-244.8-245.2-135.3.1-244.9 109.9-244.8 245.2v245.3h244.8c135.3-.1 244.9-109.9 244.8-245.3zm-652.7 0v-654c.1-135.2-109.4-245-244.7-245.2-135.3.1-244.9 109.9-244.8 245.2v654c-.2 135.3 109.4 245.1 244.7 245.3 135.3-.1 244.9-109.9 244.8-245.3z" fill="#2eb67d"/><path d="m1550.1 2452.5c135.3-.1 244.9-109.9 244.8-245.2.1-135.3-109.5-245.1-244.8-245.2h-244.8v245.2c-.1 135.2 109.5 245 244.8 245.2zm0-654.1h652.7c135.3-.1 244.9-109.9 244.8-245.2.2-135.3-109.4-245.1-244.7-245.3h-652.7c-135.3.1-244.9 109.9-244.8 245.2-.1 135.4 109.4 245.2 244.7 245.3z" fill="#ecb22e"/><path d="m0 1553.2c-.1 135.3 109.5 245.1 244.8 245.2 135.3-.1 244.9-109.9 244.8-245.2v-245.2h-244.8c-135.3.1-244.9 109.9-244.8 245.2zm652.7 0v654c-.2 135.3 109.4 245.1 244.7 245.3 135.3-.1 244.9-109.9 244.8-245.2v-653.9c.2-135.3-109.4-245.1-244.7-245.3-135.4 0-244.9 109.8-244.8 245.1 0 0 0 .1 0 0" fill="#e01e5a"/></g></svg>';
+
+	/**
+	 * Used to register Carrier form fields.
+	 * Uses $this->add_form_field();.
+	 *
+	 * @return void
+	 * @throws \Exception Not sure which ones.
+	 */
+	public function form_fields() {
+		$body_field = new Field\CodeEditorField(
+			[
+				'label'      => __( 'Message', 'planet4-master-theme-backend' ),
+				'name'       => 'body',
+				'resolvable' => true,
+				'settings'   => [
+					'mode'        => 'text/html',
+					'lineNumbers' => true,
+				],
+			]
+		);
+		$this->add_form_field( $body_field );
+	}
+
+	/**
+	 * Sends the notification.
+	 *
+	 * @param Triggerable $trigger trigger object.
+	 *
+	 * @return void
+	 */
+	public function send( Triggerable $trigger ) {
+		$webhook = planet4_get_option( Features::SLACK_WEBHOOK );
+		$client  = new Client( $webhook );
+		$message = $this->get_message( $trigger );
+		$client->to( '#experiment-p4-slack-notifications' )->send( $message );
+	}
+
+	/**
+	 * Get the message to send.
+	 *
+	 * @param Triggerable $trigger What triggered this notification.
+	 *
+	 * @return mixed The message, for now just the body that was entered.
+	 */
+	private function get_message( Triggerable $trigger ) {
+
+		return $this->data['body'];
+	}
+}

--- a/src/Notifications/Slack.php
+++ b/src/Notifications/Slack.php
@@ -57,7 +57,7 @@ class Slack extends Abstracts\Carrier {
 		$webhook = planet4_get_option( Features::SLACK_WEBHOOK );
 		$client  = new Client( $webhook, [ 'link_names' => true ] );
 		$message = $this->get_message( $trigger );
-		$client->to( '#experiment-p4-slack-notifications' )->send( $message );
+		$client->send( $message );
 	}
 
 	/**

--- a/src/Notifications/Slack.php
+++ b/src/Notifications/Slack.php
@@ -9,6 +9,7 @@ use BracketSpace\Notification\Interfaces\Triggerable;
 use BracketSpace\Notification\Abstracts;
 use Maknz\Slack\Client;
 use P4\MasterTheme\Features;
+use P4\MasterTheme\Settings;
 
 /**
  * Slack Carrier.
@@ -54,7 +55,7 @@ class Slack extends Abstracts\Carrier {
 	 * @return void
 	 */
 	public function send( Triggerable $trigger ) {
-		$webhook = planet4_get_option( Features::SLACK_WEBHOOK );
+		$webhook = planet4_get_option( Settings::SLACK_WEBHOOK );
 		$client  = new Client( $webhook, [ 'link_names' => true ] );
 		$message = $this->get_message( $trigger );
 		$client->send( $message );

--- a/src/Notifications/Slack.php
+++ b/src/Notifications/Slack.php
@@ -7,7 +7,6 @@ namespace P4\MasterTheme\Notifications;
 
 use BracketSpace\Notification\Interfaces\Triggerable;
 use BracketSpace\Notification\Abstracts;
-use BracketSpace\Notification\Defaults\Field;
 use Maknz\Slack\Client;
 use P4\MasterTheme\Features;
 
@@ -31,14 +30,16 @@ class Slack extends Abstracts\Carrier {
 	 * @throws \Exception Not sure which ones.
 	 */
 	public function form_fields() {
-		$body_field = new Field\CodeEditorField(
+		$body_field = new MrkDwnField(
 			[
-				'label'      => __( 'Message', 'planet4-master-theme-backend' ),
-				'name'       => 'body',
-				'resolvable' => true,
-				'settings'   => [
-					'mode'        => 'text/html',
-					'lineNumbers' => true,
+				'label'       => __( 'Message', 'planet4-master-theme-backend' ),
+				'description' => '<a target="_blank" class="external-link" href="https://api.slack.com/reference/surfaces/formatting#basics">Learn about message formatting options</a>',
+				'name'        => 'body',
+				'resolvable'  => true,
+				'settings'    => [
+					'mode'                => 'markdown',
+					'highlightFormatting' => true,
+					'lineNumbers'         => true,
 				],
 			]
 		);
@@ -67,7 +68,6 @@ class Slack extends Abstracts\Carrier {
 	 * @return mixed The message, for now just the body that was entered.
 	 */
 	private function get_message( Triggerable $trigger ) {
-
 		return $this->data['body'];
 	}
 }

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -21,6 +21,8 @@ class Settings {
 	 */
 	public const KEY = 'planet4_options';
 
+	public const SLACK_WEBHOOK = 'slack_webhook';
+
 	/**
 	 * Option page slug
 	 *
@@ -363,6 +365,20 @@ class Settings {
 				],
 			],
 			'planet4_settings_features'         => Features::get_options_page(),
+			'planet4_settings_notifications'    => [
+				'title'  => 'Notifications',
+				'fields' => [
+					[
+						'name' => __( 'Slack webhook URL', 'planet4-master-theme-backend' ),
+						'desc' => __(
+							'(Coming Soon) The webhook of the Slack channel to send notifications to.',
+							'planet4-master-theme-backend'
+						),
+						'id'   => self::SLACK_WEBHOOK,
+						'type' => 'text',
+					],
+				],
+			],
 		];
 		$this->hooks();
 	}


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6237

---

Add our own super lightweight implementation of a Slack message carrier to the notifications plugin.

Stores the webhook in a WP option (maybe we can find a better menu location, though the features section is already a place where we put early stuff).

The code that adds Slack only runs on a hook provided by the plugin, so should be safe to merge before we add the plugin. We'll initially set it up for GPI only as a pilot.

The current code was already quite extensively tested, see https://greenpeace-gpi.slack.com/archives/C022728TVT9 . The latest messages in the channel look a bit off, but that's just because of how the notification is set up. We can add a webhook and a test channel webhook to the GPI dev site, it can be used by Kelli to test a notification before setting up on prod.