### PR TITLE
POC Use WordPress's new template mechanism

### DIFF
--- a/assets/src/scss/editorOverrides.scss
+++ b/assets/src/scss/editorOverrides.scss
@@ -19,12 +19,13 @@
   }
 }
 
+.wp-block {
+  max-width: 90%;
+  margin-left: auto;
+  margin-right: auto;
+}
+
 .edit-post-visual-editor {
-  .wp-block {
-    max-width: 90%;
-    margin-left: auto;
-    margin-right: auto;
-  }
 
   li {
     font-size: unset;

--- a/assets/src/scss/editorStyle.scss
+++ b/assets/src/scss/editorStyle.scss
@@ -21,3 +21,4 @@
 @import "layout/forms";
 
 @import "editorOverrides";
+@import "layout/block-classes";

--- a/assets/src/scss/layout/_block-classes.scss
+++ b/assets/src/scss/layout/_block-classes.scss
@@ -1,5 +1,52 @@
 
 .inline-container > * {
   display: inline;
-  margin-inline-end: 4px;
+}
+
+.circle-separated > *:not(:first-child):before {
+  color: #006DFD;
+  content: "●";
+  margin: auto 4px;
+}
+
+.dash-separated > *:not(:first-child):before {
+  color: #979797;
+  content: "-";
+  margin: auto 4px;
+}
+
+.wp-block-query {
+  font-family: $roboto;
+
+  // This needs to target title inside wp-block-query specifically.
+  .wp-block-post-title {
+    margin-bottom: 4px;
+    a {
+      color: $black;
+    }
+  }
+}
+
+.wp-block-query-pagination {
+  a {
+    color: black;
+    font-weight: bold;
+  }
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  width: 100%;
+  margin-bottom: 16px;
+}
+
+.page-numbers {
+  &:not(:last-child) {
+    margin-inline-end: 8px;
+  }
+
+  &.current {
+    border: 1px solid black;
+    border-radius: 4px;
+    padding: 8px 12px;
+  }
 }

--- a/assets/src/scss/layout/_block-classes.scss
+++ b/assets/src/scss/layout/_block-classes.scss
@@ -1,0 +1,5 @@
+
+.inline-container > * {
+  display: inline;
+  margin-inline-end: 4px;
+}

--- a/assets/src/scss/pages/_page.scss
+++ b/assets/src/scss/pages/_page.scss
@@ -97,3 +97,8 @@ $min-height: 40px;
     outline: 0 none;
   }
 }
+
+.wp-block-post-author {
+  // Quick fix for the block being covered by the fixed navbar.
+  margin-top: 80px;
+}

--- a/assets/src/scss/style.scss
+++ b/assets/src/scss/style.scss
@@ -37,6 +37,7 @@ Text Domain: planet4-master-theme
 // Layout
 @import "layout/breadcrumbs";
 @import "layout/blocks";
+@import "layout/block-classes";
 @import "layout/cookies";
 @import "layout/footer";
 @import "layout/footer-social-media";

--- a/block-templates/author.html
+++ b/block-templates/author.html
@@ -2,7 +2,7 @@
 <!-- wp:group {"className":"container"} -->
 <div class="wp-block-group container"><!-- wp:post-author {"avatarSize":96,"showBio":true,"className":"author-pic","fontSize":"medium"} /-->
 
-	<!-- wp:query {"queryId":1,"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"displayLayout":{"type":"flex","columns":3}} -->
+	<!-- wp:query {"queryId":1,"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"displayLayout":{"type":"flex","columns":4}} -->
 	<div class="wp-block-query"><!-- wp:query-pagination -->
 		<!-- wp:query-pagination-previous /-->
 
@@ -14,37 +14,19 @@
 		<!-- wp:post-template -->
 		<!-- wp:post-featured-image {"isLink":true} /-->
 
-		<!-- wp:group {"className":"inline-container"} -->
-		<div class="wp-block-group inline-container"><!-- wp:post-terms {"term":"p4-page-type"} /-->
+		<!-- wp:group {"className":"inline-container circle-separated"} -->
+		<div class="wp-block-group inline-container circle-separated"><!-- wp:post-terms {"term":"p4-page-type","style":{"typography":{"fontSize":"14px"}}} /-->
 
-			<!-- wp:paragraph {"style":{"typography":{"fontSize":"11px"}},"textColor":"blue"} -->
-			<p class="has-blue-color has-text-color" style="font-size:11px">●</p>
-			<!-- /wp:paragraph -->
-
-			<!-- wp:post-terms {"term":"post_tag"} /--></div>
+			<!-- wp:post-terms {"term":"post_tag","style":{"typography":{"fontSize":"14px"}}} /--></div>
 		<!-- /wp:group -->
 
-		<!-- wp:columns -->
-		<div class="wp-block-columns"><!-- wp:column {"width":"50%"} -->
-			<div class="wp-block-column" style="flex-basis:50%"></div>
-			<!-- /wp:column -->
+		<!-- wp:post-title {"isLink":true,"style":{"typography":{"fontSize":"16px"}}} /-->
 
-			<!-- wp:column {"width":"50%"} -->
-			<div class="wp-block-column" style="flex-basis:50%"></div>
-			<!-- /wp:column --></div>
-		<!-- /wp:columns -->
+		<!-- wp:group {"className":"inline-container dash-separated"} -->
+		<div class="wp-block-group inline-container dash-separated"><!-- wp:post-date {"format":"M j, Y g:i a","style":{"typography":{"fontSize":"12px"}}} /-->
 
-		<!-- wp:post-title {"isLink":true} /-->
-
-		<!-- wp:group {"className":"inline-container"} -->
-		<div class="wp-block-group inline-container"><!-- wp:post-date {"isLink":true} /-->
-
-			<!-- wp:paragraph -->
-			<p>-</p>
-			<!-- /wp:paragraph -->
-
-			<!-- wp:paragraph -->
-			<p>5 min read</p>
+			<!-- wp:paragraph {"style":{"typography":{"fontSize":"12px"}}} -->
+			<p style="font-size:12px">5 min read</p>
 			<!-- /wp:paragraph --></div>
 		<!-- /wp:group -->
 		<!-- /wp:post-template -->

--- a/block-templates/author.html
+++ b/block-templates/author.html
@@ -1,0 +1,19 @@
+<!-- wp:planet4-blocks/framework -->
+<!-- wp:query {"queryId":1,"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"displayLayout":{"type":"flex","columns":3}} -->
+<div class="wp-block-query"><!-- wp:post-template -->
+	<!-- wp:post-featured-image /-->
+
+	<!-- wp:post-date /-->
+
+	<!-- wp:post-title /-->
+	<!-- /wp:post-template -->
+
+	<!-- wp:query-pagination -->
+	<!-- wp:query-pagination-previous /-->
+
+	<!-- wp:query-pagination-numbers /-->
+
+	<!-- wp:query-pagination-next /-->
+	<!-- /wp:query-pagination --></div>
+<!-- /wp:query -->
+<!-- /wp:planet4-blocks/framework -->

--- a/block-templates/author.html
+++ b/block-templates/author.html
@@ -1,19 +1,23 @@
 <!-- wp:planet4-blocks/framework -->
-<!-- wp:query {"queryId":1,"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"displayLayout":{"type":"flex","columns":3}} -->
-<div class="wp-block-query"><!-- wp:post-template -->
-	<!-- wp:post-featured-image /-->
+<!-- wp:group {"className":"container"} -->
+<div class="wp-block-group container">
+	<!-- wp:post-author {"showAvatar":false,"showBio":true,"fontSize":"medium"} /-->
+	<!-- wp:query {"queryId":1,"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"displayLayout":{"type":"flex","columns":3}} -->
+	<div class="wp-block-query"><!-- wp:post-template -->
+		<!-- wp:post-featured-image /-->
 
-	<!-- wp:post-date /-->
+		<!-- wp:post-date /-->
 
-	<!-- wp:post-title /-->
-	<!-- /wp:post-template -->
+		<!-- wp:post-title /-->
+		<!-- /wp:post-template -->
 
-	<!-- wp:query-pagination -->
-	<!-- wp:query-pagination-previous /-->
+		<!-- wp:query-pagination -->
+		<!-- wp:query-pagination-previous /-->
 
-	<!-- wp:query-pagination-numbers /-->
+		<!-- wp:query-pagination-numbers /-->
 
-	<!-- wp:query-pagination-next /-->
-	<!-- /wp:query-pagination --></div>
-<!-- /wp:query -->
+		<!-- wp:query-pagination-next /-->
+		<!-- /wp:query-pagination --></div>
+	<!-- /wp:query --></div>
+<!-- /wp:group -->
 <!-- /wp:planet4-blocks/framework -->

--- a/block-templates/author.html
+++ b/block-templates/author.html
@@ -9,12 +9,44 @@
 		<!-- wp:query-pagination-numbers /-->
 
 		<!-- wp:query-pagination-next /-->
-		<!-- /wp:query-pagination -->	<!-- wp:post-template -->
+		<!-- /wp:query-pagination -->
+
+		<!-- wp:post-template -->
 		<!-- wp:post-featured-image {"isLink":true} /-->
 
-		<!-- wp:post-date {"isLink":true} /-->
+		<!-- wp:group {"className":"inline-container"} -->
+		<div class="wp-block-group inline-container"><!-- wp:post-terms {"term":"p4-page-type"} /-->
+
+			<!-- wp:paragraph {"style":{"typography":{"fontSize":"11px"}},"textColor":"blue"} -->
+			<p class="has-blue-color has-text-color" style="font-size:11px">●</p>
+			<!-- /wp:paragraph -->
+
+			<!-- wp:post-terms {"term":"post_tag"} /--></div>
+		<!-- /wp:group -->
+
+		<!-- wp:columns -->
+		<div class="wp-block-columns"><!-- wp:column {"width":"50%"} -->
+			<div class="wp-block-column" style="flex-basis:50%"></div>
+			<!-- /wp:column -->
+
+			<!-- wp:column {"width":"50%"} -->
+			<div class="wp-block-column" style="flex-basis:50%"></div>
+			<!-- /wp:column --></div>
+		<!-- /wp:columns -->
 
 		<!-- wp:post-title {"isLink":true} /-->
+
+		<!-- wp:group {"className":"inline-container"} -->
+		<div class="wp-block-group inline-container"><!-- wp:post-date {"isLink":true} /-->
+
+			<!-- wp:paragraph -->
+			<p>-</p>
+			<!-- /wp:paragraph -->
+
+			<!-- wp:paragraph -->
+			<p>5 min read</p>
+			<!-- /wp:paragraph --></div>
+		<!-- /wp:group -->
 		<!-- /wp:post-template -->
 
 		<!-- wp:query-pagination -->

--- a/block-templates/author.html
+++ b/block-templates/author.html
@@ -1,14 +1,14 @@
 <!-- wp:planet4-blocks/framework -->
 <!-- wp:group {"className":"container"} -->
-<div class="wp-block-group container">
-	<!-- wp:post-author {"showAvatar":false,"showBio":true,"fontSize":"medium"} /-->
+<div class="wp-block-group container"><!-- wp:post-author {"showAvatar":false,"showBio":true,"fontSize":"medium"} /-->
+
 	<!-- wp:query {"queryId":1,"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"displayLayout":{"type":"flex","columns":3}} -->
 	<div class="wp-block-query"><!-- wp:post-template -->
-		<!-- wp:post-featured-image /-->
+		<!-- wp:post-featured-image {"isLink":true} /-->
 
-		<!-- wp:post-date /-->
+		<!-- wp:post-date {"isLink":true} /-->
 
-		<!-- wp:post-title /-->
+		<!-- wp:post-title {"isLink":true} /-->
 		<!-- /wp:post-template -->
 
 		<!-- wp:query-pagination -->

--- a/block-templates/author.html
+++ b/block-templates/author.html
@@ -1,10 +1,9 @@
 <!-- wp:planet4-blocks/framework -->
 <!-- wp:group {"className":"container"} -->
-<div class="wp-block-group container"><!-- wp:post-author {"showAvatar":false,"showBio":true,"fontSize":"medium"} /-->
+<div class="wp-block-group container"><!-- wp:post-author {"avatarSize":96,"showBio":true,"className":"author-pic","fontSize":"medium"} /-->
 
 	<!-- wp:query {"queryId":1,"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"displayLayout":{"type":"flex","columns":3}} -->
-	<div class="wp-block-query">
-		<!-- wp:query-pagination -->
+	<div class="wp-block-query"><!-- wp:query-pagination -->
 		<!-- wp:query-pagination-previous /-->
 
 		<!-- wp:query-pagination-numbers /-->

--- a/block-templates/author.html
+++ b/block-templates/author.html
@@ -3,7 +3,14 @@
 <div class="wp-block-group container"><!-- wp:post-author {"showAvatar":false,"showBio":true,"fontSize":"medium"} /-->
 
 	<!-- wp:query {"queryId":1,"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"displayLayout":{"type":"flex","columns":3}} -->
-	<div class="wp-block-query"><!-- wp:post-template -->
+	<div class="wp-block-query">
+		<!-- wp:query-pagination -->
+		<!-- wp:query-pagination-previous /-->
+
+		<!-- wp:query-pagination-numbers /-->
+
+		<!-- wp:query-pagination-next /-->
+		<!-- /wp:query-pagination -->	<!-- wp:post-template -->
 		<!-- wp:post-featured-image {"isLink":true} /-->
 
 		<!-- wp:post-date {"isLink":true} /-->

--- a/block-templates/tag.html
+++ b/block-templates/tag.html
@@ -1,0 +1,43 @@
+<!-- wp:planet4-blocks/framework -->
+<!-- wp:group {"className":"container"} -->
+<div class="wp-block-group container">
+	<!-- wp:term-description /-->
+	<!-- wp:query {"queryId":1,"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"displayLayout":{"type":"flex","columns":4}} -->
+	<div class="wp-block-query"><!-- wp:query-pagination -->
+		<!-- wp:query-pagination-previous /-->
+
+		<!-- wp:query-pagination-numbers /-->
+
+		<!-- wp:query-pagination-next /-->
+		<!-- /wp:query-pagination -->
+
+		<!-- wp:post-template -->
+		<!-- wp:post-featured-image {"isLink":true} /-->
+
+		<!-- wp:group {"className":"inline-container circle-separated"} -->
+		<div class="wp-block-group inline-container circle-separated"><!-- wp:post-terms {"term":"p4-page-type","style":{"typography":{"fontSize":"14px"}}} /-->
+
+			<!-- wp:post-terms {"term":"post_tag","style":{"typography":{"fontSize":"14px"}}} /--></div>
+		<!-- /wp:group -->
+
+		<!-- wp:post-title {"isLink":true,"style":{"typography":{"fontSize":"16px"}}} /-->
+
+		<!-- wp:group {"className":"inline-container dash-separated"} -->
+		<div class="wp-block-group inline-container dash-separated"><!-- wp:post-date {"format":"M j, Y g:i a","style":{"typography":{"fontSize":"12px"}}} /-->
+
+			<!-- wp:paragraph {"style":{"typography":{"fontSize":"12px"}}} -->
+			<p style="font-size:12px">5 min read</p>
+			<!-- /wp:paragraph --></div>
+		<!-- /wp:group -->
+		<!-- /wp:post-template -->
+
+		<!-- wp:query-pagination -->
+		<!-- wp:query-pagination-previous /-->
+
+		<!-- wp:query-pagination-numbers /-->
+
+		<!-- wp:query-pagination-next /-->
+		<!-- /wp:query-pagination --></div>
+	<!-- /wp:query --></div>
+<!-- /wp:group -->
+<!-- /wp:planet4-blocks/framework -->

--- a/block-templates/taxonomy-p4-page-type.html
+++ b/block-templates/taxonomy-p4-page-type.html
@@ -1,0 +1,44 @@
+<!-- wp:planet4-blocks/framework -->
+<!-- wp:group {"className":"container"} -->
+<div class="wp-block-group container">
+	<!-- wp:term-description /-->
+
+	<!-- wp:query {"queryId":1,"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"displayLayout":{"type":"flex","columns":4}} -->
+	<div class="wp-block-query"><!-- wp:query-pagination -->
+		<!-- wp:query-pagination-previous /-->
+
+		<!-- wp:query-pagination-numbers /-->
+
+		<!-- wp:query-pagination-next /-->
+		<!-- /wp:query-pagination -->
+
+		<!-- wp:post-template -->
+		<!-- wp:post-featured-image {"isLink":true} /-->
+
+		<!-- wp:group {"className":"inline-container circle-separated"} -->
+		<div class="wp-block-group inline-container circle-separated"><!-- wp:post-terms {"term":"p4-page-type","style":{"typography":{"fontSize":"14px"}}} /-->
+
+			<!-- wp:post-terms {"term":"post_tag","style":{"typography":{"fontSize":"14px"}}} /--></div>
+		<!-- /wp:group -->
+
+		<!-- wp:post-title {"isLink":true,"style":{"typography":{"fontSize":"16px"}}} /-->
+
+		<!-- wp:group {"className":"inline-container dash-separated"} -->
+		<div class="wp-block-group inline-container dash-separated"><!-- wp:post-date {"format":"M j, Y g:i a","style":{"typography":{"fontSize":"12px"}}} /-->
+
+			<!-- wp:paragraph {"style":{"typography":{"fontSize":"12px"}}} -->
+			<p style="font-size:12px">5 min read</p>
+			<!-- /wp:paragraph --></div>
+		<!-- /wp:group -->
+		<!-- /wp:post-template -->
+
+		<!-- wp:query-pagination -->
+		<!-- wp:query-pagination-previous /-->
+
+		<!-- wp:query-pagination-numbers /-->
+
+		<!-- wp:query-pagination-next /-->
+		<!-- /wp:query-pagination --></div>
+	<!-- /wp:query --></div>
+<!-- /wp:group -->
+<!-- /wp:planet4-blocks/framework -->

--- a/block-templates/taxonomy-p4-page-type.html
+++ b/block-templates/taxonomy-p4-page-type.html
@@ -15,11 +15,7 @@
 		<!-- wp:post-template -->
 		<!-- wp:post-featured-image {"isLink":true} /-->
 
-		<!-- wp:group {"className":"inline-container circle-separated"} -->
-		<div class="wp-block-group inline-container circle-separated"><!-- wp:post-terms {"term":"p4-page-type","style":{"typography":{"fontSize":"14px"}}} /-->
-
-			<!-- wp:post-terms {"term":"post_tag","style":{"typography":{"fontSize":"14px"}}} /--></div>
-		<!-- /wp:group -->
+		<!-- wp:post-terms {"term":"post_tag","style":{"typography":{"fontSize":"14px"}}} /-->
 
 		<!-- wp:post-title {"isLink":true,"style":{"typography":{"fontSize":"16px"}}} /-->
 

--- a/templates/base.twig
+++ b/templates/base.twig
@@ -31,9 +31,8 @@
 		{% include 'blocks/header.twig' %}
 	{% endif %}
 
-	{% block content %}
-		Sorry, no content
-	{% endblock %}
+	{% if raw_content %}{{ raw_content|raw }}{% endif %}
+	{% block content  %}{% endblock %}
 
 	{% if sidebar %}
 		<aside class="layout-sidebar">

--- a/templates/base.twig
+++ b/templates/base.twig
@@ -27,7 +27,7 @@
 	{% endif %}
 	{% include 'sidebar.twig' with data_nav_bar %}
 
-	{% if not post.password_required %}
+	{% if not post.password_required and not raw_content %}
 		{% include 'blocks/header.twig' %}
 	{% endif %}
 


### PR DESCRIPTION
This adds an Author page template using a new template mechanism in WordPress. I hope one day each of these mechanisms will get a clear own name, but for now we need to explain in more detail to avoid confusion.

This mechanism works by checking the `block-templates` directory for a file with a certain name. For example `author.html` for the Author page.

It's checked before any of the other mechanisms, so I didn't have to remove `author.php` which it would use if we didn't provide this new file.

There's just 1 problem, but a big one. We have a lot of elements of our site in Twig templates, in fact most of them. Ideally all of these should be converted to blocks so that we can just add those blocks to the new WP template files.

But that's a lot of work before we can start using this. To get around the limitation, I created a new ["Framework" block](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/768) which holds the entire Planet4 UI, except the content part. The content is created by rendering the block's inner blocks to a HTML string and output it raw in Twig.

This was surprisingly easy and could directly render the `base.twig` template with almost no modification.

### Observations
* To fully create the author page currently it misses a block to output author name as a title. Should be relatively easy to create this block ourselves as we only need to define a back end render function for this use case.
* An author bio block exists but it's more created as a secondary element on a post page. Maybe only needs styling changes.
* "Inherit from template" Query Loop block seems to work for the author page. Still need to confirm other page types.
* Pagination works and uses the items per page defined in WP's reading settings. On the test instance I changed this to 12 to better line out.
* By default it uses the path and not a query string for the page numbers. Which is nice because it makes caching easier. We can just invalidate all pages from cache every time any list entry is added, changed, or removed. Could be the CF plugin already does this to some extent.

### [Test instance demo](https://www-dev.greenpeace.org/test-venus/author/dtovbein/)
I imported data from Denmark. Keep in mind that the author IDs on posts are not updated, so the author will change to whatever user has that ID on the test instance.

### WordPress docs
* https://developer.wordpress.org/block-editor/how-to-guides/themes/block-theme-overview/

### Gutenberg repo related issues
* https://github.com/WordPress/gutenberg/issues/37407

### Other WP themes that use this feature
* https://github.com/WordPress/theme-experiments/tree/master/tt1-blocks