### PR TITLE
PLANET-6611 Add config for whether type can be switched

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -224,4 +224,6 @@ add_filter(
 	4
 );
 
+add_action( 'wp_print_scripts', fn() => wp_dequeue_script( 'pts_blockeditor' ), 100 );
+
 simple_value_filter( 'pts_post_type_filter', [ 'allow_switch_type' => true ], 1 );

--- a/functions.php
+++ b/functions.php
@@ -210,3 +210,18 @@ add_filter(
 	10,
 	1
 );
+
+add_filter(
+	'register_post_type_args',
+	function ( $args, $name ) {
+		if ( 'page' === $name ) {
+			$args['allow_switch_type'] = true;
+		}
+
+		return $args;
+	},
+	10,
+	4
+);
+
+simple_value_filter( 'pts_post_type_filter', [ 'allow_switch_type' => true ], 1 );

--- a/src/PostCampaign.php
+++ b/src/PostCampaign.php
@@ -168,6 +168,7 @@ class PostCampaign {
 				// Required to expose meta fields in the REST API.
 				'custom-fields',
 			],
+			'allow_switch_type'  => true,
 		];
 
 		register_post_type( self::POST_TYPE, $args );


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6611
* This needs to use args, the plugin only exposes the args and doesn't
directly accept a post type slug.

I'm still checking the sidebar, it doesn't seem to take this into account for whether the widget is displayed. Though the choice list is in fact properly filtered. So it's only a problem on the post page. But could be annoying because you can't switch back afterwards :grimacing: 

<img width=300 src="https://user-images.githubusercontent.com/7604138/153039001-9549de5a-789f-4d34-9909-8a8da8d5a109.png"/>
<img width=300 src="https://user-images.githubusercontent.com/7604138/153039003-8f1e0237-27b0-4731-b441-560d07226419.png"/>

I then wanted to hide it on post editor pages with CSS, but the markup has nothing we can use to reliably target it. It only re-uses classes also present in other sidebar components.

Probably the best solution is to dequeue the plugin's editor script and provide our own component. This way it's not needed to fork the whole plugin just for this component. Should be manageable as it's a [simple standalone component](https://github.com/JJJ/post-type-switcher/blob/master/src/components/post-type-switcher.js) and we only need minor modifications to it.

[Example post page](https://www-dev.greenpeace.org/test-pluto/wp-admin/post.php?post=47198&action=edit
) (same on any post)

The filter does work as intended for bulk and quick edit.

I also noticed the plugin does an [unsafe GET when switching the post type](https://github.com/JJJ/post-type-switcher/blob/master/src/components/post-type-switcher.js#L39). I think this endpoint is only used for this sidebar. We should probably make this use POST.

