### PR TITLE
PLANET-6453 Restore left margin of editor

### DIFF
--- a/assets/src/scss/editorOverrides.scss
+++ b/assets/src/scss/editorOverrides.scss
@@ -21,6 +21,8 @@
 .edit-post-visual-editor {
   .wp-block {
     max-width: 90%;
+    margin-left: auto;
+    margin-right: auto;
   }
 
   li {


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6453

When we added theme.json it resulted in left and right margins not being set on .wp-block, causing the content to be too close to the left edge.

With this change all blocks should respect our previous margin again, except for the image block which needs a separate fix. For example: https://www-dev.greenpeace.org/test-uranus/wp-admin/post.php?post=49909&action=edit

Separate fix on plugin: https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/702/files