### PR TITLE
PLANET-5798 Align contextual navigation links with Design System

### DIFF
--- a/assets/src/scss/layout/_breadcrumbs.scss
+++ b/assets/src/scss/layout/_breadcrumbs.scss
@@ -26,12 +26,17 @@
     font-weight: 400;
     margin-inline-start: -12px;
     margin-inline-end: 8px;
+    color: $link-color;
   }
 
   .tag-item {
     _-- {
       color: $link-color;
       font-weight: 400;
+
+      &:visited {
+        color: $link-color-visited;
+      }
     }
     display: inline-block;
 


### PR DESCRIPTION
### Description

See [PLANET-5798](https://jira.greenpeace.org/browse/PLANET-5798)

Related PR: [plugin-gutenberg-blocks](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/699)

- This PR also includes some code simplifications using `margin-inline-end` (instead of `margin-right`) and `margin-inline-start` (instead of `margin-left`), to remove some RTL-specific lines.
- I've also updated the bullet separator's color from black to blue after confirming with Mag that this was the expected color.

### Testing

You can see the changes on the test-phobos instance, for example:
- The Articles block on the [homepage](https://www-dev.greenpeace.org/test-phobos/)
- The contextual navigation links on these different pages:
  - [Post](https://www-dev.greenpeace.org/test-phobos/story/43455/reimagine-a-better-city-economics-covid-pandemic/)
  - [Act page](https://www-dev.greenpeace.org/test-phobos/act/forests-are-life/)
  - [Tag page](https://www-dev.greenpeace.org/test-phobos/tag/energy-revolution/)
  - [Issue page](https://www-dev.greenpeace.org/test-phobos/explore/nature/) (I think? 😅)
  - I couldn't find an Evergreen page 🤔 