### PR TITLE
Fix template error on navbar with multilingual site

### DIFF
--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -480,7 +480,7 @@ class MasterSite extends TimberSite {
 	 * @return mixed
 	 */
 	public function add_to_context( $context ) {
-		global $wp, $sitepress;
+		global $wp;
 		$context['cookies']      = [
 			'text' => planet4_get_option( 'cookies_field' ),
 		];
@@ -494,9 +494,6 @@ class MasterSite extends TimberSite {
 		];
 		$context['domain']       = 'planet4-master-theme';
 		$context['foo']          = 'bar';   // For unit test purposes.
-		if ( function_exists( 'icl_get_languages' ) ) {
-			$context['languages'] = count( icl_get_languages() );
-		}
 
 		$menu                         = new TimberMenu( 'navigation-bar-menu' );
 		$menu_items                   = $menu->get_items();
@@ -507,7 +504,10 @@ class MasterSite extends TimberSite {
 				return ! in_array( 'wpml-ls-item', $item->classes ?? [], true );
 			}
 		);
-		$context['languages']         = $sitepress ? $sitepress->get_ls_languages() : [];
+
+		$languages                 = function_exists( 'icl_get_languages' ) ? icl_get_languages() : [];
+		$context['site_languages'] = $languages;
+		$context['languages']      = count( $languages ); // Keep this variable name as long as NRO themes use it.
 
 		$context['site']         = $this;
 		$context['current_url']  = home_url( $wp->request );

--- a/templates/navigation-bar-new.twig
+++ b/templates/navigation-bar-new.twig
@@ -99,8 +99,8 @@
 				<span class="visually-hidden">{{ __( 'Clear search', 'planet4-master-theme' ) }}</span>
 			</button>
 		</form>
-		{% if languages is not empty %}
-			{% set current_lang = languages|filter(i => i.active)|first %}
+		{% if site_languages is not empty %}
+			{% set current_lang = site_languages|filter(i => i.active)|first %}
 			<button class="nav-languages-toggle" type="button"
 				aria-label="{{ __( 'Choose language', 'planet4-master-theme' ) }}"
 				aria-expanded="false"
@@ -109,7 +109,7 @@
 			>{{ current_lang.code|capitalize }}</button>
 			<nav id="nav-languages" class="nav-languages">
 				<ul>
-				{% for key,item in languages %}
+				{% for key,item in site_languages %}
 				<li class="nav-item {{ item.active ? 'current-language' : '' }}">
 					<a class="nav-link" href="{{ item.url }}">{{ item.native_name }}</a>
 					<span aria-hidden="true">&nbsp;|&nbsp;</span>


### PR DESCRIPTION
A variable `languages` used in the new navbar template is overwriting another one already used in the current template, which triggers a Twig error on local environment for multilingual sites ( cf https://app.circleci.com/pipelines/github/greenpeace/planet4-docker-compose/787/workflows/5864e815-50ec-47b6-b7bc-df3d98065ba3/jobs/2009 )

## Fix

This variable is used by the current code and other NRO templates overrides, so we're keeping the variable as it is and renaming the new one as ~`languages_list`~ `site_languages`.

## Test

Building a new multilingual site should show a twig error on the homepage
```shell
> git clone git@github.com:greenpeace/planet4-docker-compose.git pdc-fixnavbartpl
> cd pdc-fixnavbartpl
> NRO_NAME=greenland NRO_DB_VERSION=latest make nro-from-release
```
![Screenshot from 2021-12-10 10-40-30](https://user-images.githubusercontent.com/617346/145552477-0f50a25b-e1b3-4131-b5b1-bf29566a9986.png)

_(Any asset error is unrelated and fixable with `make deps`)_

Applying the fix:
```shell
> (cd persistence/app/public/wp-content/themes/planet4-master-theme && \
git fetch origin && \
git reset --hard origin/fix-navbartpl-language-error)
```

The old and the new navbar should work without template error.