### PR TITLE
PLANET-6645 Add paginated list on tag pages

### DIFF
--- a/assets/src/scss/layout/_block-classes.scss
+++ b/assets/src/scss/layout/_block-classes.scss
@@ -1,0 +1,50 @@
+.wp-block-query-pagination {
+  a {
+    color: black;
+    font-weight: bold;
+  }
+
+  font-family: $roboto;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  width: 100%;
+  margin-bottom: 16px;
+}
+
+.page-numbers {
+  &:not(:last-child) {
+    margin-inline-end: 8px;
+  }
+
+  &.current {
+    border: 1px solid black;
+    border-radius: 4px;
+    padding: 8px 12px;
+  }
+}
+
+.wp-block-post-terms {
+  font-weight: 500;
+}
+
+.taxonomy-post_tag a {
+  display: inline-block;
+
+  &:before {
+    content: "#";
+    speak: none;
+  }
+}
+
+.wp-block-post {
+  margin-bottom: 32px;
+
+  figure {
+    margin-bottom: 0;
+  }
+}
+
+.wp-block-post-excerpt__excerpt {
+  font-size: 1rem;
+}

--- a/assets/src/scss/style.scss
+++ b/assets/src/scss/style.scss
@@ -37,6 +37,7 @@ Text Domain: planet4-master-theme
 // Layout
 @import "layout/breadcrumbs";
 @import "layout/blocks";
+@import "layout/block-classes";
 @import "layout/cookies";
 @import "layout/cookies-settings";
 @import "layout/footer";

--- a/functions.php
+++ b/functions.php
@@ -79,6 +79,7 @@ function planet4_get_option( $key = '', $default = null ) {
 use P4\MasterTheme\ImageArchive\Rest;
 use P4\MasterTheme\Loader;
 use P4\MasterTheme\Notifications\Slack;
+use P4\MasterTheme\Post;
 use Timber\Timber;
 
 if ( ! class_exists( 'Timber' ) ) {
@@ -249,3 +250,62 @@ add_filter(
 	10,
 	2
 );
+
+/**
+ * I'll move this somewhere else in master theme.
+ *
+ * @return void
+ */
+function register_more_blocks() {
+	register_block_type(
+		'p4/reading-time',
+		[
+			'render_callback' => [ Post::class, 'reading_time_block' ],
+			'uses_context'    => [ 'postId' ],
+		]
+	);
+	register_block_type(
+		'p4/post-author-name',
+		[
+			'render_callback' => function ( array $attributes, $content, $block ) {
+				$author_override = get_post_meta( $block->context['postId'], 'p4_author_override', true );
+				$post_author_id  = get_post_field( 'post_author', $block->context['postId'] );
+
+				$is_override = ! empty( $author_override );
+
+				$name = $is_override ? $author_override : get_the_author_meta( 'display_name', $post_author_id );
+				$link = $is_override ? '#' : get_author_posts_url( $post_author_id );
+
+				$block_content = $author_override ? $name : "<a href='$link'>$name</a>";
+
+				return "<span class='article-list-item-author'>$block_content</span>";
+			},
+			'uses_context'    => [ 'postId' ],
+		]
+	);
+	// Like the core block but with an appropriate sizes attribute.
+	register_block_type(
+		'p4/post-featured-image',
+		[
+			'render_callback' => function ( array $attributes, $content, $block ) {
+				$post_id        = $block->context['postId'];
+				$post_link      = get_permalink( $post_id );
+				$featured_image = get_the_post_thumbnail(
+					$post_id,
+					null,
+					// For now hard coded sizes to the ones from Articles, as it's the single usage.
+					// This can be made a block attribute, or even construct a sizes attr with math based on context.
+					// For example, it could already access displayLayout from Query block to know how many columns are
+					// being rendered. If it then also knows the flex gap and container width, it should have all needed
+					// info to support a large amount of cases.
+					[ 'sizes' => '(min-width: 1600px) 389px, (min-width: 1200px) 335px, (min-width: 1000px) 281px, (min-width: 780px) 209px, (min-width: 580px) 516px, calc(100vw - 24px)' ]
+				);
+
+				return "<a href='$post_link'>$featured_image</a>";
+			},
+			'uses_context'    => [ 'postId' ],
+		]
+	);
+}
+
+add_action( 'init', 'register_more_blocks' );

--- a/functions.php
+++ b/functions.php
@@ -76,6 +76,7 @@ function planet4_get_option( $key = '', $default = null ) {
 	return $options[ $key ] ?? $default;
 }
 
+use P4\MasterTheme\Features\Dev\ListingPagePagination;
 use P4\MasterTheme\ImageArchive\Rest;
 use P4\MasterTheme\Loader;
 use P4\MasterTheme\Notifications\Slack;
@@ -313,6 +314,9 @@ add_action( 'init', 'register_more_blocks' );
 add_filter(
 	'cloudflare_purge_by_url',
 	function ( $urls, $post_id ) {
+		if ( ! ListingPagePagination::is_active() ) {
+			return $urls;
+		}
 		$new_urls = [];
 		// Most of this logic is copied from the start of \CF\WordPress\Hooks::getPostRelatedLinks.
 		// I had to adapt it to our CS, it used snake case and old arrays.

--- a/parts/query-grid.html
+++ b/parts/query-grid.html
@@ -1,0 +1,34 @@
+<!-- wp:query { "query":{ "inherit": true }, "displayLayout": { "type": "flex", "columns":4 } } -->
+<div class="wp-block-query">
+	<!-- wp:query-pagination -->
+		<!-- wp:query-pagination-previous /-->
+		<!-- wp:query-pagination-numbers /-->
+		<!-- wp:query-pagination-next /-->
+	<!-- /wp:query-pagination -->
+
+	<!-- wp:post-template -->
+	<!-- wp:post-featured-image {"isLink":true} /-->
+	<div class="article-list-item-body">
+
+		<div class="d-flex circle-separated">
+			<!-- wp:post-terms {"term":"p4-page-type"} /-->
+			<!-- wp:post-terms {"term":"post_tag"} /-->
+		</div>
+
+		<!-- wp:post-title {"isLink":true, "level":4, "className": "article-list-item-headline"} /-->
+
+		<div class="article-list-item-meta d-flex dash-separated">
+			<!-- wp:p4/post-author-name /-->
+			<!-- wp:post-date /-->
+			<!-- wp:p4/reading-time /-->
+		</div>
+	</div>
+	<!-- /wp:post-template -->
+
+	<!-- wp:query-pagination -->
+		<!-- wp:query-pagination-previous /-->
+		<!-- wp:query-pagination-numbers /-->
+		<!-- wp:query-pagination-next /-->
+	<!-- /wp:query-pagination -->
+</div>
+<!-- /wp:query -->

--- a/parts/query-list.html
+++ b/parts/query-list.html
@@ -1,0 +1,37 @@
+<!-- wp:query { "query":{ "inherit": true } } -->
+<div class="wp-block-query wp-block-query--list">
+	<!-- wp:post-template -->
+	    <article class="article-list-item">
+			<div class="article-list-item-image article-list-item-image-max-width">
+				<!-- wp:p4/post-featured-image /-->
+			</div>
+			<div class="article-list-item-body">
+				<div class="top-page-tags d-flex">
+					<!-- wp:post-terms {"term":"p4-page-type"} /-->
+					<span class="tag-wrap-bullet" aria-hidden="true">•</span>
+					<!-- wp:post-terms {"term":"post_tag", "separator": "  "} /-->
+				</div>
+
+				<header>
+					<!-- wp:post-title {"isLink":true, "level":4, "className": "article-list-item-headline"} /-->
+				</header>
+				<!-- wp:post-excerpt {"className": "article-list-item-content"} /-->
+
+				<div class="article-list-item-meta d-flex">
+					<!-- wp:p4/post-author-name /-->
+					<span class="article-list-item-bullet" aria-hidden="true">•</span>
+					<!-- wp:post-date /-->
+					<span class="article-list-item-bullet" aria-hidden="true">•</span>
+					<!-- wp:p4/reading-time /-->
+				</div>
+			</div>
+		</article>
+	<!-- /wp:post-template -->
+
+	<!-- wp:query-pagination -->
+		<!-- wp:query-pagination-previous /-->
+		<!-- wp:query-pagination-numbers /-->
+		<!-- wp:query-pagination-next /-->
+	<!-- /wp:query-pagination -->
+</div>
+<!-- /wp:query -->

--- a/src/Feature.php
+++ b/src/Feature.php
@@ -10,8 +10,6 @@ abstract class Feature {
 	public const OPTIONS_KEY = 'planet4_features';
 
 	/**
-	 * Default to using the class name, but allow override to provide BC.
-	 *
 	 * @return string ID primarily used for storing in WP options.
 	 */
 	abstract public static function id(): string;
@@ -82,7 +80,6 @@ abstract class Feature {
 		// Filter to allow setting a feature from code, to avoid chicken and egg problem when releasing adaptions to a
 		// new feature.
 		return (bool) apply_filters( "planet4_feature__$id", $active );
-
 	}
 
 	/**

--- a/src/Features/Dev/DisableTagRedirectPages.php
+++ b/src/Features/Dev/DisableTagRedirectPages.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace P4\MasterTheme\Features\Dev;
+
+use P4\MasterTheme\Feature;
+
+/**
+ * @see description().
+ */
+class DisableTagRedirectPages extends Feature {
+	/**
+	 * @inheritDoc
+	 */
+	public static function id(): string {
+		return 'disable_tag_redirect_pages';
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected static function name(): string {
+		return __( 'Disable Tag Redirect Pages', 'planet4-master-theme-backend' );
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected static function description(): string {
+		return __(
+			'Prevent redirect mechanism so that the original auto generated content is always shown. Prevents having to disable many pages to see the auto generated page.',
+			'planet4-master-theme-backend'
+		);
+	}
+}

--- a/src/Features/Dev/ListingPageGridView.php
+++ b/src/Features/Dev/ListingPageGridView.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace P4\MasterTheme\Features\Dev;
+
+use P4\MasterTheme\Feature;
+
+/**
+ * @see description().
+ */
+class ListingPageGridView extends Feature {
+
+	/**
+	 * @inheritDoc
+	 */
+	public static function id(): string {
+		return 'listing_page_grid_view';
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected static function name(): string {
+		return __( 'Listing page grid view', 'planet4-master-theme-backend' );
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected static function description(): string {
+		return __(
+			'Display the list of posts as a grid view.',
+			'planet4-master-theme-backend'
+		);
+	}
+}

--- a/src/Features/Dev/ListingPagePagination.php
+++ b/src/Features/Dev/ListingPagePagination.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace P4\MasterTheme\Features\Dev;
+
+use P4\MasterTheme\Feature;
+
+/**
+ * @see description().
+ */
+class ListingPagePagination extends Feature {
+
+	/**
+	 * @inheritDoc
+	 */
+	public static function id(): string {
+		return 'listing_page_pagination';
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected static function name(): string {
+		return __( 'Listing Page Pagination', 'planet4-master-theme-backend' );
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected static function description(): string {
+		return __( 'Use a paginated list of posts on tag pages.', 'planet4-master-theme-backend' );
+	}
+}

--- a/src/Post.php
+++ b/src/Post.php
@@ -4,6 +4,7 @@ namespace P4\MasterTheme;
 
 use Timber\Post as TimberPost;
 use Timber\Term as TimberTerm;
+use WP_Block;
 use WP_Error;
 use WP_Query;
 use WP_Term;
@@ -496,6 +497,21 @@ class Post extends TimberPost {
 		wp_cache_add( $cache_key, $time, null, 3600 * 24 );
 
 		return $time;
+	}
+
+	/**
+	 * Server side render for the reading time block.
+	 *
+	 * @param array    $attributes Block attributes, unused.
+	 * @param string   $content Content which apparently no core block uses.
+	 * @param WP_Block $block With all block properties.
+	 *
+	 * @return string Formatted reading time.
+	 */
+	public static function reading_time_block( array $attributes, $content, $block ) {
+		$time = ( new self( $block->context['postId'] ?? null ) )->reading_time();
+
+		return "<span class='article-list-item-readtime'>$time min read</span>";
 	}
 
 	/**

--- a/src/Settings/Features.php
+++ b/src/Settings/Features.php
@@ -8,12 +8,14 @@ use P4\MasterTheme\Features\CloudflareDeployPurge;
 use P4\MasterTheme\Features\Dev\AllowAllBlocks;
 use P4\MasterTheme\Features\Dev\BetaBlocks;
 use P4\MasterTheme\Features\Dev\CoreBlockPatterns;
+use P4\MasterTheme\Features\Dev\ListingPageGridView;
 use P4\MasterTheme\Features\Dev\ThemeEditor;
 use P4\MasterTheme\Features\Dev\WPTemplateEditor;
 use P4\MasterTheme\Features\EngagingNetworks;
 use P4\MasterTheme\Features\GoogleSheetReplacesSmartsheet;
 use P4\MasterTheme\Features\ImageArchive;
 use P4\MasterTheme\Features\LazyYoutubePlayer;
+use P4\MasterTheme\Features\Dev\ListingPagePagination;
 use P4\MasterTheme\Features\NewDesignCountrySelector;
 use P4\MasterTheme\Features\NewDesignNavigationBar;
 use P4\MasterTheme\Features\PurgeOnFeatureChanges;
@@ -92,6 +94,7 @@ class Features {
 			NewDesignCountrySelector::class,
 			NewDesignNavigationBar::class,
 			GoogleSheetReplacesSmartsheet::class,
+			ListingPagePagination::class,
 
 			// Dev only.
 			BetaBlocks::class,
@@ -99,6 +102,7 @@ class Features {
 			WPTemplateEditor::class,
 			CoreBlockPatterns::class,
 			AllowAllBlocks::class,
+			ListingPageGridView::class,
 		];
 	}
 

--- a/src/Settings/Features.php
+++ b/src/Settings/Features.php
@@ -8,6 +8,7 @@ use P4\MasterTheme\Features\CloudflareDeployPurge;
 use P4\MasterTheme\Features\Dev\AllowAllBlocks;
 use P4\MasterTheme\Features\Dev\BetaBlocks;
 use P4\MasterTheme\Features\Dev\CoreBlockPatterns;
+use P4\MasterTheme\Features\Dev\DisableTagRedirectPages;
 use P4\MasterTheme\Features\Dev\ListingPageGridView;
 use P4\MasterTheme\Features\Dev\ThemeEditor;
 use P4\MasterTheme\Features\Dev\WPTemplateEditor;
@@ -95,6 +96,7 @@ class Features {
 			NewDesignNavigationBar::class,
 			GoogleSheetReplacesSmartsheet::class,
 			ListingPagePagination::class,
+			DisableTagRedirectPages::class,
 
 			// Dev only.
 			BetaBlocks::class,

--- a/tag.php
+++ b/tag.php
@@ -9,6 +9,8 @@
  * @package P4MT
  */
 
+use P4\MasterTheme\Features\Dev\ListingPageGridView;
+use P4\MasterTheme\Features\Dev\ListingPagePagination;
 use P4\MasterTheme\TaxonomyCampaign;
 use Timber\Timber;
 use P4GBKS\Blocks\Articles;
@@ -63,6 +65,20 @@ if ( is_tag() ) {
 			$context['og_image_data'] = wp_get_attachment_image_src( $tag_image_id, 'full' );
 		}
 		$context['page_category'] = 'Tag Page';
+
+		if ( ListingPagePagination::is_active() ) {
+			$view = ListingPageGridView::is_active() ? 'grid' : 'list';
+
+			$query_template = file_get_contents( get_template_directory() . "/parts/query-$view.html" );
+
+			$content = do_blocks( $query_template );
+
+			$context['query_loop'] = $content;
+
+			$campaign = new TaxonomyCampaign( $templates, $context );
+			$campaign->view();
+			exit();
+		}
 
 		$campaign = new TaxonomyCampaign( $templates, $context );
 

--- a/tag.php
+++ b/tag.php
@@ -9,6 +9,7 @@
  * @package P4MT
  */
 
+use P4\MasterTheme\Features\Dev\DisableTagRedirectPages;
 use P4\MasterTheme\Features\Dev\ListingPageGridView;
 use P4\MasterTheme\Features\Dev\ListingPagePagination;
 use P4\MasterTheme\TaxonomyCampaign;
@@ -23,7 +24,7 @@ if ( is_tag() ) {
 	$explore_page_id = planet4_get_option( 'explore_page' );
 
 	$redirect_id = get_term_meta( $context['tag']->term_id, 'redirect_page', true );
-	if ( $redirect_id ) {
+	if ( ! DisableTagRedirectPages::is_active() && $redirect_id ) {
 
 		global $wp_query;
 		$redirect_page               = get_post( $redirect_id );

--- a/templates/tag.twig
+++ b/templates/tag.twig
@@ -27,6 +27,7 @@
 	</div>
 
 	<div class="page-content container">
+		{{ query_loop|raw }}
 		{% for name, block in blocks %}
 			{{ fn('do_blocks', block )|raw }}
 		{% endfor %}


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6645

As a first step of using paginated lists, the new list is only added to tag pages.

Define query loop block in HTML and use it to output almost the same markup as our Articles block.

We can gradually rewrite the CSS to make more sense with the core block, but using Article's existing CSS classes makes ensuring the same layout much easier.

I used a few **feature toggles** to aid development (just a few small if-statements really). We can probably remove them before merging.
* [Toggle old server generated pages / paginated list](https://github.com/greenpeace/planet4-master-theme/blob/e1cbd068bb0e5d31cef28f531d1d71885961a7c0/tag.php#L70-L70) (could be useful for releasing)
* [Toggle Grid / list](https://github.com/greenpeace/planet4-master-theme/blob/e1cbd068bb0e5d31cef28f531d1d71885961a7c0/tag.php#L71-L71)
* [Turn off all "redirect pages"](https://github.com/greenpeace/planet4-master-theme/blob/244993165c943fa60042897d7dd0c5410701839a/tag.php#L27-L27) to avoid needing to do it manually on each tag (maybe also useful for pilot NROs to test this functionality, they have a redirect page on every tag)

### Approach
It uses the new templates on the **server side only**.

I found that **we don't need to add block HTML comments** for additional markup, as long as it's only server side. This makes the markup a lot more manageable. Only the [outer Query block](https://github.com/greenpeace/planet4-master-theme/blob/be2366211ce6d58c85a69289a70f96289b189877/parts/query-list.html#L1-L2) has both attributes and wrapper markup.

To be a completely "correct" block template we'd need to do this for all HTML elements you see in the file. Each class of these elements needs to occur in both the attributes and the markup. And besides `div` all tag names need to be passed in the Group block's `tagName` attribute. Not very maintenance friendly...

But we only need that once we want to load these templates in the block editor. At that point we'll be able to edit the templates using the block editor and save the result to a file, making the extra code complexity a non issue. So we can add them at the point we start using the template editor.

Server side only blocks are very easy to add and can easily reuse existing server side logic. They only need an array of config and a function. It's like React components on the server side, but they render just render once.

### Examples (Mars env, data from GPI, tag redirect pages disabled)
https://www-dev.greenpeace.org/test-mars/tag/climate/
https://www-dev.greenpeace.org/test-mars/tag/consumption/
https://www-dev.greenpeace.org/test-mars/tag/oceans/

### TODO

- [x] Responsive image:
  - [x] [Create custom block to output same markup as Articles image](https://github.com/greenpeace/planet4-master-theme/pull/1631/commits/be2366211ce6d58c85a69289a70f96289b189877)
  - [x] Generalize block to support different sizes for grid view (follow up)
- [ ] Cloudflare cache purges: Ensure it purges all pages at the right time. Investigate amount of purges.
  - [x] Go through existing CF plugin purge logic
  - [x] Check if purges happen reliably (I've seen it not happen a few times, but then it does again)
  - [ ] Ensure purges for all page numbers
- [x] Other archive pages (follow up for other types, but already tested current approach there)
- [ ] Which feature toggles?
- [ ] Which options pages?
- [ ] Release steps

### Small fixes
- [x] Excerpt style: Core block has inner paragraph preventing Articles style. Either adapt CSS or create our own block with same markup as Articles


### Images
There is a core ticket to add block attributes and maybe additional context to `wp_calculate_image_sizes`. Unfortunately there's no recent development. But potentially we can use a filter to achieve this behavior already.