### PR TITLE
PLANET-5003: Fix inconsistencies in lists

### DIFF
--- a/assets/src/scss/pages/post/_article-content.scss
+++ b/assets/src/scss/pages/post/_article-content.scss
@@ -32,17 +32,6 @@
     }
   }
 
-  ul, ol {
-
-    @include medium-and-up {
-      margin-bottom: 20px;
-    }
-
-    li:not(:first-child) {
-      padding-top: 10px;
-    }
-  }
-
   h2 {
     margin-bottom: 15px;
     padding-top: 8px;


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5003

> When using lists `<ul><ol>` in Pages, for both Default and Evergreen templates, there appears to be additional spacing below the list. Additionally, there is no spacing within the list itself. The expected behaviour would be what appears on Posts.

## Fix

Removes list container padding and margin to replace them with a different margin scheme applied on list items, fixing inter-block margin (no)collapse issues and post/page differences.

See plugin PR on same branch name for more details https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/617
