### PR TITLE
Use different class for Cookies A/B test instead of additional one

### DIFF
--- a/assets/src/scss/layout/_cookies-new.scss
+++ b/assets/src/scss/layout/_cookies-new.scss
@@ -16,7 +16,7 @@
   }
 }
 
-.cookie-notice.new-design {
+.cookie-notice-new-design {
   z-index: 100;
   position: fixed;
   width: 100vw;

--- a/assets/src/scss/layout/_cookies.scss
+++ b/assets/src/scss/layout/_cookies.scss
@@ -1,4 +1,4 @@
-.cookie-notice:not(.new-design) {
+.cookie-notice {
   z-index: 100;
   display: flex;
   position: fixed;


### PR DESCRIPTION
### Description

This is to avoid breaking child themes. Initial ticket: [PLANET-6336](https://jira.greenpeace.org/browse/PLANET-6336)

### Testing
You can test this new setup in the [Optimize experiment](https://optimize.google.com/optimize/home/?authuser=0&hl=en-US#/accounts/4701225997/containers/11070199/experiments/150), it should trigger the changes for the A/B test correctly.