### PR TITLE
Move palette classes to separate file

### DIFF
--- a/assets/src/scss/base/_colors.scss
+++ b/assets/src/scss/base/_colors.scss
@@ -72,29 +72,3 @@ $table-header-blue: $dark-blue;
 $table-odd-row-blue: #c9e7fa;
 $table-even-row-blue: #e7f5fe;
 $table-footer-blue: #c3d7e2;
-
-// Allower colors for blocks palette
-$palette: (
-  "grey-80": $grey-80,
-  "grey-60": $grey-60,
-  "grey-40": $grey-40,
-  "grey-20": $grey-20,
-  "grey-10": $grey-10,
-  "grey": $grey,
-  "gp-green": $gp-green,
-  "x-dark-blue": $x-dark-blue,
-  "dark-blue": $dark-blue,
-  "blue": $blue,
-  "orange-hover": $orange-hover,
-  "yellow": $yellow
-);
-
-@each $name, $color in $palette {
-  .has-#{$name}-color {
-    color: $color;
-  }
-
-  .has-#{$name}-background-color {
-    background-color: $color;
-  }
-}

--- a/assets/src/scss/base/_palette.scss
+++ b/assets/src/scss/base/_palette.scss
@@ -1,0 +1,25 @@
+// Allower colors for blocks palette
+$palette: (
+  "grey-80": $grey-80,
+  "grey-60": $grey-60,
+  "grey-40": $grey-40,
+  "grey-20": $grey-20,
+  "grey-10": $grey-10,
+  "grey": $grey,
+  "gp-green": $gp-green,
+  "x-dark-blue": $x-dark-blue,
+  "dark-blue": $dark-blue,
+  "blue": $blue,
+  "orange-hover": $orange-hover,
+  "yellow": $yellow
+);
+
+@each $name, $color in $palette {
+  .has-#{$name}-color {
+    color: $color;
+  }
+
+  .has-#{$name}-background-color {
+    background-color: $color;
+  }
+}

--- a/assets/src/scss/editorStyle.scss
+++ b/assets/src/scss/editorStyle.scss
@@ -6,6 +6,7 @@
 
 @import "base/variables";
 @import "base/colors";
+@import "base/palette";
 @import "base/functions";
 @import "base/mixins";
 @import "base/fonts";

--- a/assets/src/scss/style.scss
+++ b/assets/src/scss/style.scss
@@ -14,6 +14,7 @@ Text Domain: planet4-master-theme
 // Base
 @import "base/variables";
 @import "base/colors";
+@import "base/palette";
 @import "base/functions";
 @import "base/mixins";
 @import "base/fonts";


### PR DESCRIPTION
The classes for the palette were being duplicated by every entry point that included it, because it looked as though the file only contained SASS variable definitions.

I moved those to a separate file which is imported only in the front end and editor style entry points.

This needs to be bumped in the plugin as submodule.