### PR TITLE
Pass _wp_http_referer to ensure correct redirect after password submission

### DIFF
--- a/templates/single-password.twig
+++ b/templates/single-password.twig
@@ -10,7 +10,7 @@
 
 		<div class="container">
 			<div class="post-content">
-				<form id="password-form" class="password-form" action="{{login_url}}?action=postpass" method="post">
+				<form id="password-form" class="password-form" action="{{login_url}}?action=postpass&_wp_http_referer={{ post.link|url_encode }}" method="post">
 					<div class="mb-3">
 						<label for="pwbox-{{post.ID}}" class="form-label"><h6>{{ __( 'To see the content of this page, please enter your password  below', 'planet4-master-theme' ) }}</h6></label>
 						<div class="input-text">


### PR DESCRIPTION
* Otherwise WordPress will use the HTTP_REFERER header, which is
unreliable and might be empty or contain only the domain root.
This is especially problematic in our case because sites are
on a path of the root domain. The root domain itself is a form that
shows you all site options.

You can test on https://www-dev.greenpeace.org/test-sinope/story/47107/which-http-headers-not-to-rely-on/
The password is `HTTP_REFERER`. After entering the password you should see the post.

Ref: https://jira.greenpeace.org/browse/PLANET-6445