### PR TITLE
Add reading time to listing pages

### DIFF
--- a/templates/tease-author.twig
+++ b/templates/tease-author.twig
@@ -45,6 +45,13 @@
 
 		<div class="search-result-item-info">
 			<span class="search-result-item-date">{{ post.post_date|date }}</span>
+			{% set reading_time = post.reading_time %}
+			{% if reading_time %}
+				<span class="single-post-meta-bullet" aria-hidden="true">&#8226;</span>
+				<span class="single-post-meta-readtime">
+					{{ __( '%d min read', 'planet4-master-theme' )|format(reading_time) }}
+				</span>
+			{% endif %}
 		</div>
 
 		<p class="search-result-item-content">{{ post.post_excerpt|excerpt( 30 )|e('wp_kses_post')|raw }}</p>

--- a/templates/tease-taxonomy-post.twig
+++ b/templates/tease-taxonomy-post.twig
@@ -54,6 +54,13 @@
 				</span>
 			{% endif %}
 			<span class="search-result-item-date">{{ post.post_date|date }}</span>
+			{% set reading_time = post.reading_time %}
+			{% if reading_time %}
+				<span class="single-post-meta-bullet" aria-hidden="true">&#8226;</span>
+				<span class="single-post-meta-readtime">
+					{{ __( '%d min read', 'planet4-master-theme' )|format(reading_time) }}
+				</span>
+			{% endif %}
 		</div>
 
 		<p class="search-result-item-content">{{ post.post_excerpt|excerpt( 30 )|e('wp_kses_post')|raw }}</p>


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6593

---

This includes:
- [Post type](https://www-dev.greenpeace.org/test-venus/story/)
- [Author page](https://www-dev.greenpeace.org/test-venus/author/admin/) (where actually only `Stories` have reading time)
- [Category listing](https://www-dev.greenpeace.org/test-venus/explore/about/)
- [Tag listing](https://www-dev.greenpeace.org/test-venus/tag/fires/)

I was tempted to align all these meta details to use the same markup as the Articles block, but since we are planning on revamping these pages anyway, I kept the scope just on adding the reading time markup.
