### PR TITLE
PLANET-6614: Save post tags as ordered

### DIFF
--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -264,6 +264,9 @@ class MasterSite extends TimberSite {
 			}
 		);
 
+		// Make post tags ordered.
+		add_filter( 'register_taxonomy_args', [ $this, 'set_post_tags_as_ordered' ], 10, 2 );
+
 		$this->register_meta_fields();
 	}
 
@@ -1470,4 +1473,21 @@ class MasterSite extends TimberSite {
 		return $endpoints;
 	}
 
+	/**
+	 * Set post tags options to retain their order on save and return them ordered
+	 *
+	 * @param array  $args     Array of arguments for registering a taxonomy.
+	 * @param string $taxonomy Taxonomy key.
+	 *
+	 * @return array $args Array of arguments for registering a taxonomy.
+	 */
+	public function set_post_tags_as_ordered( array $args, string $taxonomy ): array {
+		if ( 'post_tag' !== $taxonomy ) {
+			return $args;
+		}
+
+		$args['sort'] = true;
+		$args['args'] = [ 'orderby' => 'term_order' ];
+		return $args;
+	}
 }


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6614

> it is impossible to set the main tag (and the other page tags) in a custom order, because when there is more than 1 tag upon page save the tags get automatically rearranged in alphabetical order. 

Post tags are not ordered by default, so order is lost on save, and never used on fetch.

## Fix

Using [`register_taxonomy_args`](https://developer.wordpress.org/reference/functions/register_taxonomy/) hook to
- set `sort` parameter for keeping order when saving post tags
- set `args` parameter for using order when fetching post tags

This configuration forces the use of the DB field `wp_term_relationships.term_order`.

## Test

- Edit a new page
- Add tags in a different order than alphabetical (ie `Ocean, Coal, Forest`)
- Clicking on the `Save draft` button shouldn't reorder the tags
- Tags should be displayed on the same order on the frontend