### PR TITLE
PLANET-6189 Reverse footer aligment on RTL

### DIFF
--- a/assets/src/scss/layout/_footer.scss
+++ b/assets/src/scss/layout/_footer.scss
@@ -39,7 +39,7 @@
 
   ul {
     width: 100%;
-    text-align: left;
+    text-align: start;
     column-count: 1;
 
     @include medium-and-up {


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6189

---

Icons work fine because we use display: flex, but for the actual menu stays on the wrong side.