### PR TITLE
PLANET-6663 Fix password input width on mobile

### DIFF
--- a/assets/src/scss/pages/_page.scss
+++ b/assets/src/scss/pages/_page.scss
@@ -85,7 +85,11 @@ $min-height: 40px;
     display: inline-block;
     font-size: 16px;
     padding: 15px 14px 8px;
-    min-width: 400px;
+    width: 100%;
+
+    @include medium-and-up {
+      max-width: 400px;
+    }
   }
 
   .input-text input:hover {


### PR DESCRIPTION
### Description

See [PLANET-6663](https://jira.greenpeace.org/browse/PLANET-6663)
Before this fix the input would go off-screen in small screen widths:

<img width="433" alt="Screenshot 2022-03-09 at 11 11 09" src="https://user-images.githubusercontent.com/6949075/157421256-ba2f089d-8925-44c7-94d6-c818a967643c.png">

### Testing

In your local env, create a password-protected page or post, then check it in a small screen (< 400px). On `master` branch you'll see that the input goes off-screen, whereas on this branch it doesn't.