### PR TITLE
PLANET-6542 Disable search button when search input is empty

### DIFF
--- a/assets/src/scss/layout/navbar/_search.scss
+++ b/assets/src/scss/layout/navbar/_search.scss
@@ -71,6 +71,10 @@
   visibility: hidden;
 }
 
+#search_input:placeholder-shown ~ button.nav-search-btn {
+  pointer-events: none;
+}
+
 #search_input::-webkit-search-decoration,
 #search_input::-webkit-search-cancel-button,
 #search_input::-webkit-search-results-button,


### PR DESCRIPTION
### Description

See https://jira.greenpeace.org/browse/PLANET-6542

I couldn't think of a way to achieve this without JS, but maybe there's one? Suggestions welcome 🙃 

### Testing

On screens > 1200px, the navbar search icon should be disabled if the search input is empty. When typing in the input, the button should no longer be disabled, and when clicking on it the form should be submitted as expected.