### PR TITLE
Planet 6040 Update articles block attribute

### DIFF
--- a/src/MigrationLog.php
+++ b/src/MigrationLog.php
@@ -26,7 +26,9 @@ class MigrationLog {
 
 		$log = new self();
 
-		$log->done_migrations = $done_migrations;
+		if ( $done_migrations ) {
+			$log->done_migrations = $done_migrations;
+		}
 
 		return $log;
 	}
@@ -39,7 +41,12 @@ class MigrationLog {
 	 * @return bool Whether said migration already ran.
 	 */
 	public function already_ran( string $migration_id ): bool {
+		if ( ! $this->done_migrations )  {
+			return false;
+		}
+
 		foreach ( $this->done_migrations as $migration ) {
+
 			if ( $migration['id'] === $migration_id && $migration['success'] ) {
 				return true;
 			}
@@ -61,6 +68,6 @@ class MigrationLog {
 	 * Save the state of the log in the WP options.
 	 */
 	public function persist(): void {
-		add_option( self::OPTION_KEY, $this->done_migrations );
+		update_option( self::OPTION_KEY, $this->done_migrations);
 	}
 }

--- a/src/MigrationLog.php
+++ b/src/MigrationLog.php
@@ -41,7 +41,7 @@ class MigrationLog {
 	 * @return bool Whether said migration already ran.
 	 */
 	public function already_ran( string $migration_id ): bool {
-		if ( ! $this->done_migrations )  {
+		if ( ! $this->done_migrations ) {
 			return false;
 		}
 
@@ -68,6 +68,6 @@ class MigrationLog {
 	 * Save the state of the log in the WP options.
 	 */
 	public function persist(): void {
-		update_option( self::OPTION_KEY, $this->done_migrations);
+		update_option( self::OPTION_KEY, $this->done_migrations );
 	}
 }

--- a/src/Migrations/M003UpdateArticlesBlockAttribute.php
+++ b/src/Migrations/M003UpdateArticlesBlockAttribute.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace P4\MasterTheme\Migrations;
+
+use P4\MasterTheme\MigrationRecord;
+use P4\MasterTheme\MigrationScript;
+
+/**
+ * Update articles block attribute in block innerHTML.
+ */
+class M003UpdateArticlesBlockAttribute extends MigrationScript {
+
+	/**
+	 * Perform the actual migration.
+	 *
+	 * @param MigrationRecord $record Information on the execution, can be used to add logs.
+	 *
+	 * @return void
+	 */
+	protected static function execute( MigrationRecord $record ): void {
+		global $wpdb;
+
+		$post_types       = [ 'page', 'campaign' ];
+		$updated_post_ids = [];
+
+		// Fetch post data having articles block from DB.
+		$sql = '
+			SELECT ID, post_content
+			FROM %1$s
+			WHERE post_type IN(' . generate_list_placeholders( $post_types, 2, 's' ) . ')
+			AND post_content REGEXP \'wp\:planet4\-blocks\/articles \{.*\"articles_description\"\:.*}\'';
+
+		$prepared_sql = $wpdb->prepare( $sql, array_merge( [ $wpdb->posts ], $post_types ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		$results      = $wpdb->get_results( $prepared_sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+
+		// Iterate posts.
+		foreach ( (array) $results as $post ) {
+			$post_content         = $post->post_content;
+			$updated_post_content = $post_content;
+			$blocks               = parse_blocks( $post_content );
+
+			// Iterate post blocks.
+			foreach ( $blocks as $block ) {
+
+				if ( 'planet4-blocks/articles' === $block['blockName'] ) {
+					$article_description = $block['attrs']['articles_description'] ?? '';
+					$inner_html          = $block['innerHTML'];
+
+					/**
+					 * Check if articles description attribute added in the end. The last attribute ends with closing curly brace.
+					 * eg.
+					 * <!-- wp:planet4-blocks/articles {"articles_description":"test description"} -->
+					 * <div class="wp-block-planet4-blocks-articles" data-render="planet4-blocks/articles" data-attributes="{&quot;attributes&quot;:{&quot;article_heading&quot;:&quot;Related Articles&quot;,&quot;article_count&quot;:3,&quot;tags&quot;:[],&quot;posts&quot;:[],&quot;post_types&quot;:[],&quot;read_more_text&quot;:&quot;Load more&quot;,&quot;read_more_link&quot;:&quot;&quot;,&quot;button_link_new_tab&quot;:false,&quot;ignore_categories&quot;:false,&quot;articles_description&quot;:&quot;test description&quot;},&quot;innerBlocks&quot;:[]}"></div>
+					 * <!-- /wp:planet4-blocks/articles -->
+					 */
+					$articles_desc_substring   = '&quot;articles_description&quot;:&quot;' . $article_description . '&quot;';
+					$desc_at_the_end_substring = ',' . $articles_desc_substring . '}';
+					$search_article_count      = ',&quot;article_count&quot;';
+					$replace_article_desc      = ',' . $articles_desc_substring . $search_article_count;
+
+					if ( false !== strpos( $inner_html, $desc_at_the_end_substring ) ) {
+						// Remove articles description from end of inner_HTML.
+						$updated_inner_html = str_replace( $desc_at_the_end_substring, '}', $inner_html );
+
+						// Replace the articles description after article_heading and before article_count.
+						$updated_inner_html = str_replace( $search_article_count, $replace_article_desc, $updated_inner_html );
+
+						// Replace updated articles block innerHTML in post content.
+						$updated_post_content = str_replace( $inner_html, $updated_inner_html, $updated_post_content );
+					}
+				}
+			}
+
+			// Update post content.
+			if ( $post_content !== $updated_post_content ) {
+				$post_data = [
+					'post_content' => $updated_post_content,
+					'ID'           => $post->ID,
+				];
+				wp_update_post( $post_data );
+				$updated_post_ids[] = $post->ID;
+			}
+		}
+
+		$record->add_log( implode( ',', $updated_post_ids ) );
+		echo 'Updated post IDs:' . implode( ',', $updated_post_ids ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+	}
+}

--- a/src/Migrator.php
+++ b/src/Migrator.php
@@ -5,6 +5,7 @@ namespace P4\MasterTheme;
 use P4\MasterTheme\Migrations\M001EnableEnFormFeature;
 use P4\MasterTheme\Migrations\M002EnableLazyYoutube;
 use P4\MasterTheme\Migrations\M004UpdateMissingMediaPath;
+use P4\MasterTheme\Migrations\M003UpdateArticlesBlockAttribute;
 
 /**
  * Run any new migration scripts and record results in the log.
@@ -26,6 +27,7 @@ class Migrator {
 			M001EnableEnFormFeature::class,
 			M002EnableLazyYoutube::class,
 			M004UpdateMissingMediaPath::class,
+			M003UpdateArticlesBlockAttribute::class,
 		];
 
 		// Loop migrations and run those that haven't run yet.


### PR DESCRIPTION
Ref: [JIRA 6040](https://jira.greenpeace.org/browse/PLANET-6040)

---

Follow up PR from [#546](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/546)

**Tasks:**
- Add migration script which update articles description field in block inner HTML and place it after article_heading and before article_count
- Fix Fatal error, Warning in Migration script

 **Testing:** 
- First reproduce a "Block validation failed" error (The issue is reproducible by creating a new page/campaign with articles block with description field, refresh page and try to edit it.)
- On local development env, connect to php container by `make php-shell`
- Run migration script - `wp p4-run-activator`
- Check the page revision, it looks like -
![image](https://user-images.githubusercontent.com/5357471/122923850-bcb32b80-d382-11eb-8956-a6d999b5f4a2.png)
- The migration logs are also logged  into `planet4_migrations`  option name in `wp_options` table
