### PR TITLE
Reverse logic on template editor feature

### DIFF
--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -112,9 +112,9 @@ class MasterSite extends TimberSite {
 	protected function hooks() {
 		add_theme_support( 'post-thumbnails' );
 		add_theme_support( 'menus' );
-		if ( WPTemplateEditor::is_active() ) {
+		if ( ! WPTemplateEditor::is_active() ) {
 			// Enable Full Site Editing.
-			add_theme_support( 'block-templates' );
+			remove_theme_support( 'block-templates' );
 		}
 		if ( ! CoreBlockPatterns::is_active() ) {
 			// Disable WP Block Patterns.


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6583

Ref: https://github.com/WordPress/wordpress-develop/blob/f7d2a2ee9d003633e6c729c0835cd4addd23f9b3/src/wp-includes/class-wp-theme.php#L1470

---

It seems that with 5.9 the template editor is enabled by default if there is a `theme.json` present.