### PR TITLE
Adjust CSS Customizer typography for readability

### DIFF
--- a/assets/src/scss/editorOverrides.scss
+++ b/assets/src/scss/editorOverrides.scss
@@ -245,3 +245,9 @@ input.describe[type=text][data-setting=caption] {
 .btn {
   user-select: auto;
 }
+
+// Adjust CSS Customizer for readability
+.CodeMirror-code {
+  font-size: $font-size-xs;
+  line-height: 1rem;
+}


### PR DESCRIPTION
Customizer font is really big since it's inherited from our theme.
Since it's on a sidebar a decreased size makes it a bit easier to read.

Changes:
- Decreases font-size
- Decreases line-height