### PR TITLE
PLANET-6421 Fix inverted logic of minimal footer

### DIFF
--- a/templates/base.twig
+++ b/templates/base.twig
@@ -41,7 +41,7 @@
 	{% endif %}
 
 	{% block footer %}
-		{% include 'footer.twig' with { 'nav_type' : custom_styles.nav_type == 'planet4' ? 'minimal' : 'default' } %}
+		{% include 'footer.twig' with { 'nav_type' : custom_styles.nav_type } %}
 
 		{% block cookies %}
 			{% include 'cookies.twig' %}


### PR DESCRIPTION
* This caused campaign pages to use the inverse of the navigation
setting for the footer.

Ref: <!-- Please add a url to the ticket this change is addressing. -->

---

<!--
Please provide a brief summary of the change introduced to make review process easier.

Ideally this should also be part of the commit summary.
-->
