### PR TITLE
PLANET-5797 Align standalone links with the design system

### DIFF
--- a/assets/src/scss/base/_icons.scss
+++ b/assets/src/scss/base/_icons.scss
@@ -8,6 +8,23 @@
   transition: fill .3s;
 }
 
+a.standalone-link {
+  &::after {
+    content: "";
+    pointer-events: none;
+    margin-inline-start: .2rem;
+    height: .7rem;
+    width: .7rem;
+    display: inline-block;
+    mask-image: url("../../images/chevron.svg");
+    mask-repeat: no-repeat;
+    mask-size: contain;
+    mask-position: center;
+    background-repeat: no-repeat;
+    background-color: currentColor;
+  }
+}
+
 a.pdf-link {
   &::after {
     content: "";

--- a/images/chevron.svg
+++ b/images/chevron.svg
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   width="60"
+   height="100"
+   viewBox="0 0 60 100"
+   version="1.1"
+   id="svg11">
+  <metadata
+     id="metadata17">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>chevron next_10</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs15" />
+  <title
+     id="title2">chevron next_10</title>
+  <g
+     id="Icons"
+     stroke="none"
+     stroke-width="1"
+     fill="none"
+     fill-rule="evenodd"
+     transform="matrix(10.204064,0,0,10.204064,-6.2244264,-7.6526277)">
+    <g
+       transform="translate(-138,-86)"
+       fill="#020202"
+       fill-rule="nonzero"
+       id="Chevrons">
+      <g
+         transform="translate(47.75,78.749959)"
+         id="g7">
+        <g
+           id="next"
+           transform="translate(1)">
+          <g
+             id="chevron-next_10"
+             transform="translate(90,8)">
+            <path
+               d="M 0.16036093,0.25426674 0.1224871,0.3050634 c -0.18826104,0.27721052 -0.15703097,0.65035888 0.082538,0.8899278 L 3.9099999,4.8996165 0.2050263,8.6050406 c -0.2733682,0.2733682 -0.2733682,0.7165836 -1.2e-6,0.9899507 0.27336701,0.273367 0.71658249,0.273367 0.9899495,0 l 4.2,-4.2 c 0.273367,-0.2733671 0.273367,-0.7165825 0,-0.9899495 l -4.2,-4.20000004 -0.053075,-0.0479706 C 0.86490778,-0.06884722 0.45956714,-0.04950027 0.2050251,0.20504176 Z"
+               id="Shape-Copy-4" />
+          </g>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
### Description

See https://jira.greenpeace.org/browse/PLANET-5797

I've also changed the class name to `standalone-link` rather than `call-to-action-link` since I think it makes more sense.

Related PR: [plugin-gutenberg-blocks](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/705)

### Testing

On local, you can add a Columns block and test the standalone links in Icons and Images styles. Or you can check out [this page](https://www-dev.greenpeace.org/test-uranus/standalone-links-tests/) I made for UAT 🙂 