### PR TITLE
PLANET-6466 Anonymize Comment Authors IP address

### DIFF
--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -253,6 +253,14 @@ class MasterSite extends TimberSite {
 		// Disable xmlrpc.
 		add_filter( 'xmlrpc_enabled', '__return_false' );
 
+		// Anonymize Comment Authors IP address.
+		add_filter(
+			'pre_comment_user_ip',
+			function () {
+				return '';
+			}
+		);
+
 		$this->register_meta_fields();
 	}
 


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6466

---

Using native filter hook [pre_comment_user_ip](https://developer.wordpress.org/reference/hooks/pre_comment_user_ip/).

Returning an empty string, same as the plugin we currently use does.

### Testing

1. De-activate the "GDPR Comments" plugin.
2. Use a private/incognito window (so you are not logged in), visit a post and leave a comment.
3. One the backend in the Comments section you should see the Author's IP address.
4. Switch to this branch, are add one more comment.
5. In the backend there should be no IP address visible for the new comment Author.
6. Re-test that with plugin enabled. No IP either as expected. We can leave the plugin running till we also have [PLANET-6465](https://jira.greenpeace.org/browse/PLANET-6465) in place.

Below a screenshot of these two comments:

![comments](https://user-images.githubusercontent.com/939357/148562033-6f2244b2-d8bf-4f82-8ba2-75a8c9c1905e.png)
