### PR TITLE
PLANET-6668 Implement Highlighted CTA pattern

### DIFF
--- a/assets/src/scss/base/_colors.scss
+++ b/assets/src/scss/base/_colors.scss
@@ -14,6 +14,7 @@ $grey-05: #f5f7f8;
 $gp-green: #66cc00;
 $gp-green-80: #8bcc49;
 $gp-green-20: #e3f2d3;
+$dark-green: #019433;
 
 // Blue
 $blue: #2077bf;

--- a/assets/src/scss/base/_palette.scss
+++ b/assets/src/scss/base/_palette.scss
@@ -11,7 +11,8 @@ $palette: (
   "dark-blue": $dark-blue,
   "blue": $blue,
   "orange-hover": $orange-hover,
-  "yellow": $yellow
+  "yellow": $yellow,
+  "dark-green": $dark-green,
 );
 
 @each $name, $color in $palette {
@@ -21,5 +22,8 @@ $palette: (
 
   .has-#{$name}-background-color {
     background-color: $color;
+
+    --transparent-button--hover--color: #{$color};
+    --transparent-button--active--color: #{$color};
   }
 }

--- a/assets/src/scss/components/_buttons.scss
+++ b/assets/src/scss/components/_buttons.scss
@@ -287,3 +287,17 @@ button.load-more-mt {
   padding: 0 $sp-2;
   transition-duration: 100ms;
 }
+
+.wp-block-button.transparent-button a {
+  --transparent-button-- {
+    border-color: $white;
+    color: $white;
+    background: transparent;
+
+    &:hover,
+    &:active {
+      background: $white;
+      color: $grey-80;
+    }
+  }
+}

--- a/assets/src/scss/editorOverrides.scss
+++ b/assets/src/scss/editorOverrides.scss
@@ -126,6 +126,14 @@
   }
 }
 
+.wp-block-button.transparent-button .wp-block-button__link[role="textbox"] {
+  --transparent-button-- {
+    border-color: $white;
+    color: $white;
+    background: transparent;
+  }
+}
+
 .editor-styles-wrapper p {
   // Matches https://github.com/greenpeace/planet4-master-theme/blob/ab3ee3a5fd7975fcdb71f633d9ce8704003306e8/assets/src/scss/base/_typography.scss#L11-L19.
   // We need to redeclare with a different selector here, because a core script sets a higher specificity.


### PR DESCRIPTION
### Description

See [PLANET-6668](https://jira.greenpeace.org/browse/PLANET-6668), the [example page](https://www-dev.greenpeace.org/gutenberg/new-p4-blocks/) and the [designs](https://www.figma.com/file/leueo1LMrlPabJkZYs2NgW/IA%26nav_Final-mockups?node-id=1%3A1650)
This PR includes adding the "Dark Green" color to our palette, and creating the transparent button styles.

**Related PR:** https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/814

### Testing

You can test the new pattern on [this page](https://www-dev.greenpeace.org/test-oberon/51007-2/) for example, or on your local.