### PR TITLE
POC Add Listing Page post type

### DIFF
--- a/src/Campaigns.php
+++ b/src/Campaigns.php
@@ -88,9 +88,10 @@ class Campaigns {
 			$dropdown_args = [
 				'show_option_none' => __( 'Select Page', 'planet4-master-theme-backend' ),
 				'hide_empty'       => 0,
-				'hierarchical'     => true,
-				'selected'         => $redirect_page,
+				'selected'         => esc_attr( $redirect_page ),
 				'name'             => 'redirect_page',
+				'post_type'        => ListingPage::POST_TYPE,
+				'post_status'      => [ 'publish', 'draft' ],
 			];
 			?>
 
@@ -99,7 +100,8 @@ class Campaigns {
 					<label><?php esc_html_e( 'Redirect Page', 'planet4-master-theme-backend' ); ?></label>
 				</th>
 				<td>
-					<?php wp_dropdown_pages( array_map( 'esc_attr', $dropdown_args ) ); ?> <a href="post.php?post=<?php echo esc_attr( $redirect_page ); ?>&action=edit" target="_blank"><?php esc_html_e( 'Edit', 'planet4-master-theme-backend' ); ?></a>
+					<?php wp_dropdown_pages( $dropdown_args ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+					<a href="post.php?post=<?php echo esc_attr( $redirect_page ); ?>&action=edit" target="_blank"><?php esc_html_e( 'Edit', 'planet4-master-theme-backend' ); ?></a>
 					<p class="description"><?php esc_html_e( 'Leave this empty if you want to use the automated Tag page. Otherwise pick a page to redirect this Tag to.', 'planet4-master-theme-backend' ); ?></p>
 				</td>
 			</tr>
@@ -133,7 +135,7 @@ class Campaigns {
 						<?php esc_html_e( 'Select/Upload Image', 'planet4-master-theme-backend' ); ?>
 					</button>
 					<p class="description"><?php esc_html_e( 'Associate this tag with an image.', 'planet4-master-theme-backend' ); ?></p>
-					<img class="attachment-thumbnail size-thumbnail" src="<?php echo esc_url( $attachment_url ); ?>"/>
+					<img style="max-width: 100%" class="attachment-thumbnail size-thumbnail" src="<?php echo esc_url( $attachment_url ); ?>"/>
 					<i class="dashicons dashicons-dismiss <?php echo $image_attributes ? '' : 'hidden'; ?>" style="cursor: pointer;"></i>
 				</td>
 			</tr>

--- a/src/ListingPage.php
+++ b/src/ListingPage.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace P4\MasterTheme;
+
+/**
+ * Class P4\MasterTheme\PostCampaign
+ */
+class ListingPage {
+	public const POST_TYPE = 'listing_page';
+
+	/**
+	 * Taxonomy_Image constructor.
+	 */
+	public function __construct() {
+		$this->hooks();
+	}
+
+	/**
+	 * Class hooks.
+	 */
+	private function hooks() {
+		add_action( 'init', [ $this, 'register_post_type' ] );
+	}
+
+	/**
+	 * Register list page post type.
+	 */
+	public function register_post_type() {
+		$labels = [
+			'name'               => _x( 'Listing Pages', 'post type general name', 'planet4-master-theme-backend' ),
+			'singular_name'      => _x( 'Listing Page', 'post type singular name', 'planet4-master-theme-backend' ),
+			'menu_name'          => _x( 'Listing Pages', 'admin menu', 'planet4-master-theme-backend' ),
+			'name_admin_bar'     => _x( 'Listing Pages', 'add new on admin bar', 'planet4-master-theme-backend' ),
+			'add_new'            => _x( 'Add New', 'campaign', 'planet4-master-theme-backend' ),
+			'add_new_item'       => __( 'Add New Listing Page', 'planet4-master-theme-backend' ),
+			'new_item'           => __( 'New Listing Page', 'planet4-master-theme-backend' ),
+			'edit_item'          => __( 'Edit Listing Page', 'planet4-master-theme-backend' ),
+			'view_item'          => __( 'View Listing Page', 'planet4-master-theme-backend' ),
+			'all_items'          => __( 'All Listing Pages', 'planet4-master-theme-backend' ),
+			'search_items'       => __( 'Search Listing Pages', 'planet4-master-theme-backend' ),
+			'parent_item_colon'  => __( 'Parent Listing Page:', 'planet4-master-theme-backend' ),
+			'not_found'          => __( 'No Listing Pages found.', 'planet4-master-theme-backend' ),
+			'not_found_in_trash' => __( 'No Listing Pages found in Trash.', 'planet4-master-theme-backend' ),
+		];
+
+		$args = [
+			'labels'             => $labels,
+			'description'        => __( 'Listing Pages', 'planet4-master-theme-backend' ),
+			'public'             => true,
+			'publicly_queryable' => false,
+			'show_ui'            => true,
+			'show_in_menu'       => true,
+			'query_var'          => true,
+			'capability_type'    => [ 'campaign', 'campaigns' ],
+			'map_meta_cap'       => true,
+			'has_archive'        => false,
+			'hierarchical'       => true,
+			'show_in_nav_menus'  => true,
+			'menu_position'      => 20,
+			'menu_icon'          => 'dashicons-excerpt-view',
+			'show_in_rest'       => true,
+			'supports'           => [
+				'page-attributes',
+				'title',
+				'editor',
+				'author',
+				'thumbnail',
+				'excerpt',
+				'revisions',
+				// Required to expose meta fields in the REST API.
+				'custom-fields',
+			],
+		];
+		register_post_type( self::POST_TYPE, $args );
+	}
+}

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -64,6 +64,7 @@ final class Loader {
 		$this->default_services = [
 			CustomTaxonomy::class,
 			PostCampaign::class,
+			ListingPage::class,
 			PostArchive::class,
 			Settings::class,
 			Features::class,

--- a/tag.php
+++ b/tag.php
@@ -20,11 +20,12 @@ if ( is_tag() ) {
 	$context['tag']  = get_queried_object();
 	$explore_page_id = planet4_get_option( 'explore_page' );
 
-	$redirect_id = get_term_meta( $context['tag']->term_id, 'redirect_page', true );
-	if ( $redirect_id ) {
+	$redirect_id   = get_term_meta( $context['tag']->term_id, 'redirect_page', true );
+	$redirect_page = ! $redirect_id ? null : get_post( $redirect_id );
+
+	if ( $redirect_id && 'publish' === $redirect_page->post_status ) {
 
 		global $wp_query;
-		$redirect_page               = get_post( $redirect_id );
 		$wp_query->queried_object    = $redirect_page;
 		$wp_query->queried_object_id = $redirect_page->ID;
 


### PR DESCRIPTION
* Use it in tag redirect page dropdown.
* Check if it's published before using. This would need to be shown in
the UI.
* Use campaigns caps for now to avoid needing database updates.
* Lacks a migration script for existing content, which we would need to
release together to ensure the existing pages are shown as a value in
the dropdown.

<!-- Ref: Please add a url to the ticket this change is addressing.

---

Please provide a brief summary of the change introduced to make review process easier.

Ideally this should also be part of the commit summary.
-->
