### PR TITLE
Allow setting features with a filter

### DIFF
--- a/src/Features.php
+++ b/src/Features.php
@@ -184,7 +184,11 @@ class Features {
 	public static function is_active( string $name ): bool {
 		$features = get_option( Settings::KEY );
 
-		return isset( $features[ $name ] ) && $features[ $name ];
+		$active = isset( $features[ $name ] ) && $features[ $name ];
+
+		// Filter to allow setting a feature from code, to avoid chicken and egg problem when releasing adaptions to a
+		// new feature.
+		return (bool) apply_filters( "planet4_feature__$name", $active );
 	}
 
 	/**


### PR DESCRIPTION
* This solves the chicken and egg problem of a child theme needing to do
adjustments to work with a feature.
* (not included yet) We may want to visualize whether a filter exists on the options page,
and show the toggle as disabled, using the value of the filter.

### Example usage

A child theme would adjust their code to the new version and include the following PHP in their `functions.php`, or anywhere else that's loaded before the feature is checked for activity.
```php
add_filter( 'planet4_feature__new_design_navigation_bar`, '__return_true' );
add_filter( 'planet4_feature__new_design_country_selector`, '__return_true' );
```