### PR TITLE
PLANET-6152 Fix Twitter share text. Add a comma before via '@greenpeace'

### DIFF
--- a/templates/blocks/share_buttons.twig
+++ b/templates/blocks/share_buttons.twig
@@ -14,7 +14,7 @@
 		<span class="visually-hidden">{{ __( 'Share on', 'planet4-master-theme' ) }} Facebook</span>
 	</a>
 	<!-- Twitter -->
-	<a href="https://twitter.com/share?url={{ social.link }}&text={{ social.title|url_encode }}{% if social.description %} - {{ social.description|striptags }}{% endif %} via @{{ social_accounts.twitter }}&related={{ social_accounts.twitter }}"
+	<a href="https://twitter.com/share?url={{ social.link }}&text={{ social.title|url_encode }}{% if social.description %} - {{ social.description|striptags }}{% endif %}, via @{{ social_accounts.twitter }}&related={{ social_accounts.twitter }}"
 		 onclick="dataLayer.push({'event' : 'uaevent', 'eventCategory' : 'Social Share', 'eventAction': 'Twitter', 'eventLabel': '{{ social.link }}'});"
 		 target="_blank" class="share-btn twitter">
 		{{ 'twitter'|svgicon }}


### PR DESCRIPTION
Fix Twitter share text. Add a comma before via '@Greenpeace'

Ref: https://jira.greenpeace.org/browse/PLANET-6152

---

**Testing**

Go to any post and click on Twitter Share Button. You will be redirected to Twitter, then, a popup with this text modification would be shown.

![Screenshot 2021-06-23 at 06 34 11](https://user-images.githubusercontent.com/77975803/123073746-151f1300-d3ed-11eb-8d8f-8db4bc1a7880.png)
