### PR TITLE
Upgrade to Boostrap 5.1.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5031,9 +5031,9 @@
       "dev": true
     },
     "bootstrap": {
-      "version": "5.0.0-beta2",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.0.0-beta2.tgz",
-      "integrity": "sha512-e+uPbPHqTQWKyCX435uVlOmgH9tUt0xtjvyOC7knhKgOS643BrQKuTo+KecGpPV7qlmOyZgCfaM4xxPWtDEN/g=="
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.1.3.tgz",
+      "integrity": "sha512-fcQztozJ8jToQWXxVuEyXWW+dSo8AiXWKwiSSrKWsRB/Qt+Ewwza+JWoLKiTuQLaEPhdNAJ7+Dosc9DOIqNy7Q=="
     },
     "brace-expansion": {
       "version": "1.1.11",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "not dead"
   ],
   "dependencies": {
-    "bootstrap": "^5.0.0-beta2",
+    "bootstrap": "^5.1.3",
     "classnames": "^2.2.6",
     "jquery": "^3.5.1",
     "lite-youtube-embed": "^0.1.3",


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6272

---

In theory, no breaking changes are introduced after Beta 2. So this should be a trivial upgrade. But I tested it locally just to make sure everything look as expected. Test instance [visual regression tests](https://1323-238897008-gh.circle-artifacts.com/0/app/backstop_data/html_report/index.html) also seem fine.