### PR TITLE
PLANET-6071 Implement new comments form

### DIFF
--- a/assets/src/scss/base/_colors.scss
+++ b/assets/src/scss/base/_colors.scss
@@ -34,8 +34,6 @@ $x-dark-blue:  #042233;
 $dark-blue:    #074365;
 $active-blue:  #05324c;
 $aquamarine:   #68dfde;
-$comment-block:#e7ecf0;
-$comment-text: #d1dce2;
 
 // Various reds:
 $peach:       #eaccbb;

--- a/assets/src/scss/pages/post/_comments-block.scss
+++ b/assets/src/scss/pages/post/_comments-block.scss
@@ -1,122 +1,76 @@
-.comments-block {
-  margin-top: 0;
-  padding: $n40 15px;
-  border-top: 1px solid $blue;
-  background-color: $comment-block;
-
-  @include medium-and-up {
-    padding: $n50 $n30;
-    margin-top: 0;
-  }
-
-  @include large-and-up {
-    padding: 48px;
-    max-width: 70%;
-  }
-
-  h3 {
-    font-size: $font-size-sm;
-    margin-bottom: 16px;
-
-    @include medium-and-up {
-      margin-bottom: 22px;
-    }
-
-    @include large-and-up {
-      margin-bottom: 18px;
-    }
-
-    @include x-large-and-up {
-      margin-bottom: 16px;
-    }
-
-    &.comments-section-title {
-      margin-top: 16px;
-      margin-bottom: 0;
-    }
-  }
+.comments-block h3 {
+  font-size: 16px;
+  margin-bottom: 16px;
 }
 
 // Adds nesting on comments
 @include comment-level;
 
 .single-comment {
-  margin-top: 16px;
-  margin-bottom: 16px;
-  padding-bottom: 32px;
-  border-bottom: 1px solid $grey-20;
-  font-size: $font-size-xxs;
-  line-height: 1.5;
+  padding-bottom: 24px;
+  font-family: $roboto;
 
-  &:last-of-type {
-    border-bottom: 0;
-  }
-
-  @include medium-and-up {
-    margin-top: 22px;
-    margin-bottom: 22px;
-    padding-bottom: 24px;
+  &:not(:first-of-type) {
+    border-top: 1px solid transparentize($grey-20, 0.5);
+    padding-top: 24px;
   }
 }
 
 .single-comment-text {
-  font-size: 1.125rem;
-  font-family: $roboto;
-  font-weight: 300;
-  margin: $n20 0;
-  color: $grey-60;
+  font-size: 16px;
+  line-height: 1.5;
+  color: $grey-80;
+  margin-bottom: 8px;
 }
 
 .single-comment-meta {
-  font-size: $font-size-xxs;
-  font-weight: 500;
-  color: $grey-80;
-  text-decoration: none;
-  display: block;
+  font-size: 14px;
+  color: $grey-40;
 
-  @include medium-and-up {
-    font-weight: 400;
+  .author-info,
+  .comment-date {
+    display: inline-block;
   }
 
-  & > * {
-    display: inline-block;
-    margin-bottom: 0;
+  .author-info::after {
+    content: "\2022";
+    padding-inline-start: 8px;
+    padding-inline-end: 6px;
+  }
 
-    &:first-child:after {
-      content: "\2022";
-      padding-left: 5px;
+  .comment-reply-link {
+    display: block;
+    font-weight: bold;
+    font-size: 14px;
+    margin-top: 16px;
+  }
+}
 
-      @include medium-and-up {
-        padding-left: 7px;
+@include medium-and-up {
+  .comments-block h3 {
+    margin-bottom: 24px;
+  }
+
+  .single-comment-meta {
+    .comment-reply-link {
+      float: right;
+      margin-top: 0;
+
+      html[dir="rtl"] & {
+        float: left;
       }
     }
   }
+}
 
-  .comment-date {
-    font-weight: 400;
-    font-style: italic;
-    color: $grey-60;
-
-    @include medium-and-up {
-      font-style: italic;
-      color: $grey-60;
-    }
+@include large-and-up {
+  .comments-block {
+    max-width: 696px;
   }
+}
 
-  .comment-reply-btn {
-    clear: both;
-    display: block;
-    margin-top: 10px;
-    width: 100%;
-    padding: 0 55px;
-    font-size: $font-size-xs;
-
-    @include medium-and-up {
-      clear: none;
-      display: inline-block;
-      margin-top: -12px;
-      width: auto;
-      float: right;
-    }
+@include x-large-and-up {
+  .comments-block {
+    max-width: 736px;
   }
 }

--- a/assets/src/scss/pages/post/_comments-form.scss
+++ b/assets/src/scss/pages/post/_comments-form.scss
@@ -1,59 +1,119 @@
-.comment-form {
-  display: block;
-  padding-bottom: 60px;
+.comments-block {
+  .form-section .comment-respond {
+    background: $grey-05;
+    border-radius: 4px;
+    padding: 24px 16px;
+  }
 
-  .form-group {
+  .comment-respond {
+    font-size: 0;
     margin-bottom: 32px;
 
-    @include small-and-up {
-      margin-bottom: 32px;
+    input,
+    textarea {
+      width: 100%;
+    }
+
+    .form-submit {
+      margin-bottom: 0;
+    }
+
+    button {
+      margin-top: 8px;
+      margin-bottom: 0;
     }
 
     @include medium-and-up {
-      padding-bottom: 40px;
+      .comment-author,
+      .comment-email {
+        width: calc(50% - 8px);
+        display: inline-block;
+        vertical-align: bottom;
+      }
+
+      .comment-author {
+        margin-inline-end: 16px;
+      }
+    }
+  }
+}
+
+#gdpr-comments-compliance {
+  font-family: $roboto;
+
+  #gdpr-comments-compliance-text,
+  #gdpr-comments-label,
+  .custom-control-description {
+    font-size: 14px;
+  }
+
+  #gdpr-comments-label {
+    font-weight: bold;
+  }
+}
+
+.comment-form-cookies-consent input[type="checkbox"] ~ .custom-control-description {
+  font-size: 14px;
+}
+
+.logged-in-as {
+  font-size: 14px;
+  font-family: $roboto;
+}
+
+#cancel-comment-reply-link {
+  margin-inline-start: 8px;
+  color: $grey-40;
+
+  &:hover,
+  &:focus {
+    color: $grey-40;
+  }
+}
+
+@include medium-and-up {
+  .comment-form-cookies-consent {
+    margin-top: 8px;
+  }
+
+  .comments-block .form-section .comment-respond {
+    padding: 32px;
+
+    .logged-in-as {
+      position: absolute;
+      top: 32px;
+      right: 32px;
+
+      html[dir="rtl"] & {
+        left: 32px;
+        right: auto;
+      }
     }
   }
 
-  textarea {
-    margin-bottom: 20px;
+  .comments-block .comment-respond {
+    position: relative;
 
-    @include small-and-up {
-      margin-bottom: 56px;
-    }
+    .logged-in-as {
+      position: absolute;
+      top: 0;
+      right: 0;
 
-    @include medium-and-up {
-      margin-bottom: 40px;
-    }
-
-    @include large-and-up {
-      margin-bottom: 30px;
-    }
-  }
-
-  input {
-    width: 100%;
-
-    @include medium-and-up {
-      width: 50%;
-    }
-
-    @include medium-and-up {
-      width: 80%;
+      html[dir="rtl"] & {
+        left: 0;
+        right: auto;
+      }
     }
   }
 
-  button {
-    width: 100%;
-    margin-top: 60px;
+  .logged-in-as {
+    position: absolute;
+    top: 32px;
+    right: 32px;
 
-    @include medium-and-up {
-      width: 50%;
-      margin-top: 30px;
-    }
-
-    @include large-and-up {
-      width: 40%;
-      margin-top: 30px;
+    html[dir="rtl"] & {
+      left: 32px;
+      right: auto;
     }
   }
 }

--- a/single.php
+++ b/single.php
@@ -109,13 +109,6 @@ $comments_args = [
 	'comment_field'        => Timber::compile( 'comment_form/comment_field.twig' ),
 	'submit_button'        => Timber::compile( 'comment_form/submit_button.twig' ),
 	'title_reply'          => __( 'Leave your reply', 'planet4-master-theme' ),
-	'fields'               => apply_filters(
-		'comment_form_default_fields',
-		[
-			'author' => Timber::compile( 'comment_form/author_field.twig' ),
-			'email'  => Timber::compile( 'comment_form/email_field.twig' ),
-		]
-	),
 ];
 
 $context['comments_args']       = $comments_args;

--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -170,6 +170,8 @@ class MasterSite extends TimberSite {
 		add_filter( 'login_headertext', [ $this, 'add_login_logo_url_title' ] );
 		add_action( 'login_enqueue_scripts', [ $this, 'add_login_stylesheet' ] );
 		add_filter( 'comment_form_submit_field', [ $this, 'gdpr_cc_comment_form_add_class' ], 150, 2 );
+		add_filter( 'comment_form_default_fields', [ $this, 'comment_form_cookie_checkbox_add_class' ] );
+		add_filter( 'comment_form_default_fields', [ $this, 'comment_form_replace_inputs' ] );
 		add_filter( 'embed_oembed_html', [ $this, 'filter_youtube_oembed_nocookie' ], 10, 2 );
 		add_filter(
 			'editable_roles',
@@ -1134,6 +1136,46 @@ class MasterSite extends TimberSite {
 		$submit_field = preg_replace( $pattern, $replacement, $submit_field );
 
 		return $submit_field;
+	}
+
+	/**
+	 * Add classes to the default comment form cookie checkbox.
+	 *
+	 * @param array $fields The default fields of the comment form.
+	 *
+	 * @return array the new fields.
+	 */
+	public function comment_form_cookie_checkbox_add_class( $fields ) {
+
+		if ( isset( $fields['cookies'] ) ) {
+			$pattern[0]     = '/(class=["\']comment-form-cookies-consent["\'])/';
+			$replacement[0] = 'class="comment-form-cookies-consent custom-control"';
+			$pattern[1]     = '/(for=["\']wp-comment-cookies-consent["\'])/';
+			$replacement[1] = '$1 class="custom-control-description"';
+
+			$fields['cookies'] = preg_replace( $pattern, $replacement, $fields['cookies'] );
+		}
+
+		return $fields;
+	}
+
+	/**
+	 * Use different templates for the comment form fields (name and email).
+	 * Also remove the website field since we don't want to use it.
+	 *
+	 * @param array $fields The default fields of the comment form.
+	 *
+	 * @return array the new fields.
+	 */
+	public function comment_form_replace_inputs( $fields ) {
+
+		$fields['author'] = Timber::compile( 'comment_form/author_field.twig' );
+		$fields['email']  = Timber::compile( 'comment_form/email_field.twig' );
+		if ( isset( $fields['url'] ) ) {
+			unset( $fields['url'] );
+		}
+
+		return $fields;
 	}
 
 	/**

--- a/templates/child_comments.twig
+++ b/templates/child_comments.twig
@@ -1,11 +1,11 @@
 <article class="single-comment {{ comment.comment_type }} comment-level-{{ comment.depth }}" id="comment-{{ comment.ID }}" >
-	<p itemprop="commentText" class="single-comment-text">{{ comment.comment_content|wpautop|striptags( '<br>,<p>' )|raw }}</p>
+	<p class="single-comment-text">{{ comment.comment_content|raw }}</p>
 	<footer class="single-comment-meta">
 		<span class="author-info" itemprop="author">{{ comment.comment_author }}</span>
 		<time datetime="" class="comment-date" itemprop="commentTime">{{ comment.date }}</time>
 		{# Add custom css classes to reply button #}
 		{% if ( comment.depth < p4_comments_depth ) %}
-			{{ fn('str_replace', 'comment-reply-link', 'comment-reply-link btn btn-small btn-secondary comment-reply-btn',  comment.reply_link)|raw }}
+			{{ comment.reply_link|raw }}
 		{% endif %}
 	</footer>
 </article>

--- a/templates/comment.twig
+++ b/templates/comment.twig
@@ -1,10 +1,9 @@
 <article class="single-comment {{ comment.comment_type }}" id="comment-{{ comment.ID }}">
-	<p itemprop="commentText" class="single-comment-text">{{ comment.comment_content|wpautop|striptags( '<br>,<p>' )|raw }}</p>
+	<p class="single-comment-text">{{ comment.comment_content|raw }}</p>
 	<footer class="single-comment-meta">
 		<span class="author-info" itemprop="author">{{ comment.comment_author }}</span>
 		<time datetime="" class="comment-date" itemprop="commentTime">{{ comment.date }}</time>
-		{# Add custom css classes to reply button #}
-		{{ fn('str_replace', 'comment-reply-link', 'comment-reply-link btn btn-small btn-secondary comment-reply-btn',  comment.reply_link)|raw }}
+		{{ comment.reply_link|raw }}
 	</footer>
 </article>
 {% for cmt in comment.children %}

--- a/templates/comment_form/author_field.twig
+++ b/templates/comment_form/author_field.twig
@@ -1,5 +1,14 @@
-<div class="form-group animated-label">
-	{% set your_name = __( 'Your Name', 'planet4-master-theme' ) %}
-	<input type="text" class="form-control" id="comments-name-input" name="author" placeholder="{{ your_name }}" required />
+<div class="form-group animated-label comment-author">
+	{% set placeholder = __( 'Your Name', 'planet4-master-theme' ) %}
+	{% set commenter_name = function('wp_get_current_commenter').comment_author ?? '' %}
+	<input
+		value="{{ commenter_name }}"
+		type="text"
+		class="form-control"
+		id="comments-name-input"
+		name="author"
+		placeholder="{{ placeholder }}"
+		required
+	/>
 	<label for="comments-name-input">{{ __( 'Name', 'planet4-master-theme' )  }}*</label>
 </div>

--- a/templates/comment_form/comment_field.twig
+++ b/templates/comment_form/comment_field.twig
@@ -1,4 +1,4 @@
-<div class="form-group animated-label mb-0">
+<div class="form-group animated-label">
 	{% set your_comment = __( 'Your Comment', 'planet4-master-theme' ) %}
 	<textarea class="form-control" id="comments-textarea" name="comment" rows="6" placeholder="{{ your_comment }}" required></textarea>
 	<label for="comments-textarea">{{ __( 'Comment', 'planet4-master-theme' ) }}*</label>

--- a/templates/comment_form/email_field.twig
+++ b/templates/comment_form/email_field.twig
@@ -1,5 +1,14 @@
-<div class="form-group animated-label mb-0">
-	{% set your_email = __( 'Your Email', 'planet4-master-theme' ) %}
-	<input type="email" class="form-control" id="comments-email-input" name="email" placeholder="{{ your_email }}" required />
+<div class="form-group animated-label comment-email">
+	{% set placeholder = __( 'Your Email', 'planet4-master-theme' ) %}
+	{% set commenter_email = function('wp_get_current_commenter').comment_author_email ?? '' %}
+	<input
+		value="{{ commenter_email }}"
+		type="email"
+		class="form-control"
+		id="comments-email-input"
+		name="email"
+		placeholder="{{ placeholder }}"
+		required
+	/>
 	<label for="comments-email-input">{{ __( 'Email', 'planet4-master-theme' ) }}*</label>
 </div>

--- a/templates/comment_form/submit_button.twig
+++ b/templates/comment_form/submit_button.twig
@@ -1,1 +1,1 @@
-<button type="submit" class="btn btn-small btn-secondary">{{ __( 'Post comment', 'planet4-master-theme' ) }}</button>
+<button type="submit" class="btn btn-small btn-primary">{{ __( 'Post comment', 'planet4-master-theme' ) }}</button>

--- a/templates/comments_section.twig
+++ b/templates/comments_section.twig
@@ -4,11 +4,13 @@
 		<div class="form-section">
 			{{ fn('comment_form', comments_args) }}
 		</div>
-		<section class="comments-section" itemscope itemtype="http://schema.org/UserComments">
-			<h3 class="comments-section-title">{{ __( 'Discussion', 'planet4-master-theme' ) }}</h3>
-			{% for cmt in comments %}
-				{% include "comment.twig" with {comment:cmt, index: loop.index} %}
-			{% endfor %}
-		</section>
+		{% if ( comments|length > 0 ) %}
+			<section class="comments-section" itemscope itemtype="http://schema.org/UserComments">
+				<h3 class="comments-section-title">{{ __( 'Discussion', 'planet4-master-theme' ) }}</h3>
+				{% for cmt in comments %}
+					{% include "comment.twig" with {comment:cmt, index: loop.index} %}
+				{% endfor %}
+			</section>
+		{% endif %}
 	</div>
 </div>


### PR DESCRIPTION
### Description

See the [ticket](https://jira.greenpeace.org/browse/PLANET-6071) and the [designs](https://www.figma.com/file/tdt8olZ6RS4bTMqbo2cvCU/Post-page-V1?node-id=629%3A981)

This PR also includes a fix for the "Cookies opt-in" checkbox (Settings > Discussion > `Show comments cookies opt-in checkbox, allowing comment author cookies to be set`) which previously didn't work properly and wasn't styled. 

### Testing
You can see the new designs either on local or on the [jupiter](https://www-dev.greenpeace.org/test-jupiter/) test instance, on any post. There are a few scenarios to test in addition to the comments and the basic comment form in all screen sizes:
- The "Cookies opt-in" checkbox: if that option is enabled in the backend, users that are not logged in should see the option in the comment form to save their name and email for their follow-up comments, and that functionality should work as expected
- The GDPR compliance checkbox (Plugins > GDPR comments > Settings > Enable `Compliance required` & `Compliance text`)
- The logged-in version of the form: in that case the `Name` and `Email` inputs should be gone and you should instead see links to either check your profile or log out
- The comment reply form that appears when clicking on `Reply` in one of the existing comments