### PR TITLE
PLANET-6338: Fix duplicate results in search

### DIFF
--- a/assets/src/js/search.js
+++ b/assets/src/js/search.js
@@ -82,7 +82,6 @@ export const setupSearch = function($) {
       type: 'GET',
       data: {
         action:          'get_paged_posts',
-        'search-action': 'get_paged_posts',
         'search_query':  $( '#search_input' ).val().trim(),
         'paged':         next_page,
         'orderby': $( '#orderby', $search_form ).val(),

--- a/search.php
+++ b/search.php
@@ -14,30 +14,32 @@ use P4\MasterTheme\ElasticSearch;
 /**
  * Planet4 - Search functionality.
  */
-if ( is_main_query() && is_search() ) {
-	if ( 'GET' === filter_input( INPUT_SERVER, 'REQUEST_METHOD' ) ) {
-		$selected_sort    = filter_input( INPUT_GET, 'orderby', FILTER_SANITIZE_STRING );
-		$selected_filters = $_GET['f'] ?? ''; // phpcs:ignore
-		$filters          = [];
 
-		// Handle submitted filter options.
-		if ( $selected_filters && is_array( $selected_filters ) ) {
-			foreach ( $selected_filters as $type_name => $filter_type ) {
-				if ( ! is_array( $filter_type ) ) {
-					continue;
-				}
-				foreach ( $filter_type as $name => $filter_id ) {
-					$filters[ $type_name ][] = [
-						'id'   => $filter_id,
-						'name' => $name,
-					];
-				}
-			}
+// Limit access to GET method.
+if ( 'GET' !== filter_input( INPUT_SERVER, 'REQUEST_METHOD' ) ) {
+	return;
+}
+
+$selected_sort    = filter_input( INPUT_GET, 'orderby', FILTER_SANITIZE_STRING );
+$selected_filters = $_GET['f'] ?? ''; // phpcs:ignore
+$filters          = [];
+
+// Handle submitted filter options.
+if ( $selected_filters && is_array( $selected_filters ) ) {
+	foreach ( $selected_filters as $type_name => $filter_type ) {
+		if ( ! is_array( $filter_type ) ) {
+			continue;
 		}
-
-		$p4_search = new ElasticSearch();
-		$p4_search->load( trim( get_search_query() ), $selected_sort, $filters );
-		$p4_search->add_load_more();
-		$p4_search->view();
+		foreach ( $filter_type as $name => $filter_id ) {
+			$filters[ $type_name ][] = [
+				'id'   => $filter_id,
+				'name' => $name,
+			];
+		}
 	}
 }
+
+$p4_search = new ElasticSearch();
+$p4_search->load( trim( get_search_query() ), $selected_sort, $filters );
+$p4_search->add_load_more();
+$p4_search->view();

--- a/src/ElasticSearch.php
+++ b/src/ElasticSearch.php
@@ -3,6 +3,7 @@
 namespace P4\MasterTheme;
 
 use UnexpectedValueException;
+use ElasticPress\ElasticSearch as ElasticPressCient;
 
 /**
  * Class P4\MasterTheme\ElasticSearch
@@ -95,6 +96,7 @@ class ElasticSearch extends Search {
 		simple_value_filter( 'epwr_decay', planet4_get_option( 'epwr_decay', 0.5 ) );
 		simple_value_filter( 'epwr_offset', planet4_get_option( 'epwr_offset', '365d' ) );
 
+		add_filter( 'ep_formatted_args', [ $this, 'ensure_function_score_exists' ], 18, 1 );
 		add_filter( 'ep_formatted_args', [ $this, 'set_full_text_search' ], 19, 1 );
 		add_filter( 'ep_formatted_args', [ $this, 'set_results_weight' ], 20, 1 );
 
@@ -103,6 +105,23 @@ class ElasticSearch extends Search {
 		if ( ! wp_doing_ajax() ) {
 			add_filter( 'ep_formatted_args', [ $this, 'add_aggregations' ], 999, 1 );
 		}
+	}
+
+	/**
+	 * Ensure function_score entry exists in the query arguments.
+	 *
+	 * @param array $formatted_args  The formatted arguments.
+	 *
+	 * @return array Formatted arguments with function_score.
+	 */
+	public function ensure_function_score_exists( $formatted_args ) {
+		if ( ! isset( $formatted_args['query']['function_score'] ) ) {
+			$existing_query = $formatted_args['query'];
+			unset( $formatted_args['query'] );
+			$formatted_args['query']['function_score']['query'] = $existing_query;
+		}
+
+		return $formatted_args;
 	}
 
 	/**
@@ -135,19 +154,16 @@ class ElasticSearch extends Search {
 	 * @return mixed
 	 */
 	public function set_results_weight( $formatted_args ) {
-
-		// Move the existing query.
-		$existing_query = $formatted_args['query'];
-		unset( $formatted_args['query'] );
-		$formatted_args['query']['function_score']['query'] = $existing_query;
-
-		$options = get_option( 'planet4_options' );
+		if ( ! isset( $formatted_args['query']['function_score']['functions'] ) ) {
+			$formatted_args['query']['function_score']['functions'] = [];
+		}
 
 		/**
 		 * Use any combination of filters here, any matched filter will adjust
 		 * the weighted results according to the scoring settings set below.
 		 */
-		$formatted_args['query']['function_score']['functions'] = ( $existing_query['function_score']['functions'] ?? [] ) + [
+		array_push(
+			$formatted_args['query']['function_score']['functions'],
 			[
 				'filter' => [
 					'match' => [
@@ -159,12 +175,12 @@ class ElasticSearch extends Search {
 			[
 				'filter' => [
 					'term' => [
-						'post_parent' => esc_sql( $options['act_page'] ),
+						'post_parent' => esc_sql( planet4_get_option( 'act_page' ) ),
 					],
 				],
 				'weight' => self::DEFAULT_ACTION_WEIGHT,
 			],
-		];
+		);
 
 		// Specify how the computed scores are combined.
 		$formatted_args['query']['function_score']['score_mode'] = 'sum';
@@ -228,7 +244,6 @@ class ElasticSearch extends Search {
 	 * @return array Same args with added filter.
 	 */
 	public function add_mime_type_filter( $formatted_args ) {
-
 		$formatted_args['post_filter']['bool']['must'][] = [
 			'bool' => [
 				'should' => [
@@ -251,5 +266,34 @@ class ElasticSearch extends Search {
 		];
 
 		return $formatted_args;
+	}
+
+	/**
+	 * Debug function to validate a query through elastic server.
+	 * This will return a valid/invalid indication,
+	 * and the Lucene query generated from the arguments given.
+	 *
+	 * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-validate.html
+	 *
+	 * @param array $query Query arguments.
+	 *
+	 * @return array Server response.
+	 * @throws \Exception On request error.
+	 */
+	public static function validate_query( array $query ): array {
+		$client  = ElasticPressCient::factory();
+		$request = $client->remote_request(
+			'_validate/query?rewrite=true',
+			[
+				'method' => 'POST',
+				'body'   => wp_json_encode( [ 'query' => $query ] ),
+			],
+		);
+
+		if ( is_wp_error( $request ) ) {
+			throw new \Exception( 'Request error' );
+		}
+
+		return json_decode( wp_remote_retrieve_body( $request ), true );
 	}
 }

--- a/src/Search.php
+++ b/src/Search.php
@@ -283,60 +283,54 @@ abstract class Search {
 	/**
 	 * Gets the paged posts that belong to the next page/load and are to be used with the twig template.
 	 */
-	public static function get_paged_posts() {
-		// If this is an ajax call.
-		if ( wp_doing_ajax() ) {
-			$search_action = filter_input( INPUT_GET, 'search-action', FILTER_SANITIZE_STRING );
-			$paged         = filter_input( INPUT_GET, 'paged', FILTER_SANITIZE_STRING );
+	public static function get_paged_posts(): void {
+		$paged = filter_input( INPUT_GET, 'paged', FILTER_SANITIZE_STRING );
 
-			// Check if call action is correct.
-			if ( 'get_paged_posts' === $search_action ) {
-				$search_async = new static();
-				$search_async->set_context( $search_async->context );
-				$search_async->search_query = urldecode( filter_input( INPUT_GET, 'search_query', FILTER_SANITIZE_STRING ) );
+		$search_async = new static();
+		$search_async->set_context( $search_async->context );
+		$search_async->search_query = urldecode( filter_input( INPUT_GET, 'search_query', FILTER_SANITIZE_STRING ) );
 
-				// Get the decoded url query string and then use it as key for redis.
-				$query_string_full = urldecode( filter_input( INPUT_SERVER, 'QUERY_STRING', FILTER_SANITIZE_STRING ) );
-				$query_string      = str_replace( '&query-string=', '', strstr( $query_string_full, '&query-string=' ) );
+		// Get the decoded url query string and then use it as key for redis.
+		$query_string_full = urldecode( filter_input( INPUT_SERVER, 'QUERY_STRING', FILTER_SANITIZE_STRING ) );
+		$query_string      = str_replace( '&query-string=', '', strstr( $query_string_full, '&query-string=' ) );
 
-				$search_async->current_page = $paged;
+		$search_async->current_page = $paged;
 
-				parse_str( $query_string, $filters_array );
-				$selected_sort    = $filters_array['orderby'] ?? self::DEFAULT_SORT;
-				$selected_filters = $filters_array['f'] ?? [];
-				$filters          = [];
+		parse_str( $query_string, $filters_array );
+		$selected_sort    = $filters_array['orderby'] ?? self::DEFAULT_SORT;
+		$selected_filters = $filters_array['f'] ?? [];
+		$filters          = [];
 
-				// Handle submitted filter options.
-				if ( $selected_filters && is_array( $selected_filters ) ) {
-					foreach ( $selected_filters as $type => $filter_type ) {
-						if ( ! is_array( $filter_type ) ) {
-							continue;
-						}
-						foreach ( $filter_type as $name => $id ) {
-							$filters[ $type ][] = [
-								'id'   => $id,
-								'name' => $name,
-							];
-						}
-					}
+		// Handle submitted filter options.
+		if ( $selected_filters && is_array( $selected_filters ) ) {
+			foreach ( $selected_filters as $type => $filter_type ) {
+				if ( ! is_array( $filter_type ) ) {
+					continue;
 				}
-
-				// Validate user input (sort, filters, etc).
-				if ( $search_async->validate( $selected_sort, $filters, $search_async->context ) ) {
-					$search_async->selected_sort = $selected_sort;
-					$search_async->filters       = $filters;
-				}
-
-				$search_async->paged_posts = $search_async->get_posts( $search_async->current_page );
-
-				// If there are paged results then set their context and send them back to client.
-				if ( $search_async->paged_posts ) {
-					$search_async->set_results_context( $search_async->context );
-					$search_async->view_paged_posts();
+				foreach ( $filter_type as $name => $id ) {
+					$filters[ $type ][] = [
+						'id'   => $id,
+						'name' => $name,
+					];
 				}
 			}
-			wp_die();
 		}
+
+		// Validate user input (sort, filters, etc).
+		if ( $search_async->validate( $selected_sort, $filters, $search_async->context ) ) {
+			$search_async->selected_sort = $selected_sort;
+			$search_async->filters       = $filters;
+		}
+
+		$search_async->paged_posts = $search_async->get_posts( $search_async->current_page );
+
+		// If there are paged results then set their context and send them back to client.
+		if ( $search_async->paged_posts ) {
+			$search_async->set_results_context( $search_async->context );
+			$search_async->view_paged_posts();
+		}
+
+		wp_die();
 	}
 
 	/**
@@ -1023,9 +1017,7 @@ abstract class Search {
 	public static function edit_search_mime_types( $where ) : string {
 		global $wpdb;
 
-		$search_action = filter_input( INPUT_GET, 'search-action', FILTER_SANITIZE_STRING );
-
-		if ( ( ! is_admin() && is_search() ) || ( wp_doing_ajax() && ( 'get_paged_posts' === $search_action ) ) ) {
+		if ( ( ! is_admin() && is_search() ) || wp_doing_ajax() ) {
 			$mime_types = implode( ',', self::DOCUMENT_TYPES );
 			$where     .= ' AND ' . $wpdb->posts . '.post_mime_type IN("' . $mime_types . '","") ';
 		}

--- a/src/Search.php
+++ b/src/Search.php
@@ -915,7 +915,7 @@ abstract class Search {
 
 				$context['page_types'][ $p4_post_type_id ] = [
 					'term_id' => $p4_post_type_id,
-					'name'    => $p4_post_type->name,
+					'name'    => $p4_post_type->name ?? null,
 					'results' => $p4_post_type_agg['doc_count'],
 				];
 			}


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6338

This PR includes:
- Ensure a `function_score` is present, remove the code doubling/nesting this property
- Add a debug function, allows to check the generated Lucene query from given arguments
- Other modifications are inverted conditions to reduce indentation levels, so __hide whitespaces__ during review

## Issue

Differences between regular request and ajax request in 3 steps, the last step is the query part sent to elastic (doesn't include other props like aggregation, sort, etc.)
1. How it creates or not the `function_score` property in advance
2. How it impacts the query construction
3. What the end result is before being sent to elastic
4. Lucene query

Query `?s=greenpeace+germany&orderby=post_date`
<table>
<tr><th>Step</th><th>Regular</th><th>Ajax</th></tr>
<tr>
<td>1</td>
<td>Reaches `ElasticPress\Feature\Search\Search::weight_recent()`, gets a `function_score` property set </td>
<td>Excluded from further treatment in <a href="https://github.com/10up/ElasticPress/blob/3.5.6/includes/classes/Feature/Search/Search.php#L114">`ElasticPress\Feature\Search\Search::search_setup() l.114`</a> because of a filter `ep_ajax_wp_query_integration` for ajax admin queries, no `function_score` set.
Our <a href="https://github.com/greenpeace/planet4-master-theme/blob/17e36f39e8cc0542fef20a1b77170f30685ae2bc/src/Search.php#L219">own run</a> of this function is also not executed because the `orderby` doesn't fit the condition. </td>
</tr>
<tr>
<td>2</td>
<td>`P4\MasterTheme\ElasticSearch::set_results_weight()` includes this `function_score` property in another `query/function_score`, ending up in a nested query/function/query/function</td>
<td>`P4\MasterTheme\ElasticSearch::set_full_text_search()` does not see a `function_score`, and so doesn't change `should` condition in `must` or multimatch operator</td>
</tr>
<tr>
<td>3</td>
<td>
<details>
<summary>Resulting query parameters</summary>
<pre>
"query": {
  "function_score": {
    "query": {
      "function_score": {
        "query": {
          "bool": {
            "must": [
              {
                "multi_match": {
                  "query": "greenpeace germany",
                  "fields": [
                    "post_title",
                    "post_content",
                    "post_excerpt",
                    "post_author.display_name"
                  ],
                  "boost": 4,
                  "operator": "AND"
                }
              },
              {
                "multi_match": {
                  "query": "greenpeace germany",
                  "fields": [
                    "post_title",
                    "post_content",
                    "post_excerpt",
                    "post_author.display_name"
                  ],
                  "boost": 2,
                  "fuzziness": 0,
                  "operator": "and"
                }
              },
              {
                "multi_match": {
                  "query": "greenpeace germany",
                  "fields": [
                    "post_title",
                    "post_content",
                    "post_excerpt",
                    "post_author.display_name"
                  ],
                  "fuzziness": 1
                }
              }
            ]
          }
        },
        "functions": [
          {
            "exp": {
              "post_date_gmt": {
                "scale": "28d",
                "decay": 0.5,
                "offset": "365d"
              }
            }
          },
          {
            "weight": 0.001
          }
        ],
        "score_mode": "sum",
        "boost_mode": "multiply"
      }
    },
    "functions": [
      {
        "exp": {
          "post_date_gmt": {
            "scale": "28d",
            "decay": 0.5,
            "offset": "365d"
          }
        }
      },
      {
        "weight": 0.001
      }
    ],
    "score_mode": "sum"
  }
}</pre>
</details></td>
<td>
<details>
<summary>Resulting query parameters</summary>
<pre>"query": {
  "function_score": {
    "query": {
      "bool": {
        "should": [
          {
            "multi_match": {
              "query": "greenpeace germany",
              "type": "phrase",
              "fields": [
                "post_title",
                "post_content",
                "post_excerpt",
                "post_author.display_name"
              ],
              "boost": 4
            }
          },
          {
            "multi_match": {
              "query": "greenpeace germany",
              "fields": [
                "post_title",
                "post_content",
                "post_excerpt",
                "post_author.display_name"
              ],
              "boost": 2,
              "fuzziness": 0,
              "operator": "and"
            }
          },
          {
            "multi_match": {
              "query": "greenpeace germany",
              "fields": [
                "post_title",
                "post_content",
                "post_excerpt",
                "post_author.display_name"
              ],
              "fuzziness": 1
            }
          }
        ]
      }
    },
    "functions": [
      {
        "filter": {
          "match": {
            "post_type": "page"
          }
        },
        "weight": 100
      },
      {
        "filter": {
          "term": {
            "post_parent": "9129"
          }
        },
        "weight": 2000
      }
    ],
    "score_mode": "sum"
  }
}</pre></details></td>
</tr>
<tr>
<td>4</td>
<td><details><summary>Lucene query</summary><pre>
function
score
(
  function
  score
  (
    +(
      (
        (
          +post_author.display_name: greenpeac
          +post_author.display_name: germani
        )
        |
        (
          +post_title: greenpeac
          +post_title: germani
        )
        |
        (
          +post_content: greenpeac
          +post_content: germani
        )
        |
        (
          +post_excerpt: greenpeac
          +post_excerpt: germani
        )
      )
    )
    ^4.0
    +(
      (
        (
          +post_author.display_name: greenpeac
          +MatchNoDocsQuery(
            "empty BooleanQuery"
          )
        )
        |
        (
          +post_title: greenpeac
          +post_title: germani
        )
        |
        (
          +post_content: greenpeac
          +post_content: germani
        )
        |
        (
          +post_excerpt: greenpeac
          +post_excerpt: germani
        )
      )
    )
    ^2.0
    +(
      (
        post_author.display_name: greenpeac
        MatchNoDocsQuery(
          "empty BooleanQuery"
        )
      )
      |
      (
        post_title: greenpeac
        (
          (
            post_title: german
          )
          ^0.8333333
          post_title: germani
        )
      )
      |
      (
        (
          (
            post_content: agreenpeac
          )
          ^0.8888889
          (
            post_content: greanpeac
          )
          ^0.8888889
          post_content: greenpeac
          (
            post_content: greenpec
          )
          ^0.875
          (
            post_content: greepeac
          )
          ^0.875
          (
            post_content: grenpeac
          )
          ^0.875
        )
        (
          (
            post_content: german
          )
          ^0.8333333
          post_content: germani
          (
            post_content: german’
          )
          ^0.85714287
        )
      )
      |
      (
        post_excerpt: greenpeac
        (
          (
            post_excerpt: german
          )
          ^0.8333333
          post_excerpt: germani
        )
      )
    ),
    functions: [
      {
        org.elasticsearch.index.query.functionscore.DecayFunctionBuilder$NumericFieldDataScoreFunction@7ff9e0ed
      }
      {
        org.elasticsearch.common.lucene.search.function.WeightFactorFunction@98debbaa
      }
    ]
  ),
  functions: [
    {
      org.elasticsearch.index.query.functionscore.DecayFunctionBuilder$NumericFieldDataScoreFunction@7ff9e0ed
    }
    {
      org.elasticsearch.common.lucene.search.function.WeightFactorFunction@98debbaa
    }
  ]
)

</pre></details></td>
<td><details><summary>Lucene query</summary><pre>function
score
(
  (
    (
      post_author.display_name: "greenpeac germani"
      |
      post_title: "greenpeac germani"
      |
      post_content: "greenpeac germani"
      |
      post_excerpt: "greenpeac germani"
    )
  )
  ^4.0
  (
    (
      (
        +post_author.display_name: greenpeac
        +MatchNoDocsQuery(
          "empty BooleanQuery"
        )
      )
      |
      (
        +post_title: greenpeac
        +post_title: germani
      )
      |
      (
        +post_content: greenpeac
        +post_content: germani
      )
      |
      (
        +post_excerpt: greenpeac
        +post_excerpt: germani
      )
    )
  )
  ^2.0
  (
    (
      post_author.display_name: greenpeac
      MatchNoDocsQuery(
        "empty BooleanQuery"
      )
    )
    |
    (
      post_title: greenpeac
      (
        (
          post_title: german
        )
        ^0.8333333
        post_title: germani
      )
    )
    |
    (
      (
        (
          post_content: agreenpeac
        )
        ^0.8888889
        (
          post_content: greanpeac
        )
        ^0.8888889
        post_content: greenpeac
        (
          post_content: greenpec
        )
        ^0.875
        (
          post_content: greepeac
        )
        ^0.875
        (
          post_content: grenpeac
        )
        ^0.875
      )
      (
        (
          post_content: german
        )
        ^0.8333333
        post_content: germani
        (
          post_content: german’
        )
        ^0.85714287
      )
    )
    |
    (
      post_excerpt: greenpeac
      (
        (
          post_excerpt: german
        )
        ^0.8333333
        post_excerpt: germani
      )
    )
  ),
  functions: [
    {
      org.elasticsearch.common.lucene.search.function.FunctionScoreQuery$FilterScoreFunction@7bc65d52
    }
    {
      org.elasticsearch.common.lucene.search.function.FunctionScoreQuery$FilterScoreFunction@d4ab458a
    }
  ]
)
</pre></details></td>
</tr>
</table>

## Fix

Ensuring that the `function_score` entry exists before modifying its properties/functions fixes the nested query and the main differences in the final query.
__This does not fix the decay function difference between regular query ordered by Newest and following ajax query.__

We could try to understand and use the [`ep_ajax_wp_query_integration`](http://10up.github.io/ElasticPress/ep_ajax_wp_query_integration.html) filter, but there are some [enhancements](https://github.com/10up/ElasticPress/pull/2267) on ElasticPress side so I think we should update our version before trying further changes.

<table>
<tr><th>Regular</th><th>Ajax</th></tr>
<tr>
<td><details><summary>Resulting query parameters</summary><pre>
"query": {
  "function_score": {
    "query": {
      "bool": {
        "must": [
          {
            "multi_match": {
              "query": "greenpeace germany",
              "fields": [
                "post_title",
                "post_content",
                "post_excerpt",
                "post_author.display_name"
              ],
              "boost": 4,
              "operator": "AND"
            }
          },
          {
            "multi_match": {
              "query": "greenpeace germany",
              "fields": [
                "post_title",
                "post_content",
                "post_excerpt",
                "post_author.display_name"
              ],
              "boost": 2,
              "fuzziness": 0,
              "operator": "and"
            }
          },
          {
            "multi_match": {
              "query": "greenpeace germany",
              "fields": [
                "post_title",
                "post_content",
                "post_excerpt",
                "post_author.display_name"
              ],
              "fuzziness": 1
            }
          }
        ]
      }
    },
    "functions": [
      {
        "exp": {
          "post_date_gmt": {
            "scale": "28d",
            "decay": 0.5,
            "offset": "365d"
          }
        }
      },
      {
        "weight": 0.001
      },
      {
        "filter": {
          "match": {
            "post_type": "page"
          }
        },
        "weight": 100
      },
      {
        "filter": {
          "term": {
            "post_parent": "9129"
          }
        },
        "weight": 2000
      }
    ],
    "score_mode": "sum",
    "boost_mode": "multiply"
  }
}
</pre></details></td>
<td><details><summary>Resulting query parameters</summary><pre>
"query": {
  "function_score": {
    "query": {
      "bool": {
        "must": [
          {
            "multi_match": {
              "query": "greenpeace germany",
              "fields": [
                "post_title",
                "post_content",
                "post_excerpt",
                "post_author.display_name"
              ],
              "boost": 4,
              "operator": "AND"
            }
          },
          {
            "multi_match": {
              "query": "greenpeace germany",
              "fields": [
                "post_title",
                "post_content",
                "post_excerpt",
                "post_author.display_name"
              ],
              "boost": 2,
              "fuzziness": 0,
              "operator": "and"
            }
          },
          {
            "multi_match": {
              "query": "greenpeace germany",
              "fields": [
                "post_title",
                "post_content",
                "post_excerpt",
                "post_author.display_name"
              ],
              "fuzziness": 1
            }
          }
        ]
      }
    },
    "functions": [
      {
        "filter": {
          "match": {
            "post_type": "page"
          }
        },
        "weight": 100
      },
      {
        "filter": {
          "term": {
            "post_parent": "9129"
          }
        },
        "weight": 2000
      }
    ],
    "score_mode": "sum"
  }
}
</pre></details></td>
</tr>
<tr>
<td><details><summary>Lucene query</summary><pre>
function
score
(
  +(
    (
      (
        +post_author.display_name: greenpeac
        +post_author.display_name: germani
      )
      |
      (
        +post_title: greenpeac
        +post_title: germani
      )
      |
      (
        +post_content: greenpeac
        +post_content: germani
      )
      |
      (
        +post_excerpt: greenpeac
        +post_excerpt: germani
      )
    )
  )
  ^4.0
  +(
    (
      (
        +post_author.display_name: greenpeac
        +MatchNoDocsQuery(
          "empty BooleanQuery"
        )
      )
      |
      (
        +post_title: greenpeac
        +post_title: germani
      )
      |
      (
        +post_content: greenpeac
        +post_content: germani
      )
      |
      (
        +post_excerpt: greenpeac
        +post_excerpt: germani
      )
    )
  )
  ^2.0
  +(
    (
      post_author.display_name: greenpeac
      MatchNoDocsQuery(
        "empty BooleanQuery"
      )
    )
    |
    (
      (
        (
          post_title: greenpea
        )
        ^0.875
        post_title: greenpeac
      )
      (
        (
          post_title: german
        )
        ^0.8333333
        post_title: germani
      )
    )
    |
    (
      (
        (
          post_content: geenpeac
        )
        ^0.875
        (
          post_content: greenpac
        )
        ^0.875
        (
          post_content: greenpea
        )
        ^0.875
        (
          post_content: greenpeaac
        )
        ^0.8888889
        post_content: greenpeac
        (
          post_content: greenpec
        )
        ^0.875
        (
          post_content: greepeac
        )
        ^0.875
        (
          post_content: grenpeac
        )
        ^0.875
      )
      (
        (
          post_content: germain
        )
        ^0.85714287
        (
          post_content: german
        )
        ^0.8333333
        post_content: germani
        (
          post_content: guermani
        )
        ^0.85714287
      )
    )
    |
    (
      (
        (
          post_excerpt: greenpea
        )
        ^0.875
        post_excerpt: greenpeac
      )
      (
        (
          post_excerpt: german
        )
        ^0.8333333
        post_excerpt: germani
        (
          post_excerpt: guermani
        )
        ^0.85714287
      )
    )
  ),
  functions: [
    {
      org.elasticsearch.index.query.functionscore.DecayFunctionBuilder$NumericFieldDataScoreFunction@43a2b45c
    }
    {
      org.elasticsearch.common.lucene.search.function.WeightFactorFunction@f65bbf98
    }
    {
      org.elasticsearch.common.lucene.search.function.FunctionScoreQuery$FilterScoreFunction@8d7c589b
    }
    {
      org.elasticsearch.common.lucene.search.function.FunctionScoreQuery$FilterScoreFunction@60e6cb6f
    }
  ]
)
</pre></details></td>
<td><details><summary>Lucene query</summary><pre>
function
score
(
  +(
    (
      (
        +post_author.display_name: greenpeac
        +post_author.display_name: germani
      )
      |
      (
        +post_title: greenpeac
        +post_title: germani
      )
      |
      (
        +post_content: greenpeac
        +post_content: germani
      )
      |
      (
        +post_excerpt: greenpeac
        +post_excerpt: germani
      )
    )
  )
  ^4.0
  +(
    (
      (
        +post_author.display_name: greenpeac
        +MatchNoDocsQuery(
          "empty BooleanQuery"
        )
      )
      |
      (
        +post_title: greenpeac
        +post_title: germani
      )
      |
      (
        +post_content: greenpeac
        +post_content: germani
      )
      |
      (
        +post_excerpt: greenpeac
        +post_excerpt: germani
      )
    )
  )
  ^2.0
  +(
    (
      post_author.display_name: greenpeac
      MatchNoDocsQuery(
        "empty BooleanQuery"
      )
    )
    |
    (
      (
        (
          post_title: geenpeac
        )
        ^0.875
        (
          post_title: greenpea
        )
        ^0.875
        post_title: greenpeac
      )
      (
        (
          post_title: german
        )
        ^0.8333333
        post_title: germani
      )
    )
    |
    (
      (
        (
          post_content: geenpeac
        )
        ^0.875
        (
          post_content: greeenpeac
        )
        ^0.8888889
        (
          post_content: greeneac
        )
        ^0.875
        (
          post_content: greenepac
        )
        ^0.8888889
        (
          post_content: greenopeac
        )
        ^0.8888889
        (
          post_content: greenpea
        )
        ^0.875
        post_content: greenpeac
        (
          post_content: grenpeac
        )
        ^0.875
        (
          post_content: reenpeac
        )
        ^0.875
      )
      (
        (
          post_content: germain
        )
        ^0.85714287
        (
          post_content: german
        )
        ^0.8333333
        post_content: germani
        (
          post_content: guermani
        )
        ^0.85714287
      )
    )
    |
    (
      (
        (
          post_excerpt: geenpeac
        )
        ^0.875
        (
          post_excerpt: greenpea
        )
        ^0.875
        post_excerpt: greenpeac
      )
      (
        (
          post_excerpt: german
        )
        ^0.8333333
        post_excerpt: germani
        (
          post_excerpt: guermani
        )
        ^0.85714287
      )
    )
  ),
  functions: [
    {
      org.elasticsearch.index.query.functionscore.DecayFunctionBuilder$NumericFieldDataScoreFunction@43a2b45c
    }
    {
      org.elasticsearch.common.lucene.search.function.WeightFactorFunction@f65bbf98
    }
    {
      org.elasticsearch.common.lucene.search.function.FunctionScoreQuery$FilterScoreFunction@8d7c589b
    }
    {
      org.elasticsearch.common.lucene.search.function.FunctionScoreQuery$FilterScoreFunction@60e6cb6f
    }
  ]
)
</pre></details></td>
</tr>
</table>

## Test

The duplicate result is visible on GP International DB, that you can replicate locally:
```shell
# Build instance
> git clone git@github.com:greenpeace/planet4-docker-compose.git pdc-6338 && cd pdc-6338
> NRO_NAME=international NRO_DB_VERSION=1.40.53 make nro-from-release
# Run elastic server
> docker-compose -f docker-compose.full.yml up -d elasticsearch
> docker-compose exec php-fpm wp option update ep_host 'http://elasticsearch:9200/'
> docker-compose exec php-fpm wp elasticpress index --setup --quiet --url=www.planet4.test 
> make flush
```
Then search for `greenpeace germany`, order by _Newest_. You should see a duplicate of the article `This monster machine is built for profit`, one in the first 5 results, and one in the following 5 when you scroll down.

Switch to this branch:
```shell
> (cd persistence/app/public/wp-content/themes/planet4-master-theme && git fetch origin && git reset --hard origin/fix/search-duplicate-results-6338)
```
Rerun the search, the duplicate post should not be there anymore in the following 5 results.