### PR TITLE
Add quotes, message contains spaces

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -244,7 +244,7 @@ jobs:
           at: /tmp/workspace
       - run:
           name: Check if this is for an open PR
-          command: check-pr-exists.sh $(cat /tmp/workspace/commit-message)
+          command: check-pr-exists.sh "$(cat /tmp/workspace/commit-message)"
       - run:
           name: Book instance
           command: |


### PR DESCRIPTION
Without quotes this probably only passes the first string before a
space, and it's not able to pick up merge commits anymore. As a result
test instances are not being reset to master after merging.

Same PR for the plugin https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/638

Ref: <!-- Please add a url to the ticket this change is addressing. -->

---

<!--
Please provide a brief summary of the change introduced to make review process easier.

Ideally this should also be part of the commit summary.
-->
