### PR TITLE
Load master-theme partial styles before any child-theme

### DIFF
--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -121,6 +121,7 @@ class MasterSite extends TimberSite {
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_admin_assets' ] );
 		// Load the editor scripts only enqueuing editor scripts while in context of the editor.
 		add_action( 'enqueue_block_editor_assets', [ $this, 'enqueue_editor_assets' ] );
+		// Load main theme assets before any child theme.
 		add_action( 'wp_enqueue_scripts', [ PublicAssets::class, 'enqueue' ] );
 		add_filter( 'safe_style_css', [ $this, 'set_custom_allowed_css_properties' ] );
 		add_filter( 'wp_kses_allowed_html', [ $this, 'set_custom_allowed_attributes_filter' ], 10, 2 );

--- a/src/PublicAssets.php
+++ b/src/PublicAssets.php
@@ -23,14 +23,14 @@ final class PublicAssets {
 			Loader::theme_file_ver( 'assets/build/bootstrap.min.css' )
 		);
 
-		self::conditionally_load_partials();
 		// This loads a linked style file since the relative images paths are outside the build directory.
 		wp_enqueue_style(
 			'parent-style',
 			$theme_dir . '/assets/build/style.min.css',
-			[ 'bootstrap', 'country-selector' ],
+			[ 'bootstrap' ],
 			$css_creation
 		);
+		self::conditionally_load_partials();
 
 		$jquery_should_wait = is_plugin_active( 'planet4-plugin-gutenberg-blocks/planet4-gutenberg-blocks.php' ) && ! is_user_logged_in();
 
@@ -82,6 +82,6 @@ final class PublicAssets {
 	private static function conditionally_load_partials(): void {
 		$country_selector_version = Features::is_active( Features::NEW_DESIGN_COUNTRY_SELECTOR ) ? 'new' : 'old';
 		$country_selector_file    = '/assets/build/country-selector-' . $country_selector_version . '.min.css';
-		Loader::enqueue_versioned_style( $country_selector_file, 'country-selector' );
+		Loader::enqueue_versioned_style( $country_selector_file, 'country-selector', [ 'parent-style' ] );
 	}
 }


### PR DESCRIPTION
Prioritize master-theme styles enqueue, so that the cascading order is stable.

Action `wp_enqueue_scripts` is used without any priority, and because the child-theme `functions.php` file is loaded before the master-theme one, its styles are enqueued before any style it does not declare as a dependency.
Adding a priority 0 to master-theme enqueue fixes the issue.

_Before fix, the child theme css loads before the country-selector one, which can lead to overwriting child theme rules_
![Screenshot from 2021-11-24 08-38-58](https://user-images.githubusercontent.com/617346/143195430-bb270749-932e-4ce3-b6ba-9e66f5cf593d.png)

_After fix, the country-selector style loads with master-theme main style file_
![Screenshot from 2021-11-24 08-38-10](https://user-images.githubusercontent.com/617346/143195529-b02c1a55-a229-4435-ac7b-ac9d9d71313b.png)

edit: Adding a priority < 10 makes some unit tests fail (`Trying to get property 'queue' of non-object` on global `$wp_styles` in function `wp_maybe_inline_styles()`), so we keep the default priority for now and will ask child themes to use a higher one.
