### PR TITLE
Unwrap cookies CSS

### DIFF
--- a/assets/src/scss/components/_buttons.scss
+++ b/assets/src/scss/components/_buttons.scss
@@ -31,7 +31,6 @@
   position: relative;
   font-size: $font-size-sm;
   text-decoration: none;
-  color: $white;
   border: 1px solid transparent;
   cursor: pointer;
   line-height: 3;
@@ -40,7 +39,6 @@
   &:hover,
   &:active,
   &:visited {
-    color: $white;
     text-decoration: none;
   }
 

--- a/assets/src/scss/layout/_cookies-settings.scss
+++ b/assets/src/scss/layout/_cookies-settings.scss
@@ -6,130 +6,128 @@
     line-height: 1.5;
   }
 
-  .close-cookies-settings {
-    background-color: $grey-80;
-    cursor: pointer;
-    height: 16px;
-    width: 16px;
-    mask: url("../../images/cross.svg");
-    position: absolute;
-    top: -$sp-1;
-    right: -$sp-1;
-
-    html[dir="rtl"] & {
-      right: auto;
-      left: -$sp-1;
-    }
-  }
-
-  .cookies-settings-header h4 {
-    font-size: 16px;
-    margin-bottom: $sp-1;
-  }
-
-  .cookies-settings-details {
-    max-height: 40vh;
-    overflow-y: auto;
-    overflow-x: hidden;
-    width: calc(100% + 2 * #{$sp-3});
-    margin-inline-start: -$sp-3;
-    padding: $sp-2 $sp-3 0 $sp-3;
-    border-top: solid 1px $grey-10;
-    border-bottom: solid 1px $grey-10;
-
-    .custom-control-description,
-    .custom-control input[type="checkbox"] ~ .custom-control-description {
-      font-weight: 700;
-      font-size: 14px;
-      margin-bottom: $sp-2;
-    }
-  }
-
-  .always-enabled {
-    background: $grey-80;
-    color: white;
-    font-weight: 700;
-    border-radius: 4px;
-    padding: $sp-x;
-    font-size: 12px;
-    margin-inline-start: $sp-1;
-  }
-
-  .cookies-settings-buttons {
-    display: flex;
-    justify-content: space-between;
-    margin-top: $sp-3;
-
-    .btn {
-      width: calc(50% - 8px);
-      line-height: 2.4;
-      font-size: 14px;
-      padding: 0;
-    }
-
-    &.with-reject-all {
-      flex-wrap: wrap;
-
-      .btn-primary {
-        width: 100%;
-        margin-top: $sp-2;
-      }
-    }
-  }
-
   @include medium-and-up {
     width: 434px;
-
-    .cookies-settings-details {
-      max-height: 300px;
-      width: calc(100% + 2 * #{$sp-4});
-      margin-inline-start: -$sp-4;
-      padding-left: $sp-4;
-      padding-right: $sp-4;
-    }
-
-    .cookies-settings-buttons {
-      &.with-reject-all {
-        justify-content: flex-start;
-        flex-wrap: nowrap;
-
-        .btn-secondary {
-          width: 50%;
-
-          &:first-child {
-            margin-inline-end: $sp-2;
-          }
-        }
-
-        .btn-primary {
-          flex-grow: 1;
-          margin-top: 0;
-          margin-inline-start: $sp-8;
-        }
-      }
-
-      .btn {
-        padding: 0 $sp-2;
-        width: auto;
-      }
-    }
-
-    .close-cookies-settings {
-      right: -$sp-2;
-
-      html[dir="rtl"] & {
-        left: -$sp-2;
-      }
-    }
   }
 
   @include large-and-up {
     p {
       font-size: 14px;
     }
+  }
+}
 
-    .cookies-settings-header h4 {
-      font-size: 20px;
+.close-cookies-settings {
+  background-color: $grey-80;
+  cursor: pointer;
+  height: 16px;
+  width: 16px;
+  mask: url("../../images/cross.svg");
+  position: absolute;
+  top: -$sp-1;
+  right: -$sp-1;
+
+  html[dir="rtl"] & {
+    right: auto;
+    left: -$sp-1;
+  }
+
+  @include medium-and-up {
+    right: -$sp-2;
+
+    html[dir="rtl"] & {
+      left: -$sp-2;
+    }
+  }
+}
+
+.cookies-settings-header h4 {
+  font-size: 16px;
+  margin-bottom: $sp-1;
+
+  @include large-and-up {
+    font-size: 20px;
+  }
+}
+
+.cookies-settings-details {
+  max-height: 40vh;
+  overflow-y: auto;
+  overflow-x: hidden;
+  width: calc(100% + 2 * #{$sp-3});
+  margin-inline-start: -$sp-3;
+  padding: $sp-2 $sp-3 0 $sp-3;
+  border-top: solid 1px $grey-10;
+  border-bottom: solid 1px $grey-10;
+
+  .custom-control-description,
+  .custom-control input[type="checkbox"] ~ .custom-control-description {
+    font-weight: 700;
+    font-size: 14px;
+    margin-bottom: $sp-2;
+  }
+
+  @include medium-and-up {
+    max-height: 300px;
+    width: calc(100% + 2 * #{$sp-4});
+    margin-inline-start: -$sp-4;
+    padding-left: $sp-4;
+    padding-right: $sp-4;
+  }
+}
+
+.always-enabled {
+  background: $grey-80;
+  color: white;
+  font-weight: 700;
+  border-radius: 4px;
+  padding: $sp-x;
+  font-size: 12px;
+  margin-inline-start: $sp-1;
+}
+
+.cookies-settings-buttons {
+  display: flex;
+  justify-content: space-between;
+  margin-top: $sp-3;
+
+  .btn {
+    width: calc(50% - 8px);
+    line-height: 2.4;
+    font-size: 14px;
+    padding: 0;
+
+    @include medium-and-up {
+      padding: 0 $sp-2;
+      width: auto;
+    }
+  }
+
+  &.with-reject-all {
+    flex-wrap: wrap;
+
+    .btn-primary {
+      width: 100%;
+      margin-top: $sp-2;
+    }
+
+    @include medium-and-up {
+      justify-content: flex-start;
+      flex-wrap: nowrap;
+
+      .btn-secondary {
+        width: 50%;
+
+        &:first-child {
+          margin-inline-end: $sp-2;
+        }
+      }
+
+      .btn-primary {
+        flex-grow: 1;
+        margin-top: 0;
+        margin-inline-start: $sp-8;
+      }
     }
   }
 }

--- a/assets/src/scss/layout/_cookies.scss
+++ b/assets/src/scss/layout/_cookies.scss
@@ -109,7 +109,7 @@
   }
 }
 
-.reject-all-cookies {
+.btn-discrete {
   display: block;
   background: none;
   border: none;

--- a/assets/src/scss/layout/_cookies.scss
+++ b/assets/src/scss/layout/_cookies.scss
@@ -38,44 +38,6 @@
     visibility: visible;
   }
 
-  .cookies-intro {
-    .cookies-text {
-      font-size: 14px;
-      margin-bottom: $sp-3;
-      font-weight: 400;
-      color: $grey-80;
-      line-height: 1.5rem;
-      width: 100%;
-    }
-
-    .cookies-buttons {
-      .btn {
-        width: 100%;
-        line-height: 2.4;
-        font-size: 14px;
-      }
-
-      .btn-primary {
-        margin-top: $sp-2;
-      }
-    }
-
-    .reject-all-cookies {
-      display: block;
-      background: none;
-      border: none;
-      color: $grey-40;
-      margin: $sp-2 auto 0 auto;
-      line-height: 2.4;
-      font-size: 14px;
-      padding: 0;
-
-      &:hover {
-        text-decoration: underline;
-      }
-    }
-  }
-
   @include medium-and-up {
     width: auto;
     bottom: $sp-2;
@@ -85,25 +47,6 @@
     padding: $sp-3 $sp-4;
     box-shadow: 0 3px 12px rgba(0, 0, 0, 0.15);
     @include slide-from(right, $sp-2);
-
-    .cookies-intro {
-      width: 308px;
-
-      .cookies-buttons {
-        display: flex;
-        justify-content: space-between;
-
-        .btn-primary:only-child {
-          width: 100%;
-        }
-
-        .btn-primary,
-        .btn-secondary {
-          width: calc(50% - #{$sp-1});
-          margin-top: 0;
-        }
-      }
-    }
 
     html[dir="rtl"] & {
       right: auto;
@@ -121,5 +64,62 @@
       left: $sp-3;
       @include slide-from(left, $sp-3);
     }
+  }
+}
+
+.cookies-intro {
+  @include medium-and-up {
+    width: 308px;
+  }
+}
+
+.cookies-text {
+  font-size: 14px;
+  margin-bottom: $sp-3;
+  font-weight: 400;
+  color: $grey-80;
+  line-height: 1.5rem;
+  width: 100%;
+}
+
+.cookies-buttons {
+  .btn {
+    width: 100%;
+    line-height: 2.4;
+    font-size: 14px;
+  }
+
+  .btn-primary {
+    margin-top: $sp-2;
+  }
+
+  @include medium-and-up {
+    display: flex;
+    justify-content: space-between;
+
+    .btn-primary:only-child {
+      width: 100%;
+    }
+
+    .btn-primary,
+    .btn-secondary {
+      width: calc(50% - #{$sp-1});
+      margin-top: 0;
+    }
+  }
+}
+
+.reject-all-cookies {
+  display: block;
+  background: none;
+  border: none;
+  color: $grey-40;
+  margin: $sp-2 auto 0 auto;
+  line-height: 2.4;
+  font-size: 14px;
+  padding: 0;
+
+  &:hover {
+    text-decoration: underline;
   }
 }

--- a/templates/cookies.twig
+++ b/templates/cookies.twig
@@ -28,7 +28,7 @@
 			</div>
 			{% if show_settings and cookies.enable_reject_all_cookies %}
 				<button
-					class="btn reject-all-cookies"
+					class="btn btn-discrete reject-all-cookies"
 					data-ga-category="Cookies box"
 					data-ga-action="Reject all cookies"
 				>


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6664

Was needlessly wrapping specific selectors inside the element they happened to be in.

Also duplicate media queries instead of selectors. That way it's always close to the thing it's overriding.

[Hide whitespace changes](https://github.com/greenpeace/planet4-master-theme/pull/1646/files?diff=split&w=1)

It's easier if we merge this simplification first, as it should not change any behavior. After that I'll open a PR to address the button ellipsis issue.