### PR TITLE
Ensure a separate size is always created

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -183,3 +183,5 @@ add_filter(
 	10,
 	2
 );
+
+simple_value_filter( 'wp_image_resize_identical_dimensions', true );


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6372

* ~~It seems there's a bug in case you upload an image that is exactly
2560px wide. In that case for WPML sites the Carousel Header block gets
a non CDN URL, i.e. the PHP server's wp-uploads folder. This folder is
not persistent.~~

### Possible related issue on WP stateless plugin: https://github.com/udx/wp-stateless/issues/596
This probably explains why in the media detail page for the affected images you get a 404 link to the original. While this is not a big problem by itself (unless we would need the original to regenerate sizes in the future), ~~it's probably related to the issue of this size using a non CDN URL~~ (turns out this is not the case).