### PR TITLE
Avoid performing calculations at runtime in CSS

### DIFF
--- a/assets/src/scss/base/_variables.scss
+++ b/assets/src/scss/base/_variables.scss
@@ -12,7 +12,7 @@ $extra-extra-large-width: 1600px;
 
 // Spacing
 @function space($base) {
-  @return calc(#{$base} * 8px);
+  @return $base * 8px;
 }
 $sp-x: space(0.5);
 $sp-1: space(1);

--- a/assets/src/scss/layout/_country-selector.scss
+++ b/assets/src/scss/layout/_country-selector.scss
@@ -149,7 +149,7 @@
     font-size: $font-size-xxxs;
     font-weight: 700;
     line-height: 20px;
-    margin-inline-start: calc(-1 * #{$sp-4});
+    margin-inline-start: -$sp-4;
     opacity: 0.5;
     position: absolute;
 

--- a/assets/src/scss/layout/navbar/_search.scss
+++ b/assets/src/scss/layout/navbar/_search.scss
@@ -12,10 +12,10 @@
   width: 100%;
 
   .admin-bar & {
-    top: calc(#{$menu-height} + 46px);
+    top: $menu-height + 46px;
 
     @media (min-width: 783px) {
-      top: calc(#{$menu-height} + 32px);
+      top: $menu-height + 32px;
     }
   }
 


### PR DESCRIPTION
* The previous form of the code let the front end perform calculations
which can just as well be done compile time. Since these variables are
used very frequently, this probably has a significant (though still relatively small) impact.

[PR to bump these changes in the plugin](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/749).

<!-- Ref: Please add a url to the ticket this change is addressing.

---

Please provide a brief summary of the change introduced to make review process easier.

Ideally this should also be part of the commit summary.
-->
