### PR TITLE
Country Selector: Remove white space from button

### DIFF
--- a/assets/src/scss/layout/_country-selector.scss
+++ b/assets/src/scss/layout/_country-selector.scss
@@ -74,14 +74,14 @@
 
   &::before {
     height: 20px;
-    margin-inline-end: 8px;
+    margin-inline-end: $sp-1x;
     mask: url("../../images/gp-g-logo.png") 0 0/16px 20px no-repeat;
     vertical-align: middle;
   }
 
   &::after {
     height: 12px;
-    margin-inline-start: 8px;
+    margin-inline-start: $sp-1x;
     mask: url("../../images/chevron.svg") 0 0/16px 12px no-repeat;
     transform: rotate(0.25turn);
     transition: transform 300ms cubic-bezier(.86, 0, .07, 1);

--- a/templates/footer_country_selector.twig
+++ b/templates/footer_country_selector.twig
@@ -8,10 +8,7 @@
 			aria-label="{{ data_nav_bar.country_dropdown_toggle }}"
 			data-ga-category="Menu Navigation"
 			data-ga-action="Open Country Selector"
-			data-ga-label="{{ page_category }}">
-				<span class="visually-hidden">{{ __( 'Selected', 'planet4-master-theme' ) }}:</span> {{ website_navbar_title }}
-				<span class="visually-hidden">{{ __( 'Change Country', 'planet4-master-theme' ) }}</span>
-		</button>
+			data-ga-label="{{ page_category }}"><span class="visually-hidden">{{ __( 'Selected', 'planet4-master-theme' ) }}:</span>{{ website_navbar_title }}<span class="visually-hidden">{{ __( 'Change Country', 'planet4-master-theme' ) }}</span></button>
 	</div>
 </div>
 <div class="countries-list">


### PR DESCRIPTION
Adjusted the markup to avoid a white space being rendered on both sides of the text. It makes the code slightly less readable, but we avoid having the underline decoration overflow on hover (check the screenshot below).

To compensate for the loss of the white space, added a bit more margin to the two icons.

![hover](https://user-images.githubusercontent.com/939357/146185507-dfc6e05a-a7fe-40e0-8890-ee99c7c5c2d8.png)
