### PR TITLE
Remove enhanced donate button on new navbar, fix search toggle

### DIFF
--- a/assets/src/js/header.js
+++ b/assets/src/js/header.js
@@ -32,13 +32,9 @@ export const setupHeader = function($) {
       return attr === 'false' ? 'true' : 'false';
     });
 
-    // Set same attributes for all search toggles
+    // Propagate attributes to all search toggles
     if (evt.currentTarget.classList.contains('nav-search-toggle')) {
-      document.querySelectorAll('.nav-search-toggle').forEach(e => {
-        e.setAttribute('aria-expanded', $button.attr('aria-expanded'));
-        e.setAttribute('data-ga-action', $button.attr('aria-expanded') === 'false' ? 'Open search' : 'Close search');
-        e.classList.toggle('open', $button.hasClass('open'));
-      });
+      setSearchToggles($button.attr('aria-expanded') === 'true');
     }
 
     // Lock scroll when navigation menu is open
@@ -54,10 +50,19 @@ export const setupHeader = function($) {
 
   // Close all menus when clicking somewhere else
   $(document).on('click', function closeInactiveMenus(evt) {
+    let searchToggled = false;
     const clickedElement = evt.target;
     $('button[aria-expanded="true"]').each((i, button) => {
       const $button = $(button);
       const buttonTarget = $($button.data('bs-target')).get( 0 );
+
+      if ($button.get(0).classList.contains('nav-search-toggle')) {
+        if (searchToggled) {
+          return;
+        }
+        searchToggled = true;
+      }
+
       if (buttonTarget && ! $.contains(buttonTarget, clickedElement)) {
         // Spoof a click on the open menu's toggle to close that menu.
         $button.trigger('click');
@@ -92,6 +97,20 @@ export const setupHeader = function($) {
     // Proxy to the main navbar close button
     $('.nav-menu-toggle').trigger('click');
   });
+
+  /**
+   * Propagate attributes to all search toggles
+   *
+   * @param {bool} expanded Toggle is expanded
+   */
+  function setSearchToggles(expanded) {
+    let toggles = document.querySelectorAll('.nav-search-toggle');
+    toggles.forEach(e => {
+      e.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+      e.setAttribute('data-ga-action', expanded ? 'Close search' : 'Open search');
+      e.classList.toggle('open', ! expanded);
+    });
+  }
 
   // Hide Header on on scroll down
   function hasScrolled(lastScrollTop, delta, navbarHeight) {

--- a/assets/src/js/header.js
+++ b/assets/src/js/header.js
@@ -98,20 +98,6 @@ export const setupHeader = function($) {
     $('.nav-menu-toggle').trigger('click');
   });
 
-  /**
-   * Propagate attributes to all search toggles
-   *
-   * @param {bool} expanded Toggle is expanded
-   */
-  function setSearchToggles(expanded) {
-    let toggles = document.querySelectorAll('.nav-search-toggle');
-    toggles.forEach(e => {
-      e.setAttribute('aria-expanded', expanded ? 'true' : 'false');
-      e.setAttribute('data-ga-action', expanded ? 'Close search' : 'Open search');
-      e.classList.toggle('open', ! expanded);
-    });
-  }
-
   // Hide Header on on scroll down
   function hasScrolled(lastScrollTop, delta, navbarHeight) {
     const st = $(this).scrollTop();
@@ -175,3 +161,17 @@ export const setupHeader = function($) {
     });
   }
 };
+
+/**
+ * Propagate attributes to all search toggles
+ *
+ * @param {bool} expanded Toggle is expanded
+ */
+function setSearchToggles(expanded) {
+  let toggles = document.querySelectorAll('.nav-search-toggle');
+  toggles.forEach(e => {
+    e.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+    e.setAttribute('data-ga-action', expanded ? 'Close search' : 'Open search');
+    e.classList.toggle('open', expanded);
+  });
+}

--- a/assets/src/scss/layout/_navbar.scss
+++ b/assets/src/scss/layout/_navbar.scss
@@ -261,10 +261,6 @@ a.nav-link {
   }
 }
 
-.btn-donate-top {
-  display: none;
-}
-
 // I'll include these at the end for now because they depend on CSS order.
 @import "navbar/site-logo";
 @import "navbar/languages";

--- a/assets/src/scss/layout/_navbar.scss
+++ b/assets/src/scss/layout/_navbar.scss
@@ -261,6 +261,10 @@ a.nav-link {
   }
 }
 
+.btn-donate-top {
+  display: none;
+}
+
 // I'll include these at the end for now because they depend on CSS order.
 @import "navbar/site-logo";
 @import "navbar/languages";

--- a/assets/src/scss/layout/navbar/_search.scss
+++ b/assets/src/scss/layout/navbar/_search.scss
@@ -150,10 +150,6 @@
   height: 44px;
   width: 44px;
 
-  @include medium-and-less {
-    opacity: 0.5;
-  }
-
   &.open --top-navigation--search-toggle-- {
     background: rgba(255, 255, 255, 0.15);
   }

--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -547,10 +547,12 @@ class MasterSite extends TimberSite {
 			$context['p4_visitor_type']    = 'guest';
 		}
 
+		$new_design_navigation_bar = Features::is_active( Features::NEW_DESIGN_NAVIGATION_BAR );
+
 		$context['donatelink']           = $options['donate_button'] ?? '#';
 		$context['donatetext']           = $options['donate_text'] ?? __( 'Donate', 'planet4-master-theme' );
 		$context['website_navbar_title'] = $options['website_navigation_title'] ?? __( 'International (English)', 'planet4-master-theme' );
-		if ( is_front_page() && isset( $options['donate_btn_visible_on_mobile'] ) && $options['donate_btn_visible_on_mobile'] ) {
+		if ( is_front_page() && ! $new_design_navigation_bar && isset( $options['donate_btn_visible_on_mobile'] ) && $options['donate_btn_visible_on_mobile'] ) {
 			$context['enhanced_donate_btn_class'] = 'btn-enhanced-donate';
 		} else {
 			$context['enhanced_donate_btn_class'] = '';
@@ -579,7 +581,7 @@ class MasterSite extends TimberSite {
 
 		// New design country selector, navigation bar.
 		$context['new_design_country_selector'] = Features::is_active( Features::NEW_DESIGN_COUNTRY_SELECTOR );
-		$context['new_design_navigation_bar']   = Features::is_active( Features::NEW_DESIGN_NAVIGATION_BAR );
+		$context['new_design_navigation_bar']   = $new_design_navigation_bar;
 
 		return $context;
 	}


### PR DESCRIPTION
In Planet 4 > Donate button we can set a fixed position for the donate button
This situation doesn't exist in the new navbar, and if active the button appears at the bottom of the page. We're hiding this button on the new style, and will remove the option from the scripts and backend after the transition.

Search field is not hidden when a user clicks anywhere else on the page after opening it.
This comes from a double click generated by the `closeInactiveMenus` function, that runs on the 2 toggles.
