### PR TITLE
PLANET-6306: Run tests on PHP 7.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,7 +188,7 @@ jobs:
   php74-tests:
     <<: *php_job
     docker:
-      - image: greenpeaceinternational/p4-unit-tests:php7.4-php74
+      - image: greenpeaceinternational/p4-unit-tests:php7.4
         auth: &docker_auth
       - image: circleci/mysql:5.7.26
         auth: &docker_auth

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,7 @@ workflows:
   branch:
     jobs:
       - php73-tests
+      - php74-tests
       - frontend-tests
       - acceptance-tests
       - commitlint
@@ -180,6 +181,14 @@ jobs:
     <<: *php_job
     docker:
       - image: greenpeaceinternational/p4-unit-tests:php7.3
+        auth: &docker_auth
+      - image: circleci/mysql:5.7.26
+        auth: &docker_auth
+
+  php74-tests:
+    <<: *php_job
+    docker:
+      - image: greenpeaceinternational/p4-unit-tests:php7.4-php74
         auth: &docker_auth
       - image: circleci/mysql:5.7.26
         auth: &docker_auth

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,13 +7,19 @@ orbs:
 workflows:
   branch:
     jobs:
-      - php73-tests
-      - php74-tests
-      - frontend-tests
-      - acceptance-tests
-      - commitlint
+      - php73-tests:
+          context: org-global
+      - php74-tests:
+          context: org-global
+      - frontend-tests:
+          context: org-global
+      - acceptance-tests:
+          context: org-global
+      - commitlint:
+          context: org-global
       #- a11y-tests
       - create-zip:
+          context: org-global
           filters:
             tags:
               only: /^v\p{Digit}+\.\p{Digit}+.*/
@@ -87,7 +93,8 @@ job-references:
   p4_instance_conf: &p4_instance_conf
     docker:
       - image: greenpeaceinternational/p4-builder:latest
-        auth: &docker_auth
+        auth:
+          <<: *docker_auth
     working_directory: /home/circleci/
     environment:
       APP_HOSTNAME: www.planet4.test
@@ -181,22 +188,27 @@ jobs:
     <<: *php_job
     docker:
       - image: greenpeaceinternational/p4-unit-tests:php7.3
-        auth: &docker_auth
+        auth:
+          <<: *docker_auth
       - image: circleci/mysql:5.7.26
-        auth: &docker_auth
+        auth:
+          <<: *docker_auth
 
   php74-tests:
     <<: *php_job
     docker:
       - image: greenpeaceinternational/p4-unit-tests:php7.4
-        auth: &docker_auth
+        auth:
+          <<: *docker_auth
       - image: circleci/mysql:5.7.26
-        auth: &docker_auth
+        auth:
+          <<: *docker_auth
 
   frontend-tests:
     docker:
       - image: greenpeaceinternational/p4-unit-tests:nodelts
-        auth: &docker_auth
+        auth:
+          <<: *docker_auth
     steps:
       - checkout
       - run:
@@ -214,7 +226,8 @@ jobs:
   commitlint:
     docker:
       - image: greenpeaceinternational/p4-unit-tests:nodelts
-        auth: &docker_auth
+        auth:
+          <<: *docker_auth
     steps:
       - checkout
       - run:
@@ -247,7 +260,8 @@ jobs:
       GOOGLE_PROJECT_ID: planet-4-151612
     docker:
       - image: greenpeaceinternational/circleci-base:latest
-        auth: &docker_auth
+        auth:
+          <<: *docker_auth
     steps:
       - attach_workspace:
           at: /tmp/workspace
@@ -282,7 +296,8 @@ jobs:
   comment-pr:
     docker:
       - image: greenpeaceinternational/circleci-base:latest
-        auth: &docker_auth
+        auth:
+          <<: *docker_auth
     steps:
       - attach_workspace:
           at: /tmp/workspace
@@ -313,7 +328,8 @@ jobs:
   create-zip:
     docker:
       - image: mhart/alpine-node:14
-        auth: &docker_auth
+        auth:
+          <<: *docker_auth
     steps:
       - run: apk add zip git openssh-client python2 make g++
       - checkout
@@ -361,7 +377,8 @@ jobs:
   publish-zip:
     docker:
       - image: mhart/alpine-node:14
-        auth: &docker_auth
+        auth:
+          <<: *docker_auth
     steps:
       - attach_workspace:
           at: /tmp/workspace

--- a/src/Commands/CloudflarePurge.php
+++ b/src/Commands/CloudflarePurge.php
@@ -76,7 +76,7 @@ class CloudflarePurge extends Command {
 			// It's unlikely that only some of the chunks will fail, as Cloudflare's API responds with success
 			// for any url, even if on non-existent domains. Giving a warning per chunk anyway, just in case.
 			if ( ! $ok ) {
-				$joined = implode( $chunk, "\n" );
+				$joined = implode( "\n", $chunk );
 				WP_CLI::warning( "Chunk $i failed, one or more of these didn't work out: \n$joined" );
 			}
 		}


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6306

Add PHP 7.4 job on Circleci
Fix [deprecated usage](https://www.php.net/implode#refsect1-function.implode-changelog) of `implode`