### PR TITLE
PLANET-6194: Adapt 404 search icon to RTL

### DIFF
--- a/assets/src/scss/pages/_404.scss
+++ b/assets/src/scss/pages/_404.scss
@@ -35,6 +35,11 @@
         position: absolute;
         right: 6px;
         top: 13px;
+
+        html[dir="rtl"] & {
+          left: 6px;
+          right: auto;
+        }
       }
     }
 


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6194

SVG icon is stuck on the right side of the search input on RTL sites, on 404 pages.

![Screenshot from 2021-06-17 09-26-49](https://user-images.githubusercontent.com/617346/122351210-39db3c80-cf4e-11eb-99d6-d7e2c37f8310.png)

## Fix 

Adding the same type of rule as the navbar search icon fixes the issue.

![Screenshot from 2021-06-17 09-26-29](https://user-images.githubusercontent.com/617346/122351235-3d6ec380-cf4e-11eb-823d-d4244d7b555f.png)

## Test

The easiest way to test is to:
- go on the local 404 page `planet4.test/404` 
- edit the `<html>` tag in the browser inspector, adding attribute `dir="rtl"`
  - on master branch the icon stays on the right, over the placeholder
  - on this branch it goes on the left