### PR TITLE
PLANET-6509: Navigation Bar styling drop-down menus

### DIFF
--- a/assets/src/js/header.js
+++ b/assets/src/js/header.js
@@ -229,3 +229,4 @@ export const setupHeader = () => {
 
   setMobileTabsMenuScroll();
 };
+

--- a/assets/src/scss/layout/_navbar.scss
+++ b/assets/src/scss/layout/_navbar.scss
@@ -204,6 +204,91 @@ $navbar-default-height: 60px;
   }
 }
 
+.nav-submenu {
+  position: fixed;
+  display: none;
+  min-width: 193px;
+  padding-top: $sp-1;
+
+  .nav-submenu-wrapper {
+    border-radius: $sp-1;
+    width: 100%;
+    box-shadow: 0 1px $sp-x rgba(0, 0, 0, 0.12);
+  }
+
+  ul {
+    width: 100%;
+    // The `height` value represents the value of 6 items's height
+    // and this selectors's padding
+    height: auto;
+    max-height: 320px;
+    display: block;
+    flex-direction: column;
+    padding: $sp-2 0;
+    background: $white;
+    border-radius: $sp-1;
+    overflow-y: auto;
+
+    // Only applied to Firefox
+    scrollbar-width: thin;
+    scrollbar-color: transparent;
+
+    &::-webkit-scrollbar {
+      width: $sp-1;
+    }
+
+    &::-webkit-scrollbar-track {
+      border-radius: $sp-x;
+    }
+
+    &::-webkit-scrollbar-thumb {
+      border-radius: $sp-x;
+      background: rgba(0, 0, 0, 0.15);
+    }
+
+    &::-webkit-scrollbar-thumb:hover {
+      background: rgba(0, 0, 0, 0.2);
+    }
+  }
+
+  li {
+    width: 100%;
+    text-align: left;
+    white-space: nowrap;
+    color: $grey-80;
+    height: 48px;
+
+    a.nav-link {
+      --submenu-nav-link-- {
+        color: $grey-80;
+        font-size: $sp-2;
+        font-weight: 500;
+
+        &:hover {
+          _-- {
+            color: $grey-80;
+          }
+        }
+      }
+      text-decoration: none;
+      height: 100%;
+      display: flex;
+      align-items: center;
+      padding-right: $sp-3;
+      padding-left: $sp-3;
+
+      &:hover {
+        background: $grey-10;
+      }
+
+      &:before {
+        // Disable nav-link animation on hover
+        display: none;
+      }
+    }
+  }
+}
+
 .nav-item {
   color: inherit;
   font-size: $font-base-size;
@@ -212,6 +297,13 @@ $navbar-default-height: 60px;
   @include large-and-up {
     line-height: $menu-height;
     margin: 0 20px;
+
+    &:hover {
+      .nav-submenu {
+        display: flex;
+        z-index: 999;
+      }
+    }
   }
 }
 
@@ -221,7 +313,6 @@ a.nav-link {
 
     &:hover {
       color: $white;
-      text-decoration-color: $gp-green;
     }
   }
 
@@ -230,21 +321,10 @@ a.nav-link {
   padding: $sp-2 0;
   position: relative;
   width: 100%;
+  text-decoration: none;
 
   @include large-and-up {
     padding: 0;
-  }
-
-  &:hover {
-    opacity: 1;
-    text-decoration-line: underline;
-    text-decoration-thickness: 3px;
-    text-underline-offset: auto;
-    text-underline-position: under;
-
-    @include large-and-up {
-      text-decoration-line: none;
-    }
   }
 
   // Border-bottom for underline animation
@@ -261,34 +341,33 @@ a.nav-link {
     transform: scaleX(0);
     transition: transform 0.25s;
     z-index: -1;
+
+    @include large-and-up {
+      border-bottom-width: 4px;
+    }
   }
 }
 
 .active a.nav-link {
   --nav-link-active-- {
-    color: var(--nav-link--color, $white);
-    text-decoration-color: $gp-green;
+    color: $white;
+
+    &:hover {
+      color: $white;
+    }
   }
 
-  opacity: 1;
-  text-decoration-line: underline;
-  text-decoration-thickness: 3px;
-  text-underline-offset: auto;
-  text-underline-position: under;
-
-  @include large-and-up {
-    text-decoration-line: none;
-    text-decoration-thickness: 4px;
+  &:before {
+    transform: scaleX(1);
+    border-bottom-color: var(--nav-link--text-decoration-color, $gp-green);
   }
 }
 
 // Underline animation with border-bottom
-a.nav-link:hover:before,
-.active a.nav-link:before {
-  @include large-and-up {
-    transform: scaleX(1);
-    transition: transform 0.25s;
-  }
+.nav-item:hover a.nav-link:before {
+  transform: scaleX(1);
+  transition: transform 0.25s;
+  border-bottom-color: var(--nav-link--text-decoration-color, $gp-green);
 }
 
 .nav-menu-toggle {

--- a/assets/src/scss/partials/navigation-bar-light.scss
+++ b/assets/src/scss/partials/navigation-bar-light.scss
@@ -14,6 +14,8 @@
   --top-navigation--input--placeholder--color: #{$grey-40};
   --nav-link--color: #{$black};
   --nav-link--hover--color: #{$black};
+  --nav-link-active--color: #{$black};
+  --nav-link-active--hover--color: #{$black};
 }
 
 #nav-mobile-menu {

--- a/src/AdminAssets.php
+++ b/src/AdminAssets.php
@@ -39,7 +39,7 @@ class AdminAssets {
 						'maxChars' => 18,
 					],
 					1 => [
-						'maxItems' => 5,
+						'maxItems' => 10,
 						'maxChars' => 18,
 					],
 				],

--- a/templates/navigation-bar-new.twig
+++ b/templates/navigation-bar-new.twig
@@ -40,6 +40,34 @@
 						data-ga-label="{{ page_category }}">
 							{{ item.title }}
 					</a>
+
+					{% if item.children is not empty %}
+						<nav class='nav-submenu'>
+							<div class='nav-submenu-wrapper'>
+								<ul>
+								{% for key,item in item.children %}
+									<li>
+										{% if fn('get_post_meta', item.ID, '_menu_item_object_id', true ) == act_page_id %}
+											{% set link_ga_action = 'Act' %}
+										{% elseif fn('get_post_meta', item.ID, '_menu_item_object_id', true ) == explore_page_id %}
+											{% set link_ga_action = 'Explore' %}
+										{% else %}
+											{% set link_ga_action = item.title %}
+										{% endif %}
+										<a
+											class="nav-link"
+											href="{{ item.get_link }}"
+											data-ga-category="Submenu Navigation"
+											data-ga-action="{{ link_ga_action }}"
+											data-ga-label="{{ page_category }}">
+												{{ item.title }}
+										</a>
+									</li>
+								{% endfor %}
+								</ul>
+							</div>
+						</nav>
+					{% endif %}
 				</li>
 				{% endfor %}
 				<li class="nav-item nav-donate">


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6509

👉 [Parent PR](https://github.com/greenpeace/planet4-master-theme/pull/1628)

**How to test**
Navigate to the [instance](https://www-dev.greenpeace.org/test-nix/) and play around with the menu.

Also go to:
`Planet4 > Navigation` and change the **Website Navigation Style** to `dark|light`

**What to test**
- Validate the Design iteration2_IA & nav MVP from [here](https://www.figma.com/file/Gn8wyqgto7608rlESePXZE/Foundations-%26-Components?node-id=0%3A103).
- Analytics vars set to the sub-menu items.

**New CSS variables**
```
--submenu-nav-link--color
--submenu-nav-link--hover--color
--submenu-nav-link--font-size
--submenu-nav-link--font-weight
```
