### PR TITLE
PLANET-6430: Carousel Header - CTA button is not editable in Safari

### DIFF
--- a/assets/src/scss/editorOverrides.scss
+++ b/assets/src/scss/editorOverrides.scss
@@ -240,3 +240,8 @@ input.describe[type=text][data-setting=caption] {
   font-size: 13px;
   line-height: 1.5;
 }
+
+// Allow button edition via click on Safari
+.btn {
+  user-select: auto;
+}


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6430

A CSS definition from [bootstrap on class `.btn`](https://github.com/twbs/bootstrap-sass/blob/b34765d8a6aa775816c59012b2d6b30c4c66a8e9/assets/stylesheets/bootstrap/_buttons.scss#L21) prevents CTA button from being editable on Safari.

## Test

You need __Safari on MacOS__ to test this issue.
Has to be tested with https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/725

- Edit a page, add a Carousel header, try to edit the CTA button text:
  - On main branch, clicking on the CTA button doesn't have any effect,
  - With this branch, a click makes a caret appear and text is editable.