### PR TITLE
PLANET-6465: Add opt-in checkbox for submitting the comments form

### DIFF
--- a/assets/src/scss/pages/post/_comments-form.scss
+++ b/assets/src/scss/pages/post/_comments-form.scss
@@ -40,15 +40,17 @@
 
 #gdpr-comments-compliance {
   font-family: $roboto;
+  margin-bottom: 8px;
 
-  #gdpr-comments-compliance-text,
-  #gdpr-comments-label,
-  .custom-control-description {
-    font-size: 14px;
+  #gdpr-comments-checkbox {
+    display: inline-block;
+    margin-inline-end: 8px;
+    width: inherit;
   }
 
   #gdpr-comments-label {
-    font-weight: bold;
+    display: inline-block;
+    font-size: 14px;
   }
 }
 

--- a/single.php
+++ b/single.php
@@ -12,6 +12,7 @@
 use P4\MasterTheme\Context;
 use P4\MasterTheme\Post;
 use Timber\Timber;
+use P4\MasterTheme\Settings\Comments;
 
 // Initializing variables.
 $context = Timber::get_context();
@@ -92,7 +93,16 @@ $comments_args = [
 	'comment_notes_before' => '',
 	'comment_notes_after'  => '',
 	'comment_field'        => Timber::compile( 'comment_form/comment_field.twig' ),
-	'submit_button'        => Timber::compile( 'comment_form/submit_button.twig' ),
+	'submit_button'        => Timber::compile(
+		'comment_form/submit_button.twig',
+		[
+			'gdpr_checkbox' => Comments::is_active( Comments::GDPR_CHECKBOX ),
+			'gdpr_label'    => __(
+				'I agree on providing my name, email and content so that my comment can be stored and displayed in the website.',
+				'planet4-master-theme'
+			),
+		]
+	),
 	'title_reply'          => __( 'Leave your reply', 'planet4-master-theme' ),
 ];
 

--- a/src/Migrations/M010RemoveGdprPluginOptions.php
+++ b/src/Migrations/M010RemoveGdprPluginOptions.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace P4\MasterTheme\Migrations;
+
+use P4\MasterTheme\MigrationRecord;
+use P4\MasterTheme\MigrationScript;
+use P4\MasterTheme\Settings\Comments;
+
+/**
+ * Remove GDPR Comments plugin options
+ */
+class M010RemoveGdprPluginOptions extends MigrationScript {
+	/**
+	 * Disable plugin and remove plugin options.
+	 * Activate new option by default.
+	 *
+	 * @param MigrationRecord $record Information on the execution, can be used to add logs.
+	 *
+	 * @return void
+	 */
+	protected static function execute( MigrationRecord $record ): void {
+		\deactivate_plugins( 'gdpr-comments/gdpr-comments.php' );
+		\delete_option( 'gdpr_comments' );
+
+		$options = \get_option( Comments::OPTIONS_KEY ) ?? [];
+
+		$options[ Comments::GDPR_CHECKBOX ] = 'on';
+		\update_option( Comments::OPTIONS_KEY, $options );
+	}
+}

--- a/src/Migrator.php
+++ b/src/Migrator.php
@@ -11,6 +11,7 @@ use P4\MasterTheme\Migrations\M006MoveFeaturesToSeparateOption;
 use P4\MasterTheme\Migrations\M007RemoveEnhancedDonateButtonOption;
 use P4\MasterTheme\Migrations\M008RemoveArticlesDefaultOptions;
 use P4\MasterTheme\Migrations\M009PopulateCookiesFields;
+use P4\MasterTheme\Migrations\M010RemoveGdprPluginOptions;
 
 /**
  * Run any new migration scripts and record results in the log.
@@ -38,6 +39,7 @@ class Migrator {
 			M007RemoveEnhancedDonateButtonOption::class,
 			M008RemoveArticlesDefaultOptions::class,
 			M009PopulateCookiesFields::class,
+			M010RemoveGdprPluginOptions::class,
 		];
 
 		// Loop migrations and run those that haven't run yet.

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -3,6 +3,7 @@
 namespace P4\MasterTheme;
 
 use CMB2_Field;
+use P4\MasterTheme\Settings\Comments;
 use P4\MasterTheme\Settings\InformationArchitecture as IA;
 
 /**
@@ -444,6 +445,7 @@ class Settings {
 					],
 				],
 			],
+			'planet4_settings_comments'         => Comments::get_options_page(),
 			'planet4_settings_features'         => Features::get_options_page(),
 			'planet4_settings_ia'               => IA::get_options_page(),
 			'planet4_settings_notifications'    => [

--- a/src/Settings/Comments.php
+++ b/src/Settings/Comments.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace P4\MasterTheme\Settings;
+
+use P4\MasterTheme\Loader;
+
+/**
+ * Settings related to Posts comments.
+ */
+class Comments {
+	/** @var string Option key */
+	public const OPTIONS_KEY = 'planet4_comments';
+
+	/* @var string Mobile tabs option key **/
+	public const GDPR_CHECKBOX = 'gdpr_checkbox';
+
+	/**
+	 * Get the features options page settings.
+	 *
+	 * @return array Settings for the options page.
+	 */
+	public static function get_options_page(): array {
+		return [
+			'title'       => 'Comments',
+			'description' => 'Options related to comments.',
+			'root_option' => self::OPTIONS_KEY,
+			'fields'      => self::get_fields(),
+			'add_scripts' => static function () {
+				Loader::enqueue_versioned_script( '/admin/js/features_save_redirect.js' );
+			},
+		];
+	}
+
+	/**
+	 * Get form fields.
+	 *
+	 * @return array  The fields.
+	 */
+	public static function get_fields(): array {
+		$fields = [
+			[
+				'id'   => self::GDPR_CHECKBOX,
+				'name' => __( 'Display Opt-in checkbox', 'planet4-master-theme-backend' ),
+				'desc' => __(
+					'This will display an opt-in checkbox in the Comments form which will be mandatory for submitting the form (GDPR requirement).',
+					'planet4-master-theme-backend'
+				),
+				'type' => 'checkbox',
+			],
+		];
+
+		return $fields;
+	}
+
+	/**
+	 * Check whether an option is active.
+	 *
+	 * @param string $name Name of the option we're checking.
+	 *
+	 * @return bool Whether the option is active.
+	 */
+	public static function is_active( string $name ): bool {
+		return ! empty( self::get( $name ) );
+	}
+
+	/**
+	 * Return option value.
+	 *
+	 * @param string $name    Name of the option.
+	 * @param mixed  $default Default value.
+	 *
+	 * @return mixed
+	 */
+	public static function get( string $name, $default = null ) {
+		$options = get_option( self::OPTIONS_KEY );
+
+		return isset( $options[ $name ] ) ? $options[ $name ] : $default;
+	}
+}

--- a/templates/comment_form/submit_button.twig
+++ b/templates/comment_form/submit_button.twig
@@ -1,1 +1,23 @@
+{% if gdpr_checkbox %}
+<div id="gdpr-comments-compliance" class="form-group comments-gdpr">
+	<input id="gdpr-comments-checkbox" type="checkbox" name="gdpr_comments_checkbox" value="1" required="required">
+	<label id="gdpr-comments-label" for="gdpr-comments-checkbox">{{ gdpr_label }}</label>
+</div>
+<script>
+function toggleCommentSubmit() {
+	const checkbox = document.getElementById('gdpr-comments-checkbox');
+	const submit = document.querySelector('#commentform button[type="submit"]');
+	checkbox.checked
+		? submit.removeAttribute('disabled')
+		: submit.setAttribute('disabled', '');
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+	document.getElementById('gdpr-comments-checkbox')
+		.addEventListener('change', () => toggleCommentSubmit());
+	toggleCommentSubmit();
+});
+</script>
+{% endif %}
+
 <button type="submit" class="btn btn-small btn-primary">{{ __( 'Post comment', 'planet4-master-theme' ) }}</button>


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6465

> This a follow up from [PLANET-6454](https://jira.greenpeace.org/browse/PLANET-6454) and the fact that the [GDPR Comments](https://wordpress.org/plugins/gdpr-comments/) plugin in not maintained anymore. This ticket is about implementing one of its functions: opt-in checkbox.

This PR 
- adds a checkbox to the comments form, disabling the submit button
- disables the _GDPR Comments_ plugin and removes its options

Settings in _Planet 4 > Comments_
![Screenshot from 2022-03-07 16-31-56](https://user-images.githubusercontent.com/617346/157065055-ee267c54-474f-4e7b-9d8b-27afdbe5f290.png)

_Checkbox displayed in the comments form_
![Screenshot from 2022-03-07 16-27-50](https://user-images.githubusercontent.com/617346/157064326-ce380deb-6470-42b0-992b-e1b207cd4121.png)


## Test

- Activate the GDPR option in _Planet 4 > Comments_
- Visit a post, check the comments section
- The GDPR checkbox should be unchecked and the submit button disabled
  - Check the GDPR checkbox, the submit button is enabled

### Patch
- Run patch
`docker-compose exec php-fpm wp p4-run-activator`
- Plugin _gdpr-comments_ should be disabled
  - its options should now be deleted
`docker-compose exec php-fpm wp option get gdpr-comments`