### PR TITLE
PLANET-6238 Add private campaigns caps for editor role

### DIFF
--- a/src/Campaigner.php
+++ b/src/Campaigner.php
@@ -38,6 +38,9 @@ class Campaigner {
 			'delete_published_campaigns',
 			'delete_others_campaigns',
 			'edit_published_campaigns',
+			'read_private_campaigns',
+			'edit_private_campaigns',
+			'delete_private_campaigns',
 
 			// Needed to allow the editor rule to change the author of a post in the document sidebar. The users data for that
 			// control is fetched using the REST API, where WordPress by default doesn't perform a permissions check, however


### PR DESCRIPTION
Allows to read, write and delete them.

Ref: https://jira.greenpeace.org/browse/PLANET-6238

---

<!--
Please provide a brief summary of the change introduced to make review process easier.

Ideally this should also be part of the commit summary.
-->
