### PR TITLE
PLANET-6130: Fix Mobile logo width

### DIFF
--- a/assets/src/scss/layout/_navbar.scss
+++ b/assets/src/scss/layout/_navbar.scss
@@ -18,9 +18,9 @@ $navbar-default-height: 60px;
   z-index: 5;
   padding: 0;
   text-transform: uppercase;
-  display: flex;
-  flex-direction: row;
+  display: grid;
   justify-content: space-between;
+  grid-auto-flow: column;
   align-items: normal;
   height: $menu-height-small;
   font-family: $roboto;
@@ -34,6 +34,7 @@ $navbar-default-height: 60px;
   }
 
   @include large-and-up {
+    display: flex;
     align-items: center;
   }
 
@@ -138,7 +139,6 @@ $navbar-default-height: 60px;
   border: 0;
   background: url("../../images/search.svg") center center no-repeat;
   background-size: 28px;
-  margin-left: auto;
 
   &.open {
     outline: 0;
@@ -167,8 +167,7 @@ $navbar-default-height: 60px;
 // Styleguide Style.logo
 .site-logo {
   position: absolute;
-  width: 100%;
-  text-align: center;
+  justify-self: center;
 
   @include large-and-up {
     position: static;


### PR DESCRIPTION
Before this modification, the main logo was fitted the entire width of the main Header. In consequence, It has been caused an strange behaviour for users that accidentally clicked on the Header, outside the logo, and being redirected to the index page.

Ref: https://jira.greenpeace.org/browse/PLANET-6130

![Screenshot 2021-06-24 at 08 22 37](https://user-images.githubusercontent.com/77975803/123254777-71556600-d4c5-11eb-9f5a-d58bdd61fdb3.png)

