### PR TITLE
PLANET-6480 Disable CSS Customizer on production

### DIFF
--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -268,6 +268,16 @@ class MasterSite extends TimberSite {
 		// Make post tags ordered.
 		add_filter( 'register_taxonomy_args', [ $this, 'set_post_tags_as_ordered' ], 10, 2 );
 
+		// Disable CSS Customizer.
+		add_action(
+			'customize_register',
+			function ( $wp_customize ) {
+				if ( defined( 'WP_APP_ENV' ) && ( 'production' === WP_APP_ENV || 'staging' === WP_APP_ENV ) ) {
+					$wp_customize->remove_control( 'custom_css' );
+				}
+			}
+		);
+
 		$this->register_meta_fields();
 	}
 


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6480

---

Checking [WP_APP_ENV](https://github.com/greenpeace/planet4-docker/blob/a4d8b32057469834b2798e861e5da1de1f96ce98/src/planet-4-151612/wordpress/wp-config.php.tmpl#L66-L68). If it's production or staging hide the CSS Customizer.

### Testing

1. Get inside the php container: `make php-shell`
2. Edit `public/wp-config.php`
3. Test with changing `WP_APP_ENV` variable. It should already be there if you have a recent environment. Oherwise you would need to add it /eg. `define( 'WP_APP_ENV', 'local' );`