### PR TITLE
Keep tests folder on zip creation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -336,7 +336,7 @@ jobs:
           command: npm run build
       - run:
           name: Remove unnecessary files
-          command: rm -rf .circleci .git .githooks assets/src bin tests
+          command: rm -rf .circleci .git .githooks assets/src bin
       - run:
           name: Inject version to composer
           command: |


### PR DESCRIPTION
We need that in order to run acceptance tests on production pipelines.

To verify check [this production pipeline](https://app.circleci.com/pipelines/github/greenpeace/planet4-base/1239/workflows/b244446a-2d89-4460-a821-9c403d885f7c/jobs/6845):
1. Open the `Run tests` job.
2. Check lines 5-6. `rsync` syncs nothing because the `tests/` folder is missing.