### PR TITLE
PLANET-6690 Use secondary style by default on buttons in the editor

### DIFF
--- a/assets/src/scss/editorOverrides.scss
+++ b/assets/src/scss/editorOverrides.scss
@@ -90,6 +90,10 @@
   overflow: hidden;
   text-overflow: ellipsis;
 
+  &.has-background {
+    border-color: transparent;
+  }
+
   html[dir="rtl"] & {
     line-height: 2.5;
   }
@@ -101,6 +105,10 @@
     border-color: $orange;
     color: $white;
     box-shadow: 0 2px 5px rgba(0, 0, 0, .25);
+  }
+
+  &.has-background {
+    border-color: transparent;
   }
 }
 

--- a/assets/src/scss/editorOverrides.scss
+++ b/assets/src/scss/editorOverrides.scss
@@ -62,7 +62,6 @@
   font-family: $roboto;
   text-align: center;
   text-decoration: none;
-  color: $white;
   font-weight: bold;
   border-radius: 4px;
   border: 1px solid transparent;
@@ -76,6 +75,7 @@
   font-size: $font-size-sm;
 }
 
+.wp-block-button .wp-block-button__link[role="textbox"],
 .wp-block-button.is-style-secondary .wp-block-button__link[role="textbox"],
 [class="wp-block-button"] .wp-block-button__link[role="textbox"] {
   --button-secondary-- {


### PR DESCRIPTION
### Description

See [PLANET-6690](https://jira.greenpeace.org/browse/PLANET-6690)
This is only for the Button block, other block overrides will be handled in another PR. 

**Related PR:** https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/823

### Testing

You can test this on your local or on the [titan test instance](https://www-dev.greenpeace.org/test-titan/), by adding a Button block in the backend. It should by default have the secondary style, and the only other available style should be `Primary` (`Donate` has been removed from the style picker, all the corresponding classes and styles will be removed later as part of [PLANET-6698](https://jira.greenpeace.org/browse/PLANET-6698)). Please also make sure the buttons are still correctly styled in the frontend too.