### PR TITLE
Use grid for Planet 4 admin options

### DIFF
--- a/admin/css/campaign.css
+++ b/admin/css/campaign.css
@@ -33,7 +33,3 @@
   bottom: 0 !important;
   padding: 8px 10px 4px;
 }
-
-.planet-4_page_planet4_settings_features .cmb-th + .cmb-td {
-  float: none;
-}

--- a/admin/css/options.css
+++ b/admin/css/options.css
@@ -1,0 +1,24 @@
+.planet4_options .cmb-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+}
+
+.planet4_options .cmb-th {
+  float: none;
+  padding: 15px 10px 15px 0;
+}
+
+.planet4_options label {
+  padding: 0;
+}
+
+.planet4_options .cmb-td {
+  float: none;
+}
+
+@media (min-width: 768px) {
+  .planet4_options .cmb-row {
+    display: grid;
+    grid-template-columns: 1fr 4fr;
+  }
+}

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -428,6 +428,7 @@ class Settings {
 		add_filter( 'cmb2_render_explore_page_dropdown', [ $this, 'p4_render_explore_page_dropdown' ], 10, 2 );
 		add_filter( 'cmb2_render_category_select_taxonomy', [ $this, 'p4_render_category_dropdown' ], 10, 2 );
 		add_filter( 'cmb2_render_pagetype_select_taxonomy', [ $this, 'p4_render_pagetype_dropdown' ], 10, 2 );
+		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_admin_assets' ] );
 
 		// Make settings multilingual if wpml plugin is installed and activated.
 		if ( function_exists( 'is_plugin_active' ) && is_plugin_active( 'sitepress-multilingual-cms/sitepress.php' ) ) {
@@ -601,5 +602,18 @@ class Settings {
 	 */
 	public function make_settings_multilingual() {
 		do_action( 'wpml_multilingual_options', 'planet4_options' );
+	}
+
+	/**
+	 * Loads options assets.
+	 */
+	public function enqueue_admin_assets() {
+		wp_register_style(
+			'options-style',
+			get_template_directory_uri() . '/admin/css/options.css',
+			[],
+			Loader::theme_file_ver( 'admin/css/options.css' )
+		);
+		wp_enqueue_style( 'options-style' );
 	}
 }


### PR DESCRIPTION
Some of our field descriptions are really long that wrap and look unreadable. This minor tweak just uses grid, instead of float, to make them at least align properly.

### Current

![current](https://user-images.githubusercontent.com/939357/149494905-9e87b803-d0f0-463c-8ddc-9e32e6af4999.png)

### With grid

![grid](https://user-images.githubusercontent.com/939357/149494936-dfe0458e-21d3-406e-a10a-93e401794069.png)
