### PR TITLE
Revert "PLANET-6006 Remove Gallery carousel indicator active color"

### DIFF
--- a/assets/src/scss/base/_colors.scss
+++ b/assets/src/scss/base/_colors.scss
@@ -51,6 +51,7 @@ $whatsapp: #25d366;
 $light-blue-bg:         #d6e6f2;
 
 // Colors to be fixed/addressed:
+$carousel-indi-color:   #8bcc49;
 $cookie-bkg:            #c0dbe2;
 
 // Table/spreadsheet colors


### PR DESCRIPTION
Reverts greenpeace/planet4-master-theme#1506

I misread the PR and thought it could be merged, but it depends on a non merged PR in the other repo.