### PR TITLE
PLANET-6455 Add filter to catch core bug removing gradients

### DIFF
--- a/assets/src/js/external_links.js
+++ b/assets/src/js/external_links.js
@@ -7,6 +7,9 @@ export const setupExternalLinks = () => {
   const links = [...document.querySelectorAll(linkSelector)];
 
   links.forEach(link => {
+    if (link.matches('#action-card *')) {
+      return;
+    }
     // We don't want to show the icon in headings/titles,
     // or in links that are images
     const text = link.textContent || link.innerText;


### PR DESCRIPTION
* Core did not take the case into account where a background-image is
not only a gradient. As a result gradient + URL combination gets
stripped out.
* Workaround: add filter that checks the remainder of the
$css_test_string. This string is progressively dismantled with stuff
they don't want to perform the check for certain characters on by WP
core. So if we remove a gradient from this and only a comma is left,
it's probably valid CSS.

Ref: https://jira.greenpeace.org/browse/PLANET-6455

TODO:
* ~~There still seems to be an issue with the scrolling script which I didn't have locally but is persistent on the test instance. We can merge this PR already but that issue might need to be fixed to fully use it as a reusable block.~~ It was just in the other repo, so created a PR there as well to address that https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/708/files