### PR TITLE
Build svg sprite into build folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,3 @@ tests/backstop/
 
 # Built css and js assets
 assets/build/*
-
-images/symbol/svg/sprite.symbol.svg

--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -580,7 +580,7 @@ class MasterSite extends TimberSite {
 	 * @param string $name Icon name.
 	 */
 	public function svgicon( $name ) {
-		$svg_icon_template = '<svg viewBox="0 0 32 32" class="icon"><use xlink:href="' . $this->theme_dir . '/images/symbol/svg/sprite.symbol.svg#' . $name . '"></use></svg>';
+		$svg_icon_template = '<svg viewBox="0 0 32 32" class="icon"><use xlink:href="' . $this->theme_dir . '/assets/build/sprite.symbol.svg#' . $name . '"></use></svg>';
 		return new \Twig_Markup( $svg_icon_template, 'UTF-8' );
 	}
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -68,7 +68,7 @@ module.exports = {
         loader: 'svg-sprite-loader',
         options: {
           extract: true,
-          spriteFilename: '../../images/symbol/svg/sprite.symbol.svg',
+          spriteFilename: '../../assets/build/sprite.symbol.svg',
           runtimeCompat: true
         }
       },


### PR DESCRIPTION
We [recently](https://github.com/greenpeace/planet4-master-theme/pull/1464) removed the svg sprint from the code, since it's generated when we build assets in the CI. But our [build script](https://github.com/greenpeace/planet4-builder/blob/91e6e28895d2ad47607604fe037e0129a31c4e9a/src/bin/rewrite_app_repos.sh#L51) only copies over the `assets/build` folder. These made all svg icons disappear from dev instances that were build after the change. Production is not affected, since we create a zip file with the whole theme.

Instead of ajusting the build script and making it more complex, we can just put the svg sprite in the same folder.