### PR TITLE
PLANET-6615: Make Global project field non mandatory

### DIFF
--- a/tests/acceptance/campaign.feature
+++ b/tests/acceptance/campaign.feature
@@ -11,9 +11,6 @@ Background:
     When I add a title "Test campaign title"
     And I add a paragraph "Test campaign paragraph"
     And I publish the campaign
-    Then I see Analytics & Tracking section validation error message
-    And I select global project "Climate Emergency"
-    And I publish the campaign
     Then I see a validation message "Page published."
     And the campaign is visible on the website with title "Test campaign title" and paragraph "Test campaign paragraph"
 


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6615
Related to: https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/790

Make the Global project field non mandatory to be able to save campaign pages despite issues with the global sheet