### PR TITLE
PLANET-6006 Remove Gallery carousel indicator active color

### DIFF
--- a/assets/src/scss/base/_colors.scss
+++ b/assets/src/scss/base/_colors.scss
@@ -51,7 +51,6 @@ $whatsapp: #25d366;
 $light-blue-bg:         #d6e6f2;
 
 // Colors to be fixed/addressed:
-$carousel-indi-color:   #8bcc49;
 $cookie-bkg:            #c0dbe2;
 
 // Table/spreadsheet colors


### PR DESCRIPTION
### Description

See https://jira.greenpeace.org/browse/PLANET-6006
The changes requested for this ticket made this color redundant, so we can remove it 🎉 

Related PR: [plugin-gutenberg-blocks](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/711)

### Testing

You can test the new Gallery carousel in all screen sizes on [this page](https://www-dev.greenpeace.org/test-atlas/act/sail-aboard-a-greenpeace-ship/) for example, or you can simply add one to a page on local 🙂 