### PR TITLE
Restore loading order of country selector CSS

### DIFF
--- a/src/PublicAssets.php
+++ b/src/PublicAssets.php
@@ -28,7 +28,7 @@ final class PublicAssets {
 		wp_enqueue_style(
 			'parent-style',
 			$theme_dir . '/assets/build/style.min.css',
-			[ 'bootstrap', 'country-selector' ],
+			[ 'bootstrap' ],
 			$css_creation
 		);
 


### PR DESCRIPTION
I did a last minute change for the loading order in [this PR](https://github.com/greenpeace/planet4-master-theme/pull/1521), but didn't check enough, it breaks a few things. Since the loading order is only a problem once child themes start adapting, we can merge this fix already to unblock deploy.