### PR TITLE
PLANET-6579: Allow a drop down menu for the Donate button through the Navigation Bar

### DIFF
--- a/assets/src/js/menu_editor.js
+++ b/assets/src/js/menu_editor.js
@@ -157,7 +157,7 @@ const menuEditorRestrictions = () => {
    * @return string The current location slug
    */
   const getCurrentLocation = () => {
-    return locations.map(location => {
+    return locations.filter(location => {
       return document.querySelector(`input[name="menu-locations[${location}]"]`).checked
         ? location : null;
     })[0] || null;

--- a/assets/src/scss/layout/_navbar.scss
+++ b/assets/src/scss/layout/_navbar.scss
@@ -71,10 +71,27 @@ $navbar-default-height: 60px;
 
     height: 44px;
     line-height: 40px;
+
+    @include large-and-up {
+      &.dropdown {
+        &::after {
+          content: "";
+          display: inline-block;
+          width: 10px;
+          height: 10px;
+          margin-inline-start: $sp-x;
+          mask: url("../../images/chevron.svg") 0 0/10px 10px;
+          transform: rotate(90deg);
+          transition: transform 150ms linear;
+          background-color: $white;
+          background-repeat: no-repeat;
+        }
+      }
+    }
   }
 
   .nav-donate {
-    padding: 16px 0;
+    padding: $sp-2 0;
 
     @include large-and-up {
       padding: 0;
@@ -196,7 +213,8 @@ $navbar-default-height: 60px;
     @include large-and-up {
       display: flex;
       flex-grow: 1;
-      justify-content: end;
+      align-items: center;
+      justify-content: flex-end;
       padding-inline-end: 0;
       padding-top: 0;
       text-align: end;
@@ -205,9 +223,11 @@ $navbar-default-height: 60px;
 }
 
 .nav-submenu {
+  _-- {
+    width: 193px;
+  }
   position: fixed;
   display: none;
-  min-width: 193px;
   padding-top: $sp-1;
 
   .nav-submenu-wrapper {
@@ -254,9 +274,7 @@ $navbar-default-height: 60px;
   li {
     width: 100%;
     text-align: left;
-    white-space: nowrap;
     color: $grey-80;
-    height: 48px;
 
     a.nav-link {
       --submenu-nav-link-- {
@@ -274,8 +292,9 @@ $navbar-default-height: 60px;
       height: 100%;
       display: flex;
       align-items: center;
-      padding-right: $sp-3;
-      padding-left: $sp-3;
+      padding: 14px $sp-3;
+      font-size: 16px;
+      line-height: 19px;
 
       &:hover {
         background: $grey-10;
@@ -290,13 +309,24 @@ $navbar-default-height: 60px;
 }
 
 .nav-item {
+  @include large-and-up {
+    margin-inline-start: $sp-2x;
+  }
+}
+
+.nav-donate:hover .dropdown::after {
+  transform: rotate(-90deg);
+}
+
+.nav-item,
+.nav-donate {
   color: inherit;
   font-size: $font-base-size;
   font-weight: 700;
 
   @include large-and-up {
     line-height: $menu-height;
-    margin: 0 20px;
+    margin-inline-end: $sp-2x;
 
     &:hover {
       .nav-submenu {

--- a/src/AdminAssets.php
+++ b/src/AdminAssets.php
@@ -24,8 +24,9 @@ class AdminAssets {
 		$theme_dir       = get_template_directory_uri();
 		$menus           = get_nav_menu_locations();
 		$navbar_location = 'navigation-bar-menu';
+		$donate_location = 'donate-menu';
 
-		if ( ! isset( $menus[ $navbar_location ] ) ) {
+		if ( ! isset( $menus[ $navbar_location ] ) || ! isset( $menus[ $donate_location ] ) ) {
 			return;
 		}
 
@@ -36,6 +37,19 @@ class AdminAssets {
 				'depthConf' => [
 					0 => [
 						'maxItems' => 5,
+						'maxChars' => 18,
+					],
+					1 => [
+						'maxItems' => 10,
+						'maxChars' => 18,
+					],
+				],
+			],
+			$donate_location => [
+				'maxDepth'  => 1,
+				'depthConf' => [
+					0 => [
+						'maxItems' => 1,
 						'maxChars' => 18,
 					],
 					1 => [

--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -170,6 +170,7 @@ class MasterSite extends TimberSite {
 		register_nav_menus(
 			[
 				'navigation-bar-menu' => __( 'Navigation Bar Menu', 'planet4-master-theme-backend' ),
+				'donate-menu'         => __( 'Donate Button', 'planet4-master-theme-backend' ),
 			]
 		);
 
@@ -540,6 +541,23 @@ class MasterSite extends TimberSite {
 				return ! in_array( 'wpml-ls-item', $item->classes ?? [], true );
 			}
 		);
+
+		// Donate button menu dropdown.
+		// If no Donate menu is defined, we use the old settings from Planet 4 > Donate.
+		$donate_menu_items[] = [
+			'link'  => planet4_get_option( 'donate_button', '#' ),
+			'title' => planet4_get_option( 'donate_text', __( 'Donate', 'planet4-master-theme' ) ),
+		];
+
+		if ( has_nav_menu( 'donate-menu' ) ) {
+			$donate_menu = new TimberMenu( 'donate-menu' );
+
+			if ( ! empty( $donate_menu->get_items() ) ) {
+				$donate_menu_items = $donate_menu->get_items();
+			}
+		}
+
+		$context['donate_menu_items'] = $donate_menu_items;
 
 		$languages                 = function_exists( 'icl_get_languages' ) ? icl_get_languages() : [];
 		$context['site_languages'] = $languages;

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -625,6 +625,18 @@ class Settings {
 	public function admin_page_display( string $plugin_page ): void {
 		$page_config = $this->subpages[ $plugin_page ];
 
+		if ( 'planet4_settings_donate_button' === $plugin_page ) {
+			$message = trim( $this->show_donate_menu_notice() );
+
+			if ( empty( $message ) ) {
+				return;
+			}
+
+			echo '<div class="notice notice-info is-dismissible">'
+				. wp_kses_post( $message )
+				. '</div>';
+		}
+
 		$fields      = $page_config['fields'];
 		$description = $page_config['description'] ?? null;
 		// Allow storing options in a different database record.
@@ -652,6 +664,18 @@ class Settings {
 			wp_kses( $description ? '<div>' . $description . '</div>' : '', 'post' ),
 			$form // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		);
+	}
+
+	/**
+	 * Show notice to inform users that the Donate button settings are now in Appearance > Menus.
+	 *
+	 * @return string
+	 */
+	private function show_donate_menu_notice(): string {
+		return '<p>These settings have been moved to <a href="/wp-admin/nav-menus.php?action=locations">a new menu location</a>
+			in Appearance > Menus, specifically the "Donate Button" location.</br>
+			There you can add a custom link with your text and link for the Donate button,
+			and you will also be able to define dropdown menu items if you want to.</p>';
 	}
 
 	/**

--- a/templates/navigation-bar-new.twig
+++ b/templates/navigation-bar-new.twig
@@ -42,46 +42,27 @@
 					</a>
 
 					{% if item.children is not empty %}
-						<nav class='nav-submenu'>
-							<div class='nav-submenu-wrapper'>
-								<ul>
-								{% for key,item in item.children %}
-									<li>
-										{% if fn('get_post_meta', item.ID, '_menu_item_object_id', true ) == act_page_id %}
-											{% set link_ga_action = 'Act' %}
-										{% elseif fn('get_post_meta', item.ID, '_menu_item_object_id', true ) == explore_page_id %}
-											{% set link_ga_action = 'Explore' %}
-										{% else %}
-											{% set link_ga_action = item.title %}
-										{% endif %}
-										<a
-											class="nav-link"
-											href="{{ item.get_link }}"
-											data-ga-category="Submenu Navigation"
-											data-ga-action="{{ link_ga_action }}"
-											data-ga-label="{{ page_category }}">
-												{{ item.title }}
-										</a>
-									</li>
-								{% endfor %}
-								</ul>
-							</div>
-						</nav>
+						{% include 'navigation-submenu.twig' with { menu: item } %}
 					{% endif %}
 				</li>
 				{% endfor %}
-				<li class="nav-item nav-donate">
+
+				{% set donate_menu = donate_menu_items[0] ?? {} %}
+				<li class="nav-donate">
 					<a
-						class="btn btn-donate"
-						href="{{ donatelink }}"
+						class="btn btn-donate {{ donate_menu.children ? 'dropdown' : '' }}"
+						href="{{ donate_menu.link }}"
 						data-ga-category="Menu Navigation"
 						data-ga-action="Donate"
 						data-ga-label="{{ page_category }}">
-							{{ donatetext }}
+							{{ donate_menu.title }}
 					</a>
-				</li>
+					{% if donate_menu.children is not empty %}
+						{% include 'navigation-submenu.twig' with { menu: donate_menu } %}
+					{% endif %}
 			</ul>
 		</nav>
+
 		{% set search_icon = 'search'|svgicon %}
 		{% set search_input_id = 'search_input' %}
 		{% set data_ga_attrs = 'data-ga-category="Menu Navigation" data-ga-action="Search" data-ga-label="' ~ page_category ~ '"' %}

--- a/templates/navigation-submenu.twig
+++ b/templates/navigation-submenu.twig
@@ -1,0 +1,25 @@
+<nav class='nav-submenu'>
+	<div class='nav-submenu-wrapper'>
+		<ul>
+		{% for key,item in menu.children %}
+			<li>
+				{% if fn('get_post_meta', item.ID, '_menu_item_object_id', true ) == act_page_id %}
+					{% set link_ga_action = 'Act' %}
+				{% elseif fn('get_post_meta', item.ID, '_menu_item_object_id', true ) == explore_page_id %}
+					{% set link_ga_action = 'Explore' %}
+				{% else %}
+					{% set link_ga_action = item.title %}
+				{% endif %}
+				<a
+					class="nav-link"
+					href="{{ item.get_link }}"
+					data-ga-category="Submenu Navigation"
+					data-ga-action="{{ item.title }}"
+					data-ga-label="{{ page_category }}">
+						{{ item.title }}
+				</a>
+			</li>
+		{% endfor %}
+		</ul>
+	</div>
+</nav>


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6579

👉 [Parent PR](https://github.com/greenpeace/planet4-master-theme/pull/1628)

**How to test**
- First, check if the Donate menu has items already added going to `Appearence > Menus`
- Navigate to the [instance](https://www-dev.greenpeace.org/test-rhea/) and play around with the Donate menu.

Also go to:
`Planet4 > Navigation` and change the **Website Navigation Style** to `dark|light`

**What to test**
- Validate the Design iteration2_IA & nav MVP from [here](https://www.figma.com/file/Gn8wyqgto7608rlESePXZE/Foundations-%26-Components?node-id=0%3A103).
- Analytics vars set to the sub-menu items.