### PR TITLE
Re-add core block patterns

### DIFF
--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -109,8 +109,6 @@ class MasterSite extends TimberSite {
 		if ( planet4_get_option( FEATURES::WP_TEMPLATE_EDITOR ) ) {
 			add_theme_support( 'block-templates' );
 		}
-		// Disable wp5.5 Block Patterns.
-		remove_theme_support( 'core-block-patterns' );
 
 		add_post_type_support( 'page', 'excerpt' );  // Added excerpt option to pages.
 

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -23,6 +23,83 @@ class Settings {
 
 	public const SLACK_WEBHOOK = 'slack_webhook';
 
+	public const CORE_BLOCKS = 'core_blocks';
+
+	public const AVAILABLE_CORE_BLOCKS = [
+		'archives',
+		'audio',
+		'calendar',
+		'categories',
+		'code',
+		'column',
+		'columns',
+		'comment-author-avatar',
+		'comment-author-name',
+		'comment-content',
+		'comment-date',
+		'comment-edit-link',
+		'comment-reply-link',
+		'comments-pagination',
+		'comments-pagination-next',
+		'comments-pagination-numbers',
+		'comments-pagination-previous',
+		'comments-query-loop',
+		'comment-template',
+		'cover',
+		'gallery',
+		'home-link',
+		'latest-comments',
+		'latest-posts',
+		'list',
+		'loginout',
+		'media-text',
+		'missing',
+		'more',
+		'navigation',
+		'navigation-area',
+		'navigation-link',
+		'navigation-submenu',
+		'nextpage',
+		'page-list',
+		'pattern',
+		'post-author',
+		'post-author-name',
+		'post-comment',
+		'post-comments',
+		'post-comments-count',
+		'post-comments-form',
+		'post-comments-link',
+		'post-content',
+		'post-date',
+		'post-excerpt',
+		'post-featured-image',
+		'post-navigation-link',
+		'post-template',
+		'post-terms',
+		'post-title',
+		'preformatted',
+		'pullquote',
+		'query',
+		'query-pagination',
+		'query-pagination-next',
+		'query-pagination-numbers',
+		'query-pagination-previous',
+		'query-title',
+		'rss',
+		'search',
+		'site-logo',
+		'site-tagline',
+		'site-title',
+		'social-link',
+		'social-links',
+		'table-of-contents',
+		'tag-cloud',
+		'template-part',
+		'term-description',
+		'text-columns',
+		'verse',
+	];
+
 	/**
 	 * Option page slug
 	 *
@@ -402,6 +479,25 @@ class Settings {
 					],
 				],
 			],
+			'planet4_settings_core_blocks'    => [
+				'title'  => 'Core blocks',
+				'fields' => [
+					[
+						'name' => __( 'Core blocks', 'planet4-master-theme-backend' ),
+						'desc' => __(
+							'Allow certain unsupported core blocks in the editor.',
+							'planet4-master-theme-backend'
+						),
+						'id'   => self::CORE_BLOCKS,
+						'type' => 'multicheck_inline',
+						'default' => [],
+						'options' => array_merge ( ...array_map(
+							[ self::class, 'core_block_option' ],
+						self::AVAILABLE_CORE_BLOCKS
+						)),
+					],
+				],
+			],
 		];
 
 		if ( Features::is_active( Features::NEW_DESIGN_NAVIGATION_BAR ) ) {
@@ -419,6 +515,15 @@ class Settings {
 		}
 
 		$this->hooks();
+	}
+
+	private static function core_block_option( $name ) {
+		$link      = 'https://developer.wordpress.org/block-editor/reference-guides/core-blocks/#' . $name;
+		$nice_name = ucwords( str_replace( '-', ' ', $name ) );
+//		$label     = "<a target='_blank' href=\"$link\">$nice_name</a>";
+		$label     = $nice_name;
+
+		return [ "core/$name" => $label ];
 	}
 
 	/**


### PR DESCRIPTION
* Just for easily creating a page on a test instance to evaluate which
core block patterns (if any) we would use.

Once I enabled the core patterns, I noticed on the test instance only 2 of them are available, because most of them use core blocks which we currently don't allow.

I then added a setting to this PR with all core blocks we currently don't enable, just to easily be able to see all the core blocks on the test instance.

But then I noticed it still didn't have all core blocks yet which I saw locally. That's because I was using the latest WP 5.9 RC.

Instead of setting the RC up on this test instance, I changed strategy and [created a feature toggle](https://github.com/greenpeace/planet4-master-theme/pull/1585) which we can enable on the [`gutenberg` instance](https://www-dev.greenpeace.org/gutenberg/). That one already has all blocks + 5.9 RC.

I'll keep this open for now as it might be useful when we evaluate core blocks.

**Observation**: There are a lot of core blocks we currently don't allow. This is because a lot of the recent complex Gutenberg blocks consist of many small component blocks which can be re-arranged.

Given this, maybe an exclusion list would work better than the [inclusion list](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/blob/38812dde95747278dbc45316dc16b65a7cb3be27/planet4-gutenberg-blocks.php#L185-L227) we currently have?
![Screenshot from 2022-01-21 11-39-33](https://user-images.githubusercontent.com/7604138/150513142-142bad7a-9504-4a91-93fa-7c3f9e306c84.png)

To get to the list I just extracted all block types from the Gutenberg repo and removed the ones which we already allow. So there might be a few that are not interesting or older deprecated blocks that were still in the repo.