### PR TITLE
Planet 6189 new footer design

### DIFF
--- a/assets/src/scss/layout/_footer-social-media.scss
+++ b/assets/src/scss/layout/_footer-social-media.scss
@@ -1,0 +1,107 @@
+.site-footer__social-media {
+  text-align: left;
+  margin-bottom: 24px;
+
+  @include medium-and-up {
+    margin-bottom: 0;
+  }
+
+  &-title {
+    display: none;
+
+    @include large-and-up {
+      margin-bottom: 24px;
+      display: block;
+      line-height: 1;
+    }
+  }
+
+  &-list {
+    _-- {
+      color: $white;
+    }
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    padding-bottom: 9px;
+    border-bottom: 1px solid white;
+
+    @supports (justify-content: center) {
+      & {
+        justify-content: center;
+      }
+    }
+
+    .icon {
+      width: 24px;
+      height: 24px;
+      margin-bottom: 16px;
+    }
+
+    &--justify-space-between {
+      @supports (justify-content: space-between) {
+        & {
+          justify-content: space-between;
+        }
+      }
+    }
+
+    @include large-and-up {
+      border-bottom: none;
+      flex-wrap: nowrap;
+
+      @supports (justify-content: flex-start) {
+        & {
+          justify-content: flex-start;
+        }
+      }
+    }
+
+    li {
+      display: inline-block;
+
+      &:not(:last-child) {
+        margin-inline-end: 16px;
+      }
+    }
+
+    a {
+      --footer--social-media--link-- {
+        transition: color 100ms linear;
+
+        &:hover {
+          color: $white;
+        }
+      }
+    }
+  }
+
+  &--minimal {
+    width: 100%;
+
+    .site-footer__social-media {
+      &-title {
+        display: none;
+      }
+
+      &-list {
+        border: none;
+        margin-bottom: 0;
+        padding-bottom: 0;
+        @supports (justify-content: center) {
+          & {
+            justify-content: center;
+          }
+        }
+
+        .icon {
+          margin-bottom: 0;
+        }
+      }
+    }
+
+    @include medium-and-up {
+      margin-bottom: 24px;
+    }
+  }
+}

--- a/assets/src/scss/layout/_footer.scss
+++ b/assets/src/scss/layout/_footer.scss
@@ -4,23 +4,27 @@
     background: $dark-blue;
     color: $white;
   }
-  padding: 45px 0 $n25;
   position: relative;
   z-index: 2;
   text-align: center;
   transition: margin 1s;
+  padding-top: 24px;
   clear: both;
   line-height: 0;
 
-  @include medium-and-up {
-    padding: $n25 0 $n20;
+  a {
+    transition: color 100ms linear;
+
+    --footer--link-- {
+      color: inherit;
+
+      &:hover {
+        color: $white;
+      }
+    }
   }
 
-  @include large-and-up {
-    padding: 55px 0 $n25;
-  }
-
-  a --footer--links-- {
+  .icon --footer--icon-- {
     color: inherit;
 
     &:hover {
@@ -31,104 +35,115 @@
   li {
     line-height: 1;
   }
-}
 
-.site-footer__container {
-  padding-bottom: 0;
-  display: flex;
-  flex-direction: column;
-
-  @include large-and-up {
-    flex-direction: row-reverse;
-  }
-}
-
-.site-footer__footer-links {
-  margin-bottom: 24px;
-  width: 100%;
-  text-align: left;
-  column-count: 1;
-
-  li {
-    font-size: $font-size-sm;
-
-    &:not(:last-child) {
-      margin-bottom: 24px;
-    }
-  }
-
-  @include medium-and-up {
-    font-size: $font-size-md;
-    column-count: 3;
-  }
-
-  @include large-and-up {
-    column-count: 2;
-  }
-}
-
-.site-footer__copyright {
-  --footer--copyright-- {
-    background-color: $active-blue;
-  }
-
-  padding-top: 16px;
-  padding-bottom: 16px;
-
-  .icon {
-    top: 0;
-
-    --footer--copyright--icon-- {
-      fill: $white;
-    }
-  }
-
-  &-wrapper {
-    font-size: $font-size-xxs;
+  &__container {
+    padding-bottom: 0;
     display: flex;
     flex-direction: column;
-    text-align: left;
 
     @include large-and-up {
-      flex-direction: inherit;
+      flex-direction: row-reverse;
     }
   }
 
-  &-text {
-    --footer--copyright--text-- {
-      color: $grey-10;
-    }
+  &__footer-links {
+    margin-bottom: 24px;
+    width: 100%;
+    text-align: left;
+    column-count: 1;
 
-    a --footer--copyright--text--link-- {
-      color: $grey-10;
+    li {
+      font-size: $font-size-sm;
 
-      &:hover {
-        color: $grey-10;
+      &:not(:last-child) {
+        margin-bottom: 24px;
       }
     }
 
-    font-size: $font-size-xxs;
-    line-height: 1.4;
-    word-break: keep-all;
-    width: auto;
-    margin-bottom: 0;
-    margin-bottom: 12px;
-
-    &:last-child {
-      margin-bottom: 0;
+    @include medium-and-up {
+      font-size: $font-size-md;
+      column-count: 3;
     }
 
     @include large-and-up {
-      margin-bottom: 0;
+      column-count: 2;
+    }
+  }
 
-      &:after {
-        content: "\007C";
-        display: inline-block;
-        margin: 0 14px;
+  &__copyright {
+    --footer--copyright-- {
+      background: $active-blue;
+    }
+
+    padding-top: 16px;
+    padding-bottom: 16px;
+
+    .icon {
+      top: 0;
+
+      --footer--copyright--icon-- {
+        fill: $white;
+      }
+    }
+
+    &-wrapper {
+      font-size: $font-size-xxs;
+      display: flex;
+      flex-direction: column;
+      text-align: left;
+
+      @include large-and-up {
+        flex-direction: inherit;
+      }
+    }
+
+    &-text {
+      --footer--copyright--text-- {
+        color: $grey-10;
       }
 
-      &:last-of-type:after {
-        display: none;
+      a --footer--copyright--text--link-- {
+        color: $grey-10;
+
+        &:hover {
+          color: $grey-10;
+        }
+      }
+
+      font-size: $font-size-xxs;
+      line-height: 1.4;
+      word-break: keep-all;
+      width: auto;
+      margin-bottom: 0;
+      margin-bottom: 12px;
+
+      &:last-child {
+        margin-bottom: 0;
+      }
+
+      @include large-and-up {
+        margin-bottom: 0;
+
+        &:after {
+          content: "\007C";
+          display: inline-block;
+          margin: 0 14px;
+        }
+
+        &:last-of-type:after {
+          display: none;
+        }
+      }
+    }
+  }
+
+  &--minimal {
+    .site-footer {
+      &__copyright-wrapper {
+        @include large-and-up {
+          display: flex;
+          justify-content: center;
+        }
       }
     }
   }

--- a/assets/src/scss/layout/_footer.scss
+++ b/assets/src/scss/layout/_footer.scss
@@ -32,6 +32,16 @@
   }
 }
 
+.site-footer__container {
+  padding-bottom: 0;
+  display: flex;
+  flex-direction: column;
+
+  @include medium-and-up {
+    flex-direction: row-reverse;
+  }
+}
+
 .footer-social-media {
   _-- {
     color: $grey-20;

--- a/assets/src/scss/layout/_footer.scss
+++ b/assets/src/scss/layout/_footer.scss
@@ -38,55 +38,8 @@
   display: flex;
   flex-direction: column;
 
-  @include medium-and-up {
+  @include large-and-up {
     flex-direction: row-reverse;
-  }
-}
-
-.footer-social-media {
-  _-- {
-    color: $grey-20;
-  }
-  font-size: $font-size-xl;
-  margin: auto;
-  text-align: center;
-  width: max-content;
-  margin-bottom: 32px;
-  padding: 0;
-
-  .icon {
-    width: 2rem;
-    height: 2rem;
-  }
-
-  @include small-and-up {
-    font-size: $font-size-xxxl;
-  }
-
-  @supports (justify-content: space-between) {
-    & {
-      display: flex;
-      justify-content: space-between;
-    }
-  }
-
-  li {
-    display: inline-block;
-    font-size: $font-size-xl;
-
-    &:not(:last-child) {
-      margin-inline-end: 16px;
-    }
-  }
-
-  a {
-    --footer-social-media--link-- {
-      transition: color 100ms linear;
-
-      &:hover {
-        color: $white;
-      }
-    }
   }
 }
 

--- a/assets/src/scss/layout/_footer.scss
+++ b/assets/src/scss/layout/_footer.scss
@@ -106,101 +106,77 @@
 
   @include medium-and-up {
     font-size: $font-size-md;
+    column-count: 3;
+  }
+
+  @include large-and-up {
+    column-count: 2;
   }
 }
 
-.copyright-text {
+.site-footer__copyright {
   --footer--copyright-- {
-    color: $grey-10;
-  }
-  font-size: $font-size-xxs;
-  line-height: 1.3;
-  margin-left: auto;
-  margin-right: auto;
-  word-break: keep-all;
-  width: 80%;
-  padding: 0;
-
-  @include medium-and-up {
-    line-height: 1;
+    background-color: $active-blue;
   }
 
-  i {
-    display: block;
-    font-size: $font-size-xl;
-    margin-bottom: 10px;
+  padding-top: 16px;
+  padding-bottom: 16px;
 
-    @include medium-and-up {
-      display: inline-block;
-      position: relative;
-      bottom: -.15em;
-      margin-right: 5px;
+  .icon {
+    top: 0;
+
+    --footer--copyright--icon-- {
+      fill: $white;
     }
   }
 
-  a --footer--copyright--link-- {
-    color: $white;
-  }
-}
-
-.gp-year {
-  --footer--copyright--year-- {
-    color: $white;
-  }
-  font-size: $font-size-xxs;
-  text-transform: none;
-
-  .icon {
-    top: -.125em;
-  }
-
-  @include medium-and-up {
+  &-wrapper {
     font-size: $font-size-xxs;
+    display: flex;
+    flex-direction: column;
+    text-align: left;
+
+    @include large-and-up {
+      flex-direction: inherit;
+    }
   }
 
-  @include medium-and-up {
-    margin-top: 15px;
-  }
-}
+  &-text {
+    --footer--copyright--text-- {
+      color: $grey-10;
+    }
 
-.site-footer--minimal {
-  padding: 40px 0;
-  line-height: 1;
+    a --footer--copyright--text--link-- {
+      color: $grey-10;
 
-  .footer-social-media {
-    font-size: $font-size-xl;
-    margin: 0 auto $space-md auto;
-    text-align: center;
-    width: max-content;
-
-    @supports (justify-content: space-between) {
-      & {
-        display: flex;
-        justify-content: space-between;
+      &:hover {
+        color: $grey-10;
       }
     }
 
-    li {
-      display: inline-block;
-      margin: 0 16px 0 0;
-    }
-
-    a {
-      transition: color 100ms linear;
-    }
-
-    .list-unstyled {
-      width: 200px;
-    }
-  }
-
-  .gp-year {
     font-size: $font-size-xxs;
-    font-family: $lora;
-    margin: 40px 0 30px 0;
-  }
+    line-height: 1.4;
+    word-break: keep-all;
+    width: auto;
+    margin-bottom: 0;
+    margin-bottom: 12px;
 
-  .icon _-- {
-    fill: $white;
+    &:last-child {
+      margin-bottom: 0;
+    }
+
+    @include large-and-up {
+      margin-bottom: 0;
+
+      &:after {
+        content: "\007C";
+        display: inline-block;
+        margin: 0 14px;
+      }
+
+      &:last-of-type:after {
+        display: none;
+      }
+    }
   }
 }

--- a/assets/src/scss/layout/_footer.scss
+++ b/assets/src/scss/layout/_footer.scss
@@ -2,6 +2,7 @@
   --footer-- {
     font-family: $roboto;
     background: $dark-blue;
+    color: $white;
   }
   padding: 45px 0 $n25;
   position: relative;
@@ -89,67 +90,22 @@
   }
 }
 
-.footer-links,
-.footer-links-secondary {
-  li {
-    line-height: 2rem;
-    @include medium-and-up {
-      display: inline-block;
-
-      &:after {
-        content: "\002F";
-        display: inline-block;
-        margin: 0 16px;
-      }
-
-      &:last-of-type:after {
-        display: none;
-      }
-    }
-
-    @include large-and-up {
-      &:after {
-        margin: 0 24px 0;
-      }
-    }
-  }
-}
-
-.footer-links {
-  --footer-menu-- {
-    color: $white;
-    font-weight: bold;
-    text-transform: uppercase;
-    margin-bottom: 16px;
-  }
+.site-footer__footer-links {
+  margin-bottom: 24px;
+  width: 100%;
+  text-align: left;
+  column-count: 1;
 
   li {
-    font-size: $font-size-md;
+    font-size: $font-size-sm;
+
+    &:not(:last-child) {
+      margin-bottom: 24px;
+    }
   }
 
   @include medium-and-up {
-    font-size: $font-size-sm;
-    margin-bottom: 16px;
-  }
-
-  @include large-and-up {
     font-size: $font-size-md;
-  }
-}
-
-.footer-links-secondary {
-  --footer-menu-secondary-- {
-    color: $grey-10;
-    text-transform: uppercase;
-    margin-bottom: 30px;
-  }
-
-  @include medium-and-up {
-    font-size: $font-size-xxs;
-  }
-
-  @include large-and-up {
-    font-size: $font-size-sm;
   }
 }
 

--- a/assets/src/scss/style.scss
+++ b/assets/src/scss/style.scss
@@ -39,6 +39,7 @@ Text Domain: planet4-master-theme
 @import "layout/cookies";
 @import "layout/cookies-new";
 @import "layout/footer";
+@import "layout/footer-social-media";
 @import "layout/forms";
 @import "layout/navbar";
 @import "layout/page-header";

--- a/templates/footer.twig
+++ b/templates/footer.twig
@@ -1,5 +1,5 @@
 <footer id="footer" class="site-footer site-footer--{{ nav_type }}">
-	<div class="container">
+	<div class="container site-footer__container">
 		{% include 'footer_social_media.twig' %}
 		{% if nav_type != 'minimal' %}
 			<ul class="list-unstyled footer-links">

--- a/templates/footer.twig
+++ b/templates/footer.twig
@@ -2,7 +2,7 @@
 	<div class="container site-footer__container">
 		{% include 'footer_social_media.twig' %}
 		{% if nav_type != 'minimal' %}
-			<ul class="list-unstyled footer-links">
+			<ul class="list-unstyled site-footer__footer-links">
 				{% for primary in footer_primary_menu %}
 					<li>
 						<a href="{{ primary.url }}"
@@ -13,9 +13,7 @@
 						</a>
 					</li>
 				{% endfor %}
-			</ul>
-
-			<ul class="list-unstyled footer-links-secondary">
+				
 				{% for secondary in footer_secondary_menu %}
 					<li>
 						<a href="{{ secondary.url }}"

--- a/templates/footer.twig
+++ b/templates/footer.twig
@@ -26,14 +26,17 @@
 				{% endfor %}
 			</ul>
 		{% endif %}
+	</div>
 
-		<p class="copyright-text col-md-8" role="text">
-			{{ copyright_text_line1|e('wp_kses_post')|raw }}
-		</p>
-
-		<p class="gp-year" role="text">
-			{{ 'creative-commons'|svgicon }}
-			{{ copyright_text_line2|e('wp_kses_post')|raw }} {{"now"|date('Y')}}
-		</p>
+	<div class="site-footer__copyright">
+		<div class="container site-footer__copyright-wrapper">
+			<span class="site-footer__copyright-text" role="text">
+				{{ 'creative-commons'|svgicon }}
+				{{ copyright_text_line2|e('wp_kses_post')|raw }} {{"now"|date('Y')}}
+			</span>
+			<span class="site-footer__copyright-text" role="text">
+				{{ copyright_text_line1|e('wp_kses_post')|raw }}
+			</span>
+		</div>
 	</div>
 </footer>

--- a/templates/footer_social_media.twig
+++ b/templates/footer_social_media.twig
@@ -1,36 +1,40 @@
-<ul class="footer-social-media list-unstyled col-md-8 col-lg-5">
-  {% if social_overrides is defined and social_overrides|length %}
-    {% for social in social_overrides %}
-      <li>
-        <a href="{{ social.url }}"
+{% set total_social_icons = social_overrides is defined and social_overrides|length ? social_overrides|length : footer_social_menu|length %}
+
+<div class="site-footer__social-media site-footer__social-media--{{ nav_type }}">
+  <span class="site-footer__social-media-title">{{ __( 'Follow us', 'planet4-master-theme' ) }}</span>
+  <ul class="site-footer__social-media-list {{ total_social_icons >= 4 and total_social_icons <= 6 ? 'site-footer__social-media-list--justify-space-between' : '' }} list-unstyled">
+    {% if social_overrides is defined and social_overrides|length %}
+      {% for social in social_overrides %}
+        <li>
+          <a href="{{ social.url }}"
             data-ga-category="Footer Navigation"
             data-ga-action="Social Icons"
             data-ga-label="{{ social.icon }}">
-          {{ social.icon|svgicon }}
-          <span class="visually-hidden">{{ social.icon }}</span>
-        </a>
-      </li>
-    {% endfor %}
-  {% else %}
-    {% for social in footer_social_menu %}
-      {% set name = "" %}
-      {% for class_name in social.classes %}
-        {% if 'fa-' in class_name %}
-          {% set name = class_name[3:] %}
-        {% else %}
-          {% set name = class_name %}
-        {% endif %}
+            {{ social.icon|svgicon }}
+            <span class="visually-hidden">{{ social.icon }}</span>
+          </a>
+        </li>
       {% endfor %}
-      <li>
-        {% set social_url = social.url %}
-        <a href="{{ social_url }}"
+    {% else %}
+      {% for social in footer_social_menu %}
+        {% set name = "" %}
+        {% for class_name in social.classes %}
+          {% if 'fa-' in class_name %}
+            {% set name = class_name[3:] %}
+          {% else %}
+            {% set name = class_name %}
+          {% endif %}
+        {% endfor %}
+        <li>
+          <a href="{{ social.url }}"
             data-ga-category="Footer Navigation"
             data-ga-action="Social Icons"
             data-ga-label="{{ social.title }}">
-          {{ name|svgicon }}
-          <span class="visually-hidden">{{ social.title }}</span>
-        </a>
-      </li>
-    {% endfor %}
-  {% endif %}
-</ul>
+            {{ name|svgicon }}
+            <span class="visually-hidden">{{ social.title }}</span>
+          </a>
+        </li>
+      {% endfor %}
+    {% endif %}
+  </ul>
+</div>


### PR DESCRIPTION
This is the new version of the Footer site based in these [versions](https://p4-designsystem.greenpeace.org/05f6e9516/p/16a899-footer).

**What is done.**
- Footer S, M, L and XL
- Minimal Footer S and L. Because we haven't any mockup for minimal's version, we reported it to the Designer and suggested a potential layout and it was approved by Magali. Here is the [thread of the conversation](https://greenpeace-gpi.slack.com/archives/G015K63081W/p1626186385006500)
- Added a new Facebook and Linkedin rounded icons styled by adding this class name  `[social-name]-rounded` format. i.e. `facebook-rounded`.
- Improve the css using BEM for class names.
- Modify class names from footer
- Layout changes

Ref: https://jira.greenpeace.org/browse/PLANET-6189

---

<!--
Please provide a brief summary of the change introduced to make review process easier.

Ideally this should also be part of the commit summary.
-->
