### PR TITLE
Add toggle to allow all blocks on development environments

### DIFF
--- a/src/Features.php
+++ b/src/Features.php
@@ -38,6 +38,8 @@ class Features {
 
 	public const CORE_BLOCK_PATTERNS = 'core_block_patterns';
 
+	public const ALLOW_ALL_BLOCKS = 'allow_all_blocks';
+
 	/**
 	 * @var bool Purge Cloudflare cache on save
 	 */
@@ -183,6 +185,15 @@ class Features {
 					'planet4-master-theme-backend'
 				),
 				'id'   => self::CORE_BLOCK_PATTERNS,
+				'type' => 'checkbox',
+			];
+			$fields[] = [
+				'name' => __( 'Allow all blocks', 'planet4-master-theme-backend' ),
+				'desc' => __(
+					'Enable all blocks in the editor for all post types.',
+					'planet4-master-theme-backend'
+				),
+				'id'   => self::ALLOW_ALL_BLOCKS,
 				'type' => 'checkbox',
 			];
 		}


### PR DESCRIPTION
* This way we don't need a branch to allow blocks on the [gutenberg instance](https://github.com/greenpeace/planet4-gutenberg/blob/46c4a5f68e3879c6cac19856819957f300ed066e/composer-local.json#L6), making it much easier to test branches on that instance without having to merge them with the all_blocks branch.

Used in https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/785