### PR TITLE
Convert Take Action Boxout setting to blocks, and remove field

### DIFF
--- a/src/MetaboxRegister.php
+++ b/src/MetaboxRegister.php
@@ -173,17 +173,6 @@ class MetaboxRegister {
 
 		$p4_post->add_field(
 			[
-				'name'             => __( 'Take Action Page Selector', 'planet4-master-theme-backend' ),
-				'desc'             => __( 'Select a Take Action Page to populate take action boxout block', 'planet4-master-theme-backend' ),
-				'id'               => 'p4_take_action_page',
-				'type'             => 'select',
-				'show_option_none' => true,
-				'options_cb'       => [ $this, 'populate_act_page_children_options' ],
-			]
-		);
-
-		$p4_post->add_field(
-			[
 				'name'    => __( 'Include Articles In Post', 'planet4-master-theme-backend' ),
 				'id'      => 'include_articles',
 				'type'    => 'select',
@@ -338,35 +327,6 @@ class MetaboxRegister {
 				],
 			]
 		);
-	}
-
-	/**
-	 * Populate an associative array with all the children of the ACT page
-	 *
-	 * @return array
-	 */
-	public function populate_act_page_children_options() {
-		$parent_act_id = planet4_get_option( 'act_page' );
-		$options       = [];
-
-		if ( 0 !== absint( $parent_act_id ) ) {
-			$take_action_pages_args = [
-				'post_type'        => 'page',
-				'post_parent'      => $parent_act_id,
-				'post_status'      => 'publish',
-				'orderby'          => 'post_title',
-				'order'            => 'ASC',
-				'suppress_filters' => false,
-				'numberposts'      => self::MAX_TAKE_ACTION_PAGES,
-			];
-
-			$posts = get_posts( $take_action_pages_args );
-			foreach ( $posts as $post ) {
-				$options[ $post->ID ] = $post->post_title;
-			}
-		}
-
-		return $options;
 	}
 
 	/**

--- a/src/Migrations/M005TurnBoxoutSettingIntoBlock.php
+++ b/src/Migrations/M005TurnBoxoutSettingIntoBlock.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace P4\MasterTheme\Migrations;
+
+use P4\MasterTheme\MigrationRecord;
+use P4\MasterTheme\MigrationScript;
+use WP_Post;
+
+/**
+ * Add the Take Action Boxout block as a block to all posts that use it with the settings field, and remove field.
+ */
+class M005TurnBoxoutSettingIntoBlock extends MigrationScript {
+
+	private const BOXOUT_META_KEY = 'p4_take_action_page';
+
+	/**
+	 * Perform the actual migration.
+	 *
+	 * @param MigrationRecord $record Information on the execution, can be used to add logs.
+	 *
+	 * @return void
+	 */
+	protected static function execute( MigrationRecord $record ): void {
+		$args = [
+			'posts_per_page' => - 1,
+			'meta_query'     => [
+				[
+					'key'     => self::BOXOUT_META_KEY,
+					'value'   => '',
+					'compare' => 'NOT IN',
+				],
+			],
+		];
+
+		$tab_posts = get_posts( $args );
+		echo 'Converting ' . count( $tab_posts ) . " posts with Take Action Boxout setting to blocks.\n";
+
+		foreach ( $tab_posts as $tab_post ) {
+			// If the post already has a TAB inside, that one took precedence before and only meta cleanup needed.
+			if ( ! has_block( 'planet4-blocks/take-action-boxout', $tab_post ) ) {
+				self::append_boxout_from_meta( $tab_post );
+			}
+			delete_post_meta( $tab_post->ID, self::BOXOUT_META_KEY );
+		}
+	}
+
+	/**
+	 * Add the Take Action Boxout block that is in the meta to the end of the post content.
+	 *
+	 * @param WP_Post $post A post that has a TAB set through its meta.
+	 */
+	private static function append_boxout_from_meta( WP_Post $post ): void {
+		$attrs  = [
+			'take_action_page' => (int) get_post_meta( $post->ID, self::BOXOUT_META_KEY, true ),
+		];
+		$boxout = '<!-- wp:planet4-blocks/take-action-boxout ' . wp_json_encode( $attrs, JSON_UNESCAPED_SLASHES ) . ' /-->';
+
+		$args = [
+			'ID'           => $post->ID,
+			'post_content' => $post->post_content . "\n" . $boxout,
+		];
+
+		wp_update_post( $args );
+	}
+}

--- a/src/Migrator.php
+++ b/src/Migrator.php
@@ -6,6 +6,7 @@ use P4\MasterTheme\Migrations\M001EnableEnFormFeature;
 use P4\MasterTheme\Migrations\M002EnableLazyYoutube;
 use P4\MasterTheme\Migrations\M004UpdateMissingMediaPath;
 use P4\MasterTheme\Migrations\M003UpdateArticlesBlockAttribute;
+use P4\MasterTheme\Migrations\M005TurnBoxoutSettingIntoBlock;
 
 /**
  * Run any new migration scripts and record results in the log.
@@ -28,6 +29,7 @@ class Migrator {
 			M002EnableLazyYoutube::class,
 			M004UpdateMissingMediaPath::class,
 			M003UpdateArticlesBlockAttribute::class,
+			M005TurnBoxoutSettingIntoBlock::class,
 		];
 
 		// Loop migrations and run those that haven't run yet.


### PR DESCRIPTION
Remove the field for the Take Action Boxout and convert existing usages of the field to have the block at the end of the post content.

This should also make it easier to see the actual usage of the block (which is quite a lot).

To test: You can run the migration locally. To run it multiple times you need to remove the migration record, or temporarily exclude [the check](https://github.com/greenpeace/planet4-master-theme/blob/0dbbaa694102bc517d3690389f24afcc54e01fc0/src/MigrationLog.php#L43-L46) for this particular script in code.

You can also check the [workflows of this test instance](https://app.circleci.com/pipelines/github/greenpeace/planet4-test-mars?branch=main).

Ref: https://jira.greenpeace.org/browse/PLANET-6450