### PR TITLE
PLANET-6702: Fix Mobile nav link color

### DIFF
--- a/assets/src/scss/layout/navbar/mobile.scss
+++ b/assets/src/scss/layout/navbar/mobile.scss
@@ -47,12 +47,9 @@
   }
 
   .nav-link {
+    color: var(--nav-link--color, transparentize($white, 0.5));
     white-space: nowrap;
     padding: 0;
-
-    &:not(:hover) {
-      opacity: 0.5;
-    }
 
     &:hover {
       text-decoration-line: none;
@@ -61,6 +58,7 @@
   }
 
   .active .nav-link {
+    color: var(--nav-link--active--color, $white);
     opacity: 1;
     text-decoration: none;
   }

--- a/assets/src/scss/partials/navigation-bar-light.scss
+++ b/assets/src/scss/partials/navigation-bar-light.scss
@@ -18,5 +18,6 @@
 
 #nav-mobile-menu {
   --nav-link--color: #{$grey-40};
+  --nav-link--active--color: #{$black};
   --nav-link--opacity: 1;
 }


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6702

Demo page (pending)

[Design](https://www.figma.com/file/Gn8wyqgto7608rlESePXZE/Foundations-%26-Components?node-id=0%3A103)

Message from Mag
> I noticed that the tabs menu on mobile doesn’t have the right color when the menu items are with the default state. They should use this color #6F7376

Also fixed active colors on Light and Dark themes.

<img width="415" alt="Screenshot 2022-04-06 at 15 03 53" src="https://user-images.githubusercontent.com/77975803/162044144-761824de-4ffb-46c0-8b79-8e2901eb5383.png">

