### PR TITLE
PLANET-6253 Add analytical cookies setting in Planet4 settings

### DIFF
--- a/src/Settings.php
+++ b/src/Settings.php
@@ -220,7 +220,7 @@ class Settings {
 				],
 			],
 			'planet4_settings_cookies_text'     => [
-				'title'  => 'Cookies Text',
+				'title'  => 'Cookies',
 				'fields' => [
 					[
 						'name'    => __( 'Cookies Text', 'planet4-master-theme-backend' ),
@@ -241,6 +241,13 @@ class Settings {
 							'planet4-master-theme-backend'
 						),
 						'id'   => 'enforce_cookies_policy',
+						'type' => 'checkbox',
+					],
+
+					[
+						'name' => __( 'Enable Analytical Cookies', 'planet4-master-theme-backend' ),
+						'desc' => __( 'Enable the Analytical cookies option in Cookies block.', 'planet4-master-theme-backend' ),
+						'id'   => 'enable_analytical_cookies',
 						'type' => 'checkbox',
 					],
 				],


### PR DESCRIPTION
The "Enable Analytical Cookies" checkbox is added under Planet4 > Cookies Text setting

Ref: [JIRA 6253](https://jira.greenpeace.org/browse/PLANET-6253)

---

- The "Enable Analytical Cookies" checkbox is added under Planet4 > Cookies Text setting
