### PR TITLE
PLANET-6548 Fix new navbar site logo link width in small screens

### DIFF
--- a/assets/src/scss/layout/_navbar.scss
+++ b/assets/src/scss/layout/_navbar.scss
@@ -21,6 +21,7 @@ $navbar-default-height: 60px;
   top: 0;
   width: 100%;
   z-index: 4;
+  justify-content: space-between;
 
   .admin-bar & {
     top: 46px;
@@ -236,6 +237,12 @@ a.nav-link {
 .navigation-bar_min {
   --top-navigation-min-- {
     height: $min-height;
+  }
+
+  justify-content: center;
+
+  @include large-and-up {
+    justify-content: flex-start;
   }
 }
 

--- a/assets/src/scss/layout/navbar/_site-logo.scss
+++ b/assets/src/scss/layout/navbar/_site-logo.scss
@@ -1,19 +1,12 @@
 .site-logo {
-  flex-grow: 1;
   line-height: $menu-height;
-  padding: 0;
-  position: unset;
-  text-align: center;
 
   img {
     height: 26px;
   }
 
   @include large-and-up {
-    flex-grow: 0;
     margin-inline-start: calc((100vw - 960px) / 2);
-    text-align: start;
-    width: auto;
   }
 
   @include x-large-and-up {


### PR DESCRIPTION
### Description

See [PLANET-6548](https://jira.greenpeace.org/browse/PLANET-6548)
The site logo link should be as wide as the logo itself, otherwise it might be confusing for users.

### Testing

With the new navbar enabled, make sure that the `site-logo` link is always the size of the actual logo, and that it's correctly positioned in all screen sizes within the bar. Also check campaign pages with the minimal navbar, to make sure it also still looks good!