### PR TITLE
Restore buttons hover border

### DIFF
--- a/assets/src/scss/components/_buttons.scss
+++ b/assets/src/scss/components/_buttons.scss
@@ -34,8 +34,6 @@
   &:visited {
     color: $white;
     text-decoration: none;
-    outline: none;
-    border: none;
   }
 
   &:disabled,
@@ -87,7 +85,7 @@ $primary-button-box-shadow: 0 2px 5px rgba(0, 0, 0, .25);
     &:active {
       background: $orange-hover;
       color: $white;
-      border-color: $orange-hover;
+      border: 1px solid $orange-hover;
       box-shadow: $primary-button-box-shadow;
     }
 
@@ -181,6 +179,7 @@ $donate-button-box-shadow: 0 2px 5px rgba(0, 0, 0, .25);
       background: $aquamarine;
       color: transparentize($grey-80, 0.2);
       box-shadow: $donate-button-box-shadow;
+      border: 1px solid transparent;
     }
   }
   line-height: 1.65;


### PR DESCRIPTION
We need to change the border property on alternative states for buttons and make it more explicit. 
Otherwise it gets overridden by [typography rules](https://github.com/greenpeace/planet4-master-theme/blob/115d069b89e6c1508207f59f7d7c5a78e1c7e2db/assets/src/scss/base/_typography.scss#L113).