### PR TITLE
PLANET-6124: Change the way of setting the target to links when are externals

### DIFF
--- a/assets/src/js/external_links.js
+++ b/assets/src/js/external_links.js
@@ -12,7 +12,7 @@ export const setupExternalLinks = () => {
       return;
     }
 
-    link.target = '_blank';
+    link.target = link.target ? link.target : '';
     link.classList.add('external-link');
   });
 };


### PR DESCRIPTION
I tackled this modification to be ensure that external links, the ones that were set by the block, would always have set the defined target value. If not, just keep the default.

Linked PR https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/624

Ref: https://jira.greenpeace.org/browse/PLANET-6124

---

<!--
Please provide a brief summary of the change introduced to make review process easier.

Ideally this should also be part of the commit summary.
-->
