### PR TITLE
Fix navbar search position in large screens

### DIFF
--- a/assets/src/scss/layout/navbar/_search.scss
+++ b/assets/src/scss/layout/navbar/_search.scss
@@ -17,6 +17,10 @@
     @media (min-width: 783px) {
       top: $menu-height-small + 32px;
     }
+
+    @include large-and-up {
+      top: $menu-height + 32px;
+    }
   }
 
   &.open {
@@ -48,6 +52,10 @@
         }
       }
     }
+  }
+
+  @include large-and-up {
+    top: $menu-height;
   }
 
   @include x-large-and-up {


### PR DESCRIPTION
### Description

It should adapt to the bigger height of the navbar for screen widths between 992px and 1200px.

### Testing

You can see the fixed version on the [sinope test instance](https://www-dev.greenpeace.org/test-sinope/) or on local. You can see the broken version on the [GPI site](https://www.greenpeace.org/international/) for example!