### PR TITLE
PLANET-6549 Fix ga-action attribute for navbar hamburger menu

### DIFF
--- a/assets/src/js/header.js
+++ b/assets/src/js/header.js
@@ -59,6 +59,7 @@ const toggleNavElement = element => {
   const countryDropdownToggle = document.querySelector('.country-dropdown-toggle');
   const countrySelectorToggle = document.querySelector('.country-selector-toggle');
   const navbarSearchToggle = document.querySelector('.navbar-search-toggle');
+  const navMenuToggle = document.querySelector('.nav-menu-toggle');
 
   if (countryDropdownToggle) {
     updateGaAction(countryDropdownToggle, 'Country Selector');
@@ -70,6 +71,10 @@ const toggleNavElement = element => {
 
   if (navbarSearchToggle) {
     updateGaAction(navbarSearchToggle, 'Search');
+  }
+
+  if (navMenuToggle) {
+    updateGaAction(navMenuToggle, 'Menu');
   }
 };
 

--- a/templates/navigation-bar-new.twig
+++ b/templates/navigation-bar-new.twig
@@ -1,7 +1,10 @@
 <section id="header" class="top-navigation navbar {% if custom_styles.nav_border == 'border' %}navigation-bar_border{% endif %}">
-	{% set data_ga_attrs = 'data-ga-category="Menu Navigation" data-ga-action="Open Menu" data-ga-label="' ~ page_category ~ '"' %}
+	{% set data_ga_attrs = 'data-ga-category="Menu Navigation" data-ga-action="Menu" data-ga-label="' ~ page_category ~ '"' %}
 	<button class="nav-menu-toggle" type="button"
 		aria-label="{{ __( 'Toggle navigation menu', 'planet4-master-theme' ) }}"
+		data-ga-category="Menu Navigation"
+		data-ga-action="Open Menu"
+		data-ga-label="{{ page_category }}"
 		aria-expanded="false"
 		data-bs-toggle="open"
 		data-bs-target="#nav-main">


### PR DESCRIPTION
### Description

See [PLANET-6549](https://jira.greenpeace.org/browse/PLANET-6549).
This was previously wrongly set to the svg icon instead of the actual button. The change of text (from "Open menu" to "Close menu" for example) was not implemented, probably because the button is under the menu when the menu is open so it's not visible to the user... However it's still on the page and accessible, for instance by tab or by changing the `z-index` value, so I've added the behaviour anyway 🙃 

### Testing

If you check any page with the new navbar and narrow it down to a width < 992px, with the dev tools open you can inspect the hamburger menu button:
- At first you should see on it a ga-action attribute with value "Open Menu"
- When opening the menu this value should change to "Close Menu"
- When closing the menu it should switch back to the initial value