### PR TITLE
PLANET-6647: Youtube Embed - block not showing in the editor

### DIFF
--- a/assets/src/scss/editorStyle.scss
+++ b/assets/src/scss/editorStyle.scss
@@ -3,7 +3,6 @@
 @import "~bootstrap/scss/carousel";
 @import "~bootstrap/scss/tooltip";
 @import "~bootstrap/scss/buttons";
-@import "~lite-youtube-embed";
 
 @import "base/variables";
 @import "base/colors";

--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -812,13 +812,6 @@ class MasterSite extends TimberSite {
 	 */
 	public function enqueue_editor_assets(): void {
 		Loader::enqueue_versioned_style( 'assets/build/editorStyle.min.css' );
-		wp_enqueue_script(
-			'youtube',
-			get_template_directory_uri() . '/assets/build/lite-yt-embed.js',
-			[],
-			1,
-			true
-		);
 	}
 
 	/**
@@ -1235,6 +1228,10 @@ class MasterSite extends TimberSite {
 	 * @return mixed
 	 */
 	private function new_youtube_filter( $cache, $url ) {
+		if ( is_admin() || ( defined( 'REST_REQUEST' ) && REST_REQUEST ) ) {
+			return $cache;
+		}
+
 		if ( ! empty( $url ) ) {
 			if ( strpos( $url, 'youtube.com' ) !== false || strpos( $url, 'youtu.be' ) !== false ) {
 				[ $youtube_id, $query_string ] = self::parse_youtube_url( $url );


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6647

> Videos added using the Youtube embed block disappear in the editor.
> The block is still there, but has a height of 0 in Gutenberg as a preview. Videos do show up in the frontend, so it's only the preview and editing that doesn't work.

Gutenberg editor is forcing an iframe for any embed, which doesn't allow for lite-youtube styles to be applied.
Cf. Gutenberg [embed preview component](https://github.com/WordPress/gutenberg/blob/aa05bd47df3247730065b197a170ab84e4c6761f/packages/block-library/src/embed/embed-preview.js#L96) and [sandbox component](https://github.com/WordPress/gutenberg/blob/d5915916abc45e6682f4bdb70888aa41e98aa395/packages/components/src/sandbox/index.js#L94) 

Removing lite-youtube integration in the editor fixes the issue, while keeping its integration on the frontend.

## Test
:warning: Pay attention to cache, **use a different youtube URLs for each test**. :warning: In details, there are 2 caches you can hit:
- embed cache in wp_postmeta table, it should not contain any reference to lite-youtube, but you can also empty it with `docker-compose exec php-fpm wp embed cache clear {postID}`
- rest api cache (a call to `https://www.planet4.test/wp-json/oembed/1.0/proxy?url={youtubeurl}` used by the editor to generate the preview), might return the same response to the same url call even after code change  and mutliple refresh

To test:
- Add a youtube embed in a post
- The video should show in the editor
  - Control with your browser inspector that the iframe contains the youtube iframe and not a lite-youtube tag
- The video should show on the frontend (preview or published)
  - Control with your browser inspector that a `<lite-youtube>` tag is used