### PR TITLE
PLANET-6197: Fix Twitter embed width on mobile screen

### DIFF
--- a/assets/src/scss/pages/post/_article-content.scss
+++ b/assets/src/scss/pages/post/_article-content.scss
@@ -250,12 +250,6 @@
   q {
     font-style: italic;
   }
-
-  iframe.instagram-media,
-  .twitter-tweet {
-    width: 500px !important;
-    max-width: 100%;
-  }
 }
 
 .post-content-lead {


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6197

On posts (only), twitter embed is larger than a regular mobile width (<500px).
The current rule only applies to posts, and only to twitter.
Twitter embeds on pages, and instagram embeds on posts/pages, follow different rules and fit properly.

Some other embeds are also too large on 320px width, because of a general rule of width:330px in gutenberg blocks, fixed in this commit https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/compare/planet-6197 . Embeds usually have their own min-width included in their containers or frames (250px for twitter, 200px for reddit, etc.).
The test instance has commits of both theme and plugin. 

## Fix

Removing the rule fixes the issue.

![Screenshot from 2021-06-16 18-28-19](https://user-images.githubusercontent.com/617346/122257931-c7784700-ced0-11eb-8654-2423f703505b.png) ![Screenshot from 2021-06-16 18-28-59](https://user-images.githubusercontent.com/617346/122257943-cb0bce00-ced0-11eb-80c1-d192153da822.png)

## Test

I created a page with multiple embed there https://www-dev.greenpeace.org/test-umbriel/story/1006/embed-test/
All embed should fit in a 320px width

- Create a new post, embed a tweet with the Embed block (I use this one https://twitter.com/0xdade/status/1215061340282179584)
- Preview the post with different sizes, using browser tools
- Embed should fit entirely in the post between 350px and 500px wide