### PR TITLE
Use a class per feature

### DIFF
--- a/src/AnalyticsValues.php
+++ b/src/AnalyticsValues.php
@@ -2,6 +2,8 @@
 
 namespace P4\MasterTheme;
 
+use P4\MasterTheme\Features\GoogleSheetReplacesSmartsheet;
+
 /**
  * Data class for post editor analytics values.
  */
@@ -110,7 +112,7 @@ final class AnalyticsValues {
 			return self::from_cache_array( $cache );
 		}
 
-		$use_google = Features::is_active( Features::GOOGLE_SHEET_REPLACES_SMARTSHEET );
+		$use_google = GoogleSheetReplacesSmartsheet::is_active();
 
 		$instance = $use_google ? self::using_google() : self::using_smartsheet();
 

--- a/src/Commands/CloudflarePurge.php
+++ b/src/Commands/CloudflarePurge.php
@@ -36,7 +36,7 @@ class CloudflarePurge extends Command {
 	 * @param array|null $assoc_args Named arguments.
 	 */
 	public static function execute( ?array $args, ?array $assoc_args ): void {
-		if ( ! Features::is_active( Features::CLOUDFLARE_DEPLOY_PURGE ) ) {
+		if ( ! Features\CloudflareDeployPurge::is_active() ) {
 			WP_CLI::warning( 'Purge on deploy is not enabled, not purging.' );
 
 			return;

--- a/src/Feature.php
+++ b/src/Feature.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace P4\MasterTheme;
+
+/**
+ * Base class for toggleable features.
+ */
+abstract class Feature {
+
+	public const OPTIONS_KEY = 'planet4_features';
+
+	/**
+	 * Default to using the class name, but allow override to provide BC.
+	 *
+	 * @return string ID primarily used for storing in WP options.
+	 */
+	abstract public static function id(): string;
+
+	/**
+	 * Get the translated name. It's important the class includes the translation function call. This is used by
+	 * automation to extract translatable strings from the source code.
+	 *
+	 * @return string A human readable name.
+	 */
+	abstract protected static function name(): string;
+
+	/**
+	 * Get the translated description. It's important the class includes the translation function call. This is used by
+	 * automation to extract translatable strings from the source code.
+	 *
+	 * @return string A description shown on the feature settings page. This should provide enough context so that it's
+	 * clear what effect turning on the feature will have.
+	 */
+	abstract protected static function description(): string;
+
+	/**
+	 * This determines whether to include the toggle on the feature settings page. It doesn't prevent a feature from
+	 * being active if enabled already.
+	 *
+	 * @return bool Whether the feature toggle can be used on production.
+	 */
+	public static function show_toggle_production(): bool {
+		return false;
+	}
+
+	/**
+	 * Not added as abstract as this function will only return true when we decided to remove the feature.
+	 * So we can avoid having to declare it most of the time.
+	 *
+	 * @return bool Whether the feature has become generally available, meaning it's always on for everyone.
+	 */
+	protected static function is_generally_available(): bool {
+		return false;
+	}
+
+	/**
+	 * Whether the feature is currently active.
+	 *
+	 * @return bool Whether the feature is currently active.
+	 */
+	public static function is_active(): bool {
+		if ( static::is_generally_available() ) {
+			return true;
+		}
+		$features = get_option( self::OPTIONS_KEY );
+
+		// Temporary fallback to ensure it works before migration runs.
+		if ( ! $features ) {
+			$features = get_option( Settings::KEY );
+		}
+
+		$id     = static::id();
+		$active = isset( $features[ $id ] ) && $features[ $id ];
+
+		// Filter to allow setting a feature from code, to avoid chicken and egg problem when releasing adaptions to a
+		// new feature.
+		return (bool) apply_filters( "planet4_feature__$id", $active );
+
+	}
+
+	/**
+	 * The config for CMB2 options page.
+	 *
+	 * @return string[] The config.
+	 */
+	public static function get_cmb_field(): array {
+		return [
+			'id'   => static::id(),
+			'name' => static::name(),
+			'desc' => static::description(),
+			'type' => 'checkbox',
+		];
+	}
+}

--- a/src/Features/CloudflareDeployPurge.php
+++ b/src/Features/CloudflareDeployPurge.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace P4\MasterTheme\Features;
+
+use P4\MasterTheme\Feature;
+
+/**
+ * @see description().
+ */
+class CloudflareDeployPurge extends Feature {
+
+	/**
+	 * @inheritDoc
+	 */
+	public static function id(): string {
+		return 'cloudflare_deploy_purge';
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected static function name(): string {
+		return __( 'Purge HTML from Cloudflare on deploy', 'planet4-master-theme-backend' );
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected static function description(): string {
+		return __(
+			'Whether to purge all pages from Cloudflare cache when changing features.<br>Only enable on production, on test instances it results in too many purge requests.',
+			'planet4-master-theme-backend'
+		);
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public static function show_toggle_production(): bool {
+		return true;
+	}
+}

--- a/src/Features/Dev/AllowAllBlocks.php
+++ b/src/Features/Dev/AllowAllBlocks.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace P4\MasterTheme\Features\Dev;
+
+use P4\MasterTheme\Feature;
+
+/**
+ * @see description().
+ */
+class AllowAllBlocks extends Feature {
+
+	/**
+	 * @inheritDoc
+	 */
+	public static function id(): string {
+		return 'allow_all_blocks';
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected static function name(): string {
+		return __( 'Allow all blocks', 'planet4-master-theme-backend' );
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected static function description(): string {
+		return __(
+			'Enable all blocks in the editor for all post types.',
+			'planet4-master-theme-backend'
+		);
+	}
+}

--- a/src/Features/Dev/BetaBlocks.php
+++ b/src/Features/Dev/BetaBlocks.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace P4\MasterTheme\Features\Dev;
+
+use P4\MasterTheme\Feature;
+
+/**
+ * @see description().
+ */
+class BetaBlocks extends Feature {
+
+	/**
+	 * @inheritDoc
+	 */
+	public static function id(): string {
+		return 'beta_blocks';
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected static function name(): string {
+		return __( 'Allow Beta Blocks in post editor', 'planet4-master-theme-backend' );
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected static function description(): string {
+		return __(
+			'If enabled, you can use early or unstable versions of blocks in the post editor.<br>These will be in the "Planet 4 Blocks - BETA" category.',
+			'planet4-master-theme-backend'
+		);
+	}
+}

--- a/src/Features/Dev/CoreBlockPatterns.php
+++ b/src/Features/Dev/CoreBlockPatterns.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace P4\MasterTheme\Features\Dev;
+
+use P4\MasterTheme\Feature;
+
+/**
+ * @see description()
+ */
+class CoreBlockPatterns extends Feature {
+
+	/**
+	 * @inheritDoc
+	 */
+	public static function id(): string {
+		return 'core_block_patterns';
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected static function name(): string {
+		return __( 'Enable core block patterns', 'planet4-master-theme-backend' );
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected static function description(): string {
+		return __(
+			'Allows using the default block patterns that come with WordPress.',
+			'planet4-master-theme-backend'
+		);
+	}
+}

--- a/src/Features/Dev/ThemeEditor.php
+++ b/src/Features/Dev/ThemeEditor.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace P4\MasterTheme\Features\Dev;
+
+use P4\MasterTheme\Feature;
+
+/**
+ * @see description().
+ */
+class ThemeEditor extends Feature {
+
+	/**
+	 * @inheritDoc
+	 */
+	public static function id(): string {
+		return 'theme_editor';
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected static function name(): string {
+		return __( 'Theme editor (experimental)', 'planet4-master-theme-backend' );
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected static function description(): string {
+		return __(
+			'Enable CSS variables based theme editor for logged in users.',
+			'planet4-master-theme-backend'
+		);
+	}
+}

--- a/src/Features/Dev/WPTemplateEditor.php
+++ b/src/Features/Dev/WPTemplateEditor.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace P4\MasterTheme\Features\Dev;
+
+use P4\MasterTheme\Feature;
+
+/**
+ * @see description().
+ */
+class WPTemplateEditor extends Feature {
+
+	/**
+	 * @inheritDoc
+	 */
+	public static function id(): string {
+		return 'wp_template_editor';
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected static function name(): string {
+		return __( 'Enable WordPress template editor', 'planet4-master-theme-backend' );
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected static function description(): string {
+		return __(
+			'Enable the WordPress "template editor" to allow Full Site Editiong.',
+			'planet4-master-theme-backend'
+		);
+	}
+}

--- a/src/Features/EngagingNetworks.php
+++ b/src/Features/EngagingNetworks.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace P4\MasterTheme\Features;
+
+use P4\MasterTheme\Feature;
+
+/**
+ * @see description().
+ */
+class EngagingNetworks extends Feature {
+
+	/**
+	 * @inheritDoc
+	 */
+	public static function id(): string {
+		return 'feature_engaging_networks';
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected static function name(): string {
+		return __( 'Engaging Networks integration', 'planet4-master-theme-backend' );
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected static function description(): string {
+		return __(
+			'Enable the Engaging Networks integration.<br>If turned on you will be able to use the EN Form block, as well as the "Progress Bar inside EN Form" Counter block style.',
+			'planet4-master-theme-backend'
+		);
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public static function show_toggle_production(): bool {
+		return true;
+	}
+}

--- a/src/Features/GoogleSheetReplacesSmartsheet.php
+++ b/src/Features/GoogleSheetReplacesSmartsheet.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace P4\MasterTheme\Features;
+
+use P4\MasterTheme\Feature;
+
+/**
+ * @see description().
+ */
+class GoogleSheetReplacesSmartsheet extends Feature {
+
+	/**
+	 * @inheritDoc
+	 */
+	public static function id(): string {
+		return 'google_sheet_replaces_smartsheet';
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected static function name(): string {
+		return __( 'Google Sheets replaces Smartsheet', 'planet4-master-theme-backend' );
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected static function description(): string {
+		return __(
+			'Toggle whether to use Google Sheets to fetch the list of analytics options.',
+			'planet4-master-theme-backend'
+		);
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public static function show_toggle_production(): bool {
+		return true;
+	}
+}

--- a/src/Features/ImageArchive.php
+++ b/src/Features/ImageArchive.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace P4\MasterTheme\Features;
+
+use P4\MasterTheme\Feature;
+
+/**
+ * @see description().
+ */
+class ImageArchive extends Feature {
+
+	/**
+	 * @inheritDoc
+	 */
+	public static function id(): string {
+		return 'feature_image_archive';
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected static function name(): string {
+		return __(
+			'New Image Archive (Beta)',
+			'planet4-master-theme-backend'
+		);
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected static function description(): string {
+		return __(
+			'Beta test the new Image Archive. This will replace the GPI Media Library plugin.',
+			'planet4-master-theme-backend'
+		);
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public static function show_toggle_production(): bool {
+		return true;
+	}
+}

--- a/src/Features/LazyYoutubePlayer.php
+++ b/src/Features/LazyYoutubePlayer.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace P4\MasterTheme\Features;
+
+use P4\MasterTheme\Feature;
+
+/**
+ * @see description().
+ */
+class LazyYoutubePlayer extends Feature {
+
+	/**
+	 * @inheritDoc
+	 */
+	public static function id(): string {
+		return 'lazy_youtube_player';
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected static function name(): string {
+		return __( 'Lazy YouTube player', 'planet4-master-theme-backend' );
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected static function description(): string {
+		return __(
+			'Only load the YouTube player after clicking a video.',
+			'planet4-master-theme-backend'
+		);
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public static function show_toggle_production(): bool {
+		return true;
+	}
+}

--- a/src/Features/NewDesignCountrySelector.php
+++ b/src/Features/NewDesignCountrySelector.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace P4\MasterTheme\Features;
+
+use P4\MasterTheme\Feature;
+
+/**
+ * @see description().
+ */
+class NewDesignCountrySelector extends Feature {
+
+	/**
+	 * @inheritDoc
+	 */
+	public static function id(): string {
+		return 'new_design_country_selector';
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected static function name(): string {
+		return __( 'Enable new Country selector design', 'planet4-master-theme-backend' );
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected static function description(): string {
+		return __(
+			'Enable the new Country selector design as described in the <a href="https://p4-designsystem.greenpeace.org/05f6e9516/v/0/p/16a899-footer" target="_blank">design system</a>.<br/>This might break your child theme, depending on how you extended the main templates and CSS.<br/>Changing this option will take a bit of time, as it also attempts to clear the Cloudflare cache.',
+			'planet4-master-theme-backend'
+		);
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public static function show_toggle_production(): bool {
+		return true;
+	}
+}

--- a/src/Features/NewDesignNavigationBar.php
+++ b/src/Features/NewDesignNavigationBar.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace P4\MasterTheme\Features;
+
+use P4\MasterTheme\Feature;
+
+/**
+ * @see description().
+ */
+class NewDesignNavigationBar extends Feature {
+
+	/**
+	 * @inheritDoc
+	 */
+	public static function id(): string {
+		return 'new_design_navigation_bar';
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected static function name(): string {
+		return __( 'Enable new Navigation bar design', 'planet4-master-theme-backend' );
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected static function description(): string {
+		return __(
+			'Enable the new Navigation bar design as described in the <a href="https://p4-designsystem.greenpeace.org/05f6e9516/p/106cdb-navigation-bar" target="_blank">design system</a>.<br/>This might break your child theme, depending on how you extended the main templates and CSS.<br/>Changing this option will take a bit of time, as it also attempts to clear the Cloudflare cache.',
+			'planet4-master-theme-backend'
+		);
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public static function show_toggle_production(): bool {
+		return true;
+	}
+}

--- a/src/Features/PurgeOnFeatureChanges.php
+++ b/src/Features/PurgeOnFeatureChanges.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace P4\MasterTheme\Features;
+
+use P4\MasterTheme\Feature;
+
+/**
+ * @see description().
+ */
+class PurgeOnFeatureChanges extends Feature {
+
+	/**
+	 * @inheritDoc
+	 */
+	public static function id(): string {
+		return 'purge_on_feature_changes';
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected static function name(): string {
+		return __( 'Purge all HTML on feature changes', 'planet4-master-theme-backend' );
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected static function description(): string {
+		return __(
+			'Whether to purge all pages from Cloudflare cache when changing features.<br>Only enable on production, on test instances it results in too many purge requests.',
+			'planet4-master-theme-backend'
+		);
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public static function show_toggle_production(): bool {
+		return true;
+	}
+}

--- a/src/ImageArchive/Rest.php
+++ b/src/ImageArchive/Rest.php
@@ -6,6 +6,7 @@ use Exception;
 use P4\MasterTheme\Capability;
 use P4\MasterTheme\Features;
 use P4\MasterTheme\Exception\RemoteCallFailed;
+use P4\MasterTheme\Features\ImageArchive;
 use WP_Http;
 use WP_REST_Request;
 use WP_REST_Response;
@@ -26,7 +27,7 @@ class Rest {
 	 * Add some REST API endpoints if feature is active.
 	 */
 	public static function register_endpoints(): void {
-		if ( ! Features::is_active( Features::IMAGE_ARCHIVE ) ) {
+		if ( ! ImageArchive::is_active() ) {
 			return;
 		}
 		$fetch_archive_images = static function ( WP_REST_Request $request ) {

--- a/src/ImageArchive/UiIntegration.php
+++ b/src/ImageArchive/UiIntegration.php
@@ -5,6 +5,7 @@ namespace P4\MasterTheme\ImageArchive;
 use P4\MasterTheme\Capability;
 use P4\MasterTheme\Exception\RemoteCallFailed;
 use P4\MasterTheme\Features;
+use P4\MasterTheme\Features\ImageArchive;
 use P4\MasterTheme\Loader;
 
 /**
@@ -22,7 +23,7 @@ class UiIntegration {
 	 * Hook up to WordPress.
 	 */
 	private static function hooks() {
-		if ( ! Features::is_active( Features::IMAGE_ARCHIVE ) ) {
+		if ( ! ImageArchive::is_active() ) {
 			return;
 		}
 		add_action( 'admin_menu', [ self::class, 'picker_page' ], 10 );

--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -2,6 +2,11 @@
 
 namespace P4\MasterTheme;
 
+use P4\MasterTheme\Features\Dev\CoreBlockPatterns;
+use P4\MasterTheme\Features\Dev\WPTemplateEditor;
+use P4\MasterTheme\Features\LazyYoutubePlayer;
+use P4\MasterTheme\Features\NewDesignCountrySelector;
+use P4\MasterTheme\Features\NewDesignNavigationBar;
 use Timber\Timber;
 use Timber\Site as TimberSite;
 use Timber\Menu as TimberMenu;
@@ -107,11 +112,11 @@ class MasterSite extends TimberSite {
 	protected function hooks() {
 		add_theme_support( 'post-thumbnails' );
 		add_theme_support( 'menus' );
-		if ( Features::is_active( Features::WP_TEMPLATE_EDITOR ) ) {
+		if ( WPTemplateEditor::is_active() ) {
 			// Enable Full Site Editing.
 			add_theme_support( 'block-templates' );
 		}
-		if ( ! Features::is_active( Features::CORE_BLOCK_PATTERNS ) ) {
+		if ( ! CoreBlockPatterns::is_active() ) {
 			// Disable WP Block Patterns.
 			remove_theme_support( 'core-block-patterns' );
 		}
@@ -582,8 +587,6 @@ class MasterSite extends TimberSite {
 			$context['p4_visitor_type']    = 'guest';
 		}
 
-		$new_design_navigation_bar = Features::is_active( Features::NEW_DESIGN_NAVIGATION_BAR );
-
 		$context['donatelink']           = $options['donate_button'] ?? '#';
 		$context['donatetext']           = $options['donate_text'] ?? __( 'Donate', 'planet4-master-theme' );
 		$context['website_navbar_title'] = $options['website_navigation_title'] ?? __( 'International (English)', 'planet4-master-theme' );
@@ -610,8 +613,8 @@ class MasterSite extends TimberSite {
 		$context['dummy_thumbnail'] = get_template_directory_uri() . '/images/dummy-thumbnail.png';
 
 		// New design country selector, navigation bar.
-		$context['new_design_country_selector'] = Features::is_active( Features::NEW_DESIGN_COUNTRY_SELECTOR );
-		$context['new_design_navigation_bar']   = $new_design_navigation_bar;
+		$context['new_design_country_selector'] = NewDesignCountrySelector::is_active();
+		$context['new_design_navigation_bar']   = NewDesignNavigationBar::is_active();
 
 		// IA: Tabs menu on mobile.
 		$context['mobile_tabs_menu'] = IA::is_active( IA::MOBILE_TABS_MENU );
@@ -1209,7 +1212,7 @@ class MasterSite extends TimberSite {
 	 * @return mixed
 	 */
 	public function filter_youtube_oembed_nocookie( $cache, $url ) {
-		if ( Features::is_active( Features::LAZY_YOUTUBE_PLAYER ) ) {
+		if ( LazyYoutubePlayer::is_active() ) {
 			return $this->new_youtube_filter( $cache, $url );
 		}
 

--- a/src/Migrations/M001EnableEnFormFeature.php
+++ b/src/Migrations/M001EnableEnFormFeature.php
@@ -22,7 +22,7 @@ class M001EnableEnFormFeature extends MigrationScript {
 	protected static function execute( MigrationRecord $record ): void {
 		$settings = get_option( Settings::KEY, [] );
 
-		$settings[ Features::ENGAGING_NETWORKS ] = 'on';
+		$settings[ Features\EngagingNetworks::id() ] = 'on';
 		update_option( Settings::KEY, $settings );
 	}
 }

--- a/src/Migrations/M002EnableLazyYoutube.php
+++ b/src/Migrations/M002EnableLazyYoutube.php
@@ -22,7 +22,7 @@ class M002EnableLazyYoutube extends MigrationScript {
 	protected static function execute( MigrationRecord $record ): void {
 		$settings = get_option( Settings::KEY, [] );
 
-		$settings[ Features::LAZY_YOUTUBE_PLAYER ] = 'on';
+		$settings[ Features\LazyYoutubePlayer::id() ] = 'on';
 		update_option( Settings::KEY, $settings );
 	}
 }

--- a/src/PublicAssets.php
+++ b/src/PublicAssets.php
@@ -2,6 +2,9 @@
 
 namespace P4\MasterTheme;
 
+use P4\MasterTheme\Features\NewDesignCountrySelector;
+use P4\MasterTheme\Features\NewDesignNavigationBar;
+
 /**
  * Wrapper class for the enqueue function because we can't autoload functions.
  */
@@ -94,13 +97,13 @@ final class PublicAssets {
 	 * - CSS specific to a particular page (e.g. search)
 	 */
 	private static function conditionally_load_partials(): void {
-		$navbar_version = Features::is_active( Features::NEW_DESIGN_NAVIGATION_BAR )
+		$navbar_version = NewDesignNavigationBar::is_active()
 			? planet4_get_option( 'website_navigation_style', 'dark' )
 			: 'old';
 		$navbar_file    = '/assets/build/navigation-bar-' . $navbar_version . '.min.css';
 		Loader::enqueue_versioned_style( $navbar_file, 'navigation-bar', [ 'parent-style' ] );
 
-		$country_selector_version = Features::is_active( Features::NEW_DESIGN_COUNTRY_SELECTOR ) ? 'new' : 'old';
+		$country_selector_version = NewDesignCountrySelector::is_active() ? 'new' : 'old';
 		$country_selector_file    = '/assets/build/country-selector-' . $country_selector_version . '.min.css';
 		Loader::enqueue_versioned_style( $country_selector_file, 'country-selector', [ 'parent-style' ] );
 	}

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -3,6 +3,7 @@
 namespace P4\MasterTheme;
 
 use CMB2_Field;
+use P4\MasterTheme\Features\NewDesignNavigationBar;
 use P4\MasterTheme\Settings\Comments;
 use P4\MasterTheme\Settings\InformationArchitecture as IA;
 
@@ -464,7 +465,7 @@ class Settings {
 			],
 		];
 
-		if ( Features::is_active( Features::NEW_DESIGN_NAVIGATION_BAR ) ) {
+		if ( NewDesignNavigationBar::is_active() ) {
 			$this->subpages['planet4_settings_navigation']['fields'][] = [
 				'name'    => __( 'Website Navigation Style', 'planet4-master-theme-backend' ),
 				'desc'    => __( 'Select a style', 'planet4-master-theme-backend' ),


### PR DESCRIPTION
With more and more features, the previous implementation that contained all feature related data in a single file became hard to manage.

We could further combine effects of each feature inside of the class, such as conditionally loading stylesheets.

This branch should result in the same behavior as `master`. With [one exception](https://github.com/greenpeace/planet4-master-theme/pull/1650/files#diff-ecf1d8c1cedf861e4a52c13d299a24fc41ebadbecc85d321eacbf40b4a3b3799L201-L211): There was 1 feature set up to only be allowed locally, but it's a leftover that we can remove instead. This avoids needing to add local only features support to the class definition.

### Testing
Needs to be tested together with the [plugin PR](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/813). You can see the plugin settings all still work and have the same order. All feature checks (now using `Feature::is_active` instead of `Features::is_active(Features::FEATURE_NAME)` should still produce the same result depending on the stored options.

### VSCode
The abstract classes make it very easy to add a new feature, but only if you can leverage your IDE to generate all the required abstract methods. PHPStorm does this very well, but requires a license not everyone has.

There is [one commonly used plugin](https://marketplace.visualstudio.com/items?itemName=bmewburn.vscode-intelephense-client) which adds many similar features like PHPStorm to VS Code. Unfortunately the most useful features require premium access. That said, [acquiring premium](https://intelephense.com/) is just a one off 15 Euro and gives you

> access to all current and future premium features on multiple devices forever

That's peanuts compared to PHPStorm's pricing model. Though even the free version of the plugin already adds tons of crucial features.

TODO:
* ~~I didn't add PHPDoc because yet in each feature class because it would just repeat the base class. We should probably configure our CS to allow `@inheritDoc` to reduce bloat.~~ I was wrong, it currently allows it :partying_face: 
* ~~Fix acceptance test chicken egg problem.~~ I used string literals in the plugin for now.
* Further clean up, but maybe better in a follow up? For example renaming `Features` to `FeatureSettings`.