### PR TITLE
PLANET-6075 Add settings to Cookies box

### DIFF
--- a/assets/src/js/cookies.js
+++ b/assets/src/js/cookies.js
@@ -153,6 +153,27 @@ export const setupCookies = () => {
     };
   }
 
+  const rejectAllCookies = () => {
+    createCookie('active_consent_choice', '1', 365);
+    createCookie('greenpeace', ONLY_NECESSARY, 365);
+
+    // Grant ad storage and analytics storage if Google Consent Mode is enabled.
+    updateGoogleConsent('ad_storage', false);
+    if (ENABLE_ANALYTICAL_COOKIES) {
+      updateGoogleConsent('analytics_storage', false);
+    }
+
+    // DataLayer push event on cookies consent.
+    dataLayer.push({
+      'event' : 'cookiesConsent'
+    });
+
+    cookiesBox.classList.remove('shown');
+  };
+
+  const rejectAllCookiesButtons = [...cookiesBox.querySelectorAll('.reject-all-cookies')];
+  rejectAllCookiesButtons.forEach(rejectAllCookiesButton => rejectAllCookiesButton.onclick = rejectAllCookies);
+
   const greenpeace = readCookie('greenpeace');
   const no_track = readCookie('no_track');
   // Make the necessary cookies checked by default on user's first visit.

--- a/assets/src/js/cookies.js
+++ b/assets/src/js/cookies.js
@@ -4,9 +4,28 @@ export const setupCookies = () => {
   const ENABLE_ANALYTICAL_COOKIES = window.p4bk_vars.enable_analytical_cookies;
   const ENABLE_GOOGLE_CONSENT_MODE = window.p4bk_vars.enable_google_consent_mode;
 
+  // Possible cookie values
+  const ONLY_NECESSARY = '1';
+  const ALL_COOKIES = '2';
+  const NECESSARY_ANALYTICAL_MARKETING = '4';
+
   function gtag() {
     dataLayer.push(arguments);
   }
+
+  const updateGoogleConsent = (key, granted) => {
+    if (!ENABLE_GOOGLE_CONSENT_MODE) {
+      return;
+    }
+
+    gtag('consent', 'update', {
+      [key]: granted ? 'granted' : 'denied',
+    });
+    dataLayer.push({
+      'event': 'updateConsent',
+      [key]: granted ? 'granted' : 'denied',
+    });
+  };
 
   // If Google Consent Mode is enabled, set default ad storage and analytics storage to 'denied' if needed
   if (ENABLE_GOOGLE_CONSENT_MODE) {
@@ -25,7 +44,7 @@ export const setupCookies = () => {
     }
   }
 
-  window.createCookie = (name, value, days) => {
+  const createCookie = (name, value, days) => {
     let date = new Date();
     date.setTime(date.getTime() + (days * 24 * 60 * 60 * 1000));
     const secureMode = document.location.protocol === 'http:'
@@ -34,7 +53,7 @@ export const setupCookies = () => {
     document.cookie = encodeURI(name) + '=' + encodeURI(value) + ';domain=.' + document.domain + ';path=/;' + '; expires=' + date.toGMTString() + secureMode;
   };
 
-  window.readCookie = name => {
+  const readCookie = name => {
     const nameEQ = name + '=';
     const ca = document.cookie.split(';');
     let c;
@@ -47,58 +66,98 @@ export const setupCookies = () => {
     return null;
   };
 
-  const cookie = window.readCookie('active_consent_choice');
-  const cookieElement = document.querySelector('#set-cookie');
+  const cookie = readCookie('active_consent_choice');
+  const cookiesBox = document.querySelector('#set-cookie');
   const nro = document.body.dataset.nro;
 
   if (cookie === null) {
-    if (cookieElement) {
-      cookieElement.classList.add('shown');
+    if (cookiesBox) {
+      cookiesBox.classList.add('shown');
     }
   } else {
-    window.createCookie('gp_nro', nro, 30);
+    createCookie('gp_nro', nro, 30);
   }
 
-  const hideCookieButton = document.querySelector('#hidecookie');
-  if (hideCookieButton) {
-    hideCookieButton.onclick = () => {
-      window.createCookie('active_consent_choice', '1', 365);
-      const newCookieValue = ENABLE_ANALYTICAL_COOKIES ? '4' : '2';
-      window.createCookie('greenpeace', newCookieValue, 365);
+  const allowAllCookies = () => {
+    createCookie('active_consent_choice', '1', 365);
+    const newCookieValue = ENABLE_ANALYTICAL_COOKIES ? NECESSARY_ANALYTICAL_MARKETING : ALL_COOKIES;
+    createCookie('greenpeace', newCookieValue, 365);
 
-      // Remove the 'no_track' cookie, if user accept the cookies consent.
-      window.createCookie('no_track', '0', -1);
+    // Remove the 'no_track' cookie, if user accept the cookies consent.
+    createCookie('no_track', '0', -1);
 
-      // Create cookie to store last visited nro.
-      window.createCookie('gp_nro', nro, 30);
+    // Create cookie to store last visited nro.
+    createCookie('gp_nro', nro, 30);
 
-      // Grant ad storage and analytics storage if Google Consent Mode is enabled.
-      if (ENABLE_GOOGLE_CONSENT_MODE) {
-        gtag('consent', 'update', {
-          'ad_storage': 'granted',
-          ...ENABLE_ANALYTICAL_COOKIES && { 'analytics_storage': 'granted' },
-        });
-        dataLayer.push({
-          'event' : 'updateConsent',
-          'ad_storage': 'granted',
-          ...ENABLE_ANALYTICAL_COOKIES && { 'analytics_storage': 'granted' },
-        });
+    // Grant ad storage and analytics storage if Google Consent Mode is enabled.
+    updateGoogleConsent('ad_storage', true);
+    if (ENABLE_ANALYTICAL_COOKIES) {
+      updateGoogleConsent('analytics_storage', true);
+    }
+
+    // DataLayer push event on cookies consent.
+    dataLayer.push({
+      'event' : 'cookiesConsent'
+    });
+
+    cookiesBox.classList.remove('shown');
+  };
+
+  const allowAllCookiesButtons = [...document.querySelectorAll('.allow-all-cookies')];
+  allowAllCookiesButtons.forEach(allowAllCookiesButton => allowAllCookiesButton.onclick = allowAllCookies);
+
+  const toggleCookiesSettings = () => {
+    const cookiesSettings = document.querySelector('.cookies-settings');
+    const cookiesIntro = document.querySelector('.cookies-intro');
+    cookiesSettings.classList.toggle('d-none');
+    cookiesIntro.classList.toggle('d-none');
+  };
+
+  const showCookiesSettingsButton = cookiesBox.querySelector('#show-cookies-settings');
+  if (showCookiesSettingsButton) {
+    showCookiesSettingsButton.onclick = toggleCookiesSettings;
+  }
+
+  const closeCookiesSettingsButton = cookiesBox.querySelector('.close-cookies-settings');
+  if (closeCookiesSettingsButton) {
+    closeCookiesSettingsButton.onclick = toggleCookiesSettings;
+  }
+
+  const saveCookiesSettingsButton = document.querySelector('#save-cookies-settings');
+  if (saveCookiesSettingsButton) {
+    saveCookiesSettingsButton.onclick = () => {
+      // Get checked settings
+      const analyticalCookiesCheckbox = cookiesBox.querySelector('input[name="analytical_cookies"]');
+      const allCookiesCheckbox = cookiesBox.querySelector('input[name="all_cookies"]');
+
+      const analyticalCookiesChecked = analyticalCookiesCheckbox ? analyticalCookiesCheckbox.checked : false;
+      const allCookiesChecked = allCookiesCheckbox ? allCookiesCheckbox.checked : false;
+
+      let newCookieValue = allCookiesChecked ? ALL_COOKIES : ONLY_NECESSARY;
+      if (ENABLE_ANALYTICAL_COOKIES && analyticalCookiesChecked) {
+        newCookieValue = NECESSARY_ANALYTICAL_MARKETING;
       }
 
-      // DataLayer push event on cookies consent.
-      dataLayer.push({
-        'event' : 'cookiesConsent'
-      });
+      // Update cookie value
+      createCookie('greenpeace', newCookieValue, 365);
+      createCookie('active_consent_choice', '1', 365);
 
-      cookieElement.classList.remove('shown');
+      // Update ad storage and analytics storage if Google Consent Mode is enabled
+      updateGoogleConsent('ad_storage', allCookiesChecked);
+      if (ENABLE_ANALYTICAL_COOKIES) {
+        updateGoogleConsent('analytics_storage', analyticalCookiesChecked);
+      }
+
+      // Hide cookies box
+      cookiesBox.classList.remove('shown');
     };
   }
 
-  const greenpeace = window.readCookie('greenpeace');
-  const no_track = window.readCookie('no_track');
+  const greenpeace = readCookie('greenpeace');
+  const no_track = readCookie('no_track');
   // Make the necessary cookies checked by default on user's first visit.
   // Here if the No cookies set(absence of 'greenpeace' & 'no_track' cookies) consider as first visit of user.
   if (ENABLE_ANALYTICAL_COOKIES && greenpeace === null && no_track === null) {
-    window.createCookie('greenpeace', '1', 365);
+    createCookie('greenpeace', ONLY_NECESSARY, 365);
   }
 };

--- a/assets/src/scss/layout/_cookies-settings.scss
+++ b/assets/src/scss/layout/_cookies-settings.scss
@@ -22,28 +22,26 @@
     }
   }
 
-  .cookies-settings-header {
-    padding: 0 $sp-3;
-    width: 100vw;
-    margin-bottom: $sp-2;
-    border-bottom: solid 1px $grey-10;
-    margin-inline-start: -$sp-3;
-
-    h4 {
-      font-size: 16px;
-      margin-bottom: 8px;
-    }
+  .cookies-settings-header h4 {
+    font-size: 16px;
+    margin-bottom: $sp-1;
   }
 
   .cookies-settings-details {
     max-height: 40vh;
-    overflow: scroll;
+    overflow-y: auto;
+    overflow-x: hidden;
+    width: calc(100% + 2 * #{$sp-3});
+    margin-inline-start: -$sp-3;
+    padding: $sp-2 $sp-3 0 $sp-3;
+    border-top: solid 1px $grey-10;
+    border-bottom: solid 1px $grey-10;
 
     .custom-control-description,
     .custom-control input[type="checkbox"] ~ .custom-control-description {
       font-weight: 700;
       font-size: 14px;
-      margin-bottom: 16px;
+      margin-bottom: $sp-2;
     }
   }
 
@@ -60,10 +58,7 @@
   .cookies-settings-buttons {
     display: flex;
     justify-content: space-between;
-    border-top: solid 1px $grey-10;
-    padding: $sp-3 $sp-3 0 $sp-3;
-    width: 100vw;
-    margin-inline-start: -$sp-3;
+    margin-top: $sp-3;
 
     .btn {
       width: calc(50% - 8px);
@@ -77,7 +72,7 @@
 
       .btn-primary {
         width: 100%;
-        margin-top: 16px;
+        margin-top: $sp-2;
       }
     }
   }
@@ -87,11 +82,7 @@
 
     .cookies-settings-details {
       max-height: 300px;
-    }
-
-    .cookies-settings-header,
-    .cookies-settings-buttons {
-      width: calc(100% + 64px);
+      width: calc(100% + 2 * #{$sp-4});
       margin-inline-start: -$sp-4;
       padding-left: $sp-4;
       padding-right: $sp-4;
@@ -118,8 +109,16 @@
       }
 
       .btn {
-        padding: 0 16px;
+        padding: 0 $sp-2;
         width: auto;
+      }
+    }
+
+    .close-cookies-settings {
+      right: -$sp-2;
+
+      html[dir="rtl"] & {
+        left: -$sp-2;
       }
     }
   }

--- a/assets/src/scss/layout/_cookies-settings.scss
+++ b/assets/src/scss/layout/_cookies-settings.scss
@@ -1,0 +1,106 @@
+.cookies-settings {
+  position: relative;
+
+  p {
+    font-size: 12px;
+    line-height: 1.5;
+  }
+
+  .close-cookies-settings {
+    background-color: $grey-80;
+    cursor: pointer;
+    height: 16px;
+    width: 16px;
+    mask: url("../../images/cross.svg");
+    position: absolute;
+    top: -$sp-1;
+    right: -$sp-1;
+
+    html[dir="rtl"] & {
+      right: auto;
+      left: -$sp-1;
+    }
+  }
+
+  .cookies-settings-header {
+    padding: 0 $sp-3;
+    width: 100vw;
+    margin-bottom: $sp-2;
+    border-bottom: solid 1px $grey-10;
+    margin-inline-start: -$sp-3;
+
+    h4 {
+      font-size: 16px;
+      margin-bottom: 8px;
+    }
+  }
+
+  .cookies-settings-details {
+    max-height: 40vh;
+    overflow: scroll;
+
+    .custom-control-description,
+    .custom-control input[type="checkbox"] ~ .custom-control-description {
+      font-weight: 700;
+      font-size: 14px;
+      margin-bottom: 16px;
+    }
+  }
+
+  .always-enabled {
+    background: $grey-80;
+    color: white;
+    font-weight: 700;
+    border-radius: 4px;
+    padding: $sp-x;
+    font-size: 12px;
+    margin-inline-start: $sp-1;
+  }
+
+  .cookies-settings-buttons {
+    display: flex;
+    justify-content: space-between;
+    border-top: solid 1px $grey-10;
+    padding: $sp-3 $sp-3 0 $sp-3;
+    width: 100vw;
+    margin-inline-start: -$sp-3;
+
+    .btn {
+      width: calc(50% - 8px);
+      line-height: 2.4;
+      font-size: 14px;
+      padding: 0;
+    }
+  }
+
+  @include medium-and-up {
+    width: 434px;
+
+    .cookies-settings-details {
+      max-height: 300px;
+    }
+
+    .cookies-settings-header,
+    .cookies-settings-buttons {
+      width: calc(100% + 64px);
+      margin-inline-start: -$sp-4;
+      padding-left: $sp-4;
+      padding-right: $sp-4;
+    }
+
+    .cookies-settings-buttons .btn {
+      padding: 0 16px;
+      width: auto;
+    }
+  }
+
+  @include large-and-up {
+    p {
+      font-size: 14px;
+    }
+
+    .cookies-settings-header h4 {
+      font-size: 20px;
+    }
+  }
+}

--- a/assets/src/scss/layout/_cookies-settings.scss
+++ b/assets/src/scss/layout/_cookies-settings.scss
@@ -71,6 +71,15 @@
       font-size: 14px;
       padding: 0;
     }
+
+    &.with-reject-all {
+      flex-wrap: wrap;
+
+      .btn-primary {
+        width: 100%;
+        margin-top: 16px;
+      }
+    }
   }
 
   @include medium-and-up {
@@ -88,9 +97,30 @@
       padding-right: $sp-4;
     }
 
-    .cookies-settings-buttons .btn {
-      padding: 0 16px;
-      width: auto;
+    .cookies-settings-buttons {
+      &.with-reject-all {
+        justify-content: flex-start;
+        flex-wrap: nowrap;
+
+        .btn-secondary {
+          width: 50%;
+
+          &:first-child {
+            margin-inline-end: $sp-2;
+          }
+        }
+
+        .btn-primary {
+          flex-grow: 1;
+          margin-top: 0;
+          margin-inline-start: $sp-8;
+        }
+      }
+
+      .btn {
+        padding: 0 16px;
+        width: auto;
+      }
     }
   }
 

--- a/assets/src/scss/layout/_cookies.scss
+++ b/assets/src/scss/layout/_cookies.scss
@@ -47,13 +47,32 @@
     width: 100%;
   }
 
-  .cookies-buttons .btn {
-    width: 100%;
-    line-height: 2.4;
-    font-size: 14px;
+  .cookies-buttons {
+    &.with-reject-all {
+      .btn-primary {
+        margin-bottom: $sp-2;
+      }
 
-    &:first-child {
-      margin-bottom: $sp-2;
+      .reject-all-cookies {
+        background: none;
+        border: none;
+        color: $grey-40;
+        line-height: 1;
+
+        &:hover {
+          text-decoration: underline;
+        }
+      }
+    }
+
+    .btn {
+      width: 100%;
+      line-height: 2.4;
+      font-size: 14px;
+    }
+
+    .btn-primary {
+      margin-top: $sp-2;
     }
   }
 
@@ -75,12 +94,17 @@
       display: flex;
       justify-content: space-between;
 
-      .btn {
-        width: 130px;
+      .btn-primary {
+        margin: 0;
+      }
 
-        &:first-child {
-          margin-bottom: 0;
-        }
+      &.with-reject-all {
+        flex-wrap: wrap;
+        align-items: baseline;
+      }
+
+      .btn:not(.reject-all-cookies) {
+        width: 130px;
       }
     }
 

--- a/assets/src/scss/layout/_cookies.scss
+++ b/assets/src/scss/layout/_cookies.scss
@@ -17,11 +17,12 @@
 }
 
 .cookie-notice {
+  font-family: $roboto;
   z-index: 100;
   position: fixed;
   width: 100vw;
   background: white;
-  padding: 24px 24px 32px;
+  padding: $sp-3;
   visibility: hidden;
   opacity: 0;
   transition: visibility 0.5s, opacity 0.5s linear;
@@ -29,6 +30,7 @@
   border-top-right-radius: 4px;
   box-shadow: 0 0 12px rgba(0, 0, 0, 0.15);
   bottom: 0;
+  color: $grey-80;
   @include slide-from(bottom, 0);
 
   &.shown {
@@ -36,23 +38,27 @@
     visibility: visible;
   }
 
-  > div {
+  .cookies-text {
     font-size: 14px;
     margin-bottom: 24px;
     font-weight: 400;
     color: $grey-80;
-    font-family: $roboto;
     line-height: 1.5rem;
     width: 100%;
   }
 
-  .btn {
+  .cookies-buttons .btn {
     width: 100%;
     line-height: 2.4;
+    font-size: 14px;
+
+    &:first-child {
+      margin-bottom: $sp-2;
+    }
   }
 
   @include medium-and-up {
-    width: 344px;
+    width: auto;
     bottom: 16px;
     right: 16px;
     left: auto;
@@ -60,6 +66,23 @@
     padding: 24px 32px 32px;
     box-shadow: 0 3px 12px rgba(0, 0, 0, 0.15);
     @include slide-from(right, 16px);
+
+    .cookies-intro {
+      width: 276px;
+    }
+
+    .cookies-buttons {
+      display: flex;
+      justify-content: space-between;
+
+      .btn {
+        width: 130px;
+
+        &:first-child {
+          margin-bottom: 0;
+        }
+      }
+    }
 
     html[dir="rtl"] & {
       right: auto;

--- a/assets/src/scss/layout/_cookies.scss
+++ b/assets/src/scss/layout/_cookies.scss
@@ -38,91 +38,88 @@
     visibility: visible;
   }
 
-  .cookies-text {
-    font-size: 14px;
-    margin-bottom: 24px;
-    font-weight: 400;
-    color: $grey-80;
-    line-height: 1.5rem;
-    width: 100%;
-  }
+  .cookies-intro {
+    .cookies-text {
+      font-size: 14px;
+      margin-bottom: $sp-3;
+      font-weight: 400;
+      color: $grey-80;
+      line-height: 1.5rem;
+      width: 100%;
+    }
 
-  .cookies-buttons {
-    &.with-reject-all {
-      .btn-primary {
-        margin-bottom: $sp-2;
+    .cookies-buttons {
+      .btn {
+        width: 100%;
+        line-height: 2.4;
+        font-size: 14px;
       }
 
-      .reject-all-cookies {
-        background: none;
-        border: none;
-        color: $grey-40;
-        line-height: 1;
-
-        &:hover {
-          text-decoration: underline;
-        }
+      .btn-primary {
+        margin-top: $sp-2;
       }
     }
 
-    .btn {
-      width: 100%;
+    .reject-all-cookies {
+      display: block;
+      background: none;
+      border: none;
+      color: $grey-40;
+      margin: $sp-2 auto 0 auto;
       line-height: 2.4;
       font-size: 14px;
-    }
+      padding: 0;
 
-    .btn-primary {
-      margin-top: $sp-2;
+      &:hover {
+        text-decoration: underline;
+      }
     }
   }
 
   @include medium-and-up {
     width: auto;
-    bottom: 16px;
-    right: 16px;
+    bottom: $sp-2;
+    right: $sp-2;
     left: auto;
     border-radius: 4px;
-    padding: 24px 32px 32px;
+    padding: $sp-3 $sp-4;
     box-shadow: 0 3px 12px rgba(0, 0, 0, 0.15);
-    @include slide-from(right, 16px);
+    @include slide-from(right, $sp-2);
 
     .cookies-intro {
-      width: 276px;
-    }
+      width: 308px;
 
-    .cookies-buttons {
-      display: flex;
-      justify-content: space-between;
+      .cookies-buttons {
+        display: flex;
+        justify-content: space-between;
 
-      .btn-primary {
-        margin: 0;
-      }
+        .btn-primary:only-child {
+          width: 100%;
+        }
 
-      &.with-reject-all {
-        flex-wrap: wrap;
-        align-items: baseline;
-      }
-
-      .btn:not(.reject-all-cookies) {
-        width: 130px;
+        .btn-primary,
+        .btn-secondary {
+          width: calc(50% - #{$sp-1});
+          margin-top: 0;
+        }
       }
     }
 
     html[dir="rtl"] & {
       right: auto;
-      left: 16px;
-      @include slide-from(left, 16px);
+      left: $sp-2;
+      @include slide-from(left, $sp-2);
     }
   }
 
   @include large-and-up {
-    bottom: 24px;
-    right: 24px;
-    @include slide-from(right, 24px);
+    bottom: $sp-3;
+    right: $sp-3;
+    @include slide-from(right, $sp-3);
 
     html[dir="rtl"] & {
-      left: 24px;
-      @include slide-from(left, 24px);
+      left: $sp-3;
+      @include slide-from(left, $sp-3);
     }
   }
 }

--- a/assets/src/scss/style.scss
+++ b/assets/src/scss/style.scss
@@ -38,6 +38,7 @@ Text Domain: planet4-master-theme
 @import "layout/breadcrumbs";
 @import "layout/blocks";
 @import "layout/cookies";
+@import "layout/cookies-settings";
 @import "layout/footer";
 @import "layout/footer-social-media";
 @import "layout/forms";

--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -494,18 +494,17 @@ class MasterSite extends TimberSite {
 	public function add_to_context( $context ) {
 		global $wp;
 
-		$options = get_option( 'planet4_options' );
-
 		$context['cookies']      = [
-			'text'              => planet4_get_option( 'cookies_field' ),
-			'enable_analytical' => planet4_get_option( 'enable_analytical_cookies' ),
-			'settings_copy'     => [
-				'necessary_cookies_name'         => $options['necessary_cookies_name'] ?? '',
-				'necessary_cookies_description'  => $options['necessary_cookies_description'] ?? '',
-				'analytical_cookies_name'        => $options['analytical_cookies_name'] ?? '',
-				'analytical_cookies_description' => $options['analytical_cookies_description'] ?? '',
-				'all_cookies_name'               => $options['all_cookies_name'] ?? '',
-				'all_cookies_description'        => $options['all_cookies_description'] ?? '',
+			'text'                      => planet4_get_option( 'cookies_field' ),
+			'enable_analytical_cookies' => planet4_get_option( 'enable_analytical_cookies' ),
+			'enable_reject_all_cookies' => planet4_get_option( 'enable_reject_all_cookies' ),
+			'settings_copy'             => [
+				'necessary_cookies_name'         => planet4_get_option( 'necessary_cookies_name' ) ?? '',
+				'necessary_cookies_description'  => planet4_get_option( 'necessary_cookies_description' ) ?? '',
+				'analytical_cookies_name'        => planet4_get_option( 'analytical_cookies_name' ) ?? '',
+				'analytical_cookies_description' => planet4_get_option( 'analytical_cookies_description' ) ?? '',
+				'all_cookies_name'               => planet4_get_option( 'all_cookies_name' ) ?? '',
+				'all_cookies_description'        => planet4_get_option( 'all_cookies_description' ) ?? '',
 			],
 		];
 		$context['theme_uri']    = $this->theme_dir;

--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -493,8 +493,20 @@ class MasterSite extends TimberSite {
 	 */
 	public function add_to_context( $context ) {
 		global $wp;
+
+		$options = get_option( 'planet4_options' );
+
 		$context['cookies']      = [
-			'text' => planet4_get_option( 'cookies_field' ),
+			'text'              => planet4_get_option( 'cookies_field' ),
+			'enable_analytical' => planet4_get_option( 'enable_analytical_cookies' ),
+			'settings_copy'     => [
+				'necessary_cookies_name'         => $options['necessary_cookies_name'] ?? '',
+				'necessary_cookies_description'  => $options['necessary_cookies_description'] ?? '',
+				'analytical_cookies_name'        => $options['analytical_cookies_name'] ?? '',
+				'analytical_cookies_description' => $options['analytical_cookies_description'] ?? '',
+				'all_cookies_name'               => $options['all_cookies_name'] ?? '',
+				'all_cookies_description'        => $options['all_cookies_description'] ?? '',
+			],
 		];
 		$context['theme_uri']    = $this->theme_dir;
 		$context['data_nav_bar'] = [

--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -499,12 +499,12 @@ class MasterSite extends TimberSite {
 			'enable_analytical_cookies' => planet4_get_option( 'enable_analytical_cookies' ),
 			'enable_reject_all_cookies' => planet4_get_option( 'enable_reject_all_cookies' ),
 			'settings_copy'             => [
-				'necessary_cookies_name'         => planet4_get_option( 'necessary_cookies_name' ) ?? '',
-				'necessary_cookies_description'  => planet4_get_option( 'necessary_cookies_description' ) ?? '',
-				'analytical_cookies_name'        => planet4_get_option( 'analytical_cookies_name' ) ?? '',
-				'analytical_cookies_description' => planet4_get_option( 'analytical_cookies_description' ) ?? '',
-				'all_cookies_name'               => planet4_get_option( 'all_cookies_name' ) ?? '',
-				'all_cookies_description'        => planet4_get_option( 'all_cookies_description' ) ?? '',
+				'necessary_cookies_name'         => planet4_get_option( 'necessary_cookies_name', '' ),
+				'necessary_cookies_description'  => planet4_get_option( 'necessary_cookies_description', '' ),
+				'analytical_cookies_name'        => planet4_get_option( 'analytical_cookies_name', '' ),
+				'analytical_cookies_description' => planet4_get_option( 'analytical_cookies_description', '' ),
+				'all_cookies_name'               => planet4_get_option( 'all_cookies_name', '' ),
+				'all_cookies_description'        => planet4_get_option( 'all_cookies_description', '' ),
 			],
 		];
 		$context['theme_uri']    = $this->theme_dir;

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -328,6 +328,13 @@ class Settings {
 						'id'   => 'enable_analytical_cookies',
 						'type' => 'checkbox',
 					],
+
+					[
+						'name' => __( 'Reject all cookies', 'planet4-master-theme-backend' ),
+						'desc' => __( 'Add the "Reject all" option in the Cookies box', 'planet4-master-theme-backend' ),
+						'id'   => 'enable_reject_all_cookies',
+						'type' => 'checkbox',
+					],
 				],
 			],
 			'planet4_settings_copyright'        => [

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -293,12 +293,12 @@ class Settings {
 						],
 					],
 					[
-						'name' => __( 'All Cookies label', 'planet4-master-theme-backend' ),
+						'name' => __( 'Marketing Cookies label', 'planet4-master-theme-backend' ),
 						'id'   => 'all_cookies_name',
 						'type' => 'text',
 					],
 					[
-						'name'    => __( 'All Cookies description', 'planet4-master-theme-backend' ),
+						'name'    => __( 'Marketing Cookies description', 'planet4-master-theme-backend' ),
 						'id'      => 'all_cookies_description',
 						'type'    => 'wysiwyg',
 						'options' => [
@@ -324,7 +324,7 @@ class Settings {
 
 					[
 						'name' => __( 'Enable Analytical Cookies', 'planet4-master-theme-backend' ),
-						'desc' => __( 'Enable the Analytical cookies option in Cookies block.', 'planet4-master-theme-backend' ),
+						'desc' => __( 'Enable the Analytical cookies option in Cookies block and box', 'planet4-master-theme-backend' ),
 						'id'   => 'enable_analytical_cookies',
 						'type' => 'checkbox',
 					],

--- a/templates/cookies.twig
+++ b/templates/cookies.twig
@@ -1,13 +1,16 @@
 {% if ( cookies.text ) %}
 	<div class="cookie-notice" id="set-cookie">
-		{% include 'cookies/cookies_settings.twig' with { enable_analytical: cookies.enable_analytical, settings_copy: cookies.settings_copy } %}
+		{% include 'cookies/cookies_settings.twig' %}
 		<div class="cookies-intro">
 			<div class="cookies-text">
 				{{ cookies.text|e('wp_kses_post')|raw }}
 			</div>
-			<div class="cookies-buttons">
+			<div class="cookies-buttons {{ cookies.enable_reject_all_cookies ? 'with-reject-all' : '' }}">
 				<button class="btn btn-secondary p-0" id="show-cookies-settings">{{ __( 'Settings', 'planet4-master-theme' ) }}</button>
 				<button class="btn btn-primary p-0 allow-all-cookies">{{ __( 'Accept all cookies', 'planet4-master-theme' ) }}</button>
+				{% if cookies.enable_reject_all_cookies %}
+					<button class="btn reject-all-cookies">{{ __( 'Reject all cookies', 'planet4-master-theme' ) }}</button>
+				{% endif %}
 			</div>
 		</div>
 	</div>

--- a/templates/cookies.twig
+++ b/templates/cookies.twig
@@ -1,8 +1,14 @@
 {% if ( cookies.text ) %}
 	<div class="cookie-notice" id="set-cookie">
-		<div>
-			{{ cookies.text|e('wp_kses_post')|raw }}
+		{% include 'cookies/cookies_settings.twig' with { enable_analytical: cookies.enable_analytical, settings_copy: cookies.settings_copy } %}
+		<div class="cookies-intro">
+			<div class="cookies-text">
+				{{ cookies.text|e('wp_kses_post')|raw }}
+			</div>
+			<div class="cookies-buttons">
+				<button class="btn btn-secondary p-0" id="show-cookies-settings">{{ __( 'Settings', 'planet4-master-theme' ) }}</button>
+				<button class="btn btn-primary p-0 allow-all-cookies">{{ __( 'Accept all cookies', 'planet4-master-theme' ) }}</button>
+			</div>
 		</div>
-		<button class="btn btn-primary p-0" id="hidecookie">{{ __( 'Got it!', 'planet4-master-theme' ) }}</button>
 	</div>
 {% endif %}

--- a/templates/cookies.twig
+++ b/templates/cookies.twig
@@ -1,3 +1,5 @@
+{% set show_settings = cookies.settings_copy.analytical_cookies_name or cookies.settings_copy.all_cookies_name %}
+
 {% if ( cookies.text ) %}
 	<div class="cookie-notice" id="set-cookie">
 		{% include 'cookies/cookies_settings.twig' %}
@@ -5,13 +7,34 @@
 			<div class="cookies-text">
 				{{ cookies.text|e('wp_kses_post')|raw }}
 			</div>
-			<div class="cookies-buttons {{ cookies.enable_reject_all_cookies ? 'with-reject-all' : '' }}">
-				<button class="btn btn-secondary p-0" id="show-cookies-settings">{{ __( 'Settings', 'planet4-master-theme' ) }}</button>
-				<button class="btn btn-primary p-0 allow-all-cookies">{{ __( 'Accept all cookies', 'planet4-master-theme' ) }}</button>
-				{% if cookies.enable_reject_all_cookies %}
-					<button class="btn reject-all-cookies">{{ __( 'Reject all cookies', 'planet4-master-theme' ) }}</button>
+			<div class="cookies-buttons">
+				{% if show_settings %}
+					<button
+						class="btn btn-secondary p-0"
+						id="show-cookies-settings"
+						data-ga-category="Cookies box"
+						data-ga-action="Settings"
+					>
+						{{ __( 'Settings', 'planet4-master-theme' ) }}
+					</button>
 				{% endif %}
+				<button
+					class="btn btn-primary p-0 allow-all-cookies"
+					data-ga-category="Cookies box"
+					data-ga-action="Accept all cookies"
+				>
+					{{ __( 'Accept all cookies', 'planet4-master-theme' ) }}
+				</button>
 			</div>
+			{% if show_settings and cookies.enable_reject_all_cookies %}
+				<button
+					class="btn reject-all-cookies"
+					data-ga-category="Cookies box"
+					data-ga-action="Reject all cookies"
+				>
+					{{ __( 'Reject all cookies', 'planet4-master-theme' ) }}
+				</button>
+			{% endif %}
 		</div>
 	</div>
 {% endif %}

--- a/templates/cookies/cookies_settings.twig
+++ b/templates/cookies/cookies_settings.twig
@@ -1,0 +1,44 @@
+{% set necessary_cookies_name = settings_copy.necessary_cookies_name %}
+{% set necessary_cookies_description = settings_copy.necessary_cookies_description %}
+{% set analytical_cookies_name = settings_copy.analytical_cookies_name %}
+{% set analytical_cookies_description = settings_copy.analytical_cookies_description %}
+{% set all_cookies_name = settings_copy.all_cookies_name %}
+{% set all_cookies_description = settings_copy.all_cookies_description %}
+
+<div class="d-none cookies-settings">
+	<div class="close-cookies-settings"></div>
+	<div class="cookies-settings-header">
+		<h4>{{__('Manage your cookies preferences', 'planet4-master-theme')}}</h4>
+		<p>{{__('Please select which cookies you are willing to store.', 'planet4-master-theme')}}</p>
+	</div>
+	<div class="cookies-settings-details">
+		{% if necessary_cookies_name is not empty %}
+			<div class="custom-control-description">{{ necessary_cookies_name }} <span class="always-enabled">{{__('Always enabled', 'planet4-master-theme')}}</span></div>
+			{% if necessary_cookies_description is not empty %}
+				<p>{{ necessary_cookies_description }}</p>
+			{% endif %}
+		{% endif %}
+		{% if enable_analytical and analytical_cookies_name is not empty %}
+			<label class="custom-control">
+				<input type="checkbox" name="analytical_cookies" />
+				<span class="custom-control-description">{{ analytical_cookies_name }}</span>
+			</label>
+			{% if analytical_cookies_description is not empty %}
+				<p>{{ analytical_cookies_description }}</p>
+			{% endif %}
+		{% endif %}
+		{% if all_cookies_name is not empty %}
+			<label class="custom-control">
+				<input type="checkbox" name="all_cookies" />
+				<span class="custom-control-description">{{ all_cookies_name }}</span>
+			</label>
+			{% if all_cookies_description is not empty %}
+				<p>{{ all_cookies_description }}</p>
+			{% endif %}
+		{% endif %}
+	</div>
+	<div class="cookies-settings-buttons">
+		<button class="btn btn-secondary allow-all-cookies">{{ __( 'Allow all', 'planet4-master-theme' ) }}</button>
+		<button class="btn btn-primary" id="save-cookies-settings">{{ __( 'Save preferences', 'planet4-master-theme' ) }}</button>
+	</div>
+</div>

--- a/templates/cookies/cookies_settings.twig
+++ b/templates/cookies/cookies_settings.twig
@@ -1,9 +1,9 @@
-{% set necessary_cookies_name = settings_copy.necessary_cookies_name %}
-{% set necessary_cookies_description = settings_copy.necessary_cookies_description %}
-{% set analytical_cookies_name = settings_copy.analytical_cookies_name %}
-{% set analytical_cookies_description = settings_copy.analytical_cookies_description %}
-{% set all_cookies_name = settings_copy.all_cookies_name %}
-{% set all_cookies_description = settings_copy.all_cookies_description %}
+{% set necessary_cookies_name = cookies.settings_copy.necessary_cookies_name %}
+{% set necessary_cookies_description = cookies.settings_copy.necessary_cookies_description %}
+{% set analytical_cookies_name = cookies.settings_copy.analytical_cookies_name %}
+{% set analytical_cookies_description = cookies.settings_copy.analytical_cookies_description %}
+{% set all_cookies_name = cookies.settings_copy.all_cookies_name %}
+{% set all_cookies_description = cookies.settings_copy.all_cookies_description %}
 
 <div class="d-none cookies-settings">
 	<div class="close-cookies-settings"></div>
@@ -18,7 +18,7 @@
 				<p>{{ necessary_cookies_description }}</p>
 			{% endif %}
 		{% endif %}
-		{% if enable_analytical and analytical_cookies_name is not empty %}
+		{% if cookies.enable_analytical_cookies and analytical_cookies_name is not empty %}
 			<label class="custom-control">
 				<input type="checkbox" name="analytical_cookies" />
 				<span class="custom-control-description">{{ analytical_cookies_name }}</span>
@@ -37,7 +37,10 @@
 			{% endif %}
 		{% endif %}
 	</div>
-	<div class="cookies-settings-buttons">
+	<div class="cookies-settings-buttons {{ cookies.enable_reject_all_cookies ? 'with-reject-all' : '' }}">
+		{% if cookies.enable_reject_all_cookies %}
+			<button class="btn btn-secondary reject-all-cookies">{{ __( 'Reject all', 'planet4-master-theme' ) }}</button>
+		{% endif %}
 		<button class="btn btn-secondary allow-all-cookies">{{ __( 'Allow all', 'planet4-master-theme' ) }}</button>
 		<button class="btn btn-primary" id="save-cookies-settings">{{ __( 'Save preferences', 'planet4-master-theme' ) }}</button>
 	</div>

--- a/templates/cookies/cookies_settings.twig
+++ b/templates/cookies/cookies_settings.twig
@@ -15,7 +15,7 @@
 		{% if necessary_cookies_name is not empty %}
 			<div class="custom-control-description">{{ necessary_cookies_name }} <span class="always-enabled">{{__('Always enabled', 'planet4-master-theme')}}</span></div>
 			{% if necessary_cookies_description is not empty %}
-				<p>{{ necessary_cookies_description }}</p>
+				<p>{{ necessary_cookies_description|e('wp_kses_post')|raw }}</p>
 			{% endif %}
 		{% endif %}
 		{% if cookies.enable_analytical_cookies and analytical_cookies_name is not empty %}
@@ -24,7 +24,7 @@
 				<span class="custom-control-description">{{ analytical_cookies_name }}</span>
 			</label>
 			{% if analytical_cookies_description is not empty %}
-				<p>{{ analytical_cookies_description }}</p>
+				<p>{{ analytical_cookies_description|e('wp_kses_post')|raw }}</p>
 			{% endif %}
 		{% endif %}
 		{% if all_cookies_name is not empty %}
@@ -33,15 +33,34 @@
 				<span class="custom-control-description">{{ all_cookies_name }}</span>
 			</label>
 			{% if all_cookies_description is not empty %}
-				<p>{{ all_cookies_description }}</p>
+				<p>{{ all_cookies_description|e('wp_kses_post')|raw }}</p>
 			{% endif %}
 		{% endif %}
 	</div>
 	<div class="cookies-settings-buttons {{ cookies.enable_reject_all_cookies ? 'with-reject-all' : '' }}">
 		{% if cookies.enable_reject_all_cookies %}
-			<button class="btn btn-secondary reject-all-cookies">{{ __( 'Reject all', 'planet4-master-theme' ) }}</button>
+			<button
+				class="btn btn-secondary reject-all-cookies"
+				data-ga-category="Cookies box"
+				data-ga-action="Reject all"
+			>
+				{{ __( 'Reject all', 'planet4-master-theme' ) }}
+			</button>
 		{% endif %}
-		<button class="btn btn-secondary allow-all-cookies">{{ __( 'Allow all', 'planet4-master-theme' ) }}</button>
-		<button class="btn btn-primary" id="save-cookies-settings">{{ __( 'Save preferences', 'planet4-master-theme' ) }}</button>
+		<button
+			class="btn btn-secondary allow-all-cookies"
+			data-ga-category="Cookies box"
+			data-ga-action="Allow all"
+		>
+			{{ __( 'Allow all', 'planet4-master-theme' ) }}
+		</button>
+		<button
+			class="btn btn-primary"
+			id="save-cookies-settings"
+			data-ga-category="Cookies box"
+			data-ga-action="Save preferences"
+		>
+			{{ __( 'Save preferences', 'planet4-master-theme' ) }}
+		</button>
 	</div>
 </div>

--- a/tests/acceptance/CookiesBannerCept.php
+++ b/tests/acceptance/CookiesBannerCept.php
@@ -11,7 +11,7 @@ $I->amOnPage('/');
 $I->see($cookieText, '#set-cookie');
 
 // accept the cookies
-$I->click('Got it!');
+$I->click('Accept all cookies');
 
 // and it's gone
 $I->waitForElementNotVisible('#set-cookie', 5);


### PR DESCRIPTION
### Description

See https://jira.greenpeace.org/browse/PLANET-6075

**Related PR:** [blocks](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/779)

### Testing

You can see the new Cookies box with settings on the [jupiter test instance](https://www-dev.greenpeace.org/test-jupiter/), please check the design in all screen sizes. You can also change the texts in the settings (`Planet 4 > Cookies`) and make sure that all is updated properly, knowing that leaving a label or description empty will hide them in the box. Also try adding/removing the `Reject all` option (in the same settings section). I'll ping Julia to make sure the analytics part is working as expected and the correct events are fired 🙂