### PR TITLE
PLANET-6729 Make IA features use feature classes

### DIFF
--- a/single.php
+++ b/single.php
@@ -10,6 +10,7 @@
  */
 
 use P4\MasterTheme\Context;
+use P4\MasterTheme\Features\GdprCheckbox;
 use P4\MasterTheme\Post;
 use Timber\Timber;
 use P4\MasterTheme\Settings\Comments;
@@ -96,7 +97,7 @@ $comments_args = [
 	'submit_button'        => Timber::compile(
 		'comment_form/submit_button.twig',
 		[
-			'gdpr_checkbox' => Comments::is_active( Comments::GDPR_CHECKBOX ),
+			'gdpr_checkbox' => GdprCheckbox::is_active(),
 			'gdpr_label'    => __(
 				'I agree on providing my name, email and content so that my comment can be stored and displayed in the website.',
 				'planet4-master-theme'

--- a/src/ActionPage.php
+++ b/src/ActionPage.php
@@ -2,6 +2,7 @@
 
 namespace P4\MasterTheme;
 
+use P4\MasterTheme\Features\ActionPostType;
 use P4\MasterTheme\Settings\InformationArchitecture as IA;
 
 /**
@@ -38,7 +39,7 @@ class ActionPage {
 	public function register_post_type() {
 
 		// IA: display action page type in admin sidebar.
-		$enable_action_post_type = IA::is_active( IA::ACTION_POST_TYPE ) ? true : false;
+		$enable_action_post_type = ActionPostType::is_active();
 
 		$labels = [
 			'name'               => _x( 'Actions', 'post type general name', 'planet4-master-theme-backend' ),

--- a/src/Feature.php
+++ b/src/Feature.php
@@ -98,4 +98,16 @@ abstract class Feature {
 			'type' => 'checkbox',
 		];
 	}
+
+	/**
+	 * Enable the feature.
+	 *
+	 * @return void
+	 */
+	public static function enable(): void {
+		$settings = get_option( static::options_key(), [] );
+
+		$settings[ static::id() ] = 'on';
+		update_option( static::options_key(), $settings );
+	}
 }

--- a/src/Feature.php
+++ b/src/Feature.php
@@ -93,10 +93,19 @@ abstract class Feature {
 	public static function get_cmb_field(): array {
 		return [
 			'id'   => static::id(),
-			'name' => static::name(),
-			'desc' => static::description(),
+			'name' => self::dev_prefix( '👷' ) . static::name(),
+			'desc' => self::dev_prefix( '(dev only)' ) . static::description(),
 			'type' => 'checkbox',
 		];
+	}
+
+	/**
+	 * @param string $prefix Prefix to add in case of dev env.
+	 *
+	 * @return string A prefix in case this is a dev only toggle.
+	 */
+	private static function dev_prefix( string $prefix ): string {
+		return static::show_toggle_production() ? '' : "$prefix ";
 	}
 
 	/**

--- a/src/Feature.php
+++ b/src/Feature.php
@@ -34,6 +34,13 @@ abstract class Feature {
 	abstract protected static function description(): string;
 
 	/**
+	 * @return string The options key the feature is stored in.
+	 */
+	protected static function options_key(): string {
+		return self::OPTIONS_KEY;
+	}
+
+	/**
 	 * This determines whether to include the toggle on the feature settings page. It doesn't prevent a feature from
 	 * being active if enabled already.
 	 *
@@ -62,7 +69,7 @@ abstract class Feature {
 		if ( static::is_generally_available() ) {
 			return true;
 		}
-		$features = get_option( self::OPTIONS_KEY );
+		$features = get_option( static::options_key() );
 
 		// Temporary fallback to ensure it works before migration runs.
 		if ( ! $features ) {

--- a/src/Features/ActionPostType.php
+++ b/src/Features/ActionPostType.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace P4\MasterTheme\Features;
+
+use P4\MasterTheme\Feature;
+use P4\MasterTheme\Settings\InformationArchitecture;
+
+/**
+ * @see description().
+ */
+class ActionPostType extends Feature {
+
+	/**
+	 * @inheritDoc
+	 */
+	public static function id(): string {
+		return 'action_post_type';
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected static function name(): string {
+		return __( 'Action post type', 'planet4-master-theme-backend' );
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected static function description(): string {
+		return __(
+			'Enable Action post type',
+			'planet4-master-theme-backend'
+		);
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected static function options_key(): string {
+		return InformationArchitecture::OPTIONS_KEY;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public static function show_toggle_production(): bool {
+		return true;
+	}
+}

--- a/src/Features/GdprCheckbox.php
+++ b/src/Features/GdprCheckbox.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace P4\MasterTheme\Features;
+
+use P4\MasterTheme\Feature;
+use P4\MasterTheme\Settings\Comments;
+
+/**
+ * @see description().
+ */
+class GdprCheckbox extends Feature {
+
+	/**
+	 * @inheritDoc
+	 */
+	public static function id(): string {
+		return 'gdpr_checkbox';
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected static function name(): string {
+		return __( 'Display Opt-in checkbox', 'planet4-master-theme-backend' );
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected static function description(): string {
+		return __(
+			'This will display an opt-in checkbox in the Comments form which will be mandatory for submitting the form (GDPR requirement).',
+			'planet4-master-theme-backend'
+		);
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected static function options_key(): string {
+		return Comments::OPTIONS_KEY;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public static function show_toggle_production(): bool {
+		return true;
+	}
+}

--- a/src/Features/MobileTabsMenu.php
+++ b/src/Features/MobileTabsMenu.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace P4\MasterTheme\Features;
+
+use P4\MasterTheme\Feature;
+use P4\MasterTheme\Settings\InformationArchitecture;
+
+/**
+ * @see description().
+ */
+class MobileTabsMenu extends Feature {
+
+	/**
+	 * @inheritDoc
+	 */
+	public static function id(): string {
+		return 'mobile_tabs_menu';
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected static function name(): string {
+		return __( 'Enable mobile tabs menu', 'planet4-master-theme-backend' );
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected static function description(): string {
+		return __(
+			'Display a sticky tabs menu visible on screen width smaller than 992px.',
+			'planet4-master-theme-backend'
+		);
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected static function options_key(): string {
+		return InformationArchitecture::OPTIONS_KEY;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public static function show_toggle_production(): bool {
+		return true;
+	}
+}

--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -5,6 +5,7 @@ namespace P4\MasterTheme;
 use P4\MasterTheme\Features\Dev\CoreBlockPatterns;
 use P4\MasterTheme\Features\Dev\WPTemplateEditor;
 use P4\MasterTheme\Features\LazyYoutubePlayer;
+use P4\MasterTheme\Features\MobileTabsMenu;
 use P4\MasterTheme\Features\NewDesignCountrySelector;
 use P4\MasterTheme\Features\NewDesignNavigationBar;
 use Timber\Timber;
@@ -16,7 +17,6 @@ use Twig_SimpleFilter;
 use WP_Error;
 use WP_Post;
 use WP_User;
-use P4\MasterTheme\Settings\InformationArchitecture as IA;
 
 /**
  * Class MasterSite.
@@ -629,7 +629,7 @@ class MasterSite extends TimberSite {
 		$context['new_design_navigation_bar']   = NewDesignNavigationBar::is_active();
 
 		// IA: Tabs menu on mobile.
-		$context['mobile_tabs_menu'] = IA::is_active( IA::MOBILE_TABS_MENU );
+		$context['mobile_tabs_menu'] = MobileTabsMenu::is_active();
 
 		return $context;
 	}

--- a/src/Migrations/M001EnableEnFormFeature.php
+++ b/src/Migrations/M001EnableEnFormFeature.php
@@ -5,7 +5,6 @@ namespace P4\MasterTheme\Migrations;
 use P4\MasterTheme\Features;
 use P4\MasterTheme\MigrationRecord;
 use P4\MasterTheme\MigrationScript;
-use P4\MasterTheme\Settings;
 
 /**
  * Turn on the EN form feature everywhere.
@@ -20,9 +19,6 @@ class M001EnableEnFormFeature extends MigrationScript {
 	 * @return void
 	 */
 	protected static function execute( MigrationRecord $record ): void {
-		$settings = get_option( Settings::KEY, [] );
-
-		$settings[ Features\EngagingNetworks::id() ] = 'on';
-		update_option( Settings::KEY, $settings );
+		Features\EngagingNetworks::enable();
 	}
 }

--- a/src/Migrations/M002EnableLazyYoutube.php
+++ b/src/Migrations/M002EnableLazyYoutube.php
@@ -20,9 +20,6 @@ class M002EnableLazyYoutube extends MigrationScript {
 	 * @return void
 	 */
 	protected static function execute( MigrationRecord $record ): void {
-		$settings = get_option( Settings::KEY, [] );
-
-		$settings[ Features\LazyYoutubePlayer::id() ] = 'on';
-		update_option( Settings::KEY, $settings );
+		Features\LazyYoutubePlayer::enable();
 	}
 }

--- a/src/Migrations/M010RemoveGdprPluginOptions.php
+++ b/src/Migrations/M010RemoveGdprPluginOptions.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace P4\MasterTheme\Migrations;
 
+use P4\MasterTheme\Features\GdprCheckbox;
 use P4\MasterTheme\MigrationRecord;
 use P4\MasterTheme\MigrationScript;
 use P4\MasterTheme\Settings\Comments;
@@ -26,7 +27,7 @@ class M010RemoveGdprPluginOptions extends MigrationScript {
 
 		$options = \get_option( Comments::OPTIONS_KEY ) ?? [];
 
-		$options[ Comments::GDPR_CHECKBOX ] = 'on';
+		$options[ GdprCheckbox::id() ] = 'on';
 		\update_option( Comments::OPTIONS_KEY, $options );
 	}
 }

--- a/src/Migrations/M010RemoveGdprPluginOptions.php
+++ b/src/Migrations/M010RemoveGdprPluginOptions.php
@@ -7,7 +7,6 @@ namespace P4\MasterTheme\Migrations;
 use P4\MasterTheme\Features\GdprCheckbox;
 use P4\MasterTheme\MigrationRecord;
 use P4\MasterTheme\MigrationScript;
-use P4\MasterTheme\Settings\Comments;
 
 /**
  * Remove GDPR Comments plugin options
@@ -25,9 +24,6 @@ class M010RemoveGdprPluginOptions extends MigrationScript {
 		\deactivate_plugins( 'gdpr-comments/gdpr-comments.php' );
 		\delete_option( 'gdpr_comments' );
 
-		$options = \get_option( Comments::OPTIONS_KEY ) ?? [];
-
-		$options[ GdprCheckbox::id() ] = 'on';
-		\update_option( Comments::OPTIONS_KEY, $options );
+		GdprCheckbox::enable();
 	}
 }

--- a/src/Settings/Comments.php
+++ b/src/Settings/Comments.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace P4\MasterTheme\Settings;
 
+use P4\MasterTheme\Features\GdprCheckbox;
 use P4\MasterTheme\Loader;
 
 /**
@@ -12,9 +13,6 @@ use P4\MasterTheme\Loader;
 class Comments {
 	/** @var string Option key */
 	public const OPTIONS_KEY = 'planet4_comments';
-
-	/* @var string Mobile tabs option key **/
-	public const GDPR_CHECKBOX = 'gdpr_checkbox';
 
 	/**
 	 * Get the features options page settings.
@@ -39,43 +37,8 @@ class Comments {
 	 * @return array  The fields.
 	 */
 	public static function get_fields(): array {
-		$fields = [
-			[
-				'id'   => self::GDPR_CHECKBOX,
-				'name' => __( 'Display Opt-in checkbox', 'planet4-master-theme-backend' ),
-				'desc' => __(
-					'This will display an opt-in checkbox in the Comments form which will be mandatory for submitting the form (GDPR requirement).',
-					'planet4-master-theme-backend'
-				),
-				'type' => 'checkbox',
-			],
+		return [
+			GdprCheckbox::get_cmb_field(),
 		];
-
-		return $fields;
-	}
-
-	/**
-	 * Check whether an option is active.
-	 *
-	 * @param string $name Name of the option we're checking.
-	 *
-	 * @return bool Whether the option is active.
-	 */
-	public static function is_active( string $name ): bool {
-		return ! empty( self::get( $name ) );
-	}
-
-	/**
-	 * Return option value.
-	 *
-	 * @param string $name    Name of the option.
-	 * @param mixed  $default Default value.
-	 *
-	 * @return mixed
-	 */
-	public static function get( string $name, $default = null ) {
-		$options = get_option( self::OPTIONS_KEY );
-
-		return isset( $options[ $name ] ) ? $options[ $name ] : $default;
 	}
 }

--- a/src/Settings/InformationArchitecture.php
+++ b/src/Settings/InformationArchitecture.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace P4\MasterTheme\Settings;
 
+use P4\MasterTheme\Features\ActionPostType;
+use P4\MasterTheme\Features\MobileTabsMenu;
 use P4\MasterTheme\Loader;
 
 /**
@@ -14,12 +16,6 @@ use P4\MasterTheme\Loader;
 class InformationArchitecture {
 	/** @var string Option key */
 	public const OPTIONS_KEY = 'planet4_ia';
-
-	/* @var string Mobile tabs option key **/
-	public const MOBILE_TABS_MENU = 'mobile_tabs_menu';
-
-	/* @var string feature flag of action page type option key **/
-	public const ACTION_POST_TYPE = 'action_post_type';
 
 	/**
 	 * Get the features options page settings.
@@ -44,52 +40,9 @@ class InformationArchitecture {
 	 * @return array  The fields.
 	 */
 	public static function get_fields(): array {
-		$fields = [
-			[
-				'id'   => self::MOBILE_TABS_MENU,
-				'name' => __( 'Enable mobile tabs menu', 'planet4-master-theme-backend' ),
-				'desc' => __(
-					'Display a sticky tabs menu visible on screen width smaller than 992px.',
-					'planet4-master-theme-backend'
-				),
-				'type' => 'checkbox',
-			],
-			[
-				'id'   => self::ACTION_POST_TYPE,
-				'name' => __( 'Action post type', 'planet4-master-theme-backend' ),
-				'desc' => __(
-					'Enable Action post type',
-					'planet4-master-theme-backend'
-				),
-				'type' => 'checkbox',
-			],
+		return [
+			MobileTabsMenu::get_cmb_field(),
+			ActionPostType::get_cmb_field(),
 		];
-
-		return $fields;
-	}
-
-	/**
-	 * Check whether an option is active.
-	 *
-	 * @param string $name Name of the option we're checking.
-	 *
-	 * @return bool Whether the option is active.
-	 */
-	public static function is_active( string $name ): bool {
-		return ! empty( self::get( $name ) );
-	}
-
-	/**
-	 * Return option value.
-	 *
-	 * @param string $name    Name of the option.
-	 * @param mixed  $default Default value.
-	 *
-	 * @return mixed
-	 */
-	public static function get( string $name, $default = null ) {
-		$options = get_option( self::OPTIONS_KEY );
-
-		return isset( $options[ $name ] ) ? $options[ $name ] : $default;
 	}
 }

--- a/src/Settings/InformationArchitecture.php
+++ b/src/Settings/InformationArchitecture.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace P4\MasterTheme\Settings;
 
+use P4\MasterTheme\Feature;
 use P4\MasterTheme\Features\ActionPostType;
 use P4\MasterTheme\Features\MobileTabsMenu;
 use P4\MasterTheme\Loader;
@@ -16,6 +17,9 @@ use P4\MasterTheme\Loader;
 class InformationArchitecture {
 	/** @var string Option key */
 	public const OPTIONS_KEY = 'planet4_ia';
+
+	/* @var string feature flag of action page type option key. Preserved here because plugin uses it. **/
+	public const ACTION_POST_TYPE = 'action_post_type';
 
 	/**
 	 * Get the features options page settings.
@@ -44,5 +48,18 @@ class InformationArchitecture {
 			MobileTabsMenu::get_cmb_field(),
 			ActionPostType::get_cmb_field(),
 		];
+	}
+
+	/**
+	 * Check whether an option is active.
+	 *
+	 * @param string $name Name of the option we're checking.
+	 *
+	 * @return bool Whether the option is active.
+	 */
+	public static function is_active( string $name ): bool {
+		$options = get_option( self::OPTIONS_KEY );
+
+		return 'on' === $options[ $name ];
 	}
 }


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6729

I missed this part while rebasing the feature classes introduced in https://github.com/greenpeace/planet4-master-theme/pull/1650.

Create a class combining each feature's info.

I had to preserve `is_active` to avoid chicken and egg situation in the tests, as the plugin also uses it.

I also included a convenience method for enabling, to use in upgrade scripts.

Last minute we added a small improvement to distinguish dev only toggles. Created separate ticket [PLANET-6728](https://jira.greenpeace.org/browse/PLANET-6728) for the release notes.