### PR TITLE
Allow onload script attribute in posts

### DIFF
--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -667,6 +667,7 @@ class MasterSite extends TimberSite {
 			'src'    => true,
 			'id'     => true,
 			'data-*' => true,
+			'onload' => true,
 		];
 
 		// Allow source tag for WordPress audio shortcode to function.


### PR DESCRIPTION
Editors can add some scripts to posts using the html block. Some of those scripts require an `onload` attribute to run.
This attribute is not currently allowed in posts, although it works properly in pages.

## Test

- Add a post with a custom HTML block, insert this tag in the block:
```
<script src="https://wspieram.greenpeace.pl/2030/greenpeace2030counter.js" onload="window.greenpeace2030counter();"></script>
```
- The counter should appear on the post on the frontend side

![Screenshot from 2021-10-27 13-40-50](https://user-images.githubusercontent.com/617346/139058813-3781db08-f1df-405e-98e5-ebaaaca0f5dc.png)

