### PR TITLE
PLANET-6223 Implement Google's Consent Mode on Planet 4

### DIFF
--- a/assets/src/js/app.js
+++ b/assets/src/js/app.js
@@ -18,7 +18,7 @@ requireAll(require.context('../images/icons/', true, /\.svg$/));
 window.$ = $ || jQuery;
 
 jQuery(function($) {
-  setupCookies($);
+  setupCookies();
   setupCountrySelect($);
   setupHeader($);
   setupLoadMore($);

--- a/assets/src/js/cookies.js
+++ b/assets/src/js/cookies.js
@@ -1,5 +1,27 @@
 /* global dataLayer */
 export const setupCookies = () => {
+  window.dataLayer = window.dataLayer || [];
+  const ENABLE_ANALYTICAL_COOKIES = window.p4bk_vars.enable_analytical_cookies;
+
+  function gtag() {
+    dataLayer.push(arguments);
+  }
+
+  const defaultCookieConsentNeeded = !document.cookie.includes('greenpeace=') && !document.cookie.includes('no_track');
+
+  // Set default ad storage and analytics storage to 'denied'.
+  if (defaultCookieConsentNeeded) {
+    gtag('consent', 'default', {
+      'ad_storage': 'denied',
+      ...ENABLE_ANALYTICAL_COOKIES && { 'analytics_storage': 'denied' },
+    });
+    dataLayer.push({
+      'event' : 'defaultConsent',
+      'ad_storage': 'denied',
+      ...ENABLE_ANALYTICAL_COOKIES && { 'analytics_storage': 'denied' },
+    });
+  }
+
   window.createCookie = (name, value, days) => {
     let date = new Date();
     date.setTime(date.getTime() + (days * 24 * 60 * 60 * 1000));
@@ -37,7 +59,8 @@ export const setupCookies = () => {
   const hideCookieButton = document.querySelector('#hidecookie');
   if (hideCookieButton) {
     hideCookieButton.onclick = () => {
-      window.createCookie('greenpeace', '2', 365);
+      const newCookieValue = ENABLE_ANALYTICAL_COOKIES ? '4' : '2';
+      window.createCookie('greenpeace', newCookieValue, 365);
 
       // Remove the 'no_track' cookie, if user accept the cookies consent.
       window.createCookie('no_track', '0', -1);
@@ -45,8 +68,18 @@ export const setupCookies = () => {
       // Create cookie to store last visited nro.
       window.createCookie('gp_nro', nro, 30);
 
+      // Grant ad storage and analytics storage.
+      gtag('consent', 'update', {
+        'ad_storage': 'granted',
+        ...ENABLE_ANALYTICAL_COOKIES && { 'analytics_storage': 'granted' },
+      });
+      dataLayer.push({
+        'event' : 'updateConsent',
+        'ad_storage': 'granted',
+        ...ENABLE_ANALYTICAL_COOKIES && { 'analytics_storage': 'granted' },
+      });
+
       // DataLayer push event on cookies consent.
-      window.dataLayer = window.dataLayer || [];
       dataLayer.push({
         'event' : 'cookiesConsent'
       });

--- a/assets/src/js/cookies.js
+++ b/assets/src/js/cookies.js
@@ -2,24 +2,27 @@
 export const setupCookies = () => {
   window.dataLayer = window.dataLayer || [];
   const ENABLE_ANALYTICAL_COOKIES = window.p4bk_vars.enable_analytical_cookies;
+  const ENABLE_GOOGLE_CONSENT_MODE = window.p4bk_vars.enable_google_consent_mode;
 
   function gtag() {
     dataLayer.push(arguments);
   }
 
-  const defaultCookieConsentNeeded = !document.cookie.includes('greenpeace=') && !document.cookie.includes('no_track');
+  // If Google Consent Mode is enabled, set default ad storage and analytics storage to 'denied' if needed
+  if (ENABLE_GOOGLE_CONSENT_MODE) {
+    const defaultCookieConsentNeeded = !document.cookie.includes('greenpeace=') && !document.cookie.includes('no_track');
 
-  // Set default ad storage and analytics storage to 'denied'.
-  if (defaultCookieConsentNeeded) {
-    gtag('consent', 'default', {
-      'ad_storage': 'denied',
-      ...ENABLE_ANALYTICAL_COOKIES && { 'analytics_storage': 'denied' },
-    });
-    dataLayer.push({
-      'event' : 'defaultConsent',
-      'ad_storage': 'denied',
-      ...ENABLE_ANALYTICAL_COOKIES && { 'analytics_storage': 'denied' },
-    });
+    if (defaultCookieConsentNeeded) {
+      gtag('consent', 'default', {
+        'ad_storage': 'denied',
+        ...ENABLE_ANALYTICAL_COOKIES && { 'analytics_storage': 'denied' },
+      });
+      dataLayer.push({
+        'event' : 'defaultConsent',
+        'ad_storage': 'denied',
+        ...ENABLE_ANALYTICAL_COOKIES && { 'analytics_storage': 'denied' },
+      });
+    }
   }
 
   window.createCookie = (name, value, days) => {
@@ -68,16 +71,18 @@ export const setupCookies = () => {
       // Create cookie to store last visited nro.
       window.createCookie('gp_nro', nro, 30);
 
-      // Grant ad storage and analytics storage.
-      gtag('consent', 'update', {
-        'ad_storage': 'granted',
-        ...ENABLE_ANALYTICAL_COOKIES && { 'analytics_storage': 'granted' },
-      });
-      dataLayer.push({
-        'event' : 'updateConsent',
-        'ad_storage': 'granted',
-        ...ENABLE_ANALYTICAL_COOKIES && { 'analytics_storage': 'granted' },
-      });
+      // Grant ad storage and analytics storage if Google Consent Mode is enabled.
+      if (ENABLE_GOOGLE_CONSENT_MODE) {
+        gtag('consent', 'update', {
+          'ad_storage': 'granted',
+          ...ENABLE_ANALYTICAL_COOKIES && { 'analytics_storage': 'granted' },
+        });
+        dataLayer.push({
+          'event' : 'updateConsent',
+          'ad_storage': 'granted',
+          ...ENABLE_ANALYTICAL_COOKIES && { 'analytics_storage': 'granted' },
+        });
+      }
 
       // DataLayer push event on cookies consent.
       dataLayer.push({

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -369,6 +369,12 @@ class Settings {
 						'id'   => 'analytics_local_smartsheet_id',
 						'type' => 'text',
 					],
+					[
+						'name' => __( 'Enable Google Consent Mode', 'planet4-master-theme-backend' ),
+						'desc' => __( "Enabling the Consent Mode will affect your setup in Google Tag Manager. The Consent Mode will prevent tags with built-in consent checks (eg. Google Analytics) from running before the user's consent is granted.", 'planet4-master-theme-backend' ),
+						'id'   => 'enable_google_consent_mode',
+						'type' => 'checkbox',
+					],
 				],
 			],
 			'planet4_settings_features'         => Features::get_options_page(),


### PR DESCRIPTION
### Description 

See https://jira.greenpeace.org/browse/PLANET-6223

### Testing
Go to https://www-dev.greenpeace.org/test-iocaste/privacy/ to test all the possible cookie combinations (also the "Got it!" button from the cookies banner) and check that the correct events are firing.

### Related PRs
- [plugin-gutenberg-blocks](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/661)