### PR TITLE
PLANET-5757 jQuery: remove jQuery from global.js

### DIFF
--- a/assets/src/js/app.js
+++ b/assets/src/js/app.js
@@ -1,6 +1,5 @@
 import { setupCookies } from './cookies';
 import { setupCountrySelect } from './country_select';
-import { setImageTitlesFromAltText } from './global';
 import { setupHeader } from './header';
 import { setupLoadMore } from './load_more';
 import { setupPDFIcon } from './pdf_icon';
@@ -21,7 +20,6 @@ window.$ = $ || jQuery;
 jQuery(function($) {
   setupCookies($);
   setupCountrySelect($);
-  setImageTitlesFromAltText($);
   setupHeader($);
   setupLoadMore($);
   setupPDFIcon($);

--- a/assets/src/js/global.js
+++ b/assets/src/js/global.js
@@ -1,7 +1,0 @@
-export const setImageTitlesFromAltText = function($) {
-  'use strict';
-
-  $('.page-template img, .post-content img').each( function() {
-    $(this).attr('title', $(this).attr('alt') );
-  });
-};

--- a/category.php
+++ b/category.php
@@ -25,8 +25,6 @@ $post_args = [
 	'has_password'   => false,  // Skip password protected content.
 ];
 
-$context['dummy_thumbnail'] = get_template_directory_uri() . '/images/dummy-thumbnail.png';
-
 if ( get_query_var( 'page' ) ) {
 	$templates          = [ 'tease-taxonomy-post.twig' ];
 	$post_args['paged'] = get_query_var( 'page' );

--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -538,6 +538,9 @@ class MasterSite extends TimberSite {
 
 		// HubSpot.
 		$context['hubspot_active'] = is_plugin_active( 'leadin/leadin.php' );
+
+		// Dummy thumbnail.
+		$context['dummy_thumbnail'] = get_template_directory_uri() . '/images/dummy-thumbnail.png';
 		return $context;
 	}
 

--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -1248,18 +1248,25 @@ class MasterSite extends TimberSite {
 	}
 
 	/**
-	 * Override the Gutenberg core/image block render method output, To add credit field in it's caption text.
+	 * Override the Gutenberg core/image block render method output, To add credit field in it's caption text & image alt text as title.
 	 *
 	 * @param array  $attributes    Attributes of the Gutenberg core/image block.
 	 * @param string $content The image element HTML.
 	 *
-	 * @return string HTML content of image element with credit field in caption.
+	 * @return string HTML content of image element with credit field in caption and alt text in image title.
 	 */
 	public function p4_core_image_block_render( $attributes, $content ) {
-		$image_id = isset( $attributes['id'] ) ? trim( str_replace( 'attachment_', '', $attributes['id'] ) ) : '';
-		$credit   = $image_id ? get_post_meta( $image_id, self::CREDIT_META_FIELD, true ) : '';
-		if ( empty( $image_id ) || empty( $credit ) ) {
+		$image_id      = isset( $attributes['id'] ) ? trim( str_replace( 'attachment_', '', $attributes['id'] ) ) : '';
+		$img_post_meta = $image_id ? get_post_meta( $image_id ) : [];
+		if ( ! $img_post_meta ) {
 			return $content;
+		}
+
+		$credit   = $img_post_meta[ self::CREDIT_META_FIELD ][0] ?? '';
+		$alt_text = $img_post_meta['_wp_attachment_image_alt'][0] ?? '';
+
+		if ( $alt_text ) {
+			$content = str_replace( ' alt=', ' title="' . esc_attr( $alt_text ) . '" alt=', $content );
 		}
 
 		$image_credit = ' ' . $credit;
@@ -1270,7 +1277,8 @@ class MasterSite extends TimberSite {
 		$caption_open  = '<figcaption>';
 		$caption_close = '</figcaption>';
 		$caption       = explode( $caption_open, $content, 2 )[1] ?? '';
-		if ( strpos( $caption, $image_credit ) !== false ) {
+
+		if ( empty( $credit ) || strpos( $caption, $image_credit ) !== false ) {
 			return $content;
 		}
 

--- a/taxonomy.php
+++ b/taxonomy.php
@@ -27,8 +27,7 @@ $post_args = [
 	'has_password'   => false,  // Skip password protected content.
 ];
 
-$context['page_category']   = 'Post Type Page';
-$context['dummy_thumbnail'] = get_template_directory_uri() . '/images/dummy-thumbnail.png';
+$context['page_category'] = 'Post Type Page';
 
 if ( get_query_var( 'page' ) ) {
 	$templates          = [ 'tease-taxonomy-post.twig' ];

--- a/templates/blocks/image.twig
+++ b/templates/blocks/image.twig
@@ -1,0 +1,8 @@
+<img
+	class="d-flex search-result-item-image"
+	src="{{ post.thumbnail.src('thumbnail') ?? dummy_thumbnail }}"
+	loading="lazy"
+	alt="{{ fn('esc_attr', post.thumbnail.alt|default( post.title ) )|raw }}"
+	data-ga-category="Articles List"
+	data-ga-action="Image"
+	data-ga-label="n/a" />

--- a/templates/tease-author.twig
+++ b/templates/tease-author.twig
@@ -1,13 +1,5 @@
 <li id="result-row-{{ post.ID }}" class="d-flex search-result-list-item">
-	{% set img_title = fn('esc_attr', post.thumbnail.alt|default( post.title ) )|raw %}
-	<img
-		class="d-flex search-result-item-image"
-		src="{{ post.thumbnail.src('thumbnail') }}"
-		alt="{{ img_title }}"
-		title="{{ img_title }}"
-		data-ga-category="Articles List"
-		data-ga-action="Image"
-		data-ga-label="n/a" />
+	{% include "blocks/image.twig" with {post:post, dummy_thumbnail:dummy_thumbnail} %}
 
 	<div id="tease-{{ post.ID }}" class="search-result-item-body tease tease-{{ post.post_type }}">
 		<div class="search-result-tags top-page-tags">

--- a/templates/tease-author.twig
+++ b/templates/tease-author.twig
@@ -1,8 +1,10 @@
 <li id="result-row-{{ post.ID }}" class="d-flex search-result-list-item">
+	{% set img_title = fn('esc_attr', post.thumbnail.alt|default( post.title ) )|raw %}
 	<img
 		class="d-flex search-result-item-image"
 		src="{{ post.thumbnail.src('thumbnail') }}"
-		alt="{{ fn('esc_attr', post.thumbnail.alt|default( post.title ) )|raw }}"
+		alt="{{ img_title }}"
+		title="{{ img_title }}"
 		data-ga-category="Articles List"
 		data-ga-action="Image"
 		data-ga-label="n/a" />

--- a/templates/tease-taxonomy-post.twig
+++ b/templates/tease-taxonomy-post.twig
@@ -1,9 +1,11 @@
 <li id="result-row-{{ post.ID }}" class="d-flex search-result-list-item">
+	{% set img_title = fn('esc_attr', post.thumbnail.alt|default( post.title ) )|raw %}
 	<img
 		class="d-flex search-result-item-image"
 		src="{{ post.thumbnail.src('thumbnail') ?? dummy_thumbnail }}"
 		loading="lazy"
-		alt="{{ fn('esc_attr', post.thumbnail.alt|default( post.title ) )|raw }}"
+		alt="{{ img_title }}"
+		title="{{ img_title }}"
 		data-ga-category="Articles List"
 		data-ga-action="Image"
 		data-ga-label="n/a" />

--- a/templates/tease-taxonomy-post.twig
+++ b/templates/tease-taxonomy-post.twig
@@ -1,14 +1,5 @@
 <li id="result-row-{{ post.ID }}" class="d-flex search-result-list-item">
-	{% set img_title = fn('esc_attr', post.thumbnail.alt|default( post.title ) )|raw %}
-	<img
-		class="d-flex search-result-item-image"
-		src="{{ post.thumbnail.src('thumbnail') ?? dummy_thumbnail }}"
-		loading="lazy"
-		alt="{{ img_title }}"
-		title="{{ img_title }}"
-		data-ga-category="Articles List"
-		data-ga-action="Image"
-		data-ga-label="n/a" />
+	{% include "blocks/image.twig" with {post:post, dummy_thumbnail:dummy_thumbnail} %}
 
 	<div id="tease-{{ post.ID }}" class="search-result-item-body tease tease-{{ post.post_type }}">
 		<div class="search-result-tags top-page-tags">


### PR DESCRIPTION
Removed global.js file and added title attribute in twig file & in PHP file by altering original output

Ref: [JIRA 5757](https://jira.greenpeace.org/browse/PLANET-5757)

---

**Testing steps:**
- Add native image block on page/post/campaign and test the frontend page the image has a title attribute
- The same fix is added for some other pages like author profile page, search, taxonomy page etc.


