### PR TITLE
PLANET-6671: Log cookie issue

### DIFF
--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -127,6 +127,7 @@ class MasterSite extends TimberSite {
 		add_filter( 'get_twig', [ $this, 'add_to_twig' ] );
 		add_action( 'init', [ $this, 'register_taxonomies' ], 2 );
 		add_action( 'init', [ $this, 'register_oembed_provider' ] );
+		add_action( 'init', [ $this, 'log_large_cookies' ] );
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_admin_assets' ] );
 		// Load the editor scripts only enqueuing editor scripts while in context of the editor.
 		add_action( 'enqueue_block_editor_assets', [ $this, 'enqueue_editor_assets' ] );
@@ -299,6 +300,23 @@ class MasterSite extends TimberSite {
 		);
 
 		$this->register_meta_fields();
+	}
+
+	/**
+	 * Log large cookies event to sentry.
+	 */
+	public function log_large_cookies(): void {
+		if ( ! function_exists( '\\Sentry\\captureMessage' ) ) {
+			return;
+		}
+
+		if ( empty( $_SERVER['HTTP_COOKIE'] )
+			|| strlen( $_SERVER['HTTP_COOKIE'] ) <= 4096
+		) {
+			return;
+		}
+
+		\Sentry\captureMessage( 'Large cookies detected' );
 	}
 
 	/**


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6671

> Nginx: Request Header Or Cookie Too Large
> Editors get this error sometimes. Workaround is to clear their cookies.

It is possible to replicate the issue with a header over 8KB.
We want to understand if some specific cookies are growing over a certain limit. Log to sentry when cookies are over 4KB.

Capture example: https://sentry.greenpeace.org/organizations/greenpeace-org/issues/138/?project=2&query=is%3Aunresolved

I thought about logging only 1 in 2/10 events in case we have a lot, but this situation shouldn't be too common.