### PR TITLE
PLANET-6589: Fix search error when act page not selected

### DIFF
--- a/src/ElasticSearch.php
+++ b/src/ElasticSearch.php
@@ -172,15 +172,22 @@ class ElasticSearch extends Search {
 				],
 				'weight' => self::DEFAULT_PAGE_WEIGHT,
 			],
-			[
-				'filter' => [
-					'term' => [
-						'post_parent' => esc_sql( planet4_get_option( 'act_page' ) ),
-					],
-				],
-				'weight' => self::DEFAULT_ACTION_WEIGHT,
-			],
 		);
+
+		$act_page = planet4_get_option( 'act_page', null );
+		if ( $act_page ) {
+			array_push(
+				$formatted_args['query']['function_score']['functions'],
+				[
+					'filter' => [
+						'term' => [
+							'post_parent' => esc_sql( $act_page ),
+						],
+					],
+					'weight' => self::DEFAULT_ACTION_WEIGHT,
+				],
+			);
+		}
 
 		// Specify how the computed scores are combined.
 		$formatted_args['query']['function_score']['score_mode'] = 'sum';

--- a/src/Search.php
+++ b/src/Search.php
@@ -618,8 +618,8 @@ abstract class Search {
 								case 0:
 									$args['post_type']   = 'page';
 									$args['post_status'] = 'publish';
-									$options             = get_option( 'planet4_options' );
-									$args['post_parent'] = esc_sql( $options['act_page'] );
+									$act_page            = planet4_get_option( 'act_page', 0 );
+									$args['post_parent'] = esc_sql( $act_page );
 									break;
 								case 1:
 									$args['post_type']      = 'attachment';
@@ -629,8 +629,8 @@ abstract class Search {
 								case 2:
 									$args['post_type']             = 'page';
 									$args['post_status']           = 'publish';
-									$options                       = get_option( 'planet4_options' );
-									$args['post_parent__not_in'][] = esc_sql( $options['act_page'] );
+									$act_page                      = planet4_get_option( 'act_page', 0 );
+									$args['post_parent__not_in'][] = esc_sql( $act_page );
 									break;
 								case 3:
 									$args['post_type']   = 'post';
@@ -878,7 +878,7 @@ abstract class Search {
 		if ( ! empty( $this->aggregations ) ) {
 			$aggs = $this->aggregations['with_post_filter'];
 			foreach ( $aggs['post_parent']['buckets'] as $parent_agg ) {
-				if ( $parent_agg['key'] === (int) $options['act_page'] ) {
+				if ( ! empty( $options['act_page'] ) && $parent_agg['key'] === (int) $options['act_page'] ) {
 					$act_page_count                           = $parent_agg['doc_count'];
 					$context['content_types']['0']['results'] = $act_page_count;
 				}
@@ -942,7 +942,7 @@ abstract class Search {
 			// Post Type (+Action) <-> Content Type.
 			switch ( $post->post_type ) {
 				case 'page':
-					if ( $post->post_parent === (int) $options['act_page'] ) {
+					if ( ! empty( $options['act_page'] ) && $post->post_parent === (int) $options['act_page'] ) {
 						$content_type_text = __( 'ACTION', 'planet4-master-theme' );
 						$content_type      = 'action';
 					} else {


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6589
Ref: https://jira.greenpeace.org/browse/PLANET-6590
Ref: https://jira.greenpeace.org/browse/PLANET-6588

An empty `act_page` option will result in an empty search term in the post_parent filter.
This empty term raises an ElasticSearch error:
- `QueryShardException[failed to create query`,
- `NumberFormatException[empty String];; java.lang.NumberFormatException: empty String`

Adding conditions on act_page value fixes the referenced issues for the Handbook.

## Debug

I used the function added last time I had to debug the search functionality, here's a var_dump version :grin: 
```diff
diff --git a/src/ElasticSearch.php b/src/ElasticSearch.php
index e1730393..b383a152 100644
--- a/src/ElasticSearch.php
+++ b/src/ElasticSearch.php
@@ -102,6 +102,15 @@ class ElasticSearch extends Search {
 
 		add_filter( 'ep_formatted_args', [ $this, 'add_mime_type_filter' ], 21, 1 );
 
+
+		add_filter( 'ep_formatted_args', function ( $args ) {
+
+			var_dump($args);
+			var_dump(self::validate_query($args['query']));
+
+			return $args;
+		}, 99, 1 );
+
 		if ( ! wp_doing_ajax() ) {
 			add_filter( 'ep_formatted_args', [ $this, 'add_aggregations' ], 999, 1 );
 		}
```

That gives the following error as en explanation:
```
["valid"]=>
  bool(false)
  ["explanations"]=>
  array(1) {
    [0]=>
    array(3) {
      ["index"]=>
      string(18) "planet4test-post-1"
      ["valid"]=>
      bool(false)
      ["error"]=>
      string(3803) "[planet4test-post-1/9Xx7oKDhRL-s7OkcPV1NMw] QueryShardException[failed to create query: {
  "function_score" : {
    "query" : {
      "bool" : {
        "must" : [
          {
            "multi_match" : {
              "query" : "mysearch",
              "fields" : [
                "attachments.attachment.content^1.0",
                "post_author.display_name^1.0",
                "post_content^1.0",
                "post_excerpt^1.0",
                "post_title^1.0"
              ],
              "type" : "best_fields",
              "operator" : "AND",
              "slop" : 0,
              "prefix_length" : 0,
              "max_expansions" : 50,
              "zero_terms_query" : "NONE",
              "auto_generate_synonyms_phrase_query" : true,
              "fuzzy_transpositions" : true,
              "boost" : 4.0
            }
          },
          {
            "multi_match" : {
              "query" : "mysearch",
              "fields" : [
                "attachments.attachment.content^1.0",
                "post_author.display_name^1.0",
                "post_content^1.0",
                "post_excerpt^1.0",
                "post_title^1.0"
              ],
              "type" : "best_fields",
              "operator" : "AND",
              "slop" : 0,
              "fuzziness" : "0",
              "prefix_length" : 0,
              "max_expansions" : 50,
              "zero_terms_query" : "NONE",
              "auto_generate_synonyms_phrase_query" : true,
              "fuzzy_transpositions" : true,
              "boost" : 2.0
            }
          },
          {
            "multi_match" : {
              "query" : "mysearch",
              "fields" : [
                "attachments.attachment.content^1.0",
                "post_author.display_name^1.0",
                "post_content^1.0",
                "post_excerpt^1.0",
                "post_title^1.0"
              ],
              "type" : "best_fields",
              "operator" : "OR",
              "slop" : 0,
              "fuzziness" : "1",
              "prefix_length" : 0,
              "max_expansions" : 50,
              "zero_terms_query" : "NONE",
              "auto_generate_synonyms_phrase_query" : true,
              "fuzzy_transpositions" : true,
              "boost" : 1.0
            }
          }
        ],
        "adjust_pure_negative" : true,
        "boost" : 1.0
      }
    },
    "functions" : [
      {
        "filter" : {
          "match_all" : {
            "boost" : 1.0
          }
        },
        "exp" : {
          "post_date_gmt" : {
            "scale" : "28d",
            "decay" : 0.5,
            "offset" : "365d"
          },
          "multi_value_mode" : "MIN"
        }
      },
      {
        "filter" : {
          "match_all" : {
            "boost" : 1.0
          }
        },
        "weight" : 0.001
      },
      {
        "filter" : {
          "match" : {
            "post_type" : {
              "query" : "page",
              "operator" : "OR",
              "prefix_length" : 0,
              "max_expansions" : 50,
              "fuzzy_transpositions" : true,
              "lenient" : false,
              "zero_terms_query" : "NONE",
              "auto_generate_synonyms_phrase_query" : true,
              "boost" : 1.0
            }
          }
        },
        "weight" : 100.0
      },
      {
        "filter" : {
          "term" : {
            "post_parent" : {
              "value" : "",
              "boost" : 1.0
            }
          }
        },
        "weight" : 2000.0
      }
    ],
    "score_mode" : "sum",
    "boost_mode" : "multiply",
    "max_boost" : 3.4028235E38,
    "boost" : 1.0
  }
}]; nested: NumberFormatException[empty String];; java.lang.NumberFormatException: empty String"
    }
  }
```

The empty string here is the `post_parent` filter term, which is supposed to be the Act page configured in _Planet 4 > navigation_.

## Test

You can test it on a local version of the Handbook with the handbook DB, with `NRO_NAME=handbook NRO_DB_VERSION=latest make nro-enable`. It probably works with any instance by removing the _Planet 4 > Navigation :: Act page_ configuration.
