### PR TITLE
Fix footer icons to inherit hover color

### DIFF
--- a/assets/src/scss/layout/_footer.scss
+++ b/assets/src/scss/layout/_footer.scss
@@ -24,7 +24,7 @@
     color: inherit;
 
     &:hover {
-      color: $white;
+      color: inherit;
     }
   }
 


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6486

---

This way hover works again, as defined in `_footer-social-media`. We could remove this whole block, but maybe some campaign themes are using this to override colors.