### PR TITLE
PLANET-6336 Implement new Cookies banner design

### DIFF
--- a/assets/src/scss/campaigns/_campaign_cookies.scss
+++ b/assets/src/scss/campaigns/_campaign_cookies.scss
@@ -1,5 +1,0 @@
-.single-campaign {
-  .cookie-notice {
-    font-family: $lora;
-  }
-}

--- a/assets/src/scss/layout/_cookies-new.scss
+++ b/assets/src/scss/layout/_cookies-new.scss
@@ -1,16 +1,35 @@
+@mixin slide-from($direction, $margin) {
+  $animation-name: unique-id() !global;
+
+  @keyframes #{$animation-name} {
+    0% {
+      #{$direction}: -100%;
+    }
+
+    100% {
+      #{$direction}: $margin;
+    }
+  }
+
+  &.shown {
+    animation: 1s $animation-name;
+  }
+}
+
 .cookie-notice.new-design {
   z-index: 100;
   position: fixed;
-  bottom: 0;
   width: 100vw;
   background: white;
-  padding: 26px 24px 32px 24px;
+  padding: 24px 24px 32px;
   visibility: hidden;
   opacity: 0;
   transition: visibility 0.5s, opacity 0.5s linear;
   border-top-left-radius: 4px;
   border-top-right-radius: 4px;
   box-shadow: 0 0 12px rgba(0, 0, 0, 0.15);
+  bottom: 0;
+  @include slide-from(bottom, 0);
 
   &.shown {
     opacity: 1;
@@ -38,21 +57,25 @@
     right: 16px;
     left: auto;
     border-radius: 4px;
-    padding: 26px 32px 32px 32px;
+    padding: 24px 32px 32px;
     box-shadow: 0 3px 12px rgba(0, 0, 0, 0.15);
+    @include slide-from(right, 16px);
 
     html[dir="rtl"] & {
       right: auto;
       left: 16px;
+      @include slide-from(left, 16px);
     }
   }
 
   @include large-and-up {
     bottom: 24px;
     right: 24px;
+    @include slide-from(right, 24px);
 
     html[dir="rtl"] & {
       left: 24px;
+      @include slide-from(left, 24px);
     }
   }
 }

--- a/assets/src/scss/layout/_cookies-new.scss
+++ b/assets/src/scss/layout/_cookies-new.scss
@@ -1,0 +1,58 @@
+.cookie-notice.new-design {
+  z-index: 100;
+  position: fixed;
+  bottom: 0;
+  width: 100vw;
+  background: white;
+  padding: 26px 24px 32px 24px;
+  visibility: hidden;
+  opacity: 0;
+  transition: visibility 0.5s, opacity 0.5s linear;
+  border-top-left-radius: 4px;
+  border-top-right-radius: 4px;
+  box-shadow: 0 0 12px rgba(0, 0, 0, 0.15);
+
+  &.shown {
+    opacity: 1;
+    visibility: visible;
+  }
+
+  > div {
+    font-size: 14px;
+    margin-bottom: 24px;
+    font-weight: 400;
+    color: $grey-80;
+    font-family: $roboto;
+    line-height: 1.5rem;
+    width: 100%;
+  }
+
+  .btn {
+    width: 100%;
+    line-height: 2.4;
+  }
+
+  @include medium-and-up {
+    width: 344px;
+    bottom: 16px;
+    right: 16px;
+    left: auto;
+    border-radius: 4px;
+    padding: 26px 32px 32px 32px;
+    box-shadow: 0 3px 12px rgba(0, 0, 0, 0.15);
+
+    html[dir="rtl"] & {
+      right: auto;
+      left: 16px;
+    }
+  }
+
+  @include large-and-up {
+    bottom: 24px;
+    right: 24px;
+
+    html[dir="rtl"] & {
+      left: 24px;
+    }
+  }
+}

--- a/assets/src/scss/layout/_cookies.scss
+++ b/assets/src/scss/layout/_cookies.scss
@@ -1,4 +1,4 @@
-.cookie-notice {
+.cookie-notice:not(.new-design) {
   z-index: 100;
   display: flex;
   position: fixed;

--- a/assets/src/scss/style.scss
+++ b/assets/src/scss/style.scss
@@ -77,6 +77,3 @@ Text Domain: planet4-master-theme
 @import "vendors/usabilla";
 @import "vendors/gtm";
 @import "~lite-youtube-embed";
-
-// Campaign overrides
-@import "campaigns/campaign_cookies";

--- a/assets/src/scss/style.scss
+++ b/assets/src/scss/style.scss
@@ -37,6 +37,7 @@ Text Domain: planet4-master-theme
 @import "layout/breadcrumbs";
 @import "layout/blocks";
 @import "layout/cookies";
+@import "layout/cookies-new";
 @import "layout/footer";
 @import "layout/forms";
 @import "layout/navbar";


### PR DESCRIPTION
### Description

See https://jira.greenpeace.org/browse/PLANET-6336

### Testing

On local you can add `new-design` to the [class in cookies.twig](https://github.com/greenpeace/planet4-master-theme/blob/master/templates/cookies.twig#L2) and replace `btn-secondary` with `btn-primary` in the button classes in the same file. That should be enough to see the new design, if you remove all cookies from storage (or uncheck the necessary cookies in the Privacy page) 🙂 

**Note**: for the A/B test these changes are applied by Optimize.
