### PR TITLE
PLANET-5801 Align in-list sitemap links with Design System

### DIFF
--- a/assets/src/scss/base/_colors.scss
+++ b/assets/src/scss/base/_colors.scss
@@ -19,6 +19,7 @@ $blue: #2077bf;
 
 // Link color
 $link-color: #006dfd;
+$link-color-visited: #68009e;
 
 // Yellow
 $yellow: #ffd204;

--- a/assets/src/scss/base/_icons.scss
+++ b/assets/src/scss/base/_icons.scss
@@ -9,19 +9,18 @@
 }
 
 a.pdf-link {
-  &::before {
+  &::after {
     content: "";
-    background-position: center;
-    background-repeat: no-repeat;
-    background-color: var(--link--color, $link-color);
-    mask-image: url("../../images/file-pdf.svg");
-    mask-repeat: no-repeat;
-    mask-position: center;
+    display: inline-block;
     height: 1rem;
     width: 1rem;
     margin-bottom: -2px;
-    margin-inline-end: 2px;
-    display: inline-block;
+    margin-inline-start: .2rem;
+    margin-inline-end: .1rem;
+    background-color: currentColor;
+    mask-image: url("../../images/file-pdf.svg");
+    mask-repeat: no-repeat;
+    mask-position: center;
   }
 
   &:hover::before {
@@ -66,15 +65,15 @@ a.external-link {
   &::after {
     content: "";
     display: inline-block;
-    background-color: var(--link--color, $link-color);
+    height: .7rem;
+    width: .7rem;
+    margin-inline-start: .2rem;
+    margin-inline-end: .1rem;
+    background-color: currentColor;
     mask-image: url("../../images/external-link.svg");
     mask-repeat: no-repeat;
     mask-position: center;
     mask-size: contain;
-    height: .7rem;
-    width: .7rem;
-    margin-inline-start: .3rem;
-    margin-inline-end: .4rem;
   }
 
   &:hover::after {

--- a/assets/src/scss/base/_typography.scss
+++ b/assets/src/scss/base/_typography.scss
@@ -101,8 +101,23 @@ a --link-- {
   color: $link-color;
   text-decoration: none;
 
-  &:hover {
+  &:focus {
+    border: 2px solid rgba(0, 106, 255, 0.4);
+    border-radius: 4px;
+  }
+
+  &:focus-visible {
+    outline: 0;
+  }
+
+  &:hover,
+  &:active {
     color: $link-color;
     text-decoration: underline;
+    border: none;
+  }
+
+  &:visited {
+    color: $link-color-visited;
   }
 }

--- a/assets/src/scss/components/_buttons.scss
+++ b/assets/src/scss/components/_buttons.scss
@@ -30,10 +30,12 @@
 
   &:hover,
   &:focus,
-  &:active {
+  &:active,
+  &:visited {
     color: $white;
     text-decoration: none;
     outline: none;
+    border: none;
   }
 
   &:disabled,

--- a/assets/src/scss/layout/_navbar.scss
+++ b/assets/src/scss/layout/_navbar.scss
@@ -44,6 +44,16 @@ $navbar-default-height: 60px;
     &:hover {
       color: $white;
     }
+
+    &:focus {
+      border: 2px solid rgba(255, 255, 255, 0.4);
+      border-radius: 4px;
+      text-decoration: none;
+    }
+
+    &:active {
+      border: none;
+    }
   }
 
   .donate-nav-item {
@@ -162,15 +172,6 @@ $navbar-default-height: 60px;
 }
 
 // Logo
-//
-// Greenpeace logo.
-//
-// Markup:
-// <a class="site-logo" href="#">
-//   <img src="https://www.greenpeace.org/international/wp-content/themes/planet4-master-theme/images/gp-logo.svg" alt="Greenpeace">
-// </a>
-//
-// Styleguide Style.logo
 .site-logo {
   position: absolute;
   justify-self: center;
@@ -184,6 +185,7 @@ $navbar-default-height: 60px;
 
   &:focus {
     box-shadow: none;
+    border: none;
   }
 
   img {

--- a/assets/src/scss/pages/_sitemap.scss
+++ b/assets/src/scss/pages/_sitemap.scss
@@ -3,6 +3,15 @@
 
   a {
     color: $grey-80;
+    font-family: $roboto;
+
+    &:visited {
+      color: $link-color-visited;
+    }
+  }
+
+  .tag-item {
+    margin-left: 30px;
   }
 
   h5 {

--- a/templates/sitemap.twig
+++ b/templates/sitemap.twig
@@ -6,7 +6,7 @@
 			<div class="row">
 				{% if (actions) %}
 					<div class="col-md-7 order-md-1 col-lg-4">
-						<h5 class="mb-3 mt-5 mt-md-0">{{ actions_title }}</h5>
+						<h5 class="mb-3 mt-5 mt-lg-0">{{ actions_title }}</h5>
 						{% for action in actions %}
 							<a href="{{ action.link }}">{{ action.title|e('wp_kses_post')|raw }}</a><br/>
 						{% endfor %}
@@ -14,12 +14,12 @@
 				{% endif %}
 				{% if (issues) %}
 					<div class="col-md-7 order-md-3 order-lg-2 col-lg-3">
-						<h5 class="mb-3 mt-5 mt-md-0">{{ issues_title }}</h5>
+						<h5 class="mb-3 mt-5 mt-lg-0">{{ issues_title }}</h5>
 						{% for issue in issues %}
 							<a href="{{ issue.link }}">{{ issue.title|e('wp_kses_post')|raw }}</a><br/>
 							{% if ( issue.campaigns ) %}
 								{% for campaign in issue.campaigns %}
-									<a class="tag-item" style="margin-left: 30px;"
+									<a class="tag-item"
 									   href="{{ campaign.link|default('#') }}">
 									   <span aria-label="hashtag">#</span>{{ campaign.name|e('wp_kses_post')|raw }}
 									</a>
@@ -31,7 +31,7 @@
 				{% endif %}
 				{% if (evergreen_pages) %}
 					<div class="col-md-5 order-md-2 order-lg-3 col-lg-3">
-						<h5 class="mb-3 mt-5 mt-md-0">{{ evergreen_title }}</h5>
+						<h5 class="mb-3 mt-5 mt-lg-0">{{ evergreen_title }}</h5>
 						{% for evergreen_page in evergreen_pages %}
 							<a href="{{ evergreen_page.link }}">{{ evergreen_page.title|e('wp_kses_post')|raw }}</a>
 							<br/>
@@ -40,7 +40,7 @@
 				{% endif %}
 				{% if (page_types) %}
 					<div class="col-md-5 order-md-4 col-lg-2">
-						<h5 class="mb-3 mt-5 mt-md-0">{{ page_types_title }}</h5>
+						<h5 class="mb-3 mt-5 mt-lg-0">{{ page_types_title }}</h5>
 						{% for page_type in page_types %}
 							<a href="{{ page_type.link }}">{{ page_type.name|e('wp_kses_post')|raw }}</a><br/>
 						{% endfor %}


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5801

---

- Added active and visited state to main typography rules. According to the Design System, these are used almost in all links.
- Simplify sitemap css. No need for the extra nesting to match the sitemap elements.
- Move sitemap tag-item class to css to add more properties for nested links.

### Testing

1. Check the Sitemap page.
2. Make sure all states align with the [Design System in-list links](https://p4-designsystem.greenpeace.org/05f6e9516/p/266986-links/t/194ec0).