### PR TITLE
PLANET-6256: Feature toggle for new design activation

### DIFF
--- a/src/Features.php
+++ b/src/Features.php
@@ -26,6 +26,8 @@ class Features {
 
 	public const WP_TEMPLATE_EDITOR = 'wp_template_editor';
 
+	public const NEW_DESIGN_NAVBAR_CS = 'new_design_navbar_cs';
+
 	/**
 	 * Get the features options page settings.
 	 *
@@ -110,6 +112,15 @@ class Features {
 					'planet4-master-theme-backend'
 				),
 				'id'   => self::WP_TEMPLATE_EDITOR,
+				'type' => 'checkbox',
+			],
+			[
+				'name' => __( 'Enable new Navigation bar and Country selector design', 'planet4-master-theme-backend' ),
+				'desc' => __(
+					'Enable the new Navigation bar and country selector designs as described in the <a href="https://p4-designsystem.greenpeace.org/05f6e9516/p/106cdb-navigation-bar" target="_blank">design system</a>.<br/>This might break your child theme, depending on how you extended the main templates and CSS.',
+					'planet4-master-theme-backend'
+				),
+				'id'   => self::NEW_DESIGN_NAVBAR_CS,
 				'type' => 'checkbox',
 			],
 		];


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6256
Ref: https://jira.greenpeace.org/browse/PLANET-6257

![Screenshot from 2021-10-07 10-36-16](https://user-images.githubusercontent.com/617346/136349579-7e9feae5-feed-45e1-9f42-774ee8d95136.png)

New design of __navigation bar__ and __country selector__ are tweaking some templates and CSS.
This change might break some child theme, so we will release those behind a feature toggle first.
After all child themes have been adapted/converted, we will remove this toggle.

This is only a toggle, the code actually using it comes in a different PR. 