### PR TITLE
Move Features into Settings\Features

### DIFF
--- a/load-class-aliases.php
+++ b/load-class-aliases.php
@@ -32,3 +32,5 @@ class_alias( \P4\MasterTheme\Smartsheet::class, 'P4_Smartsheet' );
 class_alias( \P4\MasterTheme\SmartsheetClient::class, 'P4_Smartsheet_Client' );
 class_alias( \P4\MasterTheme\TaxonomyCampaign::class, 'P4_Taxonomy_Campaign' );
 class_alias( \P4\MasterTheme\User::class, 'P4_User' );
+
+class_alias( \P4\MasterTheme\Settings\Features::class, \P4\MasterTheme\Features::class );

--- a/src/ImageArchive/Rest.php
+++ b/src/ImageArchive/Rest.php
@@ -4,7 +4,6 @@ namespace P4\MasterTheme\ImageArchive;
 
 use Exception;
 use P4\MasterTheme\Capability;
-use P4\MasterTheme\Features;
 use P4\MasterTheme\Exception\RemoteCallFailed;
 use P4\MasterTheme\Features\ImageArchive;
 use WP_Http;

--- a/src/ImageArchive/UiIntegration.php
+++ b/src/ImageArchive/UiIntegration.php
@@ -4,7 +4,6 @@ namespace P4\MasterTheme\ImageArchive;
 
 use P4\MasterTheme\Capability;
 use P4\MasterTheme\Exception\RemoteCallFailed;
-use P4\MasterTheme\Features;
 use P4\MasterTheme\Features\ImageArchive;
 use P4\MasterTheme\Loader;
 

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -2,6 +2,7 @@
 
 namespace P4\MasterTheme;
 
+use P4\MasterTheme\Settings\Features;
 use RuntimeException;
 
 /**

--- a/src/Migrations/M006MoveFeaturesToSeparateOption.php
+++ b/src/Migrations/M006MoveFeaturesToSeparateOption.php
@@ -2,7 +2,7 @@
 
 namespace P4\MasterTheme\Migrations;
 
-use P4\MasterTheme\Features;
+use P4\MasterTheme\Settings\Features;
 use P4\MasterTheme\MigrationRecord;
 use P4\MasterTheme\MigrationScript;
 use P4\MasterTheme\Settings;

--- a/src/Notifications/Slack.php
+++ b/src/Notifications/Slack.php
@@ -8,7 +8,6 @@ namespace P4\MasterTheme\Notifications;
 use BracketSpace\Notification\Interfaces\Triggerable;
 use BracketSpace\Notification\Abstracts;
 use Maknz\Slack\Client;
-use P4\MasterTheme\Features;
 use P4\MasterTheme\Settings;
 
 /**

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -5,6 +5,7 @@ namespace P4\MasterTheme;
 use CMB2_Field;
 use P4\MasterTheme\Features\NewDesignNavigationBar;
 use P4\MasterTheme\Settings\Comments;
+use P4\MasterTheme\Settings\Features;
 use P4\MasterTheme\Settings\InformationArchitecture as IA;
 
 /**

--- a/src/Settings/Features.php
+++ b/src/Settings/Features.php
@@ -1,7 +1,9 @@
 <?php
 
-namespace P4\MasterTheme;
+namespace P4\MasterTheme\Settings;
 
+use P4\MasterTheme\CloudflarePurger;
+use P4\MasterTheme\Feature;
 use P4\MasterTheme\Features\CloudflareDeployPurge;
 use P4\MasterTheme\Features\Dev\AllowAllBlocks;
 use P4\MasterTheme\Features\Dev\BetaBlocks;
@@ -15,6 +17,8 @@ use P4\MasterTheme\Features\LazyYoutubePlayer;
 use P4\MasterTheme\Features\NewDesignCountrySelector;
 use P4\MasterTheme\Features\NewDesignNavigationBar;
 use P4\MasterTheme\Features\PurgeOnFeatureChanges;
+use P4\MasterTheme\Loader;
+use P4\MasterTheme\Settings;
 
 /**
  * Wrapper class for accessing feature settings and setting up the settings page.


### PR DESCRIPTION
* This way we don't have an identifier that is both a class name and a
namespace. This actually caused issues doing this rename, where my IDE
incorrectly changed a few usages of things in the `Features` folder.

As suggested in https://github.com/greenpeace/planet4-master-theme/pull/1650#discussion_r829172374