### PR TITLE
PLANET-6060 Fix wp-editor issue

### DIFF
--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -234,6 +234,14 @@ class MasterSite extends TimberSite {
 			}
 		);
 
+		// Set wp-editor in the 'Text' mode by default (Temporary fix for PLANET-6060).
+		add_filter(
+			'wp_default_editor',
+			function () {
+				return 'html';
+			}
+		);
+
 		// Disable xmlrpc.
 		add_filter( 'xmlrpc_enabled', '__return_false' );
 


### PR DESCRIPTION
Set wp-editor in the 'Text' mode by default (Temporary fix till the WP release a core fix for https://core.trac.wordpress.org/ticket/52050)

Ref: [JIRA 6060](https://jira.greenpeace.org/browse/PLANET-6060)

---
When we switch from text to visual, the wp-editor(tinyMCE) works fine, though its not a perfect fix but a quick win over adding a whole new plugin.
![image](https://user-images.githubusercontent.com/5357471/121179327-3aecd980-c87d-11eb-803b-d77696c4ae6d.png)

eg. https://www-dev.greenpeace.org/sagardev/wp-admin/post-new.php?post_type=page