### PR TITLE
PLANET-5968 Copy WP-Stateless field (sm_cloud) to all WPML media tran…

### DIFF
--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -245,6 +245,11 @@ class MasterSite extends TimberSite {
 		// Disable xmlrpc.
 		add_filter( 'xmlrpc_enabled', '__return_false' );
 
+		// WPML plugin & wp-stateless plugin incompatibility fix.
+		if ( function_exists( 'is_plugin_active' ) && is_plugin_active( 'sitepress-multilingual-cms/sitepress.php' ) ) {
+			add_filter( 'wp_stateless_media_synced', [ $this, 'copy_gcs_metadata' ], 10, 4 );
+		}
+
 		$this->register_meta_fields();
 	}
 
@@ -1445,5 +1450,38 @@ class MasterSite extends TimberSite {
 	public function disable_block_directory_endpoint( array $endpoints ): array {
 		unset( $endpoints['/wp/v2/block-directory/search'] );
 		return $endpoints;
+	}
+
+	/**
+	 * Copy WP-Stateless field (`sm_cloud`) to all WPML translations on a media post upload to GCS.
+	 *
+	 * @param array  $metadata       Metadata for the attachment.
+	 * @param string $attachment_id  Attachment ID.
+	 * @param bool   $force          (optional) Whether to force the sync even the file already exist in GCS.
+	 * @param bool   $args           (optional) Whether to only sync the full size image.
+	 *
+	 * @return array Metadata for the attachment.
+	 */
+	public function copy_gcs_metadata( $metadata, $attachment_id, $force, $args ): array {
+
+		global $sitepress;
+		$trid         = $sitepress->get_element_trid( $attachment_id );
+		$translations = $sitepress->get_element_translations( $trid );
+
+		// Get WP-Stateless field.
+		$cloud_meta = get_post_meta( $attachment_id, 'sm_cloud', true );
+
+		if ( $cloud_meta ) {
+			foreach ( $translations as $translation ) {
+				$translation_post_id = $translation->element_id;
+
+				// Set field in other translations that are not the current one.
+				if ( $translation_post_id !== $attachment_id && ! get_post_meta( $translation_post_id, 'sm_cloud', true ) ) {
+					update_post_meta( $translation_post_id, 'sm_cloud', $cloud_meta );
+				}
+			}
+		}
+
+		return $metadata;
 	}
 }

--- a/src/Migrations/M004UpdateMissingMediaPath.php
+++ b/src/Migrations/M004UpdateMissingMediaPath.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace P4\MasterTheme\Migrations;
+
+use P4\MasterTheme\MigrationRecord;
+use P4\MasterTheme\MigrationScript;
+
+/**
+ * Update missing media path for translated media in database(only applicable for multilingual P4 sites).
+ */
+class M004UpdateMissingMediaPath extends MigrationScript {
+
+	/**
+	 * Perform the actual migration.
+	 *
+	 * @param MigrationRecord $record Information on the execution, can be used to add logs.
+	 *
+	 * @return void
+	 */
+	protected static function execute( MigrationRecord $record ): void {
+
+		// Check if WPML plugin is active.
+		if ( function_exists( 'is_plugin_active' ) && ! is_plugin_active( 'sitepress-multilingual-cms/sitepress.php' ) ) {
+			return;
+		}
+
+		global $wpdb;
+
+		$updated_post_ids = [];
+
+		// Fetch attachment posts (having a sm_cloud metadata) from DB.
+		$sql = '
+			SELECT p.id, m.meta_value
+			FROM %1$s p JOIN %2$s m ON m.post_id = p.id
+			WHERE m.meta_key = "sm_cloud" AND p.post_type = "attachment"';
+
+		$prepared_sql = $wpdb->prepare( $sql, [ $wpdb->posts, $wpdb->postmeta ] ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		$results      = $wpdb->get_results( $prepared_sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+
+		// Iterate posts.
+		foreach ( (array) $results as $post ) {
+
+			$attachment_id = $post->id;
+			$cloud_meta    = unserialize( $post->meta_value ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_unserialize
+			$trid          = apply_filters( 'wpml_element_trid', null, $attachment_id, 'post_attachment' );
+			$translations  = apply_filters( 'wpml_get_element_translations', null, $trid, 'post_attachment' );
+
+			if ( $cloud_meta ) {
+				foreach ( $translations as $translation ) {
+					$translation_post_id = $translation->element_id;
+
+					// Set sm_cloud field in other translations, if missing.
+					if ( $translation_post_id !== $attachment_id && ! get_post_meta( $translation_post_id, 'sm_cloud', true ) ) {
+						update_post_meta( $translation_post_id, 'sm_cloud', $cloud_meta );
+						$updated_post_ids[] = $translation_post_id;
+					}
+				}
+			}
+		}
+
+		$record->add_log( implode( ',', $updated_post_ids ) );
+		echo 'Updated attachment IDs:' . implode( ',', $updated_post_ids ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+	}
+}

--- a/src/Migrator.php
+++ b/src/Migrator.php
@@ -4,6 +4,7 @@ namespace P4\MasterTheme;
 
 use P4\MasterTheme\Migrations\M001EnableEnFormFeature;
 use P4\MasterTheme\Migrations\M002EnableLazyYoutube;
+use P4\MasterTheme\Migrations\M004UpdateMissingMediaPath;
 
 /**
  * Run any new migration scripts and record results in the log.
@@ -24,6 +25,7 @@ class Migrator {
 		$scripts = [
 			M001EnableEnFormFeature::class,
 			M002EnableLazyYoutube::class,
+			M004UpdateMissingMediaPath::class,
 		];
 
 		// Loop migrations and run those that haven't run yet.


### PR DESCRIPTION
…slations

Ref: [JIRA 5968](https://jira.greenpeace.org/browse/PLANET-5968)

---

- To fix the missing images issue with existing content, added a migration script which update the missing `sm_cloud` field with actual GCS path to translation media's
- For newly media uploads,  added a `wp_stateless_media_synced` which copy `sm_cloud` field to translation media's

**Testing:**
- Testing is a bit tricky with this PR, I tested it on local by copying a live Multilingual site DB, and run the migration on local,
```
> make php-shell
> wp p4-run-activator
```
- The alternative way is, I set up the WPML plugin on [sagardev](https://www-dev.greenpeace.org/sagardev/) test instance, [here](https://github.com/greenpeace/planet4-sagardev/blob/main/composer-local.json) just change the master theme branch to `master` to reproduce the issue by uploading some sample media files
- Change the master theme branch to `planet-5968` and confirm the migration script output and also test new media upload change
