### PR TITLE
PLANET-6648 Add object tag on Posts

### DIFF
--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -755,6 +755,16 @@ class MasterSite extends TimberSite {
 			'style'   => true,
 		];
 
+		// Allow object tag with some attributes.
+		$allowedposttags['object'] = [
+			'class'      => true,
+			'data'       => true,
+			'id'         => true,
+			'type'       => true,
+			'style'      => true,
+			'aria-label' => true,
+		];
+
 		return $allowedposttags;
 	}
 


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6648

---

This needed for embedding PDFs with the core File block.