### PR TITLE
PLANET-6511: Navigation Bar: implement the new design (mobile)

### DIFF
--- a/assets/src/scss/base/_mixins.scss
+++ b/assets/src/scss/base/_mixins.scss
@@ -233,3 +233,26 @@ $nested-comment-left-margin: 50px;
     }
   }
 }
+
+@mixin scrollbar-layout {
+  // Only applied to Firefox
+  scrollbar-width: thin;
+  scrollbar-color: transparent;
+
+  &::-webkit-scrollbar {
+    width: 8px;
+  }
+
+  &::-webkit-scrollbar-track {
+    border-radius: 4px;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    border-radius: 4px;
+    background: rgba(0, 0, 0, 0.15);
+  }
+
+  &::-webkit-scrollbar-thumb:hover {
+    background: rgba(0, 0, 0, 0.2);
+  }
+}

--- a/assets/src/scss/layout/_navbar.scss
+++ b/assets/src/scss/layout/_navbar.scss
@@ -12,7 +12,7 @@ $navbar-default-height: 60px;
     color: $white;
     fill: $white;
     font-family: $roboto;
-    font-size: $font-base-size;
+    font-size: $font-size-sm;
   }
 
   display: flex;
@@ -51,136 +51,25 @@ $navbar-default-height: 60px;
       width: 24px;
     }
   }
-
-  .btn-donate {
-    _-- {
-      background: $orange;
-      border: none;
-      box-shadow: none;
-      color: $white;
-      font-size: inherit;
-      min-width: 116px;
-
-      &:hover {
-        background: $orange-hover;
-        border: none;
-        box-shadow: none;
-        color: $white;
-      }
-    }
-
-    height: 44px;
-    line-height: 40px;
-
-    @include large-and-up {
-      &.dropdown {
-        &::after {
-          content: "";
-          display: inline-block;
-          width: 10px;
-          height: 10px;
-          margin-inline-start: $sp-x;
-          mask: url("../../images/chevron.svg") 0 0/10px 10px;
-          transform: rotate(90deg);
-          transition: transform 150ms linear;
-          background-color: $white;
-          background-repeat: no-repeat;
-        }
-      }
-    }
-  }
-
-  .nav-donate {
-    padding: $sp-2 0;
-
-    @include large-and-up {
-      padding: 0;
-    }
-  }
 }
 
 #nav-main {
-  display: flex;
+  display: none;
 
-  @include medium-and-less {
-    flex-direction: column-reverse;
-    height: 100%;
-    position: fixed;
-    top: 0;
-    z-index: 99;
-
-    &.open {
-      inset-inline-start: 0;
-      transition: inset-inline-start 0.2s ease-out;
-
-      @supports not (inset-inline-start: 0) {
-        transform: translateX(0);
-        transition: transform 0.2s ease-out;
-
-        html[dir="rtl"] & {
-          transform: translateX(0);
-        }
-      }
-
-      ~ .top-navigation-overlay {
-        display: block;
-      }
-    }
-
-    .admin-bar & {
-      padding-bottom: 46px;
-      top: 46px;
-
-      @media (min-width: 783px) {
-        padding-bottom: 32px;
-        top: 32px;
-      }
-    }
-  }
-
-  @include small-and-less {
-    width: 100vw;
-    inset-inline-start: -100vw;
-
-    @supports not (inset-inline-start: -100vw) {
-      transform: translateX(-100vw);
-      transition: transform 0.2s ease-out;
-
-      html[dir="rtl"] & {
-        transform: translateX(100vw);
-      }
-    }
-
-    &.open {
-      @supports not (inset-inline-start: 0) {
-        transform: translateX(0);
-        transition: transform 0.2s ease-out;
-
-        html[dir="rtl"] & {
-          transform: translateX(0);
-        }
-      }
-    }
-  }
-
-  @include small-to-large {
-    inset-inline-start: -400px;
-    transition: inset-inline-start 0.2s ease-in;
-    width: 400px;
-
-    @supports not (inset-inline-start: -400px) {
-      transform: translateX(-400px);
-      transition: transform 0.2s ease-in;
-
-      html[dir="rtl"] & {
-        transform: translateX(400px);
-      }
-    }
+  ~ .nav-languages {
+    display: none;
   }
 
   @include large-and-up {
+    display: flex;
     flex-grow: 1;
     width: auto;
+
+    ~ .nav-languages {
+      &.open {
+        display: flex;
+      }
+    }
   }
 }
 
@@ -190,9 +79,9 @@ $navbar-default-height: 60px;
   top: 0;
   width: auto;
   z-index: 4;
+  display: none;
 
   @include medium-and-less {
-    display: block;
     overflow-y: auto;
   }
 
@@ -207,7 +96,7 @@ $navbar-default-height: 60px;
     list-style-type: none;
     margin: 0;
     padding-inline: 40px 12px;
-    padding-top: 16px;
+    padding-block-start: 16px;
     text-align: start;
 
     @include large-and-up {
@@ -216,7 +105,7 @@ $navbar-default-height: 60px;
       align-items: center;
       justify-content: flex-end;
       padding-inline-end: 0;
-      padding-top: 0;
+      padding-block-start: 0;
       text-align: end;
     }
   }
@@ -228,12 +117,13 @@ $navbar-default-height: 60px;
   }
   position: fixed;
   display: none;
-  padding-top: $sp-1;
+  padding-block-start: $sp-1;
 
   .nav-submenu-wrapper {
-    border-radius: $sp-1;
     width: 100%;
-    box-shadow: 0 1px $sp-x rgba(0, 0, 0, 0.12);
+    border-radius: 4px;
+    background: $white;
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.12);
   }
 
   ul {
@@ -245,41 +135,21 @@ $navbar-default-height: 60px;
     display: block;
     flex-direction: column;
     padding: $sp-2 0;
-    background: $white;
-    border-radius: $sp-1;
     overflow-y: auto;
 
-    // Only applied to Firefox
-    scrollbar-width: thin;
-    scrollbar-color: transparent;
-
-    &::-webkit-scrollbar {
-      width: $sp-1;
-    }
-
-    &::-webkit-scrollbar-track {
-      border-radius: $sp-x;
-    }
-
-    &::-webkit-scrollbar-thumb {
-      border-radius: $sp-x;
-      background: rgba(0, 0, 0, 0.15);
-    }
-
-    &::-webkit-scrollbar-thumb:hover {
-      background: rgba(0, 0, 0, 0.2);
-    }
+    @include scrollbar-layout;
   }
 
-  li {
+  .nav-item {
     width: 100%;
     text-align: left;
     color: $grey-80;
+    margin-inline: 0;
 
     a.nav-link {
       --submenu-nav-link-- {
         color: $grey-80;
-        font-size: $sp-2;
+        font-size: $font-size-sm;
         font-weight: 500;
 
         &:hover {
@@ -293,7 +163,7 @@ $navbar-default-height: 60px;
       display: flex;
       align-items: center;
       padding: 14px $sp-3;
-      font-size: 16px;
+      font-size: $font-size-sm;
       line-height: 19px;
 
       &:hover {
@@ -301,38 +171,16 @@ $navbar-default-height: 60px;
       }
 
       &:before {
-        // Disable nav-link animation on hover
         display: none;
       }
     }
-  }
-}
 
-.nav-item {
-  @include large-and-up {
-    margin-inline-start: $sp-2x;
-  }
-}
+    &.active {
+      pointer-events: none;
+    }
 
-.nav-donate:hover .dropdown::after {
-  transform: rotate(-90deg);
-}
-
-.nav-item,
-.nav-donate {
-  color: inherit;
-  font-size: $font-base-size;
-  font-weight: 700;
-
-  @include large-and-up {
-    line-height: $menu-height;
-    margin-inline-end: $sp-2x;
-
-    &:hover {
-      .nav-submenu {
-        display: flex;
-        z-index: 999;
-      }
+    &.active a.nav-link {
+      font-weight: bold;
     }
   }
 }
@@ -340,10 +188,6 @@ $navbar-default-height: 60px;
 a.nav-link {
   --nav-link-- {
     color: $white;
-
-    &:hover {
-      color: $white;
-    }
   }
 
   opacity: 1;
@@ -351,7 +195,7 @@ a.nav-link {
   padding: $sp-2 0;
   position: relative;
   width: 100%;
-  text-decoration: none;
+  text-decoration-line: none;
 
   @include large-and-up {
     padding: 0;
@@ -371,33 +215,99 @@ a.nav-link {
     transform: scaleX(0);
     transition: transform 0.25s;
     z-index: -1;
-
-    @include large-and-up {
-      border-bottom-width: 4px;
-    }
-  }
-}
-
-.active a.nav-link {
-  --nav-link-active-- {
-    color: $white;
-
-    &:hover {
-      color: $white;
-    }
-  }
-
-  &:before {
-    transform: scaleX(1);
-    border-bottom-color: var(--nav-link--text-decoration-color, $gp-green);
   }
 }
 
 // Underline animation with border-bottom
-.nav-item:hover a.nav-link:before {
+// Using > * because there are some cases where
+// there a container, wrapped by the nav-item
+// is wrapping the nav-item
+a.nav-link:hover:before,
+.nav-item:not(.burger-menu-item):hover > a.nav-link:before,
+.active > a.nav-link:before,
+.active > * > a.nav-link:before {
   transform: scaleX(1);
   transition: transform 0.25s;
-  border-bottom-color: var(--nav-link--text-decoration-color, $gp-green);
+  z-index: 1;
+
+  @include large-and-up {
+    border-bottom-width: 4px;
+  }
+}
+
+.nav-item {
+  @include large-and-up {
+    margin-inline-start: $sp-2x;
+  }
+}
+
+.nav-donate {
+  padding: $sp-2 0;
+
+  @include large-and-up {
+    padding: 0;
+  }
+}
+
+.nav-donate:hover .dropdown::after {
+  transform: rotate(-90deg);
+}
+
+.nav-item,
+.nav-donate {
+  color: inherit;
+  font-size: $font-size-sm;
+  font-weight: 700;
+
+  @include large-and-up {
+    line-height: $menu-height;
+    margin-inline-end: $sp-2x;
+
+    &:hover {
+      .nav-submenu {
+        display: flex;
+        z-index: 999;
+      }
+    }
+  }
+}
+
+.btn-donate {
+  _-- {
+    background: $orange;
+    border: none;
+    box-shadow: none;
+    color: $white;
+    font-size: inherit;
+    min-width: 116px;
+
+    &:hover {
+      background: $orange-hover;
+      border: none;
+      box-shadow: none;
+      color: $white;
+    }
+  }
+
+  height: 44px;
+  line-height: 40px;
+
+  @include large-and-up {
+    &.dropdown {
+      &::after {
+        content: "";
+        display: inline-block;
+        width: 10px;
+        height: 10px;
+        margin-inline-start: $sp-x;
+        mask: url("../../images/chevron.svg") 0 0/10px 10px;
+        transform: rotate(90deg);
+        transition: transform 150ms linear;
+        background-color: $white;
+        background-repeat: no-repeat;
+      }
+    }
+  }
 }
 
 .nav-menu-toggle {
@@ -405,35 +315,6 @@ a.nav-link {
   border: none;
   border-radius: 4px;
   padding: 0 24px;
-
-  @include large-and-up {
-    display: none;
-  }
-}
-
-.nav-menu-close {
-  background-color: var(--top-navigation--color, $white);
-  border: none;
-  display: block;
-  height: 68px;
-  inset-inline-end: 0;
-  mask: url("../../images/cross.svg") 50% 50%/16px 16px no-repeat;
-  position: absolute;
-  top: 0;
-  width: 68px;
-  z-index: 5;
-
-  @include medium-and-less {
-    @supports not (inset-inline-end: 0) {
-      right: 0;
-      left: auto;
-
-      html[dir="rtl"] & {
-        left: 0;
-        right: auto;
-      }
-    }
-  }
 
   @include large-and-up {
     display: none;
@@ -452,20 +333,6 @@ a.nav-link {
   }
 }
 
-.top-navigation-overlay {
-  display: none;
-  background: $black;
-  height: 100%;
-  opacity: 0.5;
-  overflow: hidden;
-  overflow-y: scroll;
-  pointer-events: all;
-  position: fixed;
-  top: 0;
-  width: calc(100% + 20px);
-  z-index: 4;
-}
-
 .no-scroll-nav-open {
   @include medium-and-less {
     overflow-y: hidden;
@@ -479,3 +346,4 @@ a.nav-link {
 @import "navbar/languages";
 @import "navbar/search";
 @import "navbar/mobile";
+@import "navbar/burger-menu";

--- a/assets/src/scss/layout/navbar/_burger-menu.scss
+++ b/assets/src/scss/layout/navbar/_burger-menu.scss
@@ -1,0 +1,260 @@
+#burger-menu {
+  _-- {
+    background: $white;
+    color: $grey-80;
+    font-family: $roboto;
+  }
+
+  position: fixed;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  top: 0;
+  left: 0;
+  inset-inline-start: -100%;
+  padding: 18px $sp-3;
+  z-index: 99999;
+  overflow: hidden;
+  height: 100%;
+
+  &.open {
+    inset-inline-start: 0;
+    transition: inset-inline-start 0.2s ease-out;
+
+    @supports not (inset-inline-start: 0) {
+      transform: translateX(0);
+      transition: transform 0.2s ease-out;
+
+      html[dir="rtl"] & {
+        transform: translateX(0);
+      }
+    }
+
+    ~ .burger-menu-overlay {
+      display: block;
+
+      @include large-and-up {
+        display: none;
+      }
+    }
+  }
+
+  ul {
+    padding: 0;
+    list-style: none;
+  }
+
+  a.nav-link {
+    color: $grey-80;
+    width: auto;
+  }
+
+  .admin-bar & {
+    @include medium-and-less {
+      top: 46px;
+      height: calc(100% - 46px);
+    }
+
+    @media (min-width: 783px) {
+      top: 32px;
+      height: calc(100% - 32px);
+    }
+  }
+
+  @include small-and-less {
+    width: 100vw;
+    inset-inline-start: -100vw;
+
+    @supports not (inset-inline-start: -100vw) {
+      transform: translateX(-100vw);
+      transition: transform 0.2s ease-in;
+
+      html[dir="rtl"] & {
+        transform: translateX(100vw);
+      }
+    }
+  }
+
+  @include small-to-large {
+    width: 400px;
+    inset-inline-start: -400px;
+    transition: inset-inline-start 0.2s ease-in;
+
+    @supports not (inset-inline-start: -400px) {
+      transform: translateX(-400px);
+      transition: transform 0.2s ease-in;
+
+      html[dir="rtl"] & {
+        transform: translateX(400px);
+      }
+    }
+  }
+
+  @include large-and-up {
+    display: none;
+  }
+}
+
+#burger-menu .burger-menu-header {
+  display: flex;
+  flex-direction: column;
+  flex-shrink: 0;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.2);
+  padding-block-end: $sp-2;
+
+  .site-logo {
+    display: block;
+    width: fit-content;
+    margin-inline-start: 0;
+    margin-bottom: $sp-1x;
+    line-height: 1;
+
+    img {
+      height: 23px;
+    }
+  }
+
+  .nav-languages {
+    width: 100%;
+    margin-top: $sp-1x;
+    margin-bottom: $sp-1x;
+
+    ul {
+      margin-inline: 0;
+      padding: 0;
+      margin-bottom: 0;
+    }
+  }
+}
+
+#burger-menu .nav-wrapper {
+  overflow-y: scroll;
+
+  .nav-items {
+    width: 100%;
+    padding: $sp-1x 0 0;
+  }
+
+  @include scrollbar-layout;
+}
+
+#burger-menu .burger-menu-footer {
+  display: flex;
+  justify-self: flex-end;
+  flex-shrink: 0;
+  margin-top: auto;
+  width: 100%;
+  padding: $sp-3 0 0;
+  border-top: 1px solid rgba(0, 0, 0, 0.2);
+
+  .btn-donate {
+    width: 100%;
+  }
+}
+
+// All styles related to the menu item
+#burger-menu .burger-menu-item {
+  width: 100%;
+
+  &:not(:first-child) {
+    margin-block-end: $sp-1x;
+  }
+
+  &:not(:last-child) {
+    margin-block-start: $sp-1x;
+  }
+
+  > a.nav-link, > * > a.nav-link {
+    font-size: 20px;
+    padding: 6px 0;
+  }
+
+  .nav-subitems {
+    padding-inline-start: $sp-2;
+    padding-block-start: $sp-1x;
+    padding-block-end: $sp-1x;
+
+    .nav-item.active {
+      pointer-events: none;
+    }
+
+    a.nav-link {
+      font-size: 16px;
+      line-height: 19px;
+      font-weight: 400;
+      width: auto;
+      padding: $sp-1x 0;
+    }
+  }
+
+  .item-wrapper {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+  }
+
+  .collapsable-btn {
+    width: 30px;
+    height: 30px;
+    background: transparent;
+    border: none;
+
+    &::before {
+      content: "";
+      height: 12px;
+      width: 8px;
+      display: inline-block;
+      mask-image: url("../../images/chevron.svg");
+      mask-repeat: no-repeat;
+      mask-size: contain;
+      mask-position: center;
+      background-repeat: no-repeat;
+      background-color: currentColor;
+      transform: rotate(-90deg);
+      transition: transform 0.3s linear;
+      color: $grey-80;
+    }
+
+    &.collapsed {
+      &::before {
+        transform: rotate(90deg);
+      }
+    }
+  }
+}
+
+#burger-menu .nav-menu-close {
+  display: block;
+  position: absolute;
+  top: 16px;
+  inset-inline-end: $sp-3;
+  border: none;
+  height: 16px;
+  width: 16px;
+  mask: url("../../images/cross.svg") 50% 50%/16px 16px no-repeat;
+  background-color: $grey-80;
+  z-index: 5;
+
+  @supports not (inset-inline-end: $sp-3) {
+    right: $sp-3;
+    left: auto;
+
+    html[dir="rtl"] & {
+      left: $sp-3;
+      right: auto;
+    }
+  }
+}
+
+#burger-menu ~ .burger-menu-overlay {
+  display: none;
+  background: var(--burger-menu-overlay--background, $black);
+  opacity: 0.5;
+  height: 100%;
+  pointer-events: all;
+  position: fixed;
+  top: 0;
+  width: 100vw;
+  z-index: 99;
+}

--- a/assets/src/scss/layout/navbar/languages.scss
+++ b/assets/src/scss/layout/navbar/languages.scss
@@ -32,12 +32,9 @@
 }
 
 .nav-languages {
-  display: none;
-  background: var(--top-navigation--background, $dark-blue);
   box-shadow: none;
   position: unset;
   width: 100%;
-  z-index: 4;
 
   a.nav-link {
     padding: 0;
@@ -45,7 +42,6 @@
   }
 
   ul {
-    border-bottom: var(--top-navigation--separation, 1px solid transparentize($white, 0.5));
     display: inline-block;
     flex-grow: 1;
     margin-block: 0;
@@ -79,14 +75,6 @@
 
   li:last-of-type > span[aria-hidden="true"] {
     display: none;
-  }
-
-  @include medium-and-less {
-    display: flex;
-  }
-
-  @include medium-and-up {
-    width: 400px;
   }
 
   @include large-and-up {

--- a/templates/burger-menu-items.twig
+++ b/templates/burger-menu-items.twig
@@ -1,0 +1,63 @@
+{% for key,item in menu %}
+	{% set targetId = item.ID %}
+	{% if fn('get_post_meta', item.ID, '_menu_item_object_id', true ) == act_page_id %}
+		{% set link_ga_action = 'Act' %}
+	{% elseif fn('get_post_meta', item.ID, '_menu_item_object_id', true ) == explore_page_id %}
+		{% set link_ga_action = 'Explore' %}
+	{% else %}
+		{% set link_ga_action = item.title %}
+	{% endif %}
+	<li class="burger-menu-item nav-item accordion-item {{ item.class }} {{ item == item.current ? 'active' : '' }}">
+		<div class="item-wrapper accordion-header" id="burger-menu-accordion-{{ targetId }}">
+			<a
+				class="nav-link"
+				href="{{ item.get_link }}"
+				data-ga-category="Submenu Navigation"
+				data-ga-action="{{ link_ga_action }}"
+				data-ga-label="{{ page_category }}">
+					{{ item.title }}
+			</a>
+			{% if item.children is not empty %}
+				<button
+					class="collapsable-btn accordion-button collapsed"
+					type="button"
+					data-bs-toggle="collapse"
+					data-bs-target="#menu-{{ targetId }}"
+					aria-expanded="false"
+					aria-controls="menu-{{ targetId }}"
+				/>
+			{% endif %}
+		</div>
+
+		{% if item.children is not empty %}
+		<nav
+			id="menu-{{ targetId }}"
+			class="nav-subitems accordion-collapse collapse"
+			aria-labelledby="burger-menu-accordion-{{ targetId }}"
+			data-bs-parent="#accordion-list"
+		>
+			<ul>
+			{% for key,item in item.children %}
+				<li class="nav-item accordion-body {{ item == item.current ? 'active' : '' }}">
+					{% if fn('get_post_meta', item.ID, '_menu_item_object_id', true ) == act_page_id %}
+						{% set link_ga_action = 'Act' %}
+					{% elseif fn('get_post_meta', item.ID, '_menu_item_object_id', true ) == explore_page_id %}
+						{% set link_ga_action = 'Explore' %}
+					{% else %}
+						{% set link_ga_action = item.title %}
+					{% endif %}
+					<a
+						class="nav-link"
+						href="{{ item.get_link }}"
+						data-ga-category="Submenu Navigation"
+						data-ga-action="{{ link_ga_action }}"
+						data-ga-label="{{ page_category }}">
+							{{ item.title }}
+					</a>
+				</li>
+			{% endfor %}
+			</ul>
+		</nav>
+		{% endif %}
+	</li>
+{% endfor %}

--- a/templates/burger-menu.twig
+++ b/templates/burger-menu.twig
@@ -1,0 +1,80 @@
+<div id="burger-menu">
+  <button class="nav-menu-close" type="button"
+    aria-label="{{ __( "Close navigation mobile menu", "planet4-master-theme" ) }}"
+    aria-expanded="false"
+    data-bs-toggle="open"
+    data-bs-target="#burger-menu">
+    <span class="visually-hidden">
+      {{ __( "Close navigation mobile menu", "planet4-master-theme" ) }}
+    </span>
+  </button>
+
+	<div class="burger-menu-header">
+    <a class="site-logo" href="{{ data_nav_bar.home_url }}">
+      {% include "blocks/site_logo.twig" %}
+    </a>
+		{% if site_languages is not empty %}
+			{% set current_lang = site_languages|filter(i => i.active)|first %}
+			<button class="nav-languages-toggle" type="button"
+				aria-label="{{ __( "Choose language", "planet4-master-theme" ) }}"
+				aria-expanded="false"
+				data-bs-toggle="open"
+				data-bs-target="#nav-languages"
+			>{{ current_lang.code|capitalize }}</button>
+			<nav
+				id="nav-languages"
+				class="nav-languages"
+				aria-label="{{ __( 'Languages of the site', 'planet4-master-theme' ) }}"
+			>
+				<ul>
+				{% for key,item in site_languages %}
+				<li class="nav-item {{ item.active ? "current-language" : "" }}">
+					<a class="nav-link" href="{{ item.url }}">{{ item.native_name }}</a>
+					<span aria-hidden="true">&nbsp;|&nbsp;</span>
+				</li>
+				{% endfor %}
+				</ul>
+			</nav>
+		{% endif %}
+  </div>
+
+	<div class="nav-wrapper">
+		<nav class="nav-items" aria-label="{{ __( 'Menu items', 'planet4-master-theme' ) }}">
+			<ul id="accordion-list" class="accordion">
+				<li class="burger-menu-item nav-item">
+					<a
+						class="nav-link"
+						href="/"
+						data-ga-category="Submenu Navigation"
+						data-ga-action="Home"
+						data-ga-label="{{ page_category }}">
+							{{ __( "Home", "planet4-master-theme" ) }}
+					</a>
+				</li>
+
+				{% if navbar_menu_items is not empty %}
+					{% include "burger-menu-items.twig" with { menu: navbar_menu_items } %}
+				{% endif %}
+
+				{% if donate_menu_items is not empty %}
+					{% include "burger-menu-items.twig" with { menu: donate_menu_items } %}
+				{% endif %}
+			</ul>
+		</nav>
+	</div>
+
+	{% if donate_menu_items|first is not null %}
+		{% set donate_menu = donate_menu_items|first %}
+		<div class="burger-menu-footer">
+			<a
+				class="btn btn-donate"
+				href="{{ donate_menu.link }}"
+				data-ga-category="Menu Navigation"
+				data-ga-action="Donate"
+				data-ga-label="{{ page_category }}">
+					{{ __( "Make a donation", "planet4-master-theme" ) }}
+			</a>
+		</div>
+	{% endif %}
+</div>
+<div class="burger-menu-overlay"></div>

--- a/templates/navigation-bar-new.twig
+++ b/templates/navigation-bar-new.twig
@@ -11,7 +11,7 @@
 		data-ga-label="{{ page_category }}"
 		aria-expanded="false"
 		data-bs-toggle="open"
-		data-bs-target="#nav-main">
+		data-bs-target="#burger-menu">
 		{{ 'menu'|svgicon|replace({'<svg': "<svg " ~ data_ga_attrs })|raw }}
 		<span class="visually-hidden">
 			{{ __( 'Menu', 'planet4-master-theme' ) }}
@@ -47,19 +47,22 @@
 				</li>
 				{% endfor %}
 
-				{% set donate_menu = donate_menu_items[0] ?? {} %}
-				<li class="nav-donate">
-					<a
-						class="btn btn-donate {{ donate_menu.children ? 'dropdown' : '' }}"
-						href="{{ donate_menu.link }}"
-						data-ga-category="Menu Navigation"
-						data-ga-action="Donate"
-						data-ga-label="{{ page_category }}">
-							{{ donate_menu.title }}
-					</a>
-					{% if donate_menu.children is not empty %}
-						{% include 'navigation-submenu.twig' with { menu: donate_menu } %}
-					{% endif %}
+				{% if donate_menu_items|first is not null %}
+					{% set donate_menu = donate_menu_items|first %}
+					<li class="nav-donate">
+						<a
+							class="btn btn-donate {{ donate_menu.children ? 'dropdown' : '' }}"
+							href="{{ donate_menu.link }}"
+							data-ga-category="Menu Navigation"
+							data-ga-action="Donate"
+							data-ga-label="{{ page_category }}">
+								{{ donate_menu.title }}
+						</a>
+						{% if donate_menu.children is not empty %}
+							{% include 'navigation-submenu.twig' with { menu: donate_menu } %}
+						{% endif %}
+					</li>
+				{% endif %}
 			</ul>
 		</nav>
 
@@ -81,69 +84,41 @@
 				</span>
 			</button>
 		</div>
-		<form id="search_form" class="form nav-search-form" action="{{ data_nav_bar.home_url }}">
-			{% set search_label = __( 'Search', 'planet4-master-theme' ) %}
-			<input id="{{ search_input_id }}"
-				type="search"
-				name="s"
-				class="form-control"
-				placeholder="{{ search_label }}"
-				value="{{ data_nav_bar.search_query|e('wp_kses_post')|raw }}"
-				aria-label="{{ __( 'Search input', 'planet4-master-theme' ) }}"/>
-			<input id="orderby" type="hidden" name="orderby" value="{{ selected_sort ?? default_sort }}"/>
-			<button class="nav-search-btn"
-				aria-label="{{ __( 'Press return/enter or click to search', 'planet4-master-theme' ) }}"
-				type="submit"
+	</div>
+	<form id="search_form" class="form nav-search-form" action="{{ data_nav_bar.home_url }}">
+		{% set search_label = __( 'Search', 'planet4-master-theme' ) %}
+		<input id="{{ search_input_id }}"
+			type="search"
+			name="s"
+			class="form-control"
+			placeholder="{{ search_label }}"
+			value="{{ data_nav_bar.search_query|e('wp_kses_post')|raw }}"
+			aria-label="{{ __( 'Search input', 'planet4-master-theme' ) }}"/>
+		<input id="orderby" type="hidden" name="orderby" value="{{ selected_sort ?? default_sort }}"/>
+		<button class="nav-search-btn"
+			aria-label="{{ __( 'Press return/enter or click to search', 'planet4-master-theme' ) }}"
+			type="submit"
+			data-ga-category="Menu Navigation"
+			data-ga-action="Search"
+			data-ga-label="{{ page_category }}"
+		>
+			{{ search_icon|replace({'<svg': "<svg " ~ data_ga_attrs })|raw }}
+			<span class="visually-hidden"
 				data-ga-category="Menu Navigation"
 				data-ga-action="Search"
 				data-ga-label="{{ page_category }}"
 			>
-				{{ search_icon|replace({'<svg': "<svg " ~ data_ga_attrs })|raw }}
-				<span class="visually-hidden"
-					data-ga-category="Menu Navigation"
-					data-ga-action="Search"
-					data-ga-label="{{ page_category }}"
-				>
-						{{ search_label }}
-				</span>
-			</button>
-			<button class="nav-search-clear"
-				aria-label="{{ __( 'Clear search', 'planet4-master-theme' ) }}"
-				type="button"
-				onclick="document.getElementById('{{ search_input_id }}').value=null;"
-			>
-				<span class="visually-hidden">{{ __( 'Clear search', 'planet4-master-theme' ) }}</span>
-			</button>
-		</form>
-		{% if site_languages is not empty %}
-			{% set current_lang = site_languages|filter(i => i.active)|first %}
-			<button class="nav-languages-toggle" type="button"
-				aria-label="{{ __( 'Choose language', 'planet4-master-theme' ) }}"
-				aria-expanded="false"
-				data-bs-toggle="open"
-				data-bs-target="#nav-languages"
-			>{{ current_lang.code|capitalize }}</button>
-			<nav id="nav-languages" class="nav-languages">
-				<ul>
-				{% for key,item in site_languages %}
-				<li class="nav-item {{ item.active ? 'current-language' : '' }}">
-					<a class="nav-link" href="{{ item.url }}">{{ item.native_name }}</a>
-					<span aria-hidden="true">&nbsp;|&nbsp;</span>
-				</li>
-				{% endfor %}
-				</ul>
-			</nav>
-		{% endif %}
-		<button class="nav-menu-close" type="button"
-			aria-label="{{ __( 'Close navigation menu', 'planet4-master-theme' ) }}"
-			aria-expanded="false"
-			data-bs-toggle="open"
-			data-bs-target="#nav-main">
-			<span class="visually-hidden">
-				{{ __( 'Close navigation menu', 'planet4-master-theme' ) }}
+					{{ search_label }}
 			</span>
 		</button>
-	</div>
+		<button class="nav-search-clear"
+			aria-label="{{ __( 'Clear search', 'planet4-master-theme' ) }}"
+			type="button"
+			onclick="document.getElementById('{{ search_input_id }}').value=null;"
+		>
+			<span class="visually-hidden">{{ __( 'Clear search', 'planet4-master-theme' ) }}</span>
+		</button>
+	</form>
 	<div class="nav-search-toggle-container medium-and-less">
 		<button class="nav-search-toggle" type="button"
 			aria-label="{{ data_nav_bar.navbar_search_toggle }}"
@@ -159,6 +134,25 @@
 			</span>
 		</button>
 	</div>
+	{% if site_languages is not empty %}
+		{% set current_lang = site_languages|filter(i => i.active)|first %}
+		<button class="nav-languages-toggle" type="button"
+			aria-label="{{ __( 'Choose language', 'planet4-master-theme' ) }}"
+			aria-expanded="false"
+			data-bs-toggle="open"
+			data-bs-target="#nav-languages"
+		>{{ current_lang.code|capitalize }}</button>
+		<nav id="nav-languages" class="nav-languages">
+			<ul>
+			{% for key,item in site_languages %}
+			<li class="nav-item {{ item.active ? 'current-language' : '' }}">
+				<a class="nav-link" href="{{ item.url }}">{{ item.native_name }}</a>
+				<span aria-hidden="true">&nbsp;|&nbsp;</span>
+			</li>
+			{% endfor %}
+			</ul>
+		</nav>
+	{% endif %}
 	{% if mobile_tabs_menu %}
 	<div id="nav-mobile">
 		<nav id="nav-mobile-menu">
@@ -179,6 +173,7 @@
 		</nav>
 	</div>
 	{% endif %}
-	<div class="top-navigation-overlay"></div>
 	{% include 'country_selector_banner.twig' ignore missing %}
 </section>
+{% include 'burger-menu.twig' %}
+

--- a/templates/navigation-submenu.twig
+++ b/templates/navigation-submenu.twig
@@ -2,7 +2,7 @@
 	<div class='nav-submenu-wrapper'>
 		<ul>
 		{% for key,item in menu.children %}
-			<li>
+			<li class="nav-item {{ item == item.current ? 'active' : '' }}">
 				{% if fn('get_post_meta', item.ID, '_menu_item_object_id', true ) == act_page_id %}
 					{% set link_ga_action = 'Act' %}
 				{% elseif fn('get_post_meta', item.ID, '_menu_item_object_id', true ) == explore_page_id %}


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6509

👉 [Parent PR](https://github.com/greenpeace/planet4-master-theme/pull/1628)

Go to the [Demo page](https://www-dev.greenpeace.org/test-titan) and play around the main navigation.

**What is done**
- Is changed the way of showing the main navigation on mobile version.
- Isolated markup with own styles
- Refactored code

**How to test**
Navigate to the [instance](https://www-dev.greenpeace.org/test-titan/) and play around with the **mobile menu**.

Also go to:
`Planet4 > Navigation` and change the **Website Navigation Style** to `dark|light`

**What to test**
- Validate the Design iteration2_IA & nav MVP from [here](https://www.figma.com/file/Gn8wyqgto7608rlESePXZE/Foundations-%26-Components?node-id=0%3A103).
- Analytics vars set to the sub-menu items.

**New CSS variables**
```
--burger-menu--background
--burger-menu--color
--burger-menu--font-family
--burger-menu-overlay--background
```

