### PR TITLE
PLANET-6572 Use a high z-index number for navbar

### DIFF
--- a/assets/src/scss/layout/_navbar.scss
+++ b/assets/src/scss/layout/_navbar.scss
@@ -20,7 +20,7 @@ $navbar-default-height: 60px;
   position: fixed;
   top: 0;
   width: 100%;
-  z-index: 4;
+  z-index: 99;
   justify-content: space-between;
 
   .admin-bar & {
@@ -98,7 +98,7 @@ $navbar-default-height: 60px;
     &.open {
       inset-inline-start: 0;
       transition: inset-inline-start 0.2s ease-out;
-      z-index: 5;
+      z-index: 99;
 
       ~ .top-navigation-overlay {
         display: block;


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6572

---

Switch to using a high number since we want the navbar to be always on top of everything else.

### Testing

Current code makes Submenu block float over the navbar. To test just use a page with a Submenu block and switch branches.

- [Current behavior](https://www.greenpeace.org/belgium/fr/faq/)
- [This branch](https://www-dev.greenpeace.org/test-nix/explore/)