### PR TITLE
PLANET-5799 Align search results title color with design system

### DIFF
--- a/assets/src/scss/pages/search/_search-results.scss
+++ b/assets/src/scss/pages/search/_search-results.scss
@@ -181,7 +181,9 @@
     font-size: 1.625rem;
   }
 
-  &:visited {
+  &:visited,
+  &:hover,
+  &:active {
     color: $grey-80;
   }
 }


### PR DESCRIPTION
### Description

See https://jira.greenpeace.org/browse/PLANET-5799

When working on this ticket, it seems that some occurrences of the search results component were not properly updated, for instance the press releases or stories pages.

### Testing

Make sure the title links behave as expected in the fixed version (in the broken one, they become blue on hover):
- [Broken](https://www-dev.greenpeace.org/test-uranus/story/)
- [Fixed](https://www-dev.greenpeace.org/test-jupiter/story/)