### PR TITLE
PLANET-6690 Update Table block settings in theme.json

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -35,6 +35,29 @@
             }
           ]
         }
+      },
+      "core/table": {
+        "color": {
+          "defaultPalette": false,
+          "text": false,
+          "palette": [
+            {
+              "color": "#f5f7f8",
+              "name": "Grey",
+              "slug": "grey"
+            },
+            {
+              "color": "#eafee7",
+              "name": "Green",
+              "slug": "green"
+            },
+            {
+              "color": "#e7f5fe",
+              "name": "Blue",
+              "slug": "blue"
+            }
+          ]
+        }
       }
     },
     "layout": {


### PR DESCRIPTION
### Description

See [PLANET-6690](https://jira.greenpeace.org/browse/PLANET-6690)
This includes adding our background color options, plus hiding the text color selector and the default WP color palette. The background color can now be changed for the block in the sidebar, in `Color > Background`.
The only thing I'm wondering is how to implement translations for this file, but that can be handled later 🤔 

**Related PR:** https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/825

### Testing

You can test the new version of the Table block on your local or on the titan test instance, for example on [this page](https://www-dev.greenpeace.org/test-titan/table-block-tests/) I created with all the possible colors!