### PR TITLE
POC Matching custom country selector background using theme config file

### DIFF
--- a/src/PostCampaign.php
+++ b/src/PostCampaign.php
@@ -29,6 +29,7 @@ class PostCampaign {
 		'campaign_body_font',
 		'campaign_footer_theme',
 		'footer_links_color',
+		'country-selector--countries-list--background',
 	];
 
 	public const LEGACY_THEMES = [

--- a/templates/footer.twig
+++ b/templates/footer.twig
@@ -1,5 +1,5 @@
 <footer id="footer" class="site-footer site-footer--{{ nav_type }}">
-	{% if new_design_country_selector and nav_type != 'minimal' %}
+	{% if new_design_country_selector %}
 	<div id="country-selector" class="footer-country-selector">
 		{% include 'footer_country_selector.twig' %}
 	</div>

--- a/theme_options/climate.json
+++ b/theme_options/climate.json
@@ -71,19 +71,40 @@
 			],
 			"default": "minimal"
 		},
-		{
-			"id": "campaign_nav_color",
-			"dependsOn": "campaign_nav_type",
-			"configurations": {
-				"minimal": {
-					"options": [
-						{ "value": "#ffffff" },
-						{ "value": "#000000" },
-						{ "value": "#ff513c" },
-						{ "value": "#007eff" },
+    {
+      "id": "campaign_nav_color",
+      "dependsOn": "campaign_nav_type",
+      "configurations": {
+        "minimal": {
+          "options": [
+            { "value": "#ffffff" },
+            { "value": "#000000" },
+            { "value": "#ff513c" },
+            { "value": "#007eff" },
             { "value": "#66cc00" }
-					],
-					"default": "#ff513c"
+          ],
+          "default": "#ff513c"
+        }
+      }
+    },
+		{
+			"id": "country-selector--countries-list--background",
+			"dependsOn": "campaign_nav_color",
+			"configurations": {
+        "#ffffff": {
+          "default": "#ffffff"
+        },
+        "#000000": {
+          "default": "#404040"
+        },
+        "#ff513c": {
+          "default": "#ce6c61"
+        },
+        "#007eff": {
+          "default": "#4197ef"
+        },
+				"#66cc00": {
+					"default": "#5e9f1e"
 				}
 			}
 		},


### PR DESCRIPTION
Use the configuration file to set another color on the country list depending on the color chosen for the navigation.

I only set this up on the `climate` theme.

Example page: https://www-dev.greenpeace.org/test-sinope/campaign/climate-emergency/

This is mostly a POC to verify the config file can be used in this way.

In fact I found out that the current campaign page themes don't need a variable, because they only change the colors if the minimal navigation is selected. In that case the country selector is not displayed.

We still use a separate meta field for every CSS variable, which is annoying because they all need to be registered for the rest API. If we would address this, then we can add similar dependent fields by only adding them to the config file.