### PR TITLE
Add optional support for "block templates"

### DIFF
--- a/src/Features.php
+++ b/src/Features.php
@@ -24,6 +24,8 @@ class Features {
 
 	public const BETA_BLOCKS = 'beta_blocks';
 
+	public const WP_TEMPLATE_EDITOR = 'wp_template_editor';
+
 	/**
 	 * Get the features options page settings.
 	 *
@@ -93,12 +95,21 @@ class Features {
 				'type' => 'checkbox',
 			],
 			[
-				'name' => __( 'Allow beta blocks in post editor.', 'planet4-master-theme-backend' ),
+				'name' => __( 'Allow beta blocks in post editor', 'planet4-master-theme-backend' ),
 				'desc' => __(
 					'If enabled, you can use early or unstable versions of blocks in the post editor. These will be in the "Planet 4 Blocks - BETA" category.',
 					'planet4-master-theme-backend'
 				),
 				'id'   => self::BETA_BLOCKS,
+				'type' => 'checkbox',
+			],
+			[
+				'name' => __( 'Enable WordPress 5.8 template editor', 'planet4-master-theme-backend' ),
+				'desc' => __(
+					'UNSTABLE: Enable the WordPress "template editor" to allow changing the outer template of pages.',
+					'planet4-master-theme-backend'
+				),
+				'id'   => self::WP_TEMPLATE_EDITOR,
 				'type' => 'checkbox',
 			],
 		];

--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -106,6 +106,9 @@ class MasterSite extends TimberSite {
 	protected function hooks() {
 		add_theme_support( 'post-thumbnails' );
 		add_theme_support( 'menus' );
+		if ( planet4_get_option( FEATURES::WP_TEMPLATE_EDITOR ) ) {
+			add_theme_support( 'block-templates' );
+		}
 		// Disable wp5.5 Block Patterns.
 		remove_theme_support( 'core-block-patterns' );
 


### PR DESCRIPTION
Add an option to the features menu to enable theme support for the "template editor". Because this feature is not production ready for us (see list of issues below), it's made clear in the description that it's unstable. We can add the option already because internally this feature can be used for prototyping in the Information Architecture workshop.

Blocking issues for production use:
- Everything we add to the template using Twig files (for example meta tags in the head, GTM and Google Analytics tracking code) won't be present in these templates. We would need to add these to the head in another way to support them on custom templates.
- We need documentation and best practices to avoid people building things that are hard to maintain, because of the large amount of flexibility the template editor offers.
- No navigation block yet, this is coming in 5.9 and seems like a crucial ingredient to really leverage the template editor. Although we may be able to add a navigation as a block in another less efficient way, maybe even just custom HTML. The extra work is not a big issue because these menus don't change very often.

Below are findings I gathered on this PR during experimentation day, also relating to other WP 5.8 features.
---

Things I found while testing the template editor and other new features:
- It takes some getting used to, but the template editor is very powerful to customize landing pages.
- The Query block is **amazing**. With a little effort you can make it look like both Articles and Covers, it has most (or even all) of the filters both blocks support + more + a better UI for them. It can also be used to create listing pages. Query pagination works out of the box.

Possible issues / things that need work:
- The template editor is only accessible by going to a page and clicking "Edit" below the template (or "New" to create a new one). The template editor then opens as a modal over the current page, with no dedicated URL. :facepalm: This makes it confusing as to what is being saved. It's somewhat mitigated by the save sidebar that displays whether the page or the template has changes.
- There is a bug that causes the post content to disappear when making changes in the template editor... This is a problem because you always need to open a page to edit a template. It seems to happen relatively frequently. But I did not catch yet which kind of edit causes it. (probably when undoing edits but not sure)
- It seems best to not edit any templates on top of live content, but instead provide dedicated non-published pages to edit the template on.
- Still need to investigate how to customize the markup of the added elements. Or maybe it's easier to adapt our CSS to them.
- When you save a template, the sidebar will list all affected pages. This is nice, but if you still have the template editor tab open and in the meanwhile the template is assigned to a new page, that new page is not shown until you refresh the editor.
- Our blocks can be used here, but there's a few cases where they read data from the page (e.g. Articles). That data will not be there because it's added in our templates. I did a quick and dirty workaround to allow it to work in the POC branch of our plugin.
- Image handling is not ideal and results in oversized images. Maybe we can improve this while waiting for core to properly address it.
- Behavior with revisions might be weird, will investigate.
- We would need to add Cloudflare cache purges for all affected pages when a template is saved. Should be manageable. For now to trigger a purge you need to save the post after saving the template (by pressing the save button twice after the circle at the start of the button is gone).
- Query pagination works but currently is not cached by Cloudflare. Maybe we can configure Cloudflare to still cache the relevant query parameters, though their format can be unpredictable. If we do that then we also need to ensure cache is purged in time, which might be challenging given that page number based pagination invalidates all pages every time a new item is added. Perhaps setting a short cache lifetime on any page with a query block is sufficient and we don't need complex purging setup.