### PR TITLE
PLANET-6668 Remove dark green color from our palette

### DIFF
--- a/assets/src/scss/base/_colors.scss
+++ b/assets/src/scss/base/_colors.scss
@@ -14,7 +14,6 @@ $grey-05: #f5f7f8;
 $gp-green: #66cc00;
 $gp-green-80: #8bcc49;
 $gp-green-20: #e3f2d3;
-$dark-green: #019433;
 
 // Blue
 $blue: #2077bf;

--- a/assets/src/scss/base/_palette.scss
+++ b/assets/src/scss/base/_palette.scss
@@ -12,7 +12,6 @@ $palette: (
   "blue": $blue,
   "orange-hover": $orange-hover,
   "yellow": $yellow,
-  "dark-green": $dark-green,
 );
 
 @each $name, $color in $palette {


### PR DESCRIPTION
### Description

See [PLANET-6668](https://jira.greenpeace.org/browse/PLANET-6668)

Houssam  asked that we replace the previously used dark green color by our existing dark blue, since we'll only start using the dark green in our future new identity. Therefore I've removed it from our color palette for now.

**Related PR**: https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/817