### PR TITLE
PLANET-6496: HappyPoint global switch and default content

### DIFF
--- a/src/Settings.php
+++ b/src/Settings.php
@@ -166,12 +166,7 @@ class Settings {
 						'desc'       => __( 'Average reading words per minute (usually between 220 and 320).', 'planet4-master-theme-backend' ),
 					],
 
-					[
-						'name' => __( 'Happy point Subscribe Form URL', 'planet4-master-theme-backend' ),
-						'id'   => 'engaging_network_form_id',
-						'type' => 'text',
-					],
-
+					// HappyPoint settings.
 					[
 						'name'       => __( 'Default Happy Point Background Image', 'planet4-master-theme-backend' ),
 						'id'         => 'happy_point_bg_image',
@@ -186,6 +181,23 @@ class Settings {
 							'type' => 'image',
 						],
 						'desc'       => __( 'Minimum image width should be 1920px', 'planet4-master-theme-backend' ),
+					],
+
+					[
+						'name'    => __( 'Default Happy Point Form', 'planet4-master-theme-backend' ),
+						'id'      => 'happy_point_content_provider',
+						'type'    => 'radio',
+						'options' => [
+							'iframe_url' => __( 'URL (for iframe)', 'planet4-master-theme-backend' ),
+							'embed_code' => __( 'Embed code (HubSpot)', 'planet4-master-theme-backend' ),
+						],
+						'default' => 'iframe_url',
+					],
+
+					[
+						'name' => __( 'Happy point Subscribe Form URL', 'planet4-master-theme-backend' ),
+						'id'   => 'engaging_network_form_id',
+						'type' => 'text',
 					],
 
 					[


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6496

Related to: https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/781

Add a setting in _Planet 4 > Defaults content_ to use either iframe or embed code as default HappyPoint form.

![Screenshot from 2022-02-09 07-42-10](https://user-images.githubusercontent.com/617346/153136053-841eb9c4-be65-4c97-a097-03fd7c0ae807.png)

## Test

Test with https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/781 locally, or [on Pluto](https://www-dev.greenpeace.org/test-pluto/)

This option should make the selected form appear by default on any **new** HappyPoint (if the corresponding form value is also filled in Defaults content) - see [this Jira comment](https://jira.greenpeace.org/browse/PLANET-6496?focusedCommentId=244914&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-244914) for more details.