### PR TITLE
PLANET-6696 Add white color to visited primary buttons

### DIFF
--- a/assets/src/scss/components/_buttons.scss
+++ b/assets/src/scss/components/_buttons.scss
@@ -91,6 +91,10 @@ $primary-button-box-shadow: 0 2px 5px rgba(0, 0, 0, .25);
     border-color: transparent;
     box-shadow: $primary-button-box-shadow;
 
+    &:visited {
+      color: $white;
+    }
+
     &:hover,
     &:active {
       background: $orange-hover;


### PR DESCRIPTION
### Description

See [PLANET-6696](https://jira.greenpeace.org/browse/PLANET-6696)
This visited color was recently [removed from the generic btn class](https://github.com/greenpeace/planet4-master-theme/commit/c7d37155f9ca66547ef6a3d53ed2db938520c011) but we forgot to add it to the primary class 😬 

### Testing

On your local, you should see your visited primary buttons with the generic link visited color (purple) on `master` branch, whereas on this branch you should see them with the white color.