### PR TITLE
PLANET-6622 Rename navigation title option

### DIFF
--- a/src/Settings.php
+++ b/src/Settings.php
@@ -67,7 +67,7 @@ class Settings {
 				'title'  => 'Navigation',
 				'fields' => [
 					[
-						'name' => __( 'Website Navigation Title', 'planet4-master-theme-backend' ),
+						'name' => __( 'NRO Selector Title', 'planet4-master-theme-backend' ),
 						'id'   => 'website_navigation_title',
 						'type' => 'text',
 					],


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6622
* To make it more clear this label is only used in the country selector.

<!-- Ref: Please add a url to the ticket this change is addressing.

---

Please provide a brief summary of the change introduced to make review process easier.

Ideally this should also be part of the commit summary.
-->
