### PR TITLE
PLANET-6192 Fix WPML language switcher issue

### DIFF
--- a/templates/navigation-bar.twig
+++ b/templates/navigation-bar.twig
@@ -50,7 +50,7 @@
 					{% if key == 0 %}
 						<li class="nav-item {{ item.class }}">
 					{% endif %}
-						<a class="nav-link" href="{{ item.get_link }}">{{ item.title|striptags|slice(0, 2) }}</a>
+						<a class="nav-link" href="{{ item.get_link }}">{{ item.title|striptags|trim|slice(0, 2) }}</a>
 					{% if key == (languages - 1) %}
 						</li>
 					{% endif %}

--- a/templates/navigation-bar_min.twig
+++ b/templates/navigation-bar_min.twig
@@ -10,7 +10,7 @@
 					{% if key == 0 %}
 						<li class="nav-item {{ item.class }}">
 					{% endif %}
-						<a class="nav-link" href="{{ item.get_link }}">{{ item.title|striptags|slice(0, 2) }}</a>
+						<a class="nav-link" href="{{ item.get_link }}">{{ item.title|striptags|trim|slice(0, 2) }}</a>
 					{% if key == (languages - 1) %}
 						</li>
 					{% endif %}


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6192

---

Fix: 
- After the WPML plugin upgrade the, menubar language title is appended with newline char (Thanks @lithrel ), added a trim function to fix the issue.
