### PR TITLE
PLANET-6656 Hide Follow us link when no social media links

### DIFF
--- a/assets/src/scss/layout/_footer-social-media.scss
+++ b/assets/src/scss/layout/_footer-social-media.scss
@@ -13,6 +13,7 @@
       margin-bottom: 24px;
       display: block;
       line-height: 1;
+      white-space: nowrap;
     }
   }
 

--- a/templates/footer.twig
+++ b/templates/footer.twig
@@ -5,7 +5,9 @@
 	</div>
 	{% endif %}
 	<div class="container d-flex flex-column flex-lg-row-reverse">
-		{% include 'footer_social_media.twig' %}
+		{% if (social_overrides is defined and social_overrides|length) or footer_social_menu|length %}
+			{% include 'footer_social_media.twig' %}
+		{% endif %}
 		{% if nav_type != 'minimal' %}
 			<nav class="footer-menu">
 				<ul class="list-unstyled">


### PR DESCRIPTION
### Description

See [PLANET-6656](https://jira.greenpeace.org/browse/PLANET-6656)
In the backend it is possible to remove all social media links, in this case we should completely hide the social media part of the footer including the Follow us text.

### Testing

I've removed all social media links from the [deimos test instance](https://www-dev.greenpeace.org/test-deimos/), with the fix you can see that in the footer the `Follow us` link no longer shows! Before the fix it shows like this:
<img width="1013" alt="Screenshot 2022-03-01 at 14 33 24" src="https://user-images.githubusercontent.com/6949075/156185805-19a16712-badc-4238-8f39-d700a169f18e.png">