### PR TITLE
Add container class to page-template elements

### DIFF
--- a/assets/src/scss/pages/_page.scss
+++ b/assets/src/scss/pages/_page.scss
@@ -1,28 +1,4 @@
 div.page-template {
-  width: 540px;
-  max-width: 100%;
-  margin-left: auto;
-  margin-right: auto;
-  padding: 0 16px;
-
-  @include medium-and-up {
-    width: 720px;
-    padding: 0;
-  }
-
-  @include large-and-up {
-    width: 960px;
-  }
-
-  @include x-large-and-up {
-    font-size: 1.125rem;
-    width: 1140px;
-  }
-
-  @include xx-large-and-up {
-    width: 1320px;
-  }
-
   > * {
     position: relative;
     z-index: 2;

--- a/assets/src/scss/pages/post/_post.scss
+++ b/assets/src/scss/pages/post/_post.scss
@@ -88,11 +88,6 @@
     border-top: 1px solid transparentize($grey-20, 0.5);
     padding-top: 16px;
 
-    > .container {
-      padding-left: 0;
-      padding-right: 0;
-    }
-
     @include medium-and-up {
       padding-top: 24px;
     }

--- a/templates/author.twig
+++ b/templates/author.twig
@@ -28,7 +28,7 @@
 		</div>
 	</header>
 
-	<div class="page-template">
+	<div class="page-template container">
 		<h3>{{ __( 'Posts by ', 'planet4-master-theme' ) }} {{ author.name }}</h3>
 
 		<div class="row">

--- a/templates/evergreen.twig
+++ b/templates/evergreen.twig
@@ -1,7 +1,7 @@
 {% extends "base.twig" %}
 
 {% block content %}
-	<div class="page-template">
+	<div class="page-template container">
 		{{ post.content|raw }}
 	</div>
 {% endblock %}

--- a/templates/page.twig
+++ b/templates/page.twig
@@ -1,7 +1,7 @@
 {% extends "base.twig" %}
 
 {% block content %}
-	<div class="page-template {% if hide_page_title_checkbox == 'on' %}no-page-title{% endif %}">
+	<div class="page-template container {% if hide_page_title_checkbox == 'on' %}no-page-title{% endif %}">
 		{{ post.content|raw }}
 	</div>
 {% endblock %}

--- a/templates/single-campaign.twig
+++ b/templates/single-campaign.twig
@@ -1,7 +1,7 @@
 {% extends "base.twig" %}
 
 {% block content %}
-	<div class="page-template {% if hide_page_title_checkbox == 'on' %}no-page-title{% endif %}">
+	<div class="page-template container {% if hide_page_title_checkbox == 'on' %}no-page-title{% endif %}">
 		{{ post.content|raw }}
 	</div>
 {% endblock %}

--- a/templates/single-page.twig
+++ b/templates/single-page.twig
@@ -5,7 +5,7 @@
 		<div class="page-header-background"></div>
 	</div>
 
-	<div class="page-template">
+	<div class="page-template container">
 
 		<form id="password-form" class="password-form" action="{{login_url}}?action=postpass" method="post">
 			<div class="mb-3">

--- a/templates/tag.twig
+++ b/templates/tag.twig
@@ -26,7 +26,7 @@
 		</div>
 	</div>
 
-	<div class="page-template">
+	<div class="page-template container">
 		{% for name, block in blocks %}
 			{{ fn('do_blocks', block )|raw }}
 		{% endfor %}

--- a/templates/taxonomy.twig
+++ b/templates/taxonomy.twig
@@ -14,7 +14,7 @@
 		</div>
 	</header>
 
-	<div class="page-template">
+	<div class="page-template container">
 		<h3>{{ __( 'Results', 'planet4-master-theme' ) }}</h3>
 
 		<div class="row">


### PR DESCRIPTION
### Description

We have some content width/padding issues in pages on mobile, which are due to our blocks having the `container` class but not the "non-blocks" items (paragraphs for example). Also because of this we had to manually add the page width to the `page-template` element, which doesn't make sense since we use the same ones as Bootstrap anyway so we might as well use that directly 🙂 So a solution would be to remove the `container` class from the blocks (except full-width ones) (done in [this PR](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/737)) and add it to the `page-template` div instead.

### Testing

You can see the new layout in this [test instance](https://www-dev.greenpeace.org/test-uranus), everything should look pretty much the same except with a bit less padding than before on mobile. In all screen sizes, all elements (blocks and non-blocks) of the page content should be aligned.