### PR TITLE
PLANET-6512 Update post top links

### DIFF
--- a/assets/src/scss/layout/_breadcrumbs.scss
+++ b/assets/src/scss/layout/_breadcrumbs.scss
@@ -8,10 +8,11 @@
     position: relative;
   }
 
+  .category-separator,
   .tag-wrap-bullet {
     pointer-events: none;
     font-weight: 400;
-    margin: 0 8px;
+    margin: 0 $sp-1;
     color: $link-color;
   }
 
@@ -25,19 +26,19 @@
       }
     }
     display: inline-block;
-
-    &:not(:only-child):not(:last-child):not(.page-type) {
-      margin-inline-end: 8px;
-    }
   }
 
-  .tag-item--main {
-    &.page-type {
-      text-transform: uppercase;
-
-      html[dir="rtl"] & {
-        text-transform: lowercase;
-      }
-    }
+  .main-tag-chevron {
+    pointer-events: none;
+    margin: 0 $sp-1;
+    height: 12px;
+    width: 7px;
+    mask-image: url("../../images/chevron.svg");
+    mask-repeat: no-repeat;
+    mask-size: contain;
+    mask-position: center;
+    background-repeat: no-repeat;
+    background-color: $link-color;
+    display: inline-block;
   }
 }

--- a/templates/single.twig
+++ b/templates/single.twig
@@ -21,7 +21,7 @@
 					{% endif %}
 
 					{% if ( page_type and (post.issues_nav_data or post.tags) ) %}
-						<span class="tag-wrap-bullet" aria-hidden="true">&#8226;</span>
+						<span class="main-tag-chevron" aria-hidden="true"></span>
 					{% endif %}
 
 					{% if ( post.issues_nav_data ) %}
@@ -35,25 +35,11 @@
 									data-ga-label="n/a">
 										{{ issue.name|e('wp_kses_post')|raw }}
 								</a>
-							{% endfor %}
-						</div>
-					{% endif %}
 
-					{% if ( post.issues_nav_data and post.tags ) %}
-						<span class="tag-wrap-bullet" aria-hidden="true">&#8226;</span>
-					{% endif %}
+								{% if ( loop.last == false ) %}
+									<span class="category-separator" aria-hidden="true">|</span>
+								{% endif %}
 
-					{% if (post.tags) %}
-						<div class="tag-wrap tags">
-							{% for tag in post.tags %}
-								<a
-									class="tag-item tag"
-									href="{{ tag.link }}"
-									data-ga-category="Header"
-									data-ga-action="Navigation Tag"
-									data-ga-label="n/a">
-									<span aria-label="hashtag">#<span>{{ tag.name|e('wp_kses_post')|raw }}
-								</a>
 							{% endfor %}
 						</div>
 					{% endif %}


### PR DESCRIPTION
### Description

See [PLANET-6512](https://jira.greenpeace.org/browse/PLANET-6512)
This includes removing the tags and updating the separators between the post type and the categories. It also removes the uppercase style on the post type.

**Note**: these breadcrumbs are used in a few other places, such as the Articles block or some templates (such as the author page), but I think this ticket was only about updating the posts' navigation links. The only change that will be applied everywhere is the uppercase removal, which I think will eventually be completely removed anyway.

### Testing

You can test the changes on your local on any post, or you can see them on the atlas test instance that has been set up for UAT: for example, you can check out [this post](https://www-dev.greenpeace.org/test-atlas/press-release/49484/report-major-brands-fossil-fuels-plastic-kitchen/) and compare it with [its equivalent](https://www-dev.greenpeace.org/test-mars/press-release/49484/report-major-brands-fossil-fuels-plastic-kitchen/) on the mars test instance with the former designs.