### PR TITLE
PLANET-6188: Add an author image to Posts

### DIFF
--- a/assets/src/scss/pages/post/_post.scss
+++ b/assets/src/scss/pages/post/_post.scss
@@ -119,6 +119,11 @@
         margin-left: 20px;
       }
 
+      .author-pic {
+        border-radius: 50%;
+        object-fit: cover;
+      }
+
       &:after {
         content: "\2022";
         pointer-events: none;

--- a/templates/single.twig
+++ b/templates/single.twig
@@ -66,6 +66,11 @@
 				<div class="row">
 					<div class="col-md-6">
 						<div class="single-post-meta">
+							{% if ( post.author.avatar ) %}
+								<img itemprop="image" class="author-pic"
+									src="{{ fn('get_avatar_url', post.author.id, {'size' : 50}) }}"
+									alt="{{ post.author.name }}">
+							{% endif %}
 							{% if post.author.name %}
 								<address class="single-post-author">
 									{% if not ( post.get_author_override ) %}


### PR DESCRIPTION
This commit adds an author image to posts. Changes are made in `single.twig` and necessary CSS tweaks to images to have round corners.

Ref: [PLANET-6188 Add an author image to Posts](https://github.com/greenpeace/planet4/issues/133)

---

<!--
Please provide a brief summary of the change introduced to make review process easier.

Ideally this should also be part of the commit summary.
-->

### Description
Add author image i.e. `post.author.avatar`, if exists, to the left of the author's name and other metadata about the post.

### Testing
**I would like to know how to run this locally so that I can make sure it looks as it is on prod.** I'm looking into the technical documentation, but if someone could point me to where to look I'd appreciate that. Thank you!