### PR TITLE
PLANET-6611 Hide post type in admin listings

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -192,3 +192,21 @@ add_action(
 	1,
 	2
 );
+
+/**
+ * This is not a column in WordPress by default, but is added by the Post Type Switcher plugin.
+ * It's not needed for the plugin to work, and needlessly takes up space on pages where everything has the same post
+ * type.
+ *
+ * Showing the field is only somewhat useful when using quick edit to switch a single post from the admin listing page.
+ */
+add_filter(
+	'default_hidden_columns',
+	function ( $hidden ) {
+		$hidden[] = 'post_type';
+
+		return $hidden;
+	},
+	10,
+	1
+);


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6611

Make `post_type` a hidden column by default. The Post Type Switcher plugin doesn't do this, even though it doesn't depend on the column being visible to work.

Showing the column is a bit pointless because all listings only ever have a single post type.

The only advantage of having it a visible column is it allows you to see the different type after switching. But only when using "Quick edit" in the listing view. It's because quick edit doesn't refresh the page but updates in place.