### PR TITLE
PLANET-6440: Remove unused related articles settings

### DIFF
--- a/src/Migrations/M008RemoveArticlesDefaultOptions.php
+++ b/src/Migrations/M008RemoveArticlesDefaultOptions.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace P4\MasterTheme\Migrations;
+
+use P4\MasterTheme\MigrationRecord;
+use P4\MasterTheme\MigrationScript;
+use P4\MasterTheme\Settings;
+
+/**
+ * Remove the "enchanced donate button" option from Planet 4 settings.
+ */
+class M008RemoveArticlesDefaultOptions extends MigrationScript {
+	/**
+	 * Perform the actual migration.
+	 *
+	 * @param MigrationRecord $record Information on the execution, can be used to add logs.
+	 *
+	 * @return void
+	 */
+	protected static function execute( MigrationRecord $record ): void {
+		$options = get_option( Settings::KEY );
+		unset( $options['articles_block_title'] );
+		unset( $options['articles_block_button_title'] );
+		unset( $options['articles_count'] );
+		update_option( Settings::KEY, $options );
+	}
+}

--- a/src/Migrator.php
+++ b/src/Migrator.php
@@ -9,6 +9,7 @@ use P4\MasterTheme\Migrations\M003UpdateArticlesBlockAttribute;
 use P4\MasterTheme\Migrations\M005TurnBoxoutSettingIntoBlock;
 use P4\MasterTheme\Migrations\M006MoveFeaturesToSeparateOption;
 use P4\MasterTheme\Migrations\M007RemoveEnhancedDonateButtonOption;
+use P4\MasterTheme\Migrations\M008RemoveArticlesDefaultOptions;
 
 /**
  * Run any new migration scripts and record results in the log.
@@ -34,6 +35,7 @@ class Migrator {
 			M005TurnBoxoutSettingIntoBlock::class,
 			M006MoveFeaturesToSeparateOption::class,
 			M007RemoveEnhancedDonateButtonOption::class,
+			M008RemoveArticlesDefaultOptions::class,
 		];
 
 		// Loop migrations and run those that haven't run yet.

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -122,30 +122,6 @@ class Settings {
 					],
 
 					[
-						'name' => __( 'Default title for related articles block', 'planet4-master-theme-backend' ),
-						'id'   => 'articles_block_title',
-						'type' => 'text',
-						'desc' => __( 'If no title set for <b>Article Block</b>, the default title will appear.', 'planet4-master-theme-backend' ),
-					],
-
-					[
-						'name' => __( 'Default button title for related articles block', 'planet4-master-theme-backend' ),
-						'id'   => 'articles_block_button_title',
-						'type' => 'text',
-						'desc' => __( 'If no button title set for <b>Article Block</b>, the default button title will appear.', 'planet4-master-theme-backend' ),
-					],
-
-					[
-						'name'       => __( 'Default Number Of Related Articles', 'planet4-master-theme-backend' ),
-						'id'         => 'articles_count',
-						'type'       => 'text',
-						'attributes' => [
-							'type' => 'number',
-						],
-						'desc'       => __( 'If no number of Related Articles set for <b>Article Block</b>, the default number of Related Articles will appear.', 'planet4-master-theme-backend' ),
-					],
-
-					[
 						'name'       => __( 'Take Action Covers default button text', 'planet4-master-theme-backend' ),
 						'id'         => 'take_action_covers_button_text',
 						'type'       => 'text',


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6440

These global settings are confusing for the users as they are not used anymore
- Default title for related articles block
- Default button title for related articles block
- Default Number Of Related Articles

## Test

Test the patch locally:

```shell
# Show 3 articles options
> docker-compose exec php-fpm wp option get planet4_options | grep article
# Run patch
> docker-compose exec php-fpm wp p4-run-activator
# No options should appear
> docker-compose exec php-fpm wp option get planet4_options | grep article
```