### PR TITLE
PLANET-6574 Remove unneeded filter that broke media library

### DIFF
--- a/src/Search.php
+++ b/src/Search.php
@@ -224,7 +224,6 @@ abstract class Search {
 				2
 			);
 		}
-		add_filter( 'posts_where', [ self::class, 'edit_search_mime_types' ] );
 		remove_filter(
 			'pre_get_posts',
 			[ Features::factory()->get_registered_feature( 'documents' ), 'setup_document_search' ],
@@ -1005,24 +1004,6 @@ abstract class Search {
 		}
 
 		return null;
-	}
-
-	/**
-	 * Customize which mime types we want to search for regarding attachments.
-	 *
-	 * @param string $where The WHERE clause of the query.
-	 *
-	 * @return string The edited WHERE clause.
-	 */
-	public static function edit_search_mime_types( $where ) : string {
-		global $wpdb;
-
-		if ( ( ! is_admin() && is_search() ) || wp_doing_ajax() ) {
-			$mime_types = implode( ',', self::DOCUMENT_TYPES );
-			$where     .= ' AND ' . $wpdb->posts . '.post_mime_type IN("' . $mime_types . '","") ';
-		}
-
-		return $where;
 	}
 
 	/**


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6574

* This doesn't seem to do anything anymore, except breaking the media
library because we reduced the check.

The code also has a similar filter in other places which is what is actually used https://github.com/greenpeace/planet4-master-theme/blob/cff56634ca62b529132be26307cdb35190cbbbc4/src/ElasticSearch.php#L246-L269.