### PR TITLE
Restore enhanced donate button position on new navbar

### DIFF
--- a/assets/src/scss/layout/_navbar.scss
+++ b/assets/src/scss/layout/_navbar.scss
@@ -80,6 +80,21 @@ $navbar-default-height: 60px;
   }
 }
 
+.btn-donate.btn-donate-top {
+  position: fixed;
+  left: 0;
+  z-index: 4;
+  width: 100%;
+  height: 3.3rem;
+  line-height: 3.3rem;
+  top: $menu-height;
+  transition: top .2s;
+
+  .admin-bar & {
+    top: calc(#{$menu-height} + 46px);
+  }
+}
+
 #nav-main {
   display: flex;
 


### PR DESCRIPTION
~In Planet 4 > Donate button, the donate button can be fixed below navbar on mobile
Restoring this rule to not break existing content~

Discarded, as we are dropping this option for the new navbar.