### PR TITLE
Simplify icons color states

### DIFF
--- a/assets/src/scss/base/_icons.scss
+++ b/assets/src/scss/base/_icons.scss
@@ -22,43 +22,6 @@ a.pdf-link {
     mask-repeat: no-repeat;
     mask-position: center;
   }
-
-  &:hover::before {
-    background-color: var(--link--hover--color, $link-color);
-  }
-
-  // Primary buttons
-  &.btn-primary {
-    &::before {
-      background-color: $white;
-    }
-
-    &:hover::before {
-      background-color: $white;
-    }
-  }
-
-  // Secondary buttons
-  &.btn-secondary {
-    &::before {
-      background-color: $dark-blue;
-    }
-
-    &:hover::before {
-      background-color: var(--secondary--link--hover--color, $white);
-    }
-  }
-
-  // Donate button
-  &.btn-donate {
-    &::before {
-      background-color: $grey-80;
-    }
-
-    &:hover::before {
-      background-color: transparentize($grey-80, 0.2);
-    }
-  }
 }
 
 a.external-link {
@@ -74,57 +37,5 @@ a.external-link {
     mask-repeat: no-repeat;
     mask-position: center;
     mask-size: contain;
-  }
-
-  &:hover::after {
-    background-color: var(--link--hover--color, $link-color);
-  }
-}
-
-// Button block, primary style
-.wp-block-button.is-style-cta a.pdf-link {
-  &::before,
-  &:hover::before {
-    background-color: $white;
-  }
-}
-
-// Button block, secondary style
-[class="wp-block-button"],
-.wp-block-button.is-style-secondary {
-  a.pdf-link {
-    &::before {
-      background-color: $dark-blue;
-    }
-
-    &:hover::before {
-      background-color: var(--secondary--link--hover--color, $white);
-    }
-  }
-}
-
-// Button block, donate style
-.wp-block-button.is-style-donate a.pdf-link {
-  &::before {
-    background-color: $grey-80;
-  }
-
-  &:hover::before {
-    background-color: transparentize($grey-80, 0.2);
-  }
-}
-
-// Button block, text color manually set
-.wp-block-button a.has-text-color.pdf-link {
-  &::before,
-  &:hover::before {
-    background-color: $white;
-  }
-
-  &.has-grey-80-color {
-    &::before,
-    &:hover::before {
-      background-color: $grey-80;
-    }
   }
 }


### PR DESCRIPTION
Removed all extra `color` and `background-color` definitions.

Since we currently use `mask-image` and `background-color: currentColor;` on icons they should follow whatever color has the main link element in all states.