### PR TITLE
PLANET-6625: Set default consent mode on every page

### DIFF
--- a/templates/blocks/google_tag_manager.twig
+++ b/templates/blocks/google_tag_manager.twig
@@ -9,7 +9,7 @@
   <script>
     var google_tag_value = '{{ google_tag_value }}';
 
-    var dataLayer = window.dataLayer = window.dataLayer || [];
+    window.dataLayer = window.dataLayer || [];
     dataLayer.push({
       'pageType' : '{{ page_category }}',
       'signedIn' : '{{ p4_signedin_status }}',
@@ -45,7 +45,11 @@
       }
     {% endif %}
 
-    var cookie_consent = document.cookie.split(';').filter(function(c) {return c.indexOf('greenpeace=2') >= 0}).length;
+    var cookie_consent = document.cookie.split(';').filter(function(c) {
+      return c.indexOf('greenpeace=2') >= 0
+        || c.indexOf('greenpeace=3') >= 0
+        || c.indexOf('greenpeace=4') >= 0;
+    }).length;
     var enforce_cookies_policy = '{{ enforce_cookies_policy }}';
     var gtm_allow = true;
 


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6625

> Fix Google's Consent Mode default state. 
> The default state should be included in all pages before the user gives consent/interacts with the cookies box. This means that the default values for 'ad_storage' and 'analytics_storage' should be set to'denied' in all pages until it's explicitly changed by the user. 

## Changes

Added a `defaultGoogleConsent()` function, and always run either `defaultGoogleConsent` or `updateGoogleConsent` function as long as `ENABLE_GOOGLE_CONSENT_MODE` is activated.

## Test

Test was done by UAT. Code is deployed on [Tavros](https://www-dev.greenpeace.org/test-tavros/)
- Activate Google conset mode in _Planet 4 > Analytics_
- Navigate to homepage
- If asked, save cookies preferences and reload page 
- Check the content of  `dataLayer` variable in your browser console, consent should always be there.
![Screenshot from 2022-03-31 11-09-34](https://user-images.githubusercontent.com/617346/161020058-7a868000-cc9d-4959-8a58-7e5eaa019b4f.png)



We also opened a new ticket for a follow-up after UAT : https://jira.greenpeace.org/browse/PLANET-6697
