### PR TITLE
PLANET-6515 Add new Action page type and Action Type taxonomy

### DIFF
--- a/single-p4_action.php
+++ b/single-p4_action.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * The Template for displaying all action pages
+ *
+ * Methods for TimberHelper can be found in the /lib sub-directory
+ *
+ * (Note: This file is a copy of page.php to use the same template for action pages.)
+ *
+ * @package  WordPress
+ * @subpackage  Timber
+ * @since    Timber 0.1
+ */
+
+use P4\MasterTheme\Context;
+use P4\MasterTheme\Post;
+use Timber\Timber;
+
+$context        = Timber::get_context();
+$post           = new Post(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+$page_meta_data = get_post_meta( $post->ID );
+$page_meta_data = array_map( 'reset', $page_meta_data );
+
+// Set Navigation Issues links.
+$post->set_issues_links();
+
+// Get Navigation Campaigns links.
+$page_tags = wp_get_post_tags( $post->ID );
+$tags      = [];
+
+if ( is_array( $page_tags ) && $page_tags ) {
+	foreach ( $page_tags as $page_tag ) {
+		$tags[] = [
+			'name' => $page_tag->name,
+			'link' => get_tag_link( $page_tag ),
+		];
+	}
+	$context['campaigns'] = $tags;
+}
+
+// Set GTM Data Layer values.
+$post->set_data_layer();
+$data_layer = $post->get_data_layer();
+
+Context::set_header( $context, $page_meta_data, $post->title );
+Context::set_background_image( $context );
+Context::set_og_meta_fields( $context, $post );
+Context::set_campaign_datalayer( $context, $page_meta_data );
+Context::set_utm_params( $context, $post );
+
+$context['post']                = $post;
+$context['social_accounts']     = $post->get_social_accounts( $context['footer_social_menu'] );
+$context['page_category']       = $data_layer['page_category'];
+$context['post_tags']           = implode( ', ', $post->tags() );
+$context['custom_body_classes'] = 'brown-bg ';
+
+if ( post_password_required( $post->ID ) ) {
+
+	// Password protected form validation.
+	$context['is_password_valid'] = $post->is_password_valid();
+
+	// Hide the page title from links to the extra feeds.
+	remove_action( 'wp_head', 'feed_links_extra', 3 );
+
+	$context['login_url'] = wp_login_url();
+
+	Timber::render( 'single-page.twig', $context );
+} else {
+	Timber::render( [ 'page-' . $post->post_name . '.twig', 'page.twig' ], $context );
+}

--- a/src/ActionPage.php
+++ b/src/ActionPage.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace P4\MasterTheme;
+
+use P4\MasterTheme\Settings\InformationArchitecture as IA;
+
+/**
+ * Class P4\MasterTheme\ActionPage
+ */
+class ActionPage {
+
+	public const POST_TYPE      = 'p4_action';
+	public const POST_TYPE_SLUG = 'action';
+
+	public const TAXONOMY           = 'action-type';
+	public const TAXONOMY_PARAMETER = 'action_type';
+	public const TAXONOMY_SLUG      = 'action-type';
+
+	/**
+	 * The constructor.
+	 */
+	public function __construct() {
+		$this->hooks();
+	}
+
+	/**
+	 * Class hooks.
+	 */
+	private function hooks() {
+		add_action( 'init', [ $this, 'register_post_type' ] );
+		add_action( 'init', [ $this, 'register_taxonomy' ], 2 );
+	}
+
+	/**
+	 * Register Action page post type.
+	 */
+	public function register_post_type() {
+
+		// IA: display action page type in admin sidebar.
+		$enable_action_post_type = IA::is_active( IA::ACTION_POST_TYPE ) ? true : false;
+
+		$labels = [
+			'name'               => _x( 'Actions', 'post type general name', 'planet4-master-theme-backend' ),
+			'singular_name'      => _x( 'Action', 'post type singular name', 'planet4-master-theme-backend' ),
+			'menu_name'          => _x( 'Actions', 'admin menu', 'planet4-master-theme-backend' ),
+			'name_admin_bar'     => _x( 'Actions', 'add new on admin bar', 'planet4-master-theme-backend' ),
+			'add_new'            => _x( 'Add New', 'action', 'planet4-master-theme-backend' ),
+			'add_new_item'       => __( 'Add New Action', 'planet4-master-theme-backend' ),
+			'new_item'           => __( 'New Action', 'planet4-master-theme-backend' ),
+			'edit_item'          => __( 'Edit Action', 'planet4-master-theme-backend' ),
+			'view_item'          => __( 'View Action', 'planet4-master-theme-backend' ),
+			'all_items'          => __( 'All Actions', 'planet4-master-theme-backend' ),
+			'search_items'       => __( 'Search Actions', 'planet4-master-theme-backend' ),
+			'parent_item_colon'  => __( 'Parent Action:', 'planet4-master-theme-backend' ),
+			'not_found'          => __( 'No actions found.', 'planet4-master-theme-backend' ),
+			'not_found_in_trash' => __( 'No actions found in Trash.', 'planet4-master-theme-backend' ),
+		];
+
+		$args = [
+			'labels'             => $labels,
+			'description'        => __( 'Use Actions to inspire your website\'s users to take action on issues and campaigns they care about!', 'planet4-master-theme-backend' ),
+			'public'             => true,
+			'publicly_queryable' => true,
+			'show_ui'            => true,
+			'show_in_menu'       => $enable_action_post_type,
+			'query_var'          => true,
+			'rewrite'            => [
+				'slug'       => self::POST_TYPE_SLUG,
+				'with_front' => false,
+			],
+			'has_archive'        => true,
+			'hierarchical'       => false,
+			'show_in_nav_menus'  => true,
+			'menu_position'      => 21,
+			'menu_icon'          => 'dashicons-editor-textcolor',
+			'show_in_rest'       => true,
+			'taxonomies'         => [ 'category', 'post_tag' ],
+			'supports'           => [
+				'page-attributes',
+				'title',
+				'editor',
+				'author',
+				'thumbnail',
+				'excerpt',
+				'revisions',
+				// Required to expose meta fields in the REST API.
+				'custom-fields',
+			],
+		];
+
+		register_post_type( self::POST_TYPE, $args );
+	}
+
+	/**
+	 * Register a custom taxonomy for Action page post types.
+	 */
+	public function register_taxonomy() {
+
+		$labels = [
+			'name'              => _x( 'Action Type', 'taxonomy general name', 'planet4-master-theme-backend' ),
+			'singular_name'     => _x( 'Action Type', 'taxonomy singular name', 'planet4-master-theme-backend' ),
+			'search_items'      => __( 'Search in Action Type', 'planet4-master-theme-backend' ),
+			'all_items'         => __( 'All Action Types', 'planet4-master-theme-backend' ),
+			'most_used_items'   => null,
+			'parent_item'       => null,
+			'parent_item_colon' => null,
+			'edit_item'         => __( 'Edit Action Type', 'planet4-master-theme-backend' ),
+			'update_item'       => __( 'Update Action Type', 'planet4-master-theme-backend' ),
+			'add_new_item'      => __( 'Add new Action Type', 'planet4-master-theme-backend' ),
+			'new_item_name'     => __( 'New Action Type', 'planet4-master-theme-backend' ),
+			'menu_name'         => __( 'Action Type', 'planet4-master-theme-backend' ),
+		];
+
+		$args = [
+			'hierarchical'      => true,
+			'labels'            => $labels,
+			'rewrite'           => [
+				'slug' => self::TAXONOMY_SLUG,
+			],
+			'show_in_rest'      => true,
+			'show_ui'           => true,
+			'show_admin_column' => true,
+			'query_var'         => true,
+		];
+
+		register_taxonomy( self::TAXONOMY, [ self::TAXONOMY_PARAMETER, self::POST_TYPE ], $args );
+		register_taxonomy_for_object_type( self::TAXONOMY, self::POST_TYPE );
+	}
+}

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -72,6 +72,7 @@ final class Loader {
 			DevReport::class,
 			MasterSite::class,
 			HttpHeaders::class,
+			ActionPage::class,
 		];
 
 		if ( is_admin() ) {

--- a/src/Settings/InformationArchitecture.php
+++ b/src/Settings/InformationArchitecture.php
@@ -18,6 +18,9 @@ class InformationArchitecture {
 	/* @var string Mobile tabs option key **/
 	public const MOBILE_TABS_MENU = 'mobile_tabs_menu';
 
+	/* @var string feature flag of action page type option key **/
+	public const ACTION_POST_TYPE = 'action_post_type';
+
 	/**
 	 * Get the features options page settings.
 	 *
@@ -47,6 +50,15 @@ class InformationArchitecture {
 				'name' => __( 'Enable mobile tabs menu', 'planet4-master-theme-backend' ),
 				'desc' => __(
 					'Display a sticky tabs menu visible on screen width smaller than 992px.',
+					'planet4-master-theme-backend'
+				),
+				'type' => 'checkbox',
+			],
+			[
+				'id'   => self::ACTION_POST_TYPE,
+				'name' => __( 'Action post type', 'planet4-master-theme-backend' ),
+				'desc' => __(
+					'Enable Action post type',
 					'planet4-master-theme-backend'
 				),
 				'type' => 'checkbox',


### PR DESCRIPTION
**Task:**
- Introduce a new Action page post type with Action Type taxonomy
- Added a Feature flag for Action page type menu in admin

Ref. https://jira.greenpeace.org/browse/PLANET-6515

**Testing:**
- After check out of `PLANET-6515-action-page-type` branch on local dev environment , go to "WP admin >> Planet4 >> Features" setting
- Enable the `Information Architecture >> Enable Action post type` setting
- After enabling the above setting you will able to see the new menu (Actions) in admin sidebar below the Pages menu
- Check the taxonomy available for "Action" page type
- The action pages should use the same layout as pages