### PR TITLE
Remove super large title font-size

### DIFF
--- a/themes/forest.json
+++ b/themes/forest.json
@@ -22,7 +22,6 @@
   "--block-columns--link--font-family": "Open Sans,sans-serif",
   "--button--font-family": "Open Sans,sans-serif",
   "--headings--font-family": "Kanit,sans-serif",
-  "--page-section-header--font-size": "3rem",
   "--block-articles--article--headline--font-weight": "600",
   "--block-articles--article--meta--font-weight": "400",
   "--block-columns--column-heading--font-weight": "600",

--- a/themes/oceans.json
+++ b/themes/oceans.json
@@ -28,7 +28,6 @@
   "--block-articles--article--content--font-size": "14px",
   "--block-articles--article--meta--large-and-up--font-size": "1rem",
   "--block-columns--column-heading--large-and-up--font-size": "24px",
-  "--page-section-header--font-size": "3rem",
   "--block-articles--article--meta--font-style": "normal",
   "--block-articles--article--headline--font-weight": "600",
   "--block-articles--article--meta--font-weight": "800",


### PR DESCRIPTION
* This is currently a single rule for all screen sizes. On desktop it's
clearly much bigger than needed, and on mobile it's so big that the
headings take up the whole screen.

See screenshots on the Jira ticket. The ticket only mentions the "oceans" theme, however the "forest" theme also had the same size, so I also removed it there.

Ref: https://jira.greenpeace.org/browse/PLANET-5026