### PR TITLE
PLANET-5796 Add title attribute to PDF and external links

### DIFF
--- a/assets/src/js/external_links.js
+++ b/assets/src/js/external_links.js
@@ -1,3 +1,5 @@
+const { __ } = wp.i18n;
+
 export const setupExternalLinks = () => {
   const siteURL = window.location.host;
 
@@ -14,5 +16,10 @@ export const setupExternalLinks = () => {
 
     link.target = link.target ? link.target : '';
     link.classList.add('external-link');
+
+    const url = new URL(link.href);
+    const domain = url.hostname.replace('www.','');
+
+    link.title = __('This link will lead you to ' + domain, 'planet4-master-theme');
   });
 };

--- a/assets/src/js/pdf_icon.js
+++ b/assets/src/js/pdf_icon.js
@@ -1,3 +1,5 @@
+const { __ } = wp.i18n;
+
 // Add pdf icon to pdf links
 export const setupPDFIcon = () => {
   const links = [...document.querySelectorAll('a[href*=".pdf"]:not(.search-result-item-headline):not(.cover-card-heading)')];
@@ -15,5 +17,6 @@ export const setupPDFIcon = () => {
     }
 
     link.classList.add('pdf-link');
+    link.title = __('This link will open a PDF file', 'planet4-master-theme');
   });
 };


### PR DESCRIPTION
### Description

See https://jira.greenpeace.org/browse/PLANET-5796

The other tasks listed in the ticket were already taken care of in previous tickets.

### Testing

Add an external link and a PDF link to a page and make sure that the corresponding titles are properly displayed. You can also test them on [this page](https://www-dev.greenpeace.org/test-jupiter/story/45719/the-un-in-bed-with-corporate-multinationals-that-put-profits-over-people/) that I set up for UAT 🙂 