### PR TITLE
PLANET-6225 Fix source maps for generated CSS variables

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1956,54 +1956,22 @@
       "dev": true
     },
     "@greenpeace/dashdash": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@greenpeace/dashdash/-/dashdash-1.1.1.tgz",
-      "integrity": "sha512-bFMEtgXBxFTj5Ls3A2GqYn5lu8Cbb+RaN0cIIHv6mgEHcZ1HRDJROud6dHGhcIkdPN+M2cAymr+4MC4t2Q7MVg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@greenpeace/dashdash/-/dashdash-1.1.2.tgz",
+      "integrity": "sha512-C/GyGPfK38xMISQf9vLxg7ffXSv8CiQltGyM5wU/EApvr+p3tOhtIP+FtjDGyj0OGFp11iPRnB15HHAtVGfYLw==",
       "dev": true,
       "requires": {
         "postcss": "^7.0.32"
       },
       "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          },
-          "dependencies": {
-            "supports-color": {
-              "version": "5.5.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-              "dev": true,
-              "requires": {
-                "has-flag": "^3.0.0"
-              }
-            }
-          }
-        },
         "postcss": {
-          "version": "7.0.35",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
-          "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
+          "version": "7.0.38",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.38.tgz",
+          "integrity": "sha512-wNrSHWjHDQJR/IZL5IKGxRtFgrYNaAA/UrkW2WqbtZO6uxSLMxMN+s2iqUMwnAWm3fMROlDYZB41dr0Mt7vBwQ==",
           "dev": true,
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "nanocolors": "^0.2.2",
+            "source-map": "^0.6.1"
           }
         },
         "source-map": {
@@ -2011,15 +1979,6 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
-        },
-        "supports-color": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
         }
       }
     },
@@ -13631,6 +13590,12 @@
       "version": "2.13.2",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
       "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==",
+      "dev": true
+    },
+    "nanocolors": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/nanocolors/-/nanocolors-0.2.12.tgz",
+      "integrity": "sha512-SFNdALvzW+rVlzqexid6epYdt8H9Zol7xDoQarioEFcFN0JHo4CYNztAxmtfgGTVRCmFlEOqqhBpoFGKqSAMug==",
       "dev": true
     },
     "nanomatch": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "devDependencies": {
     "@commitlint/cli": "^12.1.1",
-    "@greenpeace/dashdash": "^1.1.1",
+    "@greenpeace/dashdash": "^1.1.2",
     "@wordpress/components": "^8.3.2",
     "@wordpress/scripts": "3.3.0",
     "autoprefixer": "^9.6.1",


### PR DESCRIPTION
This was fixed in the package previously, but still needed to be bumped here.

To test, inspect an element that uses variables on any page of the test instance, and control + click on a CSS rule that has a generated variable (in Chrome). This should open the sources panel with the right line for the variable selected.

relevant changes: https://github.com/greenpeace/planet4-dashdash/commit/a265f9d64eaea6e1acbf10c7a0e0fec379e796e3#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346R72

Ref:  https://jira.greenpeace.org/browse/PLANET-6225