### PR TITLE
PLANET-6510: Navigation bar - Tabs menu on mobile

### DIFF
--- a/assets/src/js/header.js
+++ b/assets/src/js/header.js
@@ -120,11 +120,11 @@ const setMobileTabsMenuScroll = () => {
     return;
   }
 
-  const distToClose = 50
-    , distToOpen = 50;
-  let lastScrollDir = null
-    , lastScrollTop = window.pageYOffset || document.documentElement.scrollTop
-    , lastScrollRef = lastScrollTop;
+  const distToClose = 50;
+  const distToOpen = 50;
+  let lastScrollDir = null;
+  let lastScrollTop = window.pageYOffset || document.documentElement.scrollTop;
+  let lastScrollRef = lastScrollTop;
 
   /**
    * Get scroll direction, distance from the lastScrollTop, and distance from a reference point
@@ -132,16 +132,16 @@ const setMobileTabsMenuScroll = () => {
    * @return {Object} {scroll direction, top position, distance scrolled, distance scrolled from ref point}
    */
   const scrollData = () => {
-    let scrollTop = window.pageYOffset || document.documentElement.scrollTop;
+    const scrollTop = window.pageYOffset || document.documentElement.scrollTop;
     if (scrollTop === lastScrollTop) {
       return {};
     }
 
-    let dir = scrollTop > lastScrollTop ? 'down' : 'up';
-    let dist = Math.abs(scrollTop - lastScrollTop);
-    let ref = Math.abs(scrollTop - lastScrollRef);
+    const dir = scrollTop > lastScrollTop ? 'down' : 'up';
+    const dist = Math.abs(scrollTop - lastScrollTop);
+    const ref = Math.abs(scrollTop - lastScrollRef);
     lastScrollTop = Math.max(0, scrollTop);
-    return {dir: dir, pos: scrollTop, dist: dist, ref: ref};
+    return { dir, pos: scrollTop, dist, ref };
   };
 
   /**
@@ -172,9 +172,7 @@ const setMobileTabsMenuScroll = () => {
   };
 
   ['touchmove', 'scroll'].forEach((eventName) => {
-    document.addEventListener(eventName, () => {
-      toggleMobileTabsMenu();
-    });
+    document.addEventListener(eventName, toggleMobileTabsMenu);
   });
 };
 

--- a/assets/src/js/header.js
+++ b/assets/src/js/header.js
@@ -110,6 +110,74 @@ const closeElement = (event, buttonClass) => {
   closeButton.click();
 };
 
+/**
+ * Set the mobile tabs menu behavior on scroll
+ * Mobile tabs menu should hide when user scrolls down, and reappear when they scroll up
+ */
+const setMobileTabsMenuScroll = () => {
+  const menu = document.getElementById('nav-mobile');
+  if (!menu) {
+    return;
+  }
+
+  const distToClose = 50
+    , distToOpen = 50;
+  let lastScrollDir = null
+    , lastScrollTop = window.pageYOffset || document.documentElement.scrollTop
+    , lastScrollRef = lastScrollTop;
+
+  /**
+   * Get scroll direction, distance from the lastScrollTop, and distance from a reference point
+   *
+   * @return {Object} {scroll direction, top position, distance scrolled, distance scrolled from ref point}
+   */
+  const scrollData = () => {
+    let scrollTop = window.pageYOffset || document.documentElement.scrollTop;
+    if (scrollTop === lastScrollTop) {
+      return {};
+    }
+
+    let dir = scrollTop > lastScrollTop ? 'down' : 'up';
+    let dist = Math.abs(scrollTop - lastScrollTop);
+    let ref = Math.abs(scrollTop - lastScrollRef);
+    lastScrollTop = Math.max(0, scrollTop);
+    return {dir: dir, pos: scrollTop, dist: dist, ref: ref};
+  };
+
+  /**
+   * Show/hide tabs menu depending on scroll direction and distance scrolled from ref point
+   * Update reference point and reference direction only on state change
+   */
+  const toggleMobileTabsMenu = () => {
+    const {dir, ref} = scrollData();
+    if (!dir || dir === lastScrollDir) {
+      return;
+    }
+
+    // Hide
+    if (dir === 'down' && ref >= distToClose) {
+      lastScrollDir = dir;
+      lastScrollRef = lastScrollTop;
+      menu.classList.add('mobile-menu-hidden');
+      return;
+    }
+
+    // Show
+    if (dir === 'up' && ref >= distToOpen) {
+      lastScrollDir = dir;
+      lastScrollRef = lastScrollTop;
+      menu.classList.remove('mobile-menu-hidden');
+      return;
+    }
+  };
+
+  ['touchmove', 'scroll'].forEach((eventName) => {
+    document.addEventListener(eventName, () => {
+      toggleMobileTabsMenu();
+    });
+  });
+};
+
 export const setupHeader = () => {
   const toggleElementClasses = [
     '.navbar-dropdown-toggle',
@@ -160,4 +228,6 @@ export const setupHeader = () => {
       searchFocused = true;
     }
   });
+
+  setMobileTabsMenuScroll();
 };

--- a/assets/src/scss/layout/_navbar.scss
+++ b/assets/src/scss/layout/_navbar.scss
@@ -217,7 +217,7 @@ $navbar-default-height: 60px;
 :root {
   --nav-link--color: $white;
   --nav-link--opacity: 1;
-  --nav-link--padding: 16px 0;
+  --nav-link--padding: #{$sp-2} 0;
   --nav-link-active--color: var(--nav-link--color, #{$white});
   --nav-link-active--opacity: var(--nav-link--opacity, 1);
   --nav-link-active--text-decoration-color: #{$gp-green};

--- a/assets/src/scss/layout/_navbar.scss
+++ b/assets/src/scss/layout/_navbar.scss
@@ -1,6 +1,6 @@
 $menu-height: 68px;
 $menu-height-large: 68px;
-$menu-height-small: 68px;
+$menu-height-small: 60px;
 $min-height: 40px;
 $navbar-default-height: 60px;
 
@@ -13,15 +13,15 @@ $navbar-default-height: 60px;
     fill: $white;
     font-family: $roboto;
     font-size: $font-base-size;
-    height: $menu-height;
   }
 
   display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
   position: fixed;
   top: 0;
   width: 100%;
   z-index: 99;
-  justify-content: space-between;
 
   .admin-bar & {
     top: 46px;
@@ -76,7 +76,7 @@ $navbar-default-height: 60px;
     padding: 16px 0;
 
     @include large-and-up {
-      padding: 0 20px;
+      padding: 0;
     }
   }
 }
@@ -196,6 +196,7 @@ $navbar-default-height: 60px;
       display: flex;
       flex-grow: 1;
       justify-content: end;
+      padding-inline-end: 0;
       padding-top: 0;
       text-align: end;
     }
@@ -209,33 +210,97 @@ $navbar-default-height: 60px;
 
   @include large-and-up {
     line-height: $menu-height;
+    margin: 0 20px;
   }
+}
+
+:root {
+  --nav-link--color: $white;
+  --nav-link--opacity: 1;
+  --nav-link--padding: 16px 0;
+  --nav-link-active--color: var(--nav-link--color, #{$white});
+  --nav-link-active--opacity: var(--nav-link--opacity, 1);
+  --nav-link-active--text-decoration-color: #{$gp-green};
+  --nav-link-active--text-decoration-line: underline;
+  --nav-link-active--text-decoration-style: solid;
+  --nav-link-active--text-decoration-thickness: 3px;
+  --nav-link-active--text-underline-offset: auto;
+  --nav-link-active--text-underline-position: under;
+  --nav-link--hover--color: $white;
+  --nav-link--hover--opacity: 1;
+  --nav-link--hover--text-decoration-color: #{$gp-green};
+  --nav-link--hover--text-decoration-line: underline;
+  --nav-link--hover--text-decoration-style: solid;
+  --nav-link--hover--text-decoration-thickness: 3px;
+  --nav-link--hover--text-underline-offset: auto;
+  --nav-link--hover--text-underline-position: under;
 }
 
 a.nav-link {
-  --nav-link-- {
-    color: $white;
-
-    &:hover {
-      color: $white;
-      text-decoration: underline;
-      text-underline-position: auto;
-    }
-  }
-
+  color: var(--nav-link--color);
   display: inline-block;
-  padding: 16px 0;
+  opacity: var(--nav-link--opacity);
+  padding: var(--nav-link--padding);
+  position: relative;
   width: 100%;
 
   @include large-and-up {
-    padding: 0 20px;
+    --nav-link--padding: 0;
+    --nav-link-active--text-decoration-thickness: 4px;
+  }
+
+  &:hover {
+    color: var(--nav-link--hover--color);
+    opacity: var(--nav-link--hover--opacity);
+    text-decoration-color: var(--nav-link--hover--text-decoration-color);
+    text-decoration-line: var(--nav-link--hover--text-decoration-line);
+    text-decoration-thickness: var(--nav-link--hover--text-decoration-thickness);
+    text-underline-offset: var(--nav-link--hover--text-underline-offset);
+    text-underline-position: var(--nav-link--hover--text-underline-position);
+
+    @include large-and-up {
+      --nav-link--hover--text-decoration-line: none;
+    }
+  }
+
+  // Border-bottom for underline animation
+  &:before {
+    border-bottom-color: var(--nav-link--hover--text-decoration-color);
+    border-bottom-style: var(--nav-link--hover--text-decoration-style);
+    border-bottom-width: var(--nav-link--hover--text-decoration-thickness);
+    bottom: 0;
+    content: "";
+    left: 0;
+    opacity: 1;
+    position: absolute;
+    right: 0;
+    transform: scaleX(0);
+    transition: transform 0.25s;
+    z-index: -1;
   }
 }
 
-.active a.nav-link --nav-link-active-- {
-  color: var(--nav-link--hover--color, $white);
-  text-decoration: var(--nav-link--hover--text-decoration, underline);
-  text-underline-position: var(--nav-link--hover--text-underline-position, auto);
+.active a.nav-link {
+  color: var(--nav-link-active--color);
+  opacity: var(--nav-link-active--opacity);
+  text-decoration-color: var(--nav-link-active--text-decoration-color);
+  text-decoration-line: var(--nav-link-active--text-decoration-line);
+  text-decoration-thickness: var(--nav-link-active--text-decoration-thickness);
+  text-underline-offset: var(--nav-link-active--text-underline-offset);
+  text-underline-position: var(--nav-link-active--text-underline-position);
+
+  @include large-and-up {
+    --nav-link-active--text-decoration-line: none;
+  }
+}
+
+// Underline animation with border-bottom
+a.nav-link:hover:before,
+.active a.nav-link:before {
+  @include large-and-up {
+    transform: scaleX(1);
+    transition: transform 0.25s;
+  }
 }
 
 .nav-menu-toggle {
@@ -316,3 +381,4 @@ a.nav-link {
 @import "navbar/site-logo";
 @import "navbar/languages";
 @import "navbar/search";
+@import "navbar/mobile";

--- a/assets/src/scss/layout/_page-header.scss
+++ b/assets/src/scss/layout/_page-header.scss
@@ -78,6 +78,12 @@
   }
 }
 
+.with-mobile-tabs ~ .page-header {
+  @include medium-and-less {
+    padding-top: 140px;
+  }
+}
+
 .page-header-background {
   overflow: hidden;
   position: absolute;

--- a/assets/src/scss/layout/navbar/_search.scss
+++ b/assets/src/scss/layout/navbar/_search.scss
@@ -7,15 +7,15 @@
   height: 56px;
   inset-inline-start: 0;
   position: fixed;
-  top: $menu-height;
+  top: $menu-height-small;
   z-index: 3;
   width: 100%;
 
   .admin-bar & {
-    top: $menu-height + 46px;
+    top: $menu-height-small + 46px;
 
     @media (min-width: 783px) {
-      top: $menu-height + 32px;
+      top: $menu-height-small + 32px;
     }
   }
 
@@ -164,8 +164,8 @@
 
 .nav-search-toggle-container {
   display: none;
-  height: $menu-height;
-  padding: 12px;
+  height: $menu-height-small;
+  padding: 8px 12px;
 
   &.medium-and-less {
     display: inline-block;
@@ -175,8 +175,10 @@
   }
 
   @include large-and-up {
-    display: inline-block;
     border-inline-start: var(--top-navigation--separation, 1px solid transparentize($white, 0.5));
+    display: inline-block;
+    height: $menu-height-large;
+    padding: 12px;
   }
 
   @include x-large-and-up {

--- a/assets/src/scss/layout/navbar/_search.scss
+++ b/assets/src/scss/layout/navbar/_search.scss
@@ -165,7 +165,7 @@
 .nav-search-toggle-container {
   display: none;
   height: $menu-height-small;
-  padding: 8px 12px;
+  padding: $sp-1 $sp-1x;
 
   &.medium-and-less {
     display: inline-block;
@@ -178,7 +178,7 @@
     border-inline-start: var(--top-navigation--separation, 1px solid transparentize($white, 0.5));
     display: inline-block;
     height: $menu-height-large;
-    padding: 12px;
+    padding: $sp-1x;
   }
 
   @include x-large-and-up {

--- a/assets/src/scss/layout/navbar/_site-logo.scss
+++ b/assets/src/scss/layout/navbar/_site-logo.scss
@@ -1,5 +1,9 @@
 .site-logo {
-  line-height: $menu-height;
+  line-height: $menu-height-small;
+
+  @include large-and-up {
+    line-height: $menu-height-large;
+  }
 
   img {
     height: 26px;

--- a/assets/src/scss/layout/navbar/mobile.scss
+++ b/assets/src/scss/layout/navbar/mobile.scss
@@ -1,0 +1,65 @@
+@import "../base/colors";
+
+#nav-mobile {
+  _-- {
+    height: 50px;
+  }
+
+  display: flex;
+  flex: 1 1 100%;
+  flex-grow: 1;
+  justify-content: center;
+  overflow-x: auto;
+  overflow-y: hidden;
+  scrollbar-width: none;
+  transition: height 0.2s linear;
+
+  @include large-and-up {
+    display: none;
+  }
+
+  &.mobile-menu-hidden {
+    height: 0;
+    transition: height 0.2s linear;
+  }
+}
+
+#nav-mobile::-webkit-scrollbar {
+  display: none;
+}
+
+#nav-mobile-menu {
+  --nav-link--opacity: 0.5;
+  --nav-link--padding: 0;
+  --nav-link-active--text-decoration-line: none;
+  --nav-link--hover--text-decoration-line: none;
+  --nav-link--hover--text-decoration-thickness: 3px;
+
+  display: flex;
+  width: 100%;
+
+  ul {
+    display: flex;
+    flex-grow: 1;
+    justify-content: center;
+    list-style-type: none;
+    margin: 0;
+    padding-inline: 1rem 1rem;
+  }
+
+  .nav-item {
+    line-height: 50px;
+    margin: 0 20px;
+  }
+
+  a.nav-link {
+    white-space: nowrap;
+  }
+
+  // Underline animation with border-bottom
+  a.nav-link:hover:before,
+  .active a.nav-link:before {
+    transform: scaleX(1);
+    transition: transform 0.25s;
+  }
+}

--- a/assets/src/scss/pages/_page.scss
+++ b/assets/src/scss/pages/_page.scss
@@ -50,6 +50,12 @@ $min-height: 40px;
   }
 }
 
+.with-mobile-tabs + .page-content {
+  @include medium-and-less {
+    padding-top: calc(#{$menu-height-small} + 50px);
+  }
+}
+
 .single-campaign {
   .page-content {
     > p:last-child {

--- a/assets/src/scss/partials/navigation-bar-light.scss
+++ b/assets/src/scss/partials/navigation-bar-light.scss
@@ -14,6 +14,9 @@
   --top-navigation--input--placeholder--color: #{$grey-40};
   --nav-link--color: #{$black};
   --nav-link--hover--color: #{$black};
-  --nav-link--hover--text-decoration: underline 3px #{$gp-green};
-  --nav-link--hover--text-underline-position: under;
+}
+
+#nav-mobile-menu {
+  --nav-link--color: #{$grey-40};
+  --nav-link--opacity: 1;
 }

--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -11,6 +11,7 @@ use Twig_SimpleFilter;
 use WP_Error;
 use WP_Post;
 use WP_User;
+use P4\MasterTheme\Settings\InformationArchitecture as IA;
 
 /**
  * Class MasterSite.
@@ -584,6 +585,9 @@ class MasterSite extends TimberSite {
 		// New design country selector, navigation bar.
 		$context['new_design_country_selector'] = Features::is_active( Features::NEW_DESIGN_COUNTRY_SELECTOR );
 		$context['new_design_navigation_bar']   = $new_design_navigation_bar;
+
+		// IA: Tabs menu on mobile.
+		$context['mobile_tabs_menu'] = IA::is_active( IA::MOBILE_TABS_MENU );
 
 		return $context;
 	}

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -3,7 +3,7 @@
 namespace P4\MasterTheme;
 
 use CMB2_Field;
-use P4\MasterTheme\Settings\InformationArchitecture;
+use P4\MasterTheme\Settings\InformationArchitecture as IA;
 
 /**
  * Class P4\MasterTheme\Settings
@@ -450,7 +450,7 @@ class Settings {
 				],
 			],
 			'planet4_settings_features'         => Features::get_options_page(),
-			'planet4_settings_ia'               => InformationArchitecture::get_options_page(),
+			'planet4_settings_ia'               => IA::get_options_page(),
 			'planet4_settings_notifications'    => [
 				'title'  => 'Notifications',
 				'fields' => [

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -3,6 +3,7 @@
 namespace P4\MasterTheme;
 
 use CMB2_Field;
+use P4\MasterTheme\Settings\InformationArchitecture;
 
 /**
  * Class P4\MasterTheme\Settings
@@ -449,6 +450,7 @@ class Settings {
 				],
 			],
 			'planet4_settings_features'         => Features::get_options_page(),
+			'planet4_settings_ia'               => InformationArchitecture::get_options_page(),
 			'planet4_settings_notifications'    => [
 				'title'  => 'Notifications',
 				'fields' => [
@@ -625,23 +627,36 @@ class Settings {
 	 *
 	 * @param string $plugin_page The key for the current page.
 	 */
-	public function admin_page_display( string $plugin_page ) {
+	public function admin_page_display( string $plugin_page ): void {
 		$page_config = $this->subpages[ $plugin_page ];
 
-		$fields = $page_config['fields'];
+		$fields      = $page_config['fields'];
+		$description = $page_config['description'] ?? null;
 		// Allow storing options in a different database record.
 		$root_option = $page_config['root_option'] ?? self::KEY;
 
 		$add_scripts = $this->subpages[ $plugin_page ]['add_scripts'] ?? null;
-		if ( $add_scripts ) {
+		if ( is_callable( $add_scripts ) ) {
 			$add_scripts();
 		}
-		?>
-		<div class="wrap <?php echo esc_attr( self::KEY ); ?>">
-			<h2><?php echo esc_html( get_admin_page_title() ); ?></h2>
-			<?php cmb2_metabox_form( $this->option_metabox( $fields, $root_option ), $root_option ); ?>
-		</div>
-		<?php
+
+		$form = cmb2_metabox_form(
+			$this->option_metabox( $fields, $root_option ),
+			$root_option,
+			[ 'echo' => false ]
+		);
+
+		echo sprintf(
+			'<div class="wrap %s">
+				<h2>%s</h2>
+				%s
+				%s
+			</div>',
+			esc_attr( self::KEY ),
+			esc_html( get_admin_page_title() ),
+			wp_kses( $description ? '<div>' . $description . '</div>' : '', 'post' ),
+			$form // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		);
 	}
 
 	/**

--- a/src/Settings/InformationArchitecture.php
+++ b/src/Settings/InformationArchitecture.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace P4\MasterTheme\Settings;
+
+use P4\MasterTheme\Loader;
+
+/**
+ * Information architecture settings.
+ *
+ * @see https://jira.greenpeace.org/browse/PLANET-6467
+ */
+class InformationArchitecture {
+	/** @var string Option key */
+	public const OPTIONS_KEY = 'planet4_ia';
+
+	/* @var string Mobile tabs option key **/
+	public const MOBILE_TABS_MENU = 'mobile_tabs_menu';
+
+	/**
+	 * Get the features options page settings.
+	 *
+	 * @return array Settings for the options page.
+	 */
+	public static function get_options_page(): array {
+		return [
+			'title'       => 'Information architecture',
+			'description' => 'These options are related to the new <a href="https://jira.greenpeace.org/browse/PLANET-6467" target="_blank">Information architecture development</a>.',
+			'root_option' => self::OPTIONS_KEY,
+			'fields'      => self::get_fields(),
+			'add_scripts' => static function () {
+				Loader::enqueue_versioned_script( '/admin/js/features_save_redirect.js' );
+			},
+		];
+	}
+
+	/**
+	 * Get form fields.
+	 *
+	 * @return array  The fields.
+	 */
+	public static function get_fields(): array {
+		$fields = [
+			[
+				'id'   => self::MOBILE_TABS_MENU,
+				'name' => __( 'Enable mobile tabs menu', 'planet4-master-theme-backend' ),
+				'desc' => __(
+					'Display a sticky tabs menu visible only on mobile size.',
+					'planet4-master-theme-backend'
+				),
+				'type' => 'checkbox',
+			],
+		];
+
+		return $fields;
+	}
+
+	/**
+	 * Check whether an option is active.
+	 *
+	 * @param string $name Name of the option we're checking.
+	 *
+	 * @return bool Whether the option is active.
+	 */
+	public static function is_active( string $name ): bool {
+		return ! empty( self::get( $name ) );
+	}
+
+	/**
+	 * Return option value.
+	 *
+	 * @param string $name    Name of the option.
+	 * @param mixed  $default Default value.
+	 *
+	 * @return mixed
+	 */
+	public static function get( string $name, $default = null ) {
+		$options = get_option( self::OPTIONS_KEY );
+
+		return isset( $options[ $name ] ) ? $options[ $name ] : $default;
+	}
+}

--- a/src/Settings/InformationArchitecture.php
+++ b/src/Settings/InformationArchitecture.php
@@ -46,7 +46,7 @@ class InformationArchitecture {
 				'id'   => self::MOBILE_TABS_MENU,
 				'name' => __( 'Enable mobile tabs menu', 'planet4-master-theme-backend' ),
 				'desc' => __(
-					'Display a sticky tabs menu visible only on mobile size.',
+					'Display a sticky tabs menu visible on screen width smaller than 992px.',
 					'planet4-master-theme-backend'
 				),
 				'type' => 'checkbox',

--- a/templates/navigation-bar-new.twig
+++ b/templates/navigation-bar-new.twig
@@ -156,12 +156,11 @@
 			<ul>
 				{% for key,item in navbar_menu_items %}
 				<li class="nav-item {{ item.class }} {{ item == item.current ? 'active' : '' }}">
-					{% set link_ga_action = item.title %}
 					<a
 						class="nav-link"
 						href="{{ item.get_link }}"
 						data-ga-category="Menu Navigation"
-						data-ga-action="{{ link_ga_action }}"
+						data-ga-action="{{ item.title }}"
 						data-ga-label="{{ page_category }}">
 							{{ item.title }}
 					</a>

--- a/templates/navigation-bar-new.twig
+++ b/templates/navigation-bar-new.twig
@@ -1,4 +1,8 @@
-<section id="header" class="top-navigation navbar {% if custom_styles.nav_border == 'border' %}navigation-bar_border{% endif %}">
+{% set header_classes = 'top-navigation navbar'
+	~ (custom_styles.nav_border == 'border' ? ' navigation-bar_border' : '')
+	~ (mobile_tabs_menu ? ' with-mobile-tabs' : '')
+%}
+<section id="header" class="{{ header_classes }}">
 	{% set data_ga_attrs = 'data-ga-category="Menu Navigation" data-ga-action="Menu" data-ga-label="' ~ page_category ~ '"' %}
 	<button class="nav-menu-toggle" type="button"
 		aria-label="{{ __( 'Toggle navigation menu', 'planet4-master-theme' ) }}"
@@ -146,6 +150,27 @@
 			</span>
 		</button>
 	</div>
+	{% if mobile_tabs_menu %}
+	<div id="nav-mobile">
+		<nav id="nav-mobile-menu">
+			<ul>
+				{% for key,item in navbar_menu_items %}
+				<li class="nav-item {{ item.class }} {{ item == item.current ? 'active' : '' }}">
+					{% set link_ga_action = item.title %}
+					<a
+						class="nav-link"
+						href="{{ item.get_link }}"
+						data-ga-category="Menu Navigation"
+						data-ga-action="{{ link_ga_action }}"
+						data-ga-label="{{ page_category }}">
+							{{ item.title }}
+					</a>
+				</li>
+				{% endfor %}
+			</ul>
+		</nav>
+	</div>
+	{% endif %}
 	<div class="top-navigation-overlay"></div>
 	{% include 'country_selector_banner.twig' ignore missing %}
 </section>


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6510

> Navigation Bar: implement a tabs menu on mobile
> The tabs should lead to each parent/category page of the site.
> They should have a selected state on the frontend regardless the level of hierarchy (example: Parent page > sub page).
> To view all items users would be able to swipe horizontally.
> The tabs menu should be sticky at the top and disappear when users start scrolling down the page.


## Content

### New settings page 
for all Information Architecture options, in _Planet 4 > Information architecture_

Activate this navigation menu:
![Screenshot from 2022-02-01 16-31-29](https://user-images.githubusercontent.com/617346/151998539-0ea44393-db19-44c5-b76c-a153738e56b1.png)

### New menu on mobile

Menu is visible on `width < 992px`

![Screenshot from 2022-01-24 16-05-55](https://user-images.githubusercontent.com/617346/150808401-51efe06a-63e7-4cbc-9d0b-b0c707918a87.png)

### Additional changes

- Menu height is now 60px on width < 992px, (+50px if tabs menu is enabled)
- Menu links alignement with the Design iteration 2 (underline color, offset and animation, switch from padding to margin for spacing horizontal items)
- Added some CSS variables to more easily tweak theme and mobile menu

## Test
Test on [tavros](https://www-dev.greenpeace.org/test-tavros/) or locally
- Activate menu, add more menu items if necessary
- Check that current navigation still works