### PR TITLE
PLANET-6659 Fix Download file button styles

### DIFF
--- a/assets/src/scss/components/_buttons.scss
+++ b/assets/src/scss/components/_buttons.scss
@@ -1,6 +1,6 @@
 .btn,
 .wp-block-button a,
-.wp-block-file .wp-block-file__button {
+.wp-block-file a.wp-block-file__button {
   --button-- {
     font-family: $roboto;
     text-align: center;
@@ -106,7 +106,7 @@ $primary-button-box-shadow: 0 2px 5px rgba(0, 0, 0, .25);
 .btn-secondary,
 .wp-block-button.is-style-secondary a,
 [class="wp-block-button"] a,
-.wp-block-file .wp-block-file__button {
+.wp-block-file a.wp-block-file__button {
   --button-secondary-- {
     background: transparentize($white, .7);
     border-color: $dark-blue;


### PR DESCRIPTION
### Description

See [PLANET-6659](https://jira.greenpeace.org/browse/PLANET-6659)
With the upgrade to WP5.9 some of our styles for this button type were overridden in the frontend.

### Testing

In your local env, add a "File" block to a page and check the option "Show download button" in the sidebar. In the frontend on `master` branch you will see the broken version of that button, but on this branch you should see it styled as a secondary button as expected.