### PR TITLE
Faster update command for data sync to test instances

### DIFF
--- a/src/Commands.php
+++ b/src/Commands.php
@@ -8,6 +8,7 @@ namespace P4\MasterTheme;
 use P4\MasterTheme\Commands\CloudflarePurge;
 use P4\MasterTheme\Commands\RunActivator;
 use P4\MasterTheme\Commands\SaveCloudflareKey;
+use P4\MasterTheme\Commands\FixOrphans;
 
 /**
  * Class with a static function just because PHP can't autoload functions.
@@ -23,5 +24,6 @@ class Commands {
 		RunActivator::register();
 		SaveCloudflareKey::register();
 		CloudflarePurge::register();
+		FixOrphans::register();
 	}
 }

--- a/src/Commands/FixOrphans.php
+++ b/src/Commands/FixOrphans.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace P4\MasterTheme\Commands;
+
+use WP_CLI;
+
+/**
+ * Class PostUpdate
+ *
+ * @example wp p4-post fix-orphans
+ */
+class FixOrphans extends Command {
+	/**
+	 * The name to access the command.
+	 *
+	 * @return string The command name.
+	 */
+	protected static function get_name(): string {
+		return 'p4-post fix-orphans';
+	}
+
+	/**
+	 * The description shown in the argument's help.
+	 *
+	 * @return string The description text.
+	 */
+	protected static function get_short_description(): string {
+		return 'Assign admin user to orphan objects';
+	}
+
+	/**
+	 * Update wp_posts data
+	 *
+	 * @param array|null $args Positional arguments.
+	 * @param array|null $assoc_args Named arguments.
+	 */
+	public static function execute( ?array $args, ?array $assoc_args ): void {
+		global $wpdb;
+
+		$admin = get_users( [ 'role' => 'administrator' ] )[0];
+		if ( ! $admin ) {
+			WP_CLI::error( 'No admin user found.' );
+		}
+
+		WP_CLI::log( 'Assigning orphans to admin user ' . $admin->ID . '.' );
+
+		$wpdb->query(
+			$wpdb->prepare(
+				'UPDATE wp_posts SET post_author=%d WHERE
+				post_type in ("post", "page", "campaign", "attachment")
+				AND post_author NOT IN ( SELECT ID from wp_users )',
+				$admin->ID
+			)
+		);
+
+		WP_CLI::success( 'Job done, ' . $wpdb->rows_affected . ' objects were updated.' );
+	}
+}


### PR DESCRIPTION
The [command used to fix post authors](https://github.com/greenpeace/planet4-builder/blob/main/src/bin/sync_to_test_site.sh#L95-L97) during data sync takes a ridiculous amount of time. (approx 1.7sec per post, more than 20 min for 800 posts)
It makes some data sync fail: https://app.circleci.com/pipelines/github/greenpeace/planet4-test-pandora/209/workflows/6d9e5226-aada-47f3-aa55-45b96820a1cb/jobs/1108
Some others take 40 minutes: https://app.circleci.com/pipelines/github/greenpeace/planet4-test-pandora/152/workflows/4096c607-bc6c-48b7-bda8-aa84c5ee3ed9/jobs/773

Using a simple batch request and bypassing other update ripples should only take a few seconds in total.