### PR TITLE
Replace page-template with page-content as its main class

### DIFF
--- a/assets/src/js/external_links.js
+++ b/assets/src/js/external_links.js
@@ -3,7 +3,7 @@ const { __ } = wp.i18n;
 export const setupExternalLinks = () => {
   const siteURL = window.location.host;
 
-  const linkSelector = ['div.page-template', 'article'].map(sel=>`${sel} a:not(.btn):not(.cover-card-heading):not(.wp-block-button__link):not([href*="${siteURL}"]):not([href*=".pdf"]):not([href^="/"]):not([href^="#"]):not([href^="javascript:"])`).join(', ');
+  const linkSelector = ['.page-content', 'article'].map(sel=>`${sel} a:not(.btn):not(.cover-card-heading):not(.wp-block-button__link):not([href*="${siteURL}"]):not([href*=".pdf"]):not([href^="/"]):not([href^="#"]):not([href^="javascript:"])`).join(', ');
   const links = [...document.querySelectorAll(linkSelector)];
 
   links.forEach(link => {

--- a/assets/src/scss/layout/_tables.scss
+++ b/assets/src/scss/layout/_tables.scss
@@ -56,6 +56,6 @@
 }
 
 .post-content,
-.page-template {
+.page-content {
   @include table;
 }

--- a/assets/src/scss/pages/_evergreen.scss
+++ b/assets/src/scss/pages/_evergreen.scss
@@ -15,7 +15,7 @@
     }
   }
 
-  .page-template {
+  .page-content {
     > {
       p, blockquote,
       h1, h2, h3, h4, h5, h6,

--- a/assets/src/scss/pages/_page.scss
+++ b/assets/src/scss/pages/_page.scss
@@ -1,4 +1,4 @@
-div.page-template {
+.page-content {
   > * {
     position: relative;
     z-index: 2;
@@ -47,7 +47,7 @@ div.page-template {
 }
 
 .single-campaign {
-  .page-template {
+  .page-content {
     > p:last-child {
       margin-bottom: $space-xxl;
     }

--- a/templates/author.twig
+++ b/templates/author.twig
@@ -28,7 +28,7 @@
 		</div>
 	</header>
 
-	<div class="page-template container">
+	<div class="page-content container">
 		<h3>{{ __( 'Posts by ', 'planet4-master-theme' ) }} {{ author.name }}</h3>
 
 		<div class="row">

--- a/templates/evergreen.twig
+++ b/templates/evergreen.twig
@@ -1,7 +1,7 @@
 {% extends "base.twig" %}
 
 {% block content %}
-	<div class="page-template container">
+	<div class="page-content container">
 		{{ post.content|raw }}
 	</div>
 {% endblock %}

--- a/templates/page.twig
+++ b/templates/page.twig
@@ -1,7 +1,7 @@
 {% extends "base.twig" %}
 
 {% block content %}
-	<div class="page-template container {% if hide_page_title_checkbox == 'on' %}no-page-title{% endif %}">
+	<div class="page-content container {% if hide_page_title_checkbox == 'on' %}no-page-title{% endif %}">
 		{{ post.content|raw }}
 	</div>
 {% endblock %}

--- a/templates/single-campaign.twig
+++ b/templates/single-campaign.twig
@@ -1,7 +1,7 @@
 {% extends "base.twig" %}
 
 {% block content %}
-	<div class="page-template container {% if hide_page_title_checkbox == 'on' %}no-page-title{% endif %}">
+	<div class="page-content container {% if hide_page_title_checkbox == 'on' %}no-page-title{% endif %}">
 		{{ post.content|raw }}
 	</div>
 {% endblock %}

--- a/templates/single-page.twig
+++ b/templates/single-page.twig
@@ -5,7 +5,7 @@
 		<div class="page-header-background"></div>
 	</div>
 
-	<div class="page-template container">
+	<div class="page-content container">
 
 		<form id="password-form" class="password-form" action="{{login_url}}?action=postpass" method="post">
 			<div class="mb-3">

--- a/templates/tag.twig
+++ b/templates/tag.twig
@@ -26,7 +26,7 @@
 		</div>
 	</div>
 
-	<div class="page-template container">
+	<div class="page-content container">
 		{% for name, block in blocks %}
 			{{ fn('do_blocks', block )|raw }}
 		{% endfor %}

--- a/templates/taxonomy.twig
+++ b/templates/taxonomy.twig
@@ -14,7 +14,7 @@
 		</div>
 	</header>
 
-	<div class="page-template container">
+	<div class="page-content container">
 		<h3>{{ __( 'Results', 'planet4-master-theme' ) }}</h3>
 
 		<div class="row">


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5321

---

Although we use this in many places, it seems the more sane option to replace this one instead of "hacking" WP's default Page post type body classes array. It's also consistent with Post post type, where we use `.post-content` for the same purpose.

### Testing

No visual change should be noticeable in the frontend. Surprisingly even the visual regression tests in this PR [passed](https://1658-251234573-gh.circle-artifacts.com/0/app/backstop_data/html_report/index.html).