### PR TITLE
Fix space between breadcrumb tags

### DIFF
--- a/assets/src/scss/layout/_breadcrumbs.scss
+++ b/assets/src/scss/layout/_breadcrumbs.scss
@@ -25,6 +25,10 @@
       }
     }
     display: inline-block;
+
+    &:not(:only-child):not(:last-child):not(.page-type) {
+      margin-inline-end: 8px;
+    }
   }
 
   .tag-item--main {


### PR DESCRIPTION
This was removed in a previous commit causing tags to be too close to each other (eg. in the Articles block).

According to the [Design System](https://p4-designsystem.greenpeace.org/05f6e9516/v/15009/p/835f95-post-page/i/40590918), these still need some space in between.

