### PR TITLE
PLANET-6603 Add Cookies text fields to settings

### DIFF
--- a/src/Settings.php
+++ b/src/Settings.php
@@ -227,12 +227,63 @@ class Settings {
 				'title'  => 'Cookies',
 				'fields' => [
 					[
-						'name'    => __( 'Cookies Text', 'planet4-master-theme-backend' ),
+						'name'    => __( 'Cookies Box General Text', 'planet4-master-theme-backend' ),
 						'id'      => 'cookies_field',
 						'type'    => 'wysiwyg',
 						'options' => [
 							'textarea_rows' => 5,
 							'media_buttons' => false,
+						],
+					],
+					[
+						'name' => __( 'Necessary Cookies label', 'planet4-master-theme-backend' ),
+						'id'   => 'necessary_cookies_name',
+						'type' => 'text',
+					],
+					[
+						'name'    => __( 'Necessary Cookies description', 'planet4-master-theme-backend' ),
+						'id'      => 'necessary_cookies_description',
+						'type'    => 'wysiwyg',
+						'options' => [
+							'textarea_rows' => 2,
+							'media_buttons' => false,
+							'quicktags'     => [
+								'buttons' => 'strong,em',
+							],
+						],
+					],
+					[
+						'name' => __( 'Analytical Cookies label', 'planet4-master-theme-backend' ),
+						'id'   => 'analytical_cookies_name',
+						'type' => 'text',
+					],
+					[
+						'name'    => __( 'Analytical Cookies description', 'planet4-master-theme-backend' ),
+						'id'      => 'analytical_cookies_description',
+						'type'    => 'wysiwyg',
+						'options' => [
+							'textarea_rows' => 2,
+							'media_buttons' => false,
+							'quicktags'     => [
+								'buttons' => 'strong,em',
+							],
+						],
+					],
+					[
+						'name' => __( 'All Cookies label', 'planet4-master-theme-backend' ),
+						'id'   => 'all_cookies_name',
+						'type' => 'text',
+					],
+					[
+						'name'    => __( 'All Cookies description', 'planet4-master-theme-backend' ),
+						'id'      => 'all_cookies_description',
+						'type'    => 'wysiwyg',
+						'options' => [
+							'textarea_rows' => 2,
+							'media_buttons' => false,
+							'quicktags'     => [
+								'buttons' => 'strong,em',
+							],
 						],
 					],
 


### PR DESCRIPTION
### Description

See https://jira.greenpeace.org/browse/PLANET-6603
This is to be used in the Cookies box but also as default values for the Cookies block

Related blocks PR: https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/766

### Testing

You can check the new settings on local (`Planet 4 > Cookies`), or on the [neptune test instance](https://www-dev.greenpeace.org/test-neptune/wp-admin/admin.php?page=planet4_settings_cookies_text). Then once you set some values there, you can add a Cookies block to a page and see those values appear as default in the various fields.