### PR TITLE
PLANET-6505 Remove author image in case of author override

### DIFF
--- a/templates/single.twig
+++ b/templates/single.twig
@@ -60,7 +60,7 @@
 				</div>
 				<h1 class="page-header-title">{{ post.title|raw }}</h1>
 				<div class="single-post-meta">
-					{% if post.author.avatar %}
+					{% if not post.get_author_override and post.author.avatar %}
 						<img itemprop="image" class="author-pic"
 							src="{{ fn('get_avatar_url', post.author.id, {'size' : 50, 'default': 'mm'}) }}"
 							alt="{{ post.author.avatar }}">


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6505
* It didn't have the ID which always resulted in the default Gravatar
image.
* Check not needed in the bottom bio because that is not included for
overridden authors.

<!-- Ref: Please add a url to the ticket this change is addressing.

---

Please provide a brief summary of the change introduced to make review process easier.

Ideally this should also be part of the commit summary.
-->
