### PR TITLE
PLANET-6155 Prevent HubSpot cookies being set if user didn't consent

### DIFF
--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -2,7 +2,6 @@
 
 namespace P4\MasterTheme;
 
-use DateTimeImmutable;
 use Timber\Timber;
 use Timber\Site as TimberSite;
 use Timber\Menu as TimberMenu;
@@ -536,6 +535,9 @@ class MasterSite extends TimberSite {
 		$context['footer_primary_menu']   = wp_get_nav_menu_items( 'Footer Primary' );
 		$context['footer_secondary_menu'] = wp_get_nav_menu_items( 'Footer Secondary' );
 		$context['p4_comments_depth']     = get_option( 'thread_comments_depth' ) ?? 1; // Default depth level set to 1 if not selected from admin.
+
+		// HubSpot.
+		$context['hubspot_active'] = is_plugin_active( 'leadin/leadin.php' );
 		return $context;
 	}
 

--- a/templates/head/hubspot.twig
+++ b/templates/head/hubspot.twig
@@ -1,0 +1,10 @@
+<script>
+	function getCookieValue(name) {
+		return document.cookie.match('(^|;)\\s*' + name + '\\s*=\\s*([^;]+)')?.pop() || '';
+	}
+	{# Push event to revoke cookie consent as the first thing on the _hsp queue. This results in HubSpot complying to
+	our cookie consent #}
+	if (getCookieValue('greenpeace') !== '2') {
+		(window._hsp = window._hsp || []).push(['revokeCookieConsent']);
+	}
+</script>

--- a/templates/html-header.twig
+++ b/templates/html-header.twig
@@ -8,6 +8,10 @@
 
 	{% include 'blocks/google_tag_manager.twig' %}
 
+	{% if hubspot_active %}
+		{% include 'head/hubspot.twig' %}
+	{% endif %}
+
 	{% include 'blocks/p4_structured_data.twig' %}
 
 	<link rel="pingback" href="{{ site.pingback_url }}">


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6155

---

Ensure that the `revokeCookieConsent` is the first thing on the _hsp queue.

Luckily, this seems to work even if requiring consent is not enabled for the policy. Even though HubSpot documentation doesn't explicitly mention that revoking is supported in this case, it seems safe enough to do since it's unlikely that they would alter this behavior.