### PR TITLE
PLANET-6083: Add UTM Parameters to share buttons

### DIFF
--- a/page.php
+++ b/page.php
@@ -61,6 +61,7 @@ Context::set_header( $context, $page_meta_data, $post->title );
 Context::set_background_image( $context );
 Context::set_og_meta_fields( $context, $post );
 Context::set_campaign_datalayer( $context, $page_meta_data );
+Context::set_utm_params( $context, $post );
 
 $context['post']                = $post;
 $context['social_accounts']     = $post->get_social_accounts( $context['footer_social_menu'] );

--- a/single-campaign.php
+++ b/single-campaign.php
@@ -92,6 +92,7 @@ Context::set_header( $context, $meta, $post->title );
 Context::set_background_image( $context );
 Context::set_og_meta_fields( $context, $post );
 Context::set_campaign_datalayer( $context, $campaign_meta );
+Context::set_utm_params( $context, $post );
 
 $context['post']            = $post;
 $context['social_accounts'] = $post->get_social_accounts( $context['footer_social_menu'] );

--- a/single.php
+++ b/single.php
@@ -57,6 +57,7 @@ $context['post_tags']           = implode( ', ', $post->tags() );
 
 Context::set_og_meta_fields( $context, $post );
 Context::set_campaign_datalayer( $context, $page_meta_data );
+Context::set_utm_params( $context, $post );
 
 $context['filter_url'] = add_query_arg(
 	[

--- a/src/Context.php
+++ b/src/Context.php
@@ -63,6 +63,29 @@ class Context {
 	}
 
 	/**
+	 * Set the context fields relating to UTM.
+	 *
+	 * @param array  $context Context to be set.
+	 * @param object $post That the context refers to.
+	 */
+	public static function set_utm_params( &$context, $post ) {
+		$context['utm_campaign_param'] = self::parse_utm_campaign_param( $context['cf_local_project'] );
+		$context['utm_content_param']  = '&utm_content=postid-' . $post->id;
+	}
+
+	/**
+	 * Parse the utm_campaign param. It's not needed to add if the value is equal to `not set`.
+	 *
+	 * @param array $cf_local_project It comes from meta p4_global_project_tracking_id value.
+	 */
+	public static function parse_utm_campaign_param( $cf_local_project ): string {
+		if ( 'not set' !== $cf_local_project ) {
+			return '&utm_campaign=' . $cf_local_project;
+		}
+		return '';
+	}
+
+	/**
 	 * Get campaign scope from value selected in the Global Projects dropdown.
 	 * Conditions:
 	 * - If Global Project equals "Local Campaign" then Scope is Local.

--- a/templates/blocks/share_buttons.twig
+++ b/templates/blocks/share_buttons.twig
@@ -1,27 +1,27 @@
 <div class="share-buttons">
 	<!-- Whatsapp -->
-	<a href="https://wa.me/?text={{ social.link }}"
+	<a href="https://wa.me/?text={{ social.link }}&utm_source=whatsapp&utm_medium={{ utm_medium }}{{ utm_content_param }}{{ utm_campaign_param }}"
 		 onclick="dataLayer.push({'event' : 'uaevent', 'eventCategory' : 'Social Share', 'eventAction': 'Whatsapp', 'eventLabel': '{{ social.link }}'});"
 		 target="_blank" class="share-btn whatsapp">
 		{{ 'whatsapp'|svgicon }}
 		<span class="visually-hidden">{{ __( 'Share on', 'planet4-master-theme' ) }} Whatsapp</span>
 	</a>
 	<!-- Facebook -->
-	<a href="https://www.facebook.com/sharer/sharer.php?u={{ social.link }}"
+	<a href="https://www.facebook.com/sharer/sharer.php?u={{ social.link }}&utm_source=facebook&utm_medium={{ utm_medium }}{{ utm_content_param }}{{ utm_campaign_param }}"
 		 onclick="dataLayer.push({'event' : 'uaevent', 'eventCategory' : 'Social Share', 'eventAction': 'Facebook', 'eventLabel': '{{ social.link }}'});"
 		 target="_blank" class="share-btn facebook">
 		{{ 'facebook-f'|svgicon }}
 		<span class="visually-hidden">{{ __( 'Share on', 'planet4-master-theme' ) }} Facebook</span>
 	</a>
 	<!-- Twitter -->
-	<a href="https://twitter.com/share?url={{ social.link }}&text={{ social.title|url_encode }}{% if social.description %} - {{ social.description|striptags }}{% endif %}, via @{{ social_accounts.twitter }}&related={{ social_accounts.twitter }}"
+	<a href="https://twitter.com/share?url={{ social.link }}&text={{ social.title|url_encode }}{% if social.description %} - {{ social.description|striptags }}{% endif %}, via @{{ social_accounts.twitter }}&related={{ social_accounts.twitter }}&utm_source=twitter&utm_medium={{ utm_medium }}{{ utm_content_param }}{{ utm_campaign_param }}"
 		 onclick="dataLayer.push({'event' : 'uaevent', 'eventCategory' : 'Social Share', 'eventAction': 'Twitter', 'eventLabel': '{{ social.link }}'});"
 		 target="_blank" class="share-btn twitter">
 		{{ 'twitter'|svgicon }}
 		<span class="visually-hidden">{{ __( 'Share on', 'planet4-master-theme' ) }} Twitter</span>
 	</a>
 	<!-- Email -->
-	<a href="mailto:?subject={{ social.title|url_encode }}&body={% if social.description %}{{ social.description|striptags }} {% endif %}{{ social.link }}"
+	<a href="mailto:?subject={{ social.title|url_encode }}&body={% if social.description %}{{ social.description|striptags }} {% endif %}{{ social.link }}&utm_source=email&utm_medium={{ utm_medium }}{{ utm_content_param }}{{ utm_campaign_param }}"
 		 onclick="dataLayer.push({'event' : 'uaevent', 'eventCategory' : 'Social Share', 'eventAction': 'Email', 'eventLabel': '{{ social.link }}'});"
 		 target="_blank" class="share-btn email">
 		{{ 'envelope'|svgicon }}

--- a/templates/single.twig
+++ b/templates/single.twig
@@ -86,7 +86,7 @@
 						</div>
 					</div>
 					<div class="col-md-6">
-						{% include "blocks/share_buttons.twig" with {social:post.share_meta} %}
+						{% include "blocks/share_buttons.twig" with {social:post.share_meta, utm_medium: 'share'} %}
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
The Social Media share message should include the current page URL with the additional UTM parameters below (based on the [Global UTM Standards](https://app.gitbook.com/@greenpeace/s/insights/global-property/standards/utm-conventions))

Ref: https://jira.greenpeace.org/browse/PLANET-6083

![32549_table](https://user-images.githubusercontent.com/77975803/127400151-267ec5ac-0b26-4d2e-b7ac-dce00cce19bf.jpg)
