### PR TITLE
PLANET-5968 Ensure translated media gets Stateless meta

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -184,19 +184,11 @@ add_filter(
 	2
 );
 add_action(
-	'post_updated',
-	function ( $post_id, $post_after, $post_before ) {
-		if (
-			is_plugin_active( 'wp-stateless/wp-stateless-media.php' )
-			&& get_option( 'sm_custom_domain' )
-			&& 'page' === $post_after->post_type
-			&& $post_after->post_content
-			&& strpos( $post_after->post_content, 'wp-content/uploads' )
-			&& ! strpos( $post_before->post_content, 'wp-content/uploads' )
-		) {
-			trigger_error( "Post $post_id updated with a local URL instead of CDN.", E_USER_WARNING ); //phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error,WordPress.Security.EscapeOutput.OutputNotEscaped
-		}
+	'wpml_after_update_attachment_texts',
+	function ( $original_attachment_id, $translation ) {
+		$original_sm_cloud = get_post_meta( $original_attachment_id, 'sm_cloud', true );
+		update_post_meta( $translation->element_id, 'sm_cloud', $original_sm_cloud );
 	},
 	1,
-	3
+	2
 );


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5968

* WPML creates copies to use in other languages which use the same file.
However they don't copy all meta. As a result the Stateless plugin
doesn't detect it should put the CDN URL.
* Remove action that was only needed to debug this issue.

Tested on the BE site and confirmed that it does create the stateless meta in all cases. I used [this image](https://www-dev.greenpeace.org/belgium/wp-admin/upload.php?item=25838) uploaded to a French post.

Interestingly the bug of the missing media only occurred when you upload an image to a post. Uploading from the media page using "add new" already seemed to create the right WP stateless meta data. Probably the previous filter (which is removed in this PR) only ran in that case.