### PR TITLE
Fix main & partial styles enqueue order

### DIFF
--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -122,7 +122,7 @@ class MasterSite extends TimberSite {
 		// Load the editor scripts only enqueuing editor scripts while in context of the editor.
 		add_action( 'enqueue_block_editor_assets', [ $this, 'enqueue_editor_assets' ] );
 		// Load main theme assets before any child theme.
-		add_action( 'wp_enqueue_scripts', [ PublicAssets::class, 'enqueue' ] );
+		add_action( 'wp_enqueue_scripts', [ PublicAssets::class, 'enqueue' ], 0 );
 		add_filter( 'safe_style_css', [ $this, 'set_custom_allowed_css_properties' ] );
 		add_filter( 'wp_kses_allowed_html', [ $this, 'set_custom_allowed_attributes_filter' ], 10, 2 );
 		add_action( 'add_meta_boxes', [ $this, 'add_meta_box_search' ] );

--- a/src/PublicAssets.php
+++ b/src/PublicAssets.php
@@ -10,27 +10,10 @@ final class PublicAssets {
 	 * Load styling and behaviour on website pages.
 	 */
 	public static function enqueue(): void {
-		$theme_dir = get_template_directory_uri();
 		// master-theme assets.
-		$css_creation = filectime( get_template_directory() . '/assets/build/style.min.css' );
-		$js_creation  = filectime( get_template_directory() . '/assets/build/index.js' );
+		self::enqueue_css();
 
-		// CSS files.
-		wp_enqueue_style(
-			'bootstrap',
-			$theme_dir . '/assets/build/bootstrap.min.css',
-			[],
-			Loader::theme_file_ver( 'assets/build/bootstrap.min.css' )
-		);
-
-		// This loads a linked style file since the relative images paths are outside the build directory.
-		wp_enqueue_style(
-			'parent-style',
-			$theme_dir . '/assets/build/style.min.css',
-			[ 'bootstrap' ],
-			$css_creation
-		);
-		self::conditionally_load_partials();
+		$js_creation = filectime( get_template_directory() . '/assets/build/index.js' );
 
 		$jquery_should_wait = is_plugin_active( 'planet4-plugin-gutenberg-blocks/planet4-gutenberg-blocks.php' ) && ! is_user_logged_in();
 
@@ -46,6 +29,7 @@ final class PublicAssets {
 			true
 		);
 
+		$theme_dir = get_template_directory_uri();
 		// Variables reflected from PHP to the JS side.
 		$localized_variables = [
 			// The ajaxurl variable is a global js variable defined by WP itself but only for the WP admin
@@ -70,6 +54,39 @@ final class PublicAssets {
 			1,
 			true
 		);
+	}
+
+	/**
+	 * Enqueue theme styles.
+	 *
+	 * Drop enqueuing styles if main file is not built.
+	 */
+	private static function enqueue_css() {
+		$css_file = get_template_directory() . '/assets/build/style.min.css';
+		if ( ! file_exists( $css_file ) ) {
+			//phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+			trigger_error( 'File ' . esc_url( $css_file ) . ' does not exist or is not accessible.' );
+			return;
+		}
+
+		$theme_dir = get_template_directory_uri();
+		// CSS files.
+		wp_enqueue_style(
+			'bootstrap',
+			$theme_dir . '/assets/build/bootstrap.min.css',
+			[],
+			Loader::theme_file_ver( 'assets/build/bootstrap.min.css' )
+		);
+
+		// This loads a linked style file since the relative images paths are outside the build directory.
+		wp_enqueue_style(
+			'parent-style',
+			$theme_dir . '/assets/build/style.min.css',
+			[ 'bootstrap' ],
+			filectime( $css_file )
+		);
+
+		self::conditionally_load_partials();
 	}
 
 	/**


### PR DESCRIPTION
`master-theme` styles are loaded after `child-theme` styles in some situations.
This leads to style overrides in an unexpected order.

Follows: https://github.com/greenpeace/planet4-master-theme/pull/1525

## Fix
Mostly changing a default priority, and moving some enqueue code to skip it if the right file is not there.

- Ensure master-theme styles are enqueued before any child-theme style, by adding priority 0.
  Most child-themes are enqueuing their styles with priority 99, but some have no priority or priority 10, which interferes with our default priority.
- Fix unit tests by dropping style enqueue if the main style is not built.
  Unit tests are currently testing some frontend features and trigger styles inclusion, but they run without assets built. This way of testing triggers errors down the Timber chain that make those tests fail.

## Test
_From #1525_

_Before fix, the child theme css loads before the country-selector one, which can lead to overwriting child theme rules_
![Screenshot from 2021-11-24 08-38-58](https://user-images.githubusercontent.com/617346/143195430-bb270749-932e-4ce3-b6ba-9e66f5cf593d.png)

_After fix, the country-selector style loads with master-theme main style file_
![Screenshot from 2021-11-24 08-38-10](https://user-images.githubusercontent.com/617346/143195529-b02c1a55-a229-4435-ac7b-ac9d9d71313b.png)