### PR TITLE
Re-add GP green for plastics and climate nav color

### DIFF
--- a/campaign_themes/climate.json
+++ b/campaign_themes/climate.json
@@ -80,7 +80,8 @@
 						{ "value": "#ffffff" },
 						{ "value": "#000000" },
 						{ "value": "#ff513c" },
-						{ "value": "#007eff" }
+						{ "value": "#007eff" },
+            { "value": "#66cc00" }
 					],
 					"default": "#ff513c"
 				}

--- a/campaign_themes/plastic.json
+++ b/campaign_themes/plastic.json
@@ -80,7 +80,8 @@
 						{ "value": "#ffffff" },
 						{ "value": "#000000" },
 						{ "value": "#044362" },
-						{ "value": "#2cabb1" }
+						{ "value": "#2cabb1" },
+            { "value": "#66cc00" }
 					],
 					"default": "#044362"
 				}


### PR DESCRIPTION
This was added to production content before we removed the option, and that content is still using it. If the option is not there, it's
impossible to put the color back using the UI once it's unset or switched to another color. (You can use the console to set it with `wp.data.dispatch('core/editor').setEditedPostAttribute( {meta: {campaign_nav_color: any_value})`)

This is needed now because we want to test switching content to the new version of Plastics theme, and when a theme is switched, it unsets all values on a post that are not allowed in the theme.

I also added the same fix for the Climate theme.

Ref: https://jira.greenpeace.org/browse/PLANET-5983