### PR TITLE
Fix post-deploy error if P4GBKS is not available

### DIFF
--- a/src/Migrations/M009PopulateCookiesFields.php
+++ b/src/Migrations/M009PopulateCookiesFields.php
@@ -22,6 +22,11 @@ class M009PopulateCookiesFields extends MigrationScript {
 	 * @return void
 	 */
 	public static function execute( MigrationRecord $record ): void {
+		if ( ! class_exists( 'P4GBKS\Search\BlockSearch' ) ) {
+			echo 'P4 Gutenberg plugin is not available.';
+			return;
+		}
+
 		$search     = new BlockSearch();
 		$parser     = new WP_Block_Parser();
 		$block_name = 'planet4-blocks/cookies';


### PR DESCRIPTION

The `post-deploy` process fails if planet4-plugin-gutenberg-blocks classes are not available (plugin not installed or disabled).
The patch **M009PopulateCookiesFields** relies on it.
Cf. https://app.circleci.com/pipelines/github/greenpeace/planet4-taiwan/1471/workflows/522aa6dd-be6c-48b2-8e3a-5722aab46e59/jobs/4355

## Test

- Disable _Planet4 - Gutenberg blocks_ plugin
- Run `docker-compose exec php-fpm wp p4-run-activator`
  - If this patch ran already, you can change its id to make it run again
```diff
--- a/src/Migrations/M009PopulateCookiesFields.php
+++ b/src/Migrations/M009PopulateCookiesFields.php
@@ -14,6 +14,9 @@ use WP_Block_Parser;
  * Copy of Cookies block data to Cookies settings in Planet4 > Cookies.
  */
 class M009PopulateCookiesFields extends MigrationScript {
+       public static function get_id(): string {
+               return static::class.'-2';
+       }
        /**
```

The command should fail on _master_ branch and pass on this one.