### PR TITLE
Don't add our script as a jquery dep

### DIFF
--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -765,16 +765,12 @@ class MasterSite extends TimberSite {
 			$css_creation
 		);
 
-		$jquery_should_wait = is_plugin_active( 'planet4-plugin-gutenberg-blocks/planet4-gutenberg-blocks.php' ) && ! is_user_logged_in();
-
-		$jquery_deps = $jquery_should_wait ? [ 'planet4-blocks-script' ] : [];
-
 		// JS files.
 		wp_deregister_script( 'jquery' );
 		wp_register_script(
 			'jquery',
 			'https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js',
-			$jquery_deps,
+			[],
 			'3.3.1',
 			true
 		);


### PR DESCRIPTION
* Some plugins will make jquery load in the head. They shouldn't do
this, but it happens. And when it does, it results in our front end
render script being loaded in the head, when the body doesn't exist yet.
This breaks everything.

Ref: <!-- Please add a url to the ticket this change is addressing. -->

---

<!--
Please provide a brief summary of the change introduced to make review process easier.

Ideally this should also be part of the commit summary.
-->
