### PR TITLE
opacity hover color to footer social media links

### DIFF
--- a/assets/src/scss/layout/_footer-social-media.scss
+++ b/assets/src/scss/layout/_footer-social-media.scss
@@ -42,7 +42,7 @@
     transition: color 100ms linear;
 
     &:hover {
-      color: $white;
+      color: transparentize($white, .8);
     }
   }
 


### PR DESCRIPTION
Change to opacity color to 80% applied only to social media links


This change was requested by Houssam


Ref: https://jira.greenpeace.org/browse/PLANET-6189

---

<!--
Please provide a brief summary of the change introduced to make review process easier.

Ideally this should also be part of the commit summary.
-->
