### PR TITLE
PLANET-6659 Fix Download file button editor styles

### DIFF
--- a/assets/src/scss/editorOverrides.scss
+++ b/assets/src/scss/editorOverrides.scss
@@ -57,7 +57,8 @@
   }
 }
 
-.wp-block-button .wp-block-button__link[role="textbox"] {
+.wp-block-button .wp-block-button__link[role="textbox"],
+.wp-block-file .wp-block-file__button {
   display: inline-block;
   font-family: $roboto;
   text-align: center;
@@ -77,7 +78,8 @@
 
 .wp-block-button .wp-block-button__link[role="textbox"],
 .wp-block-button.is-style-secondary .wp-block-button__link[role="textbox"],
-[class="wp-block-button"] .wp-block-button__link[role="textbox"] {
+[class="wp-block-button"] .wp-block-button__link[role="textbox"],
+.wp-block-file .wp-block-file__button {
   --button-secondary-- {
     background: transparentize($white, .7);
     border-color: $dark-blue;


### PR DESCRIPTION
### Description

See [PLANET-6659](https://jira.greenpeace.org/browse/PLANET-6659), when fixing the button's styles in the frontend we broke them in the editor 🤦‍♀️ 

### Testing

In your local env, add a "File" block to a page and check the option "Show download button" in the sidebar. In the editor on `master` branch you will see the broken version of that button, but on this branch you should see it styled as a secondary button as expected. Please make sure the frontend still looks good as well 😬 