### PR TITLE
PLANET-6008 Button and link focus outline

### DIFF
--- a/assets/src/scss/base/_typography.scss
+++ b/assets/src/scss/base/_typography.scss
@@ -117,3 +117,7 @@ a --link-- {
     color: $link-color-visited;
   }
 }
+
+a:focus:not(:focus-visible) {
+  outline: 0;
+}

--- a/assets/src/scss/base/_typography.scss
+++ b/assets/src/scss/base/_typography.scss
@@ -102,7 +102,7 @@ a --link-- {
   text-decoration: none;
 
   &:focus {
-    border: 2px solid rgba(0, 106, 255, 0.4);
+    outline: 2px solid rgba(0, 106, 255, 0.4);
     border-radius: 4px;
   }
 
@@ -116,8 +116,4 @@ a --link-- {
   &:visited {
     color: $link-color-visited;
   }
-}
-
-a:focus-visible {
-  outline: 0;
 }

--- a/assets/src/scss/base/_typography.scss
+++ b/assets/src/scss/base/_typography.scss
@@ -110,7 +110,6 @@ a --link-- {
   &:active {
     color: $link-color;
     text-decoration: underline;
-    border: none;
   }
 
   &:visited {

--- a/assets/src/scss/base/_typography.scss
+++ b/assets/src/scss/base/_typography.scss
@@ -103,6 +103,7 @@ a --link-- {
 
   &:focus {
     outline: 2px solid rgba(0, 106, 255, 0.4);
+    outline-offset: 2px;
     border-radius: 4px;
   }
 

--- a/assets/src/scss/components/_buttons.scss
+++ b/assets/src/scss/components/_buttons.scss
@@ -13,6 +13,7 @@
 
     &:focus {
       outline: 2px solid rgba(0, 106, 255, 0.4);
+      outline-offset: 2px;
     }
   }
 

--- a/assets/src/scss/components/_buttons.scss
+++ b/assets/src/scss/components/_buttons.scss
@@ -17,6 +17,10 @@
     }
   }
 
+  &:focus:not(:focus-visible) {
+    outline: 0;
+  }
+
   *, &::before, &:after {
     transition-property: inherit;
     transition-duration: inherit;

--- a/assets/src/scss/components/_buttons.scss
+++ b/assets/src/scss/components/_buttons.scss
@@ -10,6 +10,10 @@
     transition-property: color, background-color, border-color;
     transition-duration: 150ms;
     transition-timing-function: linear;
+
+    &:focus {
+      outline: 2px solid rgba(0, 106, 255, 0.4);
+    }
   }
 
   *, &::before, &:after {
@@ -29,7 +33,6 @@
   appearance: none;
 
   &:hover,
-  &:focus,
   &:active,
   &:visited {
     color: $white;
@@ -51,7 +54,6 @@
     color: $grey-80 !important;
 
     &:hover,
-    &:focus,
     &:active {
       color: $grey-80 !important;
     }
@@ -81,7 +83,6 @@ $primary-button-box-shadow: 0 2px 5px rgba(0, 0, 0, .25);
     box-shadow: $primary-button-box-shadow;
 
     &:hover,
-    &:focus,
     &:active {
       background: $orange-hover;
       color: $white;
@@ -111,8 +112,7 @@ $primary-button-box-shadow: 0 2px 5px rgba(0, 0, 0, .25);
       color: $dark-blue;
     }
 
-    &:hover,
-    &:focus {
+    &:hover {
       background: $dark-blue;
       border-color: $dark-blue;
       color: $white;
@@ -149,8 +149,7 @@ $primary-button-box-shadow: 0 2px 5px rgba(0, 0, 0, .25);
   border-color: $white;
   box-shadow: 0 2px 5px rgba(0, 0, 0, .25);
 
-  &:hover,
-  &:focus {
+  &:hover {
     background-color: $orange;
     border-color: $orange;
   }
@@ -174,8 +173,7 @@ $donate-button-box-shadow: 0 2px 5px rgba(0, 0, 0, .25);
     border-width: 1px;
     border-color: transparent;
 
-    &:hover,
-    &:focus {
+    &:hover {
       background: $aquamarine;
       color: transparentize($grey-80, 0.2);
       box-shadow: $donate-button-box-shadow;
@@ -199,7 +197,6 @@ $donate-button-box-shadow: 0 2px 5px rgba(0, 0, 0, .25);
     background-color: transparent;
 
     &:hover,
-    &:focus,
     &:active {
       color: $white;
       box-shadow: none;
@@ -227,8 +224,7 @@ $donate-button-box-shadow: 0 2px 5px rgba(0, 0, 0, .25);
   position: relative;
   font-weight: 400;
 
-  &:hover,
-  &:focus {
+  &:hover {
     background-color: $dark-blue;
     border-color: $dark-blue;
   }
@@ -252,10 +248,6 @@ $donate-button-box-shadow: 0 2px 5px rgba(0, 0, 0, .25);
   border: transparent;
   padding: 0;
   cursor: pointer;
-
-  &:focus {
-    outline: none;
-  }
 }
 
 button.load-more-mt {

--- a/assets/src/scss/components/_share-buttons.scss
+++ b/assets/src/scss/components/_share-buttons.scss
@@ -32,7 +32,6 @@
     display: inline-block;
     font-size: $font-size-md;
     opacity: 0.9;
-    outline: none;
     width: 4rem;
     text-align: center;
     line-height: 2.7rem;

--- a/assets/src/scss/layout/_navbar.scss
+++ b/assets/src/scss/layout/_navbar.scss
@@ -78,10 +78,20 @@ $navbar-default-height: 60px;
   a, .btn, input {
     &:focus {
       --top-navigation--ui-controls-- {
-        outline: 2px solid rgba(255, 255, 255, 0.4);
+        outline-color: rgba(255, 255, 255, 0.4);
       }
-      // Need to undo the bootstrap outline-offset to get a consistent result.
-      outline-offset: 2px;
+    }
+  }
+
+  // Override bootstrap's default form styles because it's not accessible in the navbar.
+  // Instead use the same outline style as buttons, with offset.
+  #search_input:focus {
+    outline-style: solid;
+    outline-width: 2px;
+    outline-offset: 2px;
+
+    &:not(:focus-visible) {
+      outline: 0;
     }
   }
 }

--- a/assets/src/scss/layout/_navbar.scss
+++ b/assets/src/scss/layout/_navbar.scss
@@ -326,11 +326,6 @@ $navbar-default-height: 60px;
       @include medium-and-up {
         height: $menu-height-large;
       }
-
-      &:focus,
-      &:hover {
-        outline: 1px dotted transparentize($white, 0.5);
-      }
     }
 
     &::before {

--- a/assets/src/scss/layout/_navbar.scss
+++ b/assets/src/scss/layout/_navbar.scss
@@ -47,7 +47,6 @@ $navbar-default-height: 60px;
     }
 
     &:focus {
-      border: 2px solid rgba(255, 255, 255, 0.4);
       border-radius: 4px;
       text-decoration: none;
     }
@@ -75,6 +74,16 @@ $navbar-default-height: 60px;
       top: 32px;
     }
   }
+
+  a, .btn, input {
+    &:focus {
+      --top-navigation--ui-controls-- {
+        outline: 2px solid rgba(255, 255, 255, 0.4);
+      }
+      // Need to undo the bootstrap outline-offset to get a consistent result.
+      outline-offset: 0;
+    }
+  }
 }
 
 .site-logo,
@@ -100,7 +109,6 @@ $navbar-default-height: 60px;
 .nav-link {
   &.active,
   &:hover,
-  &:focus,
   &:active {
     text-decoration: none;
     box-shadow: none;
@@ -321,7 +329,7 @@ $navbar-default-height: 60px;
 
       &:focus,
       &:hover {
-        border: 1px dotted transparentize($white, 0.5);
+        outline: 1px dotted transparentize($white, 0.5);
       }
     }
 
@@ -445,7 +453,6 @@ $navbar-default-height: 60px;
         min-width: 20%;
 
         &:hover,
-        &:focus,
         &:active {
           border-bottom-color: $white;
         }

--- a/assets/src/scss/layout/_navbar.scss
+++ b/assets/src/scss/layout/_navbar.scss
@@ -462,6 +462,10 @@ $navbar-default-height: 60px;
           border-bottom-color: $white;
         }
       }
+
+      &:focus:not(:focus-visible) {
+        border-radius: 0;
+      }
     }
 
     .active .nav-link --nav-link-active-- {

--- a/assets/src/scss/layout/_navbar.scss
+++ b/assets/src/scss/layout/_navbar.scss
@@ -81,7 +81,7 @@ $navbar-default-height: 60px;
         outline: 2px solid rgba(255, 255, 255, 0.4);
       }
       // Need to undo the bootstrap outline-offset to get a consistent result.
-      outline-offset: 0;
+      outline-offset: 2px;
     }
   }
 }


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6008

---

This PR also includes a fix for the regular link focus state, making it also use `outline` instead of `border` to avoid changing the layout dimensions.

The PR adds the same outline as links to buttons, and removes all the other `:focus` styles, which were always the same as the hover styles.

Still investigating:
- (Probably a separate ticket/PR) We don't have a ticket for adding the focus state around images that are a link, however it could be an improvement to include those. If you check an articles block and focus through its links, it's odd to have no indication of where your tab landed for the image only. Check video below.
- ~~The current navigation background makes the focus color almost invisible around the donate button. For the new design it's only an issue for the dark variant, and maybe it's less there.~~ I simplified the code to use the same focus color on all elements in the navigation bar.

I removed the previous videos from this PR description as they didn't have a offset, might add new ones.

