### PR TITLE
Restore js enqueue order

### DIFF
--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -122,7 +122,8 @@ class MasterSite extends TimberSite {
 		// Load the editor scripts only enqueuing editor scripts while in context of the editor.
 		add_action( 'enqueue_block_editor_assets', [ $this, 'enqueue_editor_assets' ] );
 		// Load main theme assets before any child theme.
-		add_action( 'wp_enqueue_scripts', [ PublicAssets::class, 'enqueue' ], 0 );
+		add_action( 'wp_enqueue_scripts', [ PublicAssets::class, 'enqueue_css' ], 0 );
+		add_action( 'wp_enqueue_scripts', [ PublicAssets::class, 'enqueue_js' ] );
 		add_filter( 'safe_style_css', [ $this, 'set_custom_allowed_css_properties' ] );
 		add_filter( 'wp_kses_allowed_html', [ $this, 'set_custom_allowed_attributes_filter' ], 10, 2 );
 		add_action( 'add_meta_boxes', [ $this, 'add_meta_box_search' ] );

--- a/src/PublicAssets.php
+++ b/src/PublicAssets.php
@@ -7,12 +7,9 @@ namespace P4\MasterTheme;
  */
 final class PublicAssets {
 	/**
-	 * Load styling and behaviour on website pages.
+	 * Enqueue theme scripts.
 	 */
-	public static function enqueue(): void {
-		// master-theme assets.
-		self::enqueue_css();
-
+	public static function enqueue_js() {
 		$js_creation = filectime( get_template_directory() . '/assets/build/index.js' );
 
 		$jquery_should_wait = is_plugin_active( 'planet4-plugin-gutenberg-blocks/planet4-gutenberg-blocks.php' ) && ! is_user_logged_in();
@@ -61,7 +58,7 @@ final class PublicAssets {
 	 *
 	 * Drop enqueuing styles if main file is not built.
 	 */
-	private static function enqueue_css() {
+	public static function enqueue_css() {
 		$css_file = get_template_directory() . '/assets/build/style.min.css';
 		if ( ! file_exists( $css_file ) ) {
 			//phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error


### PR DESCRIPTION
Separate css and js enqueue so that js doesn't change priority.

Changing js priority leads to a frontend error with `wp` object undefined with a logged in user. The wp object exists in the console, but is apparently loaded too late.

This change is currently integrated on Pandora through https://github.com/greenpeace/planet4-master-theme/pull/1542/files#diff-d5a71432d6e94abc1260a448df306d8dfc76d15fa4047646a4d133c38cc131d7 , where the error was present before deployment.
