### PR TITLE
Revert fix added in Planet-6060

### DIFF
--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -234,14 +234,6 @@ class MasterSite extends TimberSite
             }
         );
 
-        // Set wp-editor in the 'Text' mode by default (Temporary fix for PLANET-6060).
-        add_filter(
-            'wp_default_editor',
-            function () {
-                return 'html';
-            }
-        );
-
         // Disable xmlrpc.
         add_filter('xmlrpc_enabled', '__return_false');
 


### PR DESCRIPTION
As the WP-v5.8 resolved the core issue(https://core.trac.wordpress.org/ticket/52050), no need of this patch.

Ref: [PLANET-6060](https://jira.greenpeace.org/browse/PLANET-6060)

[Old PR](https://github.com/greenpeace/planet4-master-theme/pull/1396)



