### PR TITLE
PLANET-6474 Remove space between truncated bio and remainder

### DIFF
--- a/templates/blocks/author_profile.twig
+++ b/templates/blocks/author_profile.twig
@@ -32,10 +32,9 @@
 					{% if ( post.author.description|length <= author_bio_char_limit ) %}
 						{{ post.author.description|raw }}
 					{% else %}
-						{% set post_author_description_teaser = post.author.description|slice(0, author_bio_char_limit)|join(' ') ~ '<span class="collapse show multi-collapse">&hellip;</span>' %}
-						{% set post_author_description_remainder = post.author.description|slice(author_bio_char_limit)|join(' ') %}
-						{{ post_author_description_teaser|raw }}
-						<span class="collapse multi-collapse">{{ post_author_description_remainder|raw }}</span>
+						{% set post_author_description_teaser = post.author.description|slice(0, author_bio_char_limit) ~ '<span class="collapse show multi-collapse">&hellip;</span>' %}
+						{% set post_author_description_remainder = post.author.description|slice(author_bio_char_limit) %}
+						{{ post_author_description_teaser|raw }}<span class="collapse multi-collapse">{{ post_author_description_remainder|raw }}</span>
 						<button
 							class="author-block-description-button"
 							data-bs-toggle="collapse"


### PR DESCRIPTION
### Description

See [PLANET-6474](https://jira.greenpeace.org/browse/PLANET-6474)
This space appears when clicking on Show more, when the ellipsis is removed.

### Testing

- [Broken version](https://www-dev.greenpeace.org/test-venus/story/49932/industrial-agriculture-forest-fires-climate-crisis/)
- [Fixed version](https://www-dev.greenpeace.org/test-atlas/story/49932/industrial-agriculture-forest-fires-climate-crisis/)