### PR TITLE
Correct "plastics" to "plastic"

### DIFF
--- a/src/PostCampaign.php
+++ b/src/PostCampaign.php
@@ -38,7 +38,7 @@ class PostCampaign {
 		'climate',
 		'oceans',
 		'oil',
-		'plastics',
+		'plastic',
 		'forest',
 	];
 


### PR DESCRIPTION
The incorrect name caused the sidebar settings to not work for the
plastic theme.

Ref: https://jira.greenpeace.org/browse/PLANET-6136
