### PR TITLE
PLANET-6515 Migrate "Include Articles In Post" setting to a regular Articles block on Post

### DIFF
--- a/single.php
+++ b/single.php
@@ -36,7 +36,6 @@ $page_meta_data                 = array_map( 'reset', $page_meta_data );
 $page_terms_data                = get_the_terms( $post, 'p4-page-type' );
 $page_terms_data                = is_array( $page_terms_data ) ? reset( $page_terms_data ) : null;
 $context['background_image']    = $page_meta_data['p4_background_image_override'] ?? '';
-$take_action_page               = $page_meta_data['p4_take_action_page'] ?? '';
 $context['page_type']           = $page_terms_data->name ?? '';
 $context['page_term_id']        = $page_terms_data->term_id ?? '';
 $context['custom_body_classes'] = 'white-bg';
@@ -57,36 +56,6 @@ $context['filter_url'] = add_query_arg(
 	],
 	get_home_url()
 );
-
-// Build the shortcode for articles block.
-if ( 'yes' === $post->include_articles ) {
-	$tag_id_array = [];
-	foreach ( $post->tags() as $post_tag ) {
-		$tag_id_array[] = $post_tag->id;
-	}
-	$category_id_array = [];
-	foreach ( $post->terms( 'category' ) as $category ) {
-		$category_id_array[] = $category->id;
-	}
-
-	$block_attributes = [
-		'exclude_post_id' => $post->ID,
-		'tags'            => $tag_id_array,
-		'post_categories' => $category_id_array,
-	];
-
-	$post->articles = '<!-- wp:planet4-blocks/articles ' . wp_json_encode( $block_attributes, JSON_UNESCAPED_SLASHES ) . ' /-->';
-}
-
-if ( ! empty( $take_action_page ) && ! has_block( 'planet4-blocks/take-action-boxout' ) ) {
-	$post->take_action_page = $take_action_page;
-
-	$block_attributes = [
-		'take_action_page' => $take_action_page,
-	];
-
-	$post->take_action_boxout = '<!-- wp:planet4-blocks/take-action-boxout ' . wp_json_encode( $block_attributes, JSON_UNESCAPED_SLASHES ) . ' /-->';
-}
 
 // Build an arguments array to customize WordPress comment form.
 $comments_args = [

--- a/src/MetaboxRegister.php
+++ b/src/MetaboxRegister.php
@@ -173,18 +173,6 @@ class MetaboxRegister {
 
 		$p4_post->add_field(
 			[
-				'name'    => __( 'Include Articles In Post', 'planet4-master-theme-backend' ),
-				'id'      => 'include_articles',
-				'type'    => 'select',
-				'options' => [
-					'yes' => 'Yes',
-					'no'  => 'No',
-				],
-			]
-		);
-
-		$p4_post->add_field(
-			[
 				'name'         => __( 'Background Image Override', 'planet4-master-theme-backend' ),
 				'desc'         => __( 'Upload an image or select one from the media library to override the background image', 'planet4-master-theme-backend' ),
 				'id'           => 'p4_background_image_override',

--- a/src/Migrations/M011TurnIncludeArticlesSettingIntoBlock.php
+++ b/src/Migrations/M011TurnIncludeArticlesSettingIntoBlock.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace P4\MasterTheme\Migrations;
+
+use P4\MasterTheme\MigrationRecord;
+use P4\MasterTheme\MigrationScript;
+use WP_Post;
+
+/**
+ * Add the Articles block as a block to all posts that use it with the "Include Articles In Post" settings field, and remove field.
+ */
+class M011TurnIncludeArticlesSettingIntoBlock extends MigrationScript {
+
+	private const INCLUDE_ARTICLES_META_KEY = 'include_articles';
+
+	/**
+	 * Perform the actual migration.
+	 *
+	 * @param MigrationRecord $record Information on the execution, can be used to add logs.
+	 *
+	 * @return void
+	 */
+	protected static function execute( MigrationRecord $record ): void {
+		$args = [
+			'posts_per_page' => - 1,
+			'post_type'      => 'post',
+			'meta_query'     => [
+				[
+					'key'     => self::INCLUDE_ARTICLES_META_KEY,
+					'value'   => '',
+					'compare' => 'NOT IN',
+				],
+			],
+		];
+
+		$article_posts = get_posts( $args );
+
+		echo 'Converting ' . count( $article_posts ) . " posts with \"Include Articles In Post\" setting to blocks.\n";
+
+		foreach ( $article_posts as $article_post ) {
+			self::append_articles_block_from_meta( $article_post );
+			delete_post_meta( $article_post->ID, self::INCLUDE_ARTICLES_META_KEY );
+		}
+	}
+
+	/**
+	 * Add the Articles block that is in the meta to the end of the post content.
+	 *
+	 * @param WP_Post $post A post that has a TAB set through its meta.
+	 */
+	private static function append_articles_block_from_meta( WP_Post $post ): void {
+		if ( 'yes' === $post->include_articles ) {
+			// Build the block code for the articles block.
+			$articles_block = '<!-- wp:planet4-blocks/articles /-->';
+
+			$args = [
+				'ID'           => $post->ID,
+				'post_content' => $post->post_content . "\n" .
+					$articles_block,
+			];
+
+			wp_update_post( $args );
+		}
+	}
+}

--- a/src/Migrator.php
+++ b/src/Migrator.php
@@ -12,6 +12,7 @@ use P4\MasterTheme\Migrations\M007RemoveEnhancedDonateButtonOption;
 use P4\MasterTheme\Migrations\M008RemoveArticlesDefaultOptions;
 use P4\MasterTheme\Migrations\M009PopulateCookiesFields;
 use P4\MasterTheme\Migrations\M010RemoveGdprPluginOptions;
+use P4\MasterTheme\Migrations\M011TurnIncludeArticlesSettingIntoBlock;
 
 /**
  * Run any new migration scripts and record results in the log.
@@ -40,6 +41,7 @@ class Migrator {
 			M008RemoveArticlesDefaultOptions::class,
 			M009PopulateCookiesFields::class,
 			M010RemoveGdprPluginOptions::class,
+			M011TurnIncludeArticlesSettingIntoBlock::class,
 		];
 
 		// Loop migrations and run those that haven't run yet.

--- a/templates/single.twig
+++ b/templates/single.twig
@@ -87,9 +87,6 @@
 			<div class="post-content">
 				<article class="post-details clearfix">
 					{{ post.content|e('wp_kses_post')|raw }}
-					{% if ( post.take_action_boxout ) %}
-						{{ fn('do_blocks', post.take_action_boxout )|raw }}
-					{% endif %}
 				</article>
 			</div>
 		</div>
@@ -97,11 +94,6 @@
 
 		{% include "blocks/author_profile.twig" with {post:post} %}
 
-		{% if ( post.articles ) %}
-			<section class="container post-articles-block">
-				{{ fn('do_blocks', post.articles )|raw }}
-			</section>
-		{% endif %}
 		{% if ( show_comments ) %}
 			{% include "comments_section.twig" with {comments:post.get_comments()} %}
 		{% endif %}


### PR DESCRIPTION
Ref. https://jira.greenpeace.org/browse/PLANET-6612

- Remove "Include Articles in post" setting from add/edit post
- Remove unused code of TAB setting(https://jira.greenpeace.org/browse/PLANET-6450)

**To test:** You can run the migration locally. To run it multiple times you need to remove the migration record, or temporarily exclude [the check](https://github.com/greenpeace/planet4-master-theme/blob/PLANET-6612-include_articles_migration/src/MigrationLog.php#L44-L46) for this particular script in code.

Related PR: https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/795
