### PR TITLE
Remove unused function add_terms_as_rewrite_rules

### DIFF
--- a/src/CustomTaxonomy.php
+++ b/src/CustomTaxonomy.php
@@ -245,22 +245,9 @@ class CustomTaxonomy {
 			'show_admin_column' => true,
 			'query_var'         => true,
 			'meta_box_cb'       => [ $this, 'create_taxonomy_metabox_markup' ],
-			'show_in_rest'      => true,
 		];
 
 		register_taxonomy( self::TAXONOMY, [ self::TAXONOMY_PARAMETER, 'post' ], $args );
-	}
-
-	/**
-	 * Add each taxonomy term as a rewrite rule.
-	 */
-	public function add_terms_as_rewrite_rules() {
-		// Add a rewrite rule on top of the chain for each slug
-		// of this taxonomy type (e.g.: "publication", "story", etc.).
-		$terms_slugs = $this->get_terms_slugs();
-		foreach ( $terms_slugs as $slug ) {
-			add_rewrite_rule( $slug . '/?$', 'index.php?' . self::TAXONOMY . '=' . $slug, 'top' );
-		}
 	}
 
 	/**


### PR DESCRIPTION
* Possibly a past rebase mishap. A function with almost the same name
does exist which is in fact used, add_terms_rewrite_rules.
* Also clean up duplicate array key.

The usage was removed in the [PR that added the similarly named function](https://github.com/greenpeace/planet4-master-theme/pull/701/).
