### PR TITLE
PLANET-6154 Skip indexing archived content if Archive feature flag is…

### DIFF
--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -286,6 +286,18 @@ class MasterSite extends TimberSite {
 		// Admin scripts.
 		add_action( 'admin_enqueue_scripts', [ AdminAssets::class, 'enqueue_js' ] );
 
+		// Disable the Elastic search sync, if archive posts feature is disable.
+		add_filter(
+			'ep_indexable_post_types',
+			function ( $post_types ) {
+				$setting = planet4_get_option( 'include_archive_content_for' );
+				if ( isset( $post_types['archive'] ) && 'nobody' === $setting ) {
+					unset( $post_types['archive'] );
+				}
+				return $post_types;
+			}
+		);
+
 		$this->register_meta_fields();
 	}
 

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -196,6 +196,10 @@ class Settings {
 				'fields' => [
 					[
 						'name'    => __( 'Include archived content in search for', 'planet4-master-theme-backend' ),
+						'desc'    => __(
+							'<b>Important:</b> On change of Include archive content setting, Please kindly',
+							'planet4-master-theme-backend'
+						) . ' <a href="admin.php?page=elasticpress&do_sync" target="_blank">Sync Elasticsearch</a>.',
 						'id'      => 'include_archive_content_for',
 						'type'    => 'select',
 						'default' => 'nobody',


### PR DESCRIPTION
… off

Added a notice for admins to re-sync the ES index.

Ref. https://jira.greenpeace.org/browse/PLANET-6154

---

**Task:**
- Skip indexing archived content if Archive feature flag is off. 
- Add a notice for admins to re-sync the ES index.

**Testing:**
- On local dev env, first ensure you have a achieve posts or add manually few posts(WP admin >> Archive >> Add new)
- Go to WP admin >> ElasticPress >> Index Health, check the Total size here
- Toggle the Include archive content setting from, Wp admin >> Planet 4 >> Search Content
- Check the changes in Total size in ElasticPress Index health menu 
- You can also test it on [titan test instance](https://www-dev.greenpeace.org/test-titan/wp-admin/admin.php?page=planet4_settings_search_content).

The number of post sync can observe in elasticpress sync status bar as below -

1. Include archive content for all users -
![image](https://user-images.githubusercontent.com/5357471/161700231-3d93a4d7-d416-4678-b35a-b851d0c3901f.png)

2. Include archive content for nobody -
![image](https://user-images.githubusercontent.com/5357471/161700394-1a4b9540-cad0-4ddf-9064-562eeb94d3fd.png)
