### PR TITLE
WIP Set navbar height in one place

### DIFF
--- a/assets/src/scss/layout/_navbar.scss
+++ b/assets/src/scss/layout/_navbar.scss
@@ -14,10 +14,10 @@ $navbar-default-height: 60px;
     font-family: $roboto;
     font-size: $font-base-size;
     height: $menu-height;
+    position: fixed;
   }
 
   display: flex;
-  position: fixed;
   top: 0;
   width: 100%;
   z-index: 4;
@@ -57,6 +57,7 @@ $navbar-default-height: 60px;
       box-shadow: none;
       color: $white;
       font-size: inherit;
+      height: 44px;
       min-width: 116px;
 
       &:hover {
@@ -67,8 +68,8 @@ $navbar-default-height: 60px;
       }
     }
 
-    height: 44px;
-    line-height: 40px;
+    line-height: calc(var(--top-navigation--btn-donate--height, 44px) - 4px);
+    text-align: center;
   }
 
   .nav-donate {

--- a/assets/src/scss/layout/navbar/_search.scss
+++ b/assets/src/scss/layout/navbar/_search.scss
@@ -4,10 +4,9 @@
   border-top: 1px solid #c4c4c4;
   box-shadow: 0 2px 4px transparentize($black, 0.85);
   display: none;
-  height: 56px;
+  margin: auto;
   inset-inline-start: 0;
   position: fixed;
-  top: $menu-height;
   z-index: 3;
   width: 100%;
 
@@ -23,6 +22,8 @@
     display: flex;
 
     @include medium-and-less {
+      min-height: 56px;
+
       #nav-main.open & {
         display: none;
       }
@@ -57,7 +58,6 @@
   display: inline-block;
   flex-grow: 1;
   font-size: $font-base-size;
-  line-height: $menu-height;
   padding-inline: 12px 8px;
   width: auto;
 
@@ -96,7 +96,6 @@
 
   @include x-large-and-up {
     display: inline-block;
-    line-height: $menu-height;
   }
 }
 
@@ -104,7 +103,6 @@
   background-color: $black;
   border: none;
   float: right;
-  height: 56px;
   margin-inline-end: 36px;
   mask: url("../../images/cross-circle.svg") 50% 50%/24px 24px no-repeat;
   width: 24px;
@@ -116,14 +114,12 @@
   @include x-large-and-up {
     background-color: var(--top-navigation--color, $white);
     display: inline-block;
-    height: $menu-height;
     margin-inline-end: 0;
   }
 }
 
 .nav-search-toggle-container {
   display: none;
-  height: $menu-height;
   padding: 12px;
 
   &.medium-and-less {

--- a/assets/src/scss/layout/navbar/_site-logo.scss
+++ b/assets/src/scss/layout/navbar/_site-logo.scss
@@ -5,7 +5,7 @@
   position: unset;
   text-align: center;
 
-  img {
+  img _-- {
     height: 26px;
   }
 


### PR DESCRIPTION
This doesn't seem like a blocker for releasing the navigation bar, it also still needs some adaptations for languages.

* Remove all non variable instances of the navbar height that made the
actual variable unusable.
* Make the position variable (because why not, it works non-fixed too).
* Still needs a fix for mobile.

To test:
On master, try changing `--top-navigation--height` and see it doesn't change the search box height.
On this branch, it should apply the height and nicely center all elements (except mobile for now).