### PR TITLE
Also add lite YouTube player on 2nd oembed filter

### DIFF
--- a/assets/src/scss/editorStyle.scss
+++ b/assets/src/scss/editorStyle.scss
@@ -3,6 +3,7 @@
 @import "~bootstrap/scss/carousel";
 @import "~bootstrap/scss/tooltip";
 @import "~bootstrap/scss/buttons";
+@import "~lite-youtube-embed";
 
 @import "base/variables";
 @import "base/colors";

--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -178,6 +178,7 @@ class MasterSite extends TimberSite {
 		add_filter( 'comment_form_default_fields', [ $this, 'comment_form_cookie_checkbox_add_class' ] );
 		add_filter( 'comment_form_default_fields', [ $this, 'comment_form_replace_inputs' ] );
 		add_filter( 'embed_oembed_html', [ $this, 'filter_youtube_oembed_nocookie' ], 10, 2 );
+		add_filter( 'oembed_result', [ $this, 'filter_youtube_oembed_nocookie' ], 10, 2 );
 		add_filter(
 			'editable_roles',
 			function( $roles ) {
@@ -769,6 +770,13 @@ class MasterSite extends TimberSite {
 	 */
 	public function enqueue_editor_assets(): void {
 		Loader::enqueue_versioned_style( 'assets/build/editorStyle.min.css' );
+		wp_enqueue_script(
+			'youtube',
+			get_template_directory_uri() . '/assets/build/lite-yt-embed.js',
+			[],
+			1,
+			true
+		);
 	}
 
 	/**


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6538

* The Media block uses another way to get the embed HTML which doesn't
use the filter we added for WP's embed block. As a result it was still
using the default YT player which completely cripples page load
performance.

Earlier we missed the fact that WordPress actually has 2 different filters for embeds. Luckily both have the same signature so it's a really easy fix.

### Impact on page load times:
The results speak for themselves on a page that has only the Media block with a YouTube video.

Without fix: https://pagespeed.web.dev/report?url=https%3A%2F%2Fwww-dev.greenpeace.org%2Ftest-mars%2Fonly-yt-video%2F
With fix: https://pagespeed.web.dev/report?url=https%3A%2F%2Fwww-dev.greenpeace.org%2Ftest-pluto%2Fonly-yt-video%2F

Failing acceptance test should be fixed by https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/753