### PR TITLE
PLANET-6730 Split post css

### DIFF
--- a/assets/src/scss/pages/post/_article-content.scss
+++ b/assets/src/scss/pages/post/_article-content.scss
@@ -58,11 +58,6 @@
     }
   }
 
-  blockquote,
-  blockquote > p {
-    @include blockquote;
-  }
-
   p {
     margin: 0 0 18px 0;
     overflow-wrap: break-word;
@@ -218,20 +213,6 @@
 
     br + br {
       display: none;
-    }
-  }
-
-  .more-link {
-    @extend .btn;
-    @extend .btn-secondary;
-    @extend .btn-large;
-  }
-
-  .page-links {
-    a {
-      @extend .btn;
-      @extend .btn-secondary;
-      @extend .btn-small;
     }
   }
 

--- a/assets/src/scss/pages/post/_post.scss
+++ b/assets/src/scss/pages/post/_post.scss
@@ -1,96 +1,90 @@
-.single-post,
-.single-attachment,
-.single-idea {
-  @include large-and-up {
-    .narrow-container {
-      margin-left: auto;
-      margin-right: auto;
-      max-width: 776px;
-      padding: 0;
-    }
+@include large-and-up {
+  .narrow-container {
+    margin-left: auto;
+    margin-right: auto;
+    max-width: 776px;
+    padding: 0;
+  }
+}
+
+@include x-large-and-up {
+  .narrow-container {
+    max-width: 736px;
+  }
+}
+
+.skewed-overlay {
+  mask-image: none;
+}
+
+.page-header-title {
+  color: $grey-80;
+  hyphens: none;
+  max-width: none;
+  margin-bottom: 8px;
+  line-height: 1.2;
+}
+
+.single-post-meta {
+  color: $grey-40;
+  font-size: 14px;
+  font-family: $roboto;
+  border-bottom: 1px solid transparentize($grey-20, 0.5);
+  padding-bottom: 16px;
+  line-height: 24px;
+  margin-bottom: 16px;
+  display: flex;
+  gap: 8px;
+  align-items: end;
+
+  a {
+    color: inherit;
+  }
+}
+
+.single-post-meta-bullet {
+  margin: 0 8px;
+}
+
+.author-pic {
+  border-radius: 50%;
+  object-fit: cover;
+  max-height: 50px;
+}
+
+.single-post-author {
+  display: block;
+  margin: 0;
+  font-weight: 500;
+}
+
+.single-post-time,
+.comment-link {
+  display: inline-block;
+  margin: 0;
+}
+
+.comment-link {
+  font-weight: 500;
+
+  img {
+    width: 17px;
   }
 
-  @include x-large-and-up {
-    .narrow-container {
-      max-width: 736px;
-    }
+  svg {
+    top: -2px;
   }
+}
 
-  .skewed-overlay {
-    mask-image: none;
+.articles-block {
+  border-top: 1px solid transparentize($grey-20, 0.5);
+  padding-top: 16px;
+
+  @include medium-and-up {
+    padding-top: 24px;
   }
+}
 
-  .page-header {
-    .page-header-title {
-      color: $grey-80;
-      hyphens: none;
-      max-width: none;
-      margin-bottom: 8px;
-      line-height: 1.2;
-    }
-
-    .single-post-meta {
-      color: $grey-40;
-      font-size: 14px;
-      font-family: $roboto;
-      border-bottom: 1px solid transparentize($grey-20, 0.5);
-      padding-bottom: 16px;
-      line-height: 24px;
-      margin-bottom: 16px;
-      display: flex;
-      gap: 8px;
-      align-items: end;
-
-      a {
-        color: inherit;
-      }
-
-      .single-post-meta-bullet {
-        margin: 0 8px;
-      }
-
-      .author-pic {
-        border-radius: 50%;
-        object-fit: cover;
-        max-height: 50px;
-      }
-
-      .single-post-author {
-        display: block;
-        margin: 0;
-        font-weight: 500;
-      }
-
-      .single-post-time,
-      .comment-link {
-        display: inline-block;
-        margin: 0;
-      }
-
-      .comment-link {
-        font-weight: 500;
-
-        img {
-          width: 17px;
-        }
-
-        svg {
-          top: -2px;
-        }
-      }
-    }
-  }
-
-  .post-articles-block .articles-block {
-    border-top: 1px solid transparentize($grey-20, 0.5);
-    padding-top: 16px;
-
-    @include medium-and-up {
-      padding-top: 24px;
-    }
-  }
-
-  .post-tags {
-    margin-bottom: $sp-2;
-  }
+.post-tags {
+  margin-bottom: $sp-2;
 }

--- a/assets/src/scss/post.scss
+++ b/assets/src/scss/post.scss
@@ -1,0 +1,12 @@
+@import "base/variables";
+@import "base/colors";
+@import "base/fonts";
+@import "base/functions";
+@import "base/mixins";
+
+// Posts
+@import "pages/post/post";
+@import "pages/post/article-content";
+@import "pages/post/author-block";
+@import "pages/post/comments-block";
+@import "pages/post/comments-form";

--- a/assets/src/scss/style.scss
+++ b/assets/src/scss/style.scss
@@ -48,13 +48,6 @@ Text Domain: planet4-master-theme
 @import "layout/skewed-overlay";
 @import "layout/tables";
 
-// Posts
-@import "pages/post/post";
-@import "pages/post/article-content";
-@import "pages/post/author-block";
-@import "pages/post/comments-block";
-@import "pages/post/comments-form";
-
 // Pages
 @import "pages/page";
 @import "pages/sitemap";

--- a/src/PublicAssets.php
+++ b/src/PublicAssets.php
@@ -108,7 +108,7 @@ final class PublicAssets {
 		Loader::enqueue_versioned_style( $country_selector_file, 'country-selector', [ 'parent-style' ] );
 
 		$post_type = get_post_type();
-		if ( in_array( $post_type, [ 'post', 'attachment', 'idea' ], true ) ) {
+		if ( is_single() && in_array( $post_type, [ 'post', 'attachment', 'idea' ], true ) ) {
 			Loader::enqueue_versioned_style(
 				'/assets/build/post.min.css',
 				'post-type--post',

--- a/src/PublicAssets.php
+++ b/src/PublicAssets.php
@@ -106,5 +106,14 @@ final class PublicAssets {
 		$country_selector_version = NewDesignCountrySelector::is_active() ? 'new' : 'old';
 		$country_selector_file    = '/assets/build/country-selector-' . $country_selector_version . '.min.css';
 		Loader::enqueue_versioned_style( $country_selector_file, 'country-selector', [ 'parent-style' ] );
+
+		$post_type = get_post_type();
+		if ( in_array( $post_type, [ 'post', 'attachment', 'idea' ], true ) ) {
+			Loader::enqueue_versioned_style(
+				'/assets/build/post.min.css',
+				'post-type--post',
+				[ 'parent-style' ]
+			);
+		}
 	}
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -21,6 +21,7 @@ module.exports = {
   entry: {
     index: './assets/src/js/app.js',
     style: './assets/src/scss/style.scss',
+    post: './assets/src/scss/post.scss',
     editorStyle: './assets/src/scss/editorStyle.scss',
     bootstrap: './assets/src/scss/bootstrap-build.scss',
     "country-selector-old": './assets/src/scss/partials/country-selector-old.scss',


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6730

Easier [with whitespace hidden](https://github.com/greenpeace/planet4-master-theme/pull/1660/files?diff=split&w=1).

Put all CSS that is only needed on posts in a separate entry point. This is then included in the same cases by checking post type before enqueuing (post, attachment, and idea).

TODO:

- [x]  Check child themes on dev sites.
- [x]   * Check whether decreased specificity interferes with overrides.
- [x]   * Check if the separate file is properly enqueued in the right order.
- [x] * Further reduce now obsolete CSS specificity. Perhaps better to do this in a follow up to reduce the chance of child theme regressions. (follow up)