### PR TITLE
Prevent invalid argument for foreach

### DIFF
--- a/src/Migrations/M004UpdateMissingMediaPath.php
+++ b/src/Migrations/M004UpdateMissingMediaPath.php
@@ -43,7 +43,7 @@ class M004UpdateMissingMediaPath extends MigrationScript {
 			$attachment_id = $post->id;
 			$cloud_meta    = unserialize( $post->meta_value ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_unserialize
 			$trid          = apply_filters( 'wpml_element_trid', null, $attachment_id, 'post_attachment' );
-			$translations  = apply_filters( 'wpml_get_element_translations', null, $trid, 'post_attachment' );
+			$translations  = apply_filters( 'wpml_get_element_translations', [], $trid, 'post_attachment' );
 
 			if ( $cloud_meta ) {
 				foreach ( $translations as $translation ) {


### PR DESCRIPTION
* On test instances, it's possible that wpml was installed previously
and was removed from compopser-local.json without disabling the plugin.
In that case `is_plugin_active` still returns true, and the filter
doesn't change the initial value. Defaulting it to an empty array
instead should make it not throw warnings in CI.

I spotted this during a test instance deploy. There could be better ways to catch this but this seemed a quick fix for an edge case. 

Currently it throws so many warnings the `post-deploy` job fails :grin: https://app.circleci.com/pipelines/github/greenpeace/planet4-test-nix/241/workflows/f7c2f45b-be6b-4873-8c1a-d536b5310cc6/jobs/1340

![Screenshot from 2021-08-26 11-46-50](https://user-images.githubusercontent.com/7604138/130941527-c3132b05-695e-4e10-b398-7c0331f877db.png)
