### PR TITLE
PLANET-6257: Trigger Clouflare purge on feature toggle

### DIFF
--- a/src/Cloudflare.php
+++ b/src/Cloudflare.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace P4\MasterTheme;
+
+use CF\Integration\DefaultConfig;
+use CF\Integration\DefaultIntegration;
+use CF\Integration\DefaultLogger;
+use CF\WordPress\DataStore;
+use CF\WordPress\WordPressAPI;
+use CF\WordPress\WordPressClientAPI;
+use Generator;
+
+/**
+ * Interactions with Cloudflare API.
+ */
+class Cloudflare {
+
+	/**
+	 * @var WordPressClientAPI
+	 */
+	private $api;
+
+	/**
+	 * @var ?string
+	 */
+	private $zone_id;
+
+	/**
+	 * Initiate api.
+	 */
+	public function __construct() {
+		if ( ! defined( 'CLOUDFLARE_PLUGIN_DIR' ) ) {
+			define( 'CLOUDFLARE_PLUGIN_DIR', WP_PLUGIN_DIR . '/cloudflare/' );
+		}
+		require_once CLOUDFLARE_PLUGIN_DIR . 'vendor/autoload.php';
+
+		// The following is just a copy of the plugin's dependency chain, can probably be improved.
+		$config          = new DefaultConfig( file_get_contents( CLOUDFLARE_PLUGIN_DIR . 'config.json', true ) );
+		$logger          = new DefaultLogger( $config->getValue( 'debug' ) );
+		$data_store      = new DataStore( $logger );
+		$integration_api = new WordPressAPI( $data_store );
+		$integration     = new DefaultIntegration( $config, $integration_api, $data_store, $logger );
+
+		$this->api     = new WordPressClientAPI( $integration );
+		$this->zone_id = $this->api->getZoneTag( get_option( 'cloudflare_cached_domain_name' ) );
+	}
+
+	/**
+	 * Query API to purge given URLs list, by chunks of 30.
+	 * Generates [result, chunk] for each chunk.
+	 *
+	 * @param string[] $urls URLs list.
+	 * @return Generator [(bool) result, (string[]) urls chunk]
+	 */
+	public function purge( array $urls ): Generator {
+		// 30 is Cloudflare's purge api limit.
+		$chunks = array_chunk( $urls, 30 );
+
+		foreach ( $chunks as $chunk ) {
+			yield [
+				$this->api->zonePurgeFiles( $this->zone_id, $chunk ),
+				$chunk,
+			];
+		}
+	}
+
+	/**
+	 * Purge all URLs found by default search.
+	 *
+	 * @return array [result, chunk][]
+	 */
+	public function purge_all() {
+		$urls = self::get_all_urls();
+		return iterator_to_array( $this->purge( $urls ) );
+	}
+
+	/**
+	 * Get all URLs from the instance.
+	 *
+	 * @param array $args Specify post types.
+	 * @return array
+	 */
+	public static function get_all_urls( $args = [] ): array {
+		$post_types = isset( $args['post-types'] )
+			? explode( ',', $args['post-types'] )
+			: [ 'post', 'page', 'campaign' ];
+
+		$ids = get_posts(
+			[
+				'post_type'           => $post_types,
+				'posts_per_page'      => - 1,
+				'post_status'         => 'publish',
+				'ignore_sticky_posts' => 1,
+				'fields'              => 'ids',
+			]
+		);
+
+		return array_map( 'get_permalink', $ids );
+	}
+}

--- a/src/Commands/CloudflarePurge.php
+++ b/src/Commands/CloudflarePurge.php
@@ -2,7 +2,7 @@
 
 namespace P4\MasterTheme\Commands;
 
-use P4\MasterTheme\Cloudflare;
+use P4\MasterTheme\CloudflarePurger;
 use P4\MasterTheme\Features;
 use WP_CLI;
 
@@ -42,7 +42,7 @@ class CloudflarePurge extends Command {
 			return;
 		}
 
-		$cf   = new Cloudflare();
+		$cf   = new CloudflarePurger();
 		$urls = self::get_urls( $assoc_args );
 		WP_CLI::log( 'About to purge ' . count( $urls ) . ' urls.' );
 
@@ -70,7 +70,10 @@ class CloudflarePurge extends Command {
 		}
 
 		if ( isset( $assoc_args['all'] ) ) {
-			return Cloudflare::get_all_urls( $assoc_args );
+			$post_types = ! empty( $assoc_args['post-types'] )
+				? explode( ',', $assoc_args['post-types'] )
+				: null;
+			return CloudflarePurger::get_all_urls( $post_types );
 		}
 
 		throw new \RuntimeException( 'Please provide either --urls, or purge all urls with --all.' );

--- a/src/Features.php
+++ b/src/Features.php
@@ -26,7 +26,7 @@ class Features {
 
 	public const WP_TEMPLATE_EDITOR = 'wp_template_editor';
 
-	public const NEW_DESIGN_NAVBAR_CS = 'new_design_navbar_cs';
+	public const NEW_DESIGN_CS = 'new_design_country_selector';
 
 	/**
 	 * Get the features options page settings.
@@ -34,7 +34,6 @@ class Features {
 	 * @return array Settings for the options page.
 	 */
 	public static function get_options_page(): array {
-
 		return [
 			'title'       => 'Features',
 			'fields'      => self::get_fields(),
@@ -115,12 +114,12 @@ class Features {
 				'type' => 'checkbox',
 			],
 			[
-				'name' => __( 'Enable new Navigation bar and Country selector design', 'planet4-master-theme-backend' ),
+				'name' => __( 'Enable new Country selector design', 'planet4-master-theme-backend' ),
 				'desc' => __(
-					'Enable the new Navigation bar and country selector designs as described in the <a href="https://p4-designsystem.greenpeace.org/05f6e9516/p/106cdb-navigation-bar" target="_blank">design system</a>.<br/>This might break your child theme, depending on how you extended the main templates and CSS.',
+					'Enable the new Country selector design as described in the <a href="https://p4-designsystem.greenpeace.org/05f6e9516/p/106cdb-navigation-bar" target="_blank">design system</a>.<br/>This might break your child theme, depending on how you extended the main templates and CSS.<br/>Changing this option will take a bit of time, as it also attempts to clear the Cloudflare cache.',
 					'planet4-master-theme-backend'
 				),
-				'id'   => self::NEW_DESIGN_NAVBAR_CS,
+				'id'   => self::NEW_DESIGN_CS,
 				'type' => 'checkbox',
 			],
 		];
@@ -151,5 +150,33 @@ class Features {
 		$features = get_option( Settings::KEY );
 
 		return isset( $features[ $name ] ) && $features[ $name ];
+	}
+
+	/**
+	 * Add hooks related to Features activation
+	 */
+	public static function hooks() {
+		add_action(
+			'cmb2_save_field',
+			__CLASS__ . '::on_field_save',
+			10,
+			4
+		);
+	}
+
+	/**
+	 * Hook running after field is saved
+	 *
+	 * @param string     $field_id The current field id paramater.
+	 * @param bool       $updated  Whether the metadata update action occurred.
+	 * @param string     $action   Action performed. Could be "repeatable", "updated", or "removed".
+	 * @param CMB2_Field $field    This field object.
+	 */
+	public static function on_field_save( $field_id, $updated, $action, $field ) {
+		if ( self::NEW_DESIGN_CS === $field_id ) {
+			if ( 'removed' === $action || 'updated' === $action ) {
+				( new Cloudflare() )->purge_all();
+			}
+		}
 	}
 }

--- a/src/Features.php
+++ b/src/Features.php
@@ -26,7 +26,7 @@ class Features {
 
 	public const WP_TEMPLATE_EDITOR = 'wp_template_editor';
 
-	public const NEW_DESIGN_CS = 'new_design_country_selector';
+	public const NEW_DESIGN_COUNTRY_SELECTOR = 'new_design_country_selector';
 
 	/**
 	 * Get the features options page settings.
@@ -119,7 +119,7 @@ class Features {
 					'Enable the new Country selector design as described in the <a href="https://p4-designsystem.greenpeace.org/05f6e9516/p/106cdb-navigation-bar" target="_blank">design system</a>.<br/>This might break your child theme, depending on how you extended the main templates and CSS.<br/>Changing this option will take a bit of time, as it also attempts to clear the Cloudflare cache.',
 					'planet4-master-theme-backend'
 				),
-				'id'   => self::NEW_DESIGN_CS,
+				'id'   => self::NEW_DESIGN_COUNTRY_SELECTOR,
 				'type' => 'checkbox',
 			],
 		];
@@ -173,9 +173,9 @@ class Features {
 	 * @param CMB2_Field $field    This field object.
 	 */
 	public static function on_field_save( $field_id, $updated, $action, $field ) {
-		if ( self::NEW_DESIGN_CS === $field_id ) {
+		if ( self::NEW_DESIGN_COUNTRY_SELECTOR === $field_id ) {
 			if ( 'removed' === $action || 'updated' === $action ) {
-				( new Cloudflare() )->purge_all();
+				( new CloudflarePurger() )->purge_all();
 			}
 		}
 	}

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -412,6 +412,8 @@ class Settings {
 		if ( function_exists( 'is_plugin_active' ) && is_plugin_active( 'sitepress-multilingual-cms/sitepress.php' ) ) {
 			add_action( 'init', [ $this, 'make_settings_multilingual' ] );
 		}
+
+		Features::hooks();
 	}
 
 	/**


### PR DESCRIPTION
Necessary for https://jira.greenpeace.org/browse/PLANET-6257

Since the new designs hidden behind toggle features change some markup of the frontend,
we have to purge the relevant Cloudflare cache when we switch those features.

## Changes 

- Toggle is now only for Country Selector, as it can be released by itself
- Extract Cloudflare purge execution from command
- Run purge on Country Selector feature toggle

## Test

Purge command should still work as expected
```console
> wp p4-cf-purge --urls='https://planet4.test/'
About to purge 1 urls.
Chunk 0: ok

> wp p4-cf-purge --all
About to purge 1402 urls.
Chunk 0: ok
...
Chunk 46: ok
```