### PR TITLE
Disable initial results, do ajax on page load

### DIFF
--- a/assets/src/js/search.js
+++ b/assets/src/js/search.js
@@ -69,38 +69,43 @@ export const setupSearch = function($) {
     $( 'input[name^="f["]' ).prop( 'checked', false );
     $search_form.submit();
   });
+  function loadMore(total_posts, posts_per_load, next_page) {
+    $(this).data( 'current_page', next_page );
 
+    $.ajax({
+      url: localizations.ajaxurl,
+      type: 'GET',
+      data: {
+        action:          'get_paged_posts',
+        'search-action': 'get_paged_posts',
+        'search_query':  $( '#search_input' ).val().trim(),
+        'paged':         next_page,
+        'orderby': $( '#orderby', $search_form ).val(),
+        'query-string':  decodeURIComponent( location.search ).substr( 1 ) // Ignore the ? in the search url (first char).
+      },
+      dataType: 'html'
+    }).done(( response ) => {
+      // Append the response at the bottom of the results and then show it.
+      $( '.multiple-search-result .list-unstyled' ).append( response );
+      $( '.row-hidden:last' ).removeClass( 'row-hidden' ).show( 'fast' );
+
+      if (posts_per_load * next_page > total_posts) {
+        $load_more_button.hide();
+      }
+    }).fail(( jqXHR, textStatus, errorThrown ) => {
+      console.log(errorThrown); //eslint-disable-line no-console
+    });
+  }
+
+  const total_posts = $load_more_button.data('total_posts');
+  const posts_per_load = $load_more_button.data('posts_per_load');
+
+  loadMore(total_posts, posts_per_load, 0);
   // Add click event for load more button in blocks.
   $load_more_button.off( 'click' ).on( 'click', function() {
     if ( $(this).hasClass( 'btn-load-more-async' ) ) {
-      const total_posts    = $(this).data('total_posts');
-      const posts_per_load = $(this).data('posts_per_load');
       const next_page      = $(this).data( 'current_page' ) + 1;
-      $(this).data( 'current_page', next_page );
-
-      $.ajax({
-        url: localizations.ajaxurl,
-        type: 'GET',
-        data: {
-          action:          'get_paged_posts',
-          'search-action': 'get_paged_posts',
-          'search_query':  $( '#search_input' ).val().trim(),
-          'paged':         next_page,
-          'orderby': $( '#orderby', $search_form ).val(),
-          'query-string':  decodeURIComponent( location.search ).substr( 1 ) // Ignore the ? in the search url (first char).
-        },
-        dataType: 'html'
-      }).done(( response ) => {
-        // Append the response at the bottom of the results and then show it.
-        $( '.multiple-search-result .list-unstyled' ).append( response );
-        $( '.row-hidden:last' ).removeClass( 'row-hidden' ).show( 'fast' );
-
-        if (posts_per_load * next_page > total_posts) {
-          $load_more_button.hide();
-        }
-      }).fail(( jqXHR, textStatus, errorThrown ) => {
-        console.log(errorThrown); //eslint-disable-line no-console
-      });
+      loadMore(total_posts, posts_per_load, next_page);
     } else {
       const $row = $( '.row-hidden', $load_more_button.closest( '.container' ) );
 

--- a/templates/search.twig
+++ b/templates/search.twig
@@ -359,15 +359,12 @@
 								{% set displayed_posts = posts %}
 							{% endif %}
 							<ul class="list-unstyled">
-								{% for post in displayed_posts %}
-									{% include ['tease-search.twig', 'tease-'~post.post_type~'.twig', 'tease.twig'] %}
-								{% endfor %}
 							</ul>
-							{% if ( load_more and found_posts > paged_posts|length ) %}
+							{% if ( load_more ) %}
 								<div class="col-lg-12 mb-5 load-more-button-div">
 									<button
 										class="btn btn-secondary more-btn {{ load_more.async ? 'btn-load-more-async' : '' }} btn-load-more-click-scroll"
-										data-current_page="{{ current_page }}"
+										data-current_page="-1"
 										data-total_posts="{{ found_posts }}"
 										data-posts_per_load="{{ load_more.posts_per_load }}"
 										data-ga-category="Search Page"


### PR DESCRIPTION
* Quick POC to check if loading Ajax exclusively is tricky. Seems like
it's not, I just had to move some parameters and a function.
* This will allow us to remove a large part of the search code, related
to the initial page.

<!-- Ref: Please add a url to the ticket this change is addressing.

---

Please provide a brief summary of the change introduced to make review process easier.

Ideally this should also be part of the commit summary.
-->
