### PR TITLE
Fix tags spacing in breadcrumbs

### DIFF
--- a/assets/src/scss/layout/_breadcrumbs.scss
+++ b/assets/src/scss/layout/_breadcrumbs.scss
@@ -12,8 +12,12 @@
   .tag-wrap-bullet {
     pointer-events: none;
     font-weight: 400;
-    margin: 0 $sp-1;
+    margin-inline-end: $sp-1;
     color: $link-color;
+  }
+
+  .tag-wrap-bullet {
+    margin-inline-start: $sp-1;
   }
 
   .tag-item {
@@ -26,6 +30,10 @@
       }
     }
     display: inline-block;
+
+    &:not(:only-child):not(:last-child):not(.page-type) {
+      margin-inline-end: $sp-1;
+    }
   }
 
   .main-tag-chevron {


### PR DESCRIPTION
### Description

The space between tags in the breadscrumbs had been removed by mistake when adding the new separators between categories in post navigation links. 

### Testing

You can find these tags in several places, the easiest one to check is probably in an Articles block. Make sure the new post navigation links also still look as expected!