### PR TITLE
Improve and refactor the current Footer version

### DIFF
--- a/assets/src/scss/layout/_footer.scss
+++ b/assets/src/scss/layout/_footer.scss
@@ -228,11 +228,6 @@
     }
   }
 
-  .footer-links,
-  .footer-links-secondary {
-    display: none;
-  }
-
   .gp-year {
     font-size: $font-size-xxs;
     font-family: $lora;

--- a/assets/src/scss/layout/_footer.scss
+++ b/assets/src/scss/layout/_footer.scss
@@ -197,7 +197,7 @@
   }
 }
 
-.site-footer_min {
+.site-footer--minimal {
   padding: 40px 0;
   line-height: 1;
 
@@ -226,6 +226,11 @@
     .list-unstyled {
       width: 200px;
     }
+  }
+
+  .footer-links,
+  .footer-links-secondary {
+    display: none;
   }
 
   .gp-year {

--- a/src/PostCampaign.php
+++ b/src/PostCampaign.php
@@ -543,7 +543,7 @@ class PostCampaign {
 				'footer--copyright--color',
 				'footer--copyright--link--color',
 				'footer--copyright--year--color',
-				'site-footer_min--icon--fill',
+				'site-footer--minimal--icon--fill',
 			],
 			'campaign_header_primary' => [ 'headings--font-family' ],
 			'campaign_body_font'      => [ 'body--font-family' ],

--- a/templates/base.twig
+++ b/templates/base.twig
@@ -41,7 +41,7 @@
 	{% endif %}
 
 	{% block footer %}
-		{% include 'footer.twig' with { 'nav_type' : custom_styles.nav_type ? 'minimal' : 'default' } %}
+		{% include 'footer.twig' with { 'nav_type' : custom_styles.nav_type == 'planet4' ? 'minimal' : 'default' } %}
 
 		{% block cookies %}
 			{% include 'cookies.twig' %}

--- a/templates/base.twig
+++ b/templates/base.twig
@@ -41,7 +41,7 @@
 	{% endif %}
 
 	{% block footer %}
-		{% include 'footer.twig' with { 'nav_type' : custom_styles.nav_type } %}
+		{% include 'footer.twig' with { 'nav_type' : custom_styles.nav_type ? 'minimal' : 'default' } %}
 
 		{% block cookies %}
 			{% include 'cookies.twig' %}

--- a/templates/footer.twig
+++ b/templates/footer.twig
@@ -1,4 +1,4 @@
-<footer id="footer" class="site-footer {{ nav_type == 'planet4' ? 'site-footer_min' : ''}}">
+<footer id="footer" class="site-footer site-footer--{{ nav_type ? 'minimal' : 'default'}}">
 	<div class="container">
 		<ul class="footer-social-media list-unstyled col-md-8 col-lg-5">
 			{% if social_overrides is defined and social_overrides|length %}
@@ -36,34 +36,32 @@
 				{% endfor %}
 			{% endif %}
 		</ul>
+			
+		<ul class="list-unstyled footer-links">
+			{% for primary in footer_primary_menu %}
+				<li>
+					<a href="{{ primary.url }}"
+						data-ga-category="Footer Navigation"
+						data-ga-action="Primary Links"
+						data-ga-label="{{ primary.title }}">
+						{{ primary.title }}
+					</a>
+				</li>
+			{% endfor %}
+		</ul>
 
-		{% if nav_type != 'planet4' %}
-			<ul class="list-unstyled footer-links">
-				{% for primary in footer_primary_menu %}
-					<li>
-						<a href="{{ primary.url }}"
-							data-ga-category="Footer Navigation"
-							data-ga-action="Primary Links"
-							data-ga-label="{{ primary.title }}">
-							{{ primary.title }}
-						</a>
-					</li>
-				{% endfor %}
-			</ul>
-
-			<ul class="list-unstyled footer-links-secondary">
-				{% for secondary in footer_secondary_menu %}
-					<li>
-						<a href="{{ secondary.url }}"
-							data-ga-category="Footer Navigation"
-							data-ga-action="Secondary Links"
-							data-ga-label="{{ secondary.title }}">
-							{{ secondary.title }}
-						</a>
-					</li>
-				{% endfor %}
-			</ul>
-		{% endif %}
+		<ul class="list-unstyled footer-links-secondary">
+			{% for secondary in footer_secondary_menu %}
+				<li>
+					<a href="{{ secondary.url }}"
+						data-ga-category="Footer Navigation"
+						data-ga-action="Secondary Links"
+						data-ga-label="{{ secondary.title }}">
+						{{ secondary.title }}
+					</a>
+				</li>
+			{% endfor %}
+		</ul>
 
 		<p class="copyright-text col-md-8" role="text">
 			{{ copyright_text_line1|e('wp_kses_post')|raw }}

--- a/templates/footer.twig
+++ b/templates/footer.twig
@@ -37,7 +37,7 @@
 			{% endif %}
 		</ul>
 			
-		{% if nav_type == 'default' %}
+		{% if nav_type != 'minimal' %}
 			<ul class="list-unstyled footer-links">
 				{% for primary in footer_primary_menu %}
 					<li>

--- a/templates/footer.twig
+++ b/templates/footer.twig
@@ -1,4 +1,4 @@
-<footer id="footer" class="site-footer site-footer--{{ nav_type ? 'minimal' : 'default'}}">
+<footer id="footer" class="site-footer site-footer--{{ nav_type }}">
 	<div class="container">
 		<ul class="footer-social-media list-unstyled col-md-8 col-lg-5">
 			{% if social_overrides is defined and social_overrides|length %}
@@ -37,31 +37,33 @@
 			{% endif %}
 		</ul>
 			
-		<ul class="list-unstyled footer-links">
-			{% for primary in footer_primary_menu %}
-				<li>
-					<a href="{{ primary.url }}"
-						data-ga-category="Footer Navigation"
-						data-ga-action="Primary Links"
-						data-ga-label="{{ primary.title }}">
-						{{ primary.title }}
-					</a>
-				</li>
-			{% endfor %}
-		</ul>
+		{% if nav_type == 'default' %}
+			<ul class="list-unstyled footer-links">
+				{% for primary in footer_primary_menu %}
+					<li>
+						<a href="{{ primary.url }}"
+							data-ga-category="Footer Navigation"
+							data-ga-action="Primary Links"
+							data-ga-label="{{ primary.title }}">
+							{{ primary.title }}
+						</a>
+					</li>
+				{% endfor %}
+			</ul>
 
-		<ul class="list-unstyled footer-links-secondary">
-			{% for secondary in footer_secondary_menu %}
-				<li>
-					<a href="{{ secondary.url }}"
-						data-ga-category="Footer Navigation"
-						data-ga-action="Secondary Links"
-						data-ga-label="{{ secondary.title }}">
-						{{ secondary.title }}
-					</a>
-				</li>
-			{% endfor %}
-		</ul>
+			<ul class="list-unstyled footer-links-secondary">
+				{% for secondary in footer_secondary_menu %}
+					<li>
+						<a href="{{ secondary.url }}"
+							data-ga-category="Footer Navigation"
+							data-ga-action="Secondary Links"
+							data-ga-label="{{ secondary.title }}">
+							{{ secondary.title }}
+						</a>
+					</li>
+				{% endfor %}
+			</ul>
+		{% endif %}
 
 		<p class="copyright-text col-md-8" role="text">
 			{{ copyright_text_line1|e('wp_kses_post')|raw }}

--- a/themes/climate.json
+++ b/themes/climate.json
@@ -24,7 +24,7 @@
   "--article-list-item-tags--tag-wrap--display": "none",
   "--enform-extra-header-placeholder--counter-block--progress-container--display": "none",
   "--skewed-overlay--display": "none",
-  "--site-footer_min--icon--fill": "#66cc00",
+  "--site-footer--minimal--icon--fill": "#66cc00",
   "--block-articles--article--meta--font-family": "Jost,sans-serif",
   "--block-columns--column-heading--font-family": "Jost,sans-serif",
   "--body--font-family": "\"Jost\",serif",

--- a/themes/plastic.json
+++ b/themes/plastic.json
@@ -23,7 +23,7 @@
   "--page-header--color": "#044362",
   "--page-section-header--color": "#044362",
   "--top-page-tags--tag-item--color": "#00748f",
-  "--site-footer_min--icon--fill": "#2077bf",
+  "--site-footer--minimal--icon--fill": "#2077bf",
   "--block-articles--article--meta--font-family": "Montserrat,sans-serif",
   "--block-columns--column-heading--font-family": "\"Montserrat\",sans-serif",
   "--button--font-family": "\"Montserrat\",sans-serif",


### PR DESCRIPTION
- Add classnames depending of the `nav_type`.
- If the `nav_type` is not defined, the footer will be rendered as the default one.
- Show or hide the primary and secondary nav through the css and not through the template
- Rename css variables

Demo page: https://www-dev.greenpeace.org/test-rhea/campaign/campaign-for-climate-emergency/

Ref: https://jira.greenpeace.org/browse/PLANET-6189

---

<!--
Please provide a brief summary of the change introduced to make review process easier.

Ideally this should also be part of the commit summary.
-->
