### PR TITLE
PLANET-6536 Move feature settings to a separate WP option

### DIFF
--- a/src/Features.php
+++ b/src/Features.php
@@ -7,6 +7,8 @@ namespace P4\MasterTheme;
  */
 class Features {
 
+	public const OPTIONS_KEY = 'planet4_features';
+
 	/**
 	 * @var string Media library refactored feature.
 	 */
@@ -54,6 +56,7 @@ class Features {
 	public static function get_options_page(): array {
 		return [
 			'title'       => 'Features',
+			'root_option' => self::OPTIONS_KEY,
 			'fields'      => self::get_fields(),
 			'add_scripts' => static function () {
 				Loader::enqueue_versioned_script( '/admin/js/features_save_redirect.js' );
@@ -66,7 +69,7 @@ class Features {
 	 *
 	 * @return array[] The fields for each feature.
 	 */
-	private static function get_fields(): array {
+	public static function get_fields(): array {
 		$fields = [
 			[
 				'name' => __( 'Greenpeace Image Archive (beta, name subject to change)', 'planet4-master-theme-backend' ),
@@ -192,7 +195,12 @@ class Features {
 	 * @return bool Whether the feature is active.
 	 */
 	public static function is_active( string $name ): bool {
-		$features = get_option( Settings::KEY );
+		$features = get_option( self::OPTIONS_KEY );
+
+		// Temporary fallback to ensure it works before migration runs.
+		if ( ! $features ) {
+			$features = get_option( Settings::KEY );
+		}
 
 		$active = isset( $features[ $name ] ) && $features[ $name ];
 
@@ -222,7 +230,7 @@ class Features {
 		// After all fields are saved.
 		add_action(
 			'cmb2_save_options-page_fields_' . Settings::METABOX_ID,
-			__CLASS__ . '::on_features_saved',
+			[ self::class, 'on_features_saved' ],
 			10,
 			4
 		);
@@ -235,7 +243,7 @@ class Features {
 	 * @param int   $object_id The ID of the current object.
 	 */
 	public static function on_pre_process( $cmb, $object_id ) {
-		if ( Settings::KEY !== $object_id ) {
+		if ( self::OPTIONS_KEY !== $object_id ) {
 			return;
 		}
 

--- a/src/Migrations/M006MoveFeaturesToSeparateOption.php
+++ b/src/Migrations/M006MoveFeaturesToSeparateOption.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace P4\MasterTheme\Migrations;
+
+use P4\MasterTheme\Features;
+use P4\MasterTheme\MigrationRecord;
+use P4\MasterTheme\MigrationScript;
+use P4\MasterTheme\Settings;
+
+/**
+ * Move feature settings to a separate database record. This allows disabling translation on those settings.
+ */
+class M006MoveFeaturesToSeparateOption extends MigrationScript {
+
+	/**
+	 * Perform the actual migration.
+	 *
+	 * @param MigrationRecord $record Information on the execution, can be used to add logs.
+	 *
+	 * @return void
+	 */
+	protected static function execute( MigrationRecord $record ): void {
+		// This should run for the default language during post deploy.
+		$settings       = get_option( Settings::KEY );
+		$feature_fields = Features::get_fields();
+		$feature_values = [];
+
+		foreach ( $feature_fields as $field ) {
+			$id = $field['id'];
+
+			$value = $settings[ $id ] ?? null;
+			if ( $value ) {
+				$feature_values[ $id ] = $value;
+			}
+		}
+		update_option( Features::OPTIONS_KEY, $feature_values );
+		$record->add_log( 'Successfully migrated feature settings: ' . "\n" . print_r( $feature_values, true ) ); //phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
+	}
+}

--- a/src/Migrator.php
+++ b/src/Migrator.php
@@ -7,6 +7,7 @@ use P4\MasterTheme\Migrations\M002EnableLazyYoutube;
 use P4\MasterTheme\Migrations\M004UpdateMissingMediaPath;
 use P4\MasterTheme\Migrations\M003UpdateArticlesBlockAttribute;
 use P4\MasterTheme\Migrations\M005TurnBoxoutSettingIntoBlock;
+use P4\MasterTheme\Migrations\M006MoveFeaturesToSeparateOption;
 use P4\MasterTheme\Migrations\M007RemoveEnhancedDonateButtonOption;
 
 /**
@@ -31,6 +32,7 @@ class Migrator {
 			M004UpdateMissingMediaPath::class,
 			M003UpdateArticlesBlockAttribute::class,
 			M005TurnBoxoutSettingIntoBlock::class,
+			M006MoveFeaturesToSeparateOption::class,
 			M007RemoveEnhancedDonateButtonOption::class,
 		];
 

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -564,7 +564,11 @@ class Settings {
 	 * @param string $plugin_page The key for the current page.
 	 */
 	public function admin_page_display( string $plugin_page ) {
-		$fields = $this->subpages[ $plugin_page ]['fields'];
+		$page_config = $this->subpages[ $plugin_page ];
+
+		$fields = $page_config['fields'];
+		// Allow storing options in a different database record.
+		$root_option = $page_config['root_option'] ?? self::KEY;
 
 		$add_scripts = $this->subpages[ $plugin_page ]['add_scripts'] ?? null;
 		if ( $add_scripts ) {
@@ -573,7 +577,7 @@ class Settings {
 		?>
 		<div class="wrap <?php echo esc_attr( self::KEY ); ?>">
 			<h2><?php echo esc_html( get_admin_page_title() ); ?></h2>
-			<?php cmb2_metabox_form( $this->option_metabox( $fields ), self::KEY ); ?>
+			<?php cmb2_metabox_form( $this->option_metabox( $fields, $root_option ), $root_option ); ?>
 		</div>
 		<?php
 	}
@@ -581,17 +585,18 @@ class Settings {
 	/**
 	 * Defines the theme option metabox and field configuration.
 	 *
-	 * @param array $fields expects the fields (if they exist) of this subpage.
+	 * @param array  $fields expects the fields (if they exist) of this subpage.
+	 * @param string $option_id Key of option to store serialized array in.
 	 *
 	 * @return array
 	 */
-	public function option_metabox( $fields ) {
+	public function option_metabox( array $fields, string $option_id ) {
 		return [
 			'id'         => self::METABOX_ID,
 			'show_on'    => [
 				'key'   => 'options-page',
 				'value' => [
-					self::KEY,
+					$option_id,
 				],
 			],
 			'show_names' => true,


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6536

* This ensures we can make those features non-translatable.
* Include migration script which will run on post-deploy. It's important
that no one touches the settings between releasing the code and running
post-deploy.
* In the feature check, fallback to the old options key if the new one
was not created yet. If someone makes a feature change before this
script runs, their input will be reset.

### Migration
Should be just 2 steps:
1. After merging this PR (and post-deploy ran) it will already use the new option record when checking features. The code falls back to the old option record as long as the new one wasn't created (short time between deploy and post-deploy).
2. Clean up: Remove the migration script and code fallback. Remove feature settings from the old record in the database.