### PR TITLE
PLANET-6262 WIP avoid i18n dependency

### DIFF
--- a/assets/src/js/country_select.js
+++ b/assets/src/js/country_select.js
@@ -1,4 +1,4 @@
-const { __ } = wp.i18n;
+const __ = s => s;
 
 export const setupCountrySelect = function($) {
   'use strict';

--- a/templates/html-header.twig
+++ b/templates/html-header.twig
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html {{ fn('language_attributes', 'html') }} data-base="{{ data_nav_bar.home_url }}">
 <head>
+	<script>window.wp = {}</script>
 	<meta charset="{{ site.charset }}">
 	{% include 'blocks/title.twig' %}
 


### PR DESCRIPTION
Quick fix so that it doesn't depend on wp.i18n, which is loaded in the
plugin.

Ref: https://jira.greenpeace.org/browse/PLANET-6262

---
I used this ticket already to avoid pushing unstable code to multiple test instances.
