### PR TITLE
PLANET-6552: Rewrite Search filters to follow native taxonomies

### DIFF
--- a/src/ElasticSearch.php
+++ b/src/ElasticSearch.php
@@ -27,6 +27,7 @@ class ElasticSearch extends Search {
 						case 'cat':
 						case 'tag':
 						case 'ptype':
+						case 'atype':
 							break;
 						case 'ctype':
 							switch ( $filter['id'] ) {
@@ -72,6 +73,7 @@ class ElasticSearch extends Search {
 									);
 									break;
 								case 5:
+								case 6:
 									break;
 								default:
 									throw new UnexpectedValueException( 'Unexpected content type!' );
@@ -212,29 +214,34 @@ class ElasticSearch extends Search {
 			'with_post_filter' => [
 				'filter' => $formatted_args['post_filter'],
 				'aggs'   => [
-					'post_type'    => [
+					'post_type'          => [
 						'terms' => [
 							'field' => 'post_type.raw',
 						],
 					],
-					'post_parent'  => [
+					'post_parent'        => [
 						'terms' => [
 							'field' => 'post_parent',
 						],
 					],
-					'categories'   => [
+					'categories'         => [
 						'terms' => [
 							'field' => 'terms.category.term_id',
 						],
 					],
-					'tags'         => [
+					'tags'               => [
 						'terms' => [
 							'field' => 'terms.post_tag.term_id',
 						],
 					],
-					'p4-page-type' => [
+					'p4-page-type'       => [
 						'terms' => [
 							'field' => 'terms.p4-page-type.term_id',
+						],
+					],
+					ActionPage::TAXONOMY => [
+						'terms' => [
+							'field' => 'terms.' . ActionPage::TAXONOMY . '.term_id',
 						],
 					],
 				],

--- a/src/Search/Filters/ActionTypes.php
+++ b/src/Search/Filters/ActionTypes.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace P4\MasterTheme\Search\Filters;
+
+use P4\MasterTheme\ActionPage;
+
+/**
+ * Action types used for search (Petition, Event, etc.).
+ */
+class ActionTypes {
+	/**
+	 * Get all content types.
+	 *
+	 * @return array<WP_Post_Type>
+	 */
+	public static function get_all(): array {
+		return get_terms(
+			[
+				'taxonomy'   => ActionPage::TAXONOMY,
+				'hide_empty' => false,
+			]
+		);
+	}
+
+	/**
+	 * @return array{int, array{term_id: int, name: string, results: int}}
+	 */
+	public static function get_filters(): array {
+		$types   = self::get_all();
+		$filters = [];
+
+		foreach ( $types as $type ) {
+			$filters[ $type->term_id ] = [
+				'term_id' => $type->term_id,
+				'name'    => $type->name,
+				'results' => 0,
+			];
+		}
+
+		return $filters;
+	}
+}

--- a/src/Search/Filters/Categories.php
+++ b/src/Search/Filters/Categories.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace P4\MasterTheme\Search\Filters;
+
+/**
+ * Categories used for search.
+ */
+class Categories {
+	/**
+	 * @return array<WP_Term>
+	 */
+	public static function get_all(): array {
+		return get_categories();
+	}
+
+	/**
+	 * @return array{int, array{term_id: int, name: string, results: int}}
+	 */
+	public static function get_filters(): array {
+		$categories = self::get_all();
+		$filters    = [];
+
+		foreach ( $categories as $category ) {
+			if ( 'uncategorised' === $category->slug ) {
+				continue;
+			}
+
+			$filters[ $category->term_id ] = [
+				'term_id' => $category->term_id,
+				'name'    => $category->name,
+				'results' => 0,
+			];
+		}
+
+		return $filters;
+	}
+}

--- a/src/Search/Filters/ContentTypes.php
+++ b/src/Search/Filters/ContentTypes.php
@@ -13,6 +13,7 @@ class ContentTypes {
 	public const ACT_PAGE   = 'action';
 	public const POST       = 'post';
 	public const PAGE       = 'page';
+	public const ACTION     = 'p4_action';
 	public const CAMPAIGN   = 'campaign';
 	public const ATTACHMENT = 'attachment';
 	public const ARCHIVE    = 'archive';
@@ -66,6 +67,9 @@ class ContentTypes {
 			if ( self::ARCHIVE === $name && ! $include_archive ) {
 				continue;
 			}
+			if ( self::ACTION === $name && ! $include_action ) {
+				continue;
+			}
 
 			$type_data = $config[ $type->name ] ?? null;
 			if ( ! $type_data ) {
@@ -112,6 +116,10 @@ class ContentTypes {
 			self::ARCHIVE    => [
 				'id'    => 5,
 				'label' => __( 'Archive', 'planet4-master-theme' ),
+			],
+			self::ACTION     => [
+				'id'    => 6,
+				'label' => __( 'Action', 'planet4-master-theme' ),
 			],
 		];
 	}

--- a/src/Search/Filters/ContentTypes.php
+++ b/src/Search/Filters/ContentTypes.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace P4\MasterTheme\Search\Filters;
+
+/**
+ * Content type used for search.
+ * Native types (post, page, attachment, etc.).
+ * Custom types (p4_action, etc.).
+ */
+class ContentTypes {
+	public const ACT_PAGE   = 'action';
+	public const POST       = 'post';
+	public const PAGE       = 'page';
+	public const CAMPAIGN   = 'campaign';
+	public const ATTACHMENT = 'attachment';
+	public const ARCHIVE    = 'archive';
+
+	/**
+	 * Get all content types.
+	 *
+	 * @return array<WP_Post_Type>
+	 */
+	public static function get_all(): array {
+		$config = self::get_config();
+		$types  = get_post_types(
+			[
+				'public'              => true,
+				'exclude_from_search' => false,
+			],
+			false
+		);
+
+		return array_filter(
+			$types,
+			function ( $type ) use ( $config ) {
+				return isset( $config[ $type->name ] );
+			}
+		);
+	}
+
+	/**
+	 * @param bool $include_archive Include archive type.
+	 * @param bool $include_action Include p4_action type.
+	 *
+	 * @return array{string, array{id: int, name: string, results: int}}
+	 */
+	public static function get_filters(
+		bool $include_archive = false,
+		bool $include_action = false
+	): array {
+		$types  = self::get_all();
+		$config = self::get_config();
+
+		// ACT_PAGE are sub-pages of the Act page and not a real type, adding manually.
+		$filters = [
+			0 => [
+				'id'      => 0,
+				'name'    => __( 'Action', 'planet4-master-theme' ),
+				'results' => 0,
+			],
+		];
+
+		foreach ( $types as $name => $type ) {
+			if ( self::ARCHIVE === $name && ! $include_archive ) {
+				continue;
+			}
+
+			$type_data = $config[ $type->name ] ?? null;
+			if ( ! $type_data ) {
+				continue;
+			}
+
+			$filters[ $type_data['id'] ] = [
+				'id'      => $type_data['id'],
+				'name'    => $type_data['label'],
+				'results' => 0,
+			];
+		}
+
+		return $filters;
+	}
+
+	/**
+	 * Get all content type config for search
+	 *
+	 * @return array{string, array{id: int, label: string}}
+	 */
+	public static function get_config(): array {
+		return [
+			self::ACT_PAGE   => [
+				'id'    => 0,
+				'label' => __( 'Action', 'planet4-master-theme' ),
+			],
+			self::ATTACHMENT => [
+				'id'    => 1,
+				'label' => __( 'Document', 'planet4-master-theme' ),
+			],
+			self::PAGE       => [
+				'id'    => 2,
+				'label' => __( 'Page', 'planet4-master-theme' ),
+			],
+			self::POST       => [
+				'id'    => 3,
+				'label' => __( 'Post', 'planet4-master-theme' ),
+			],
+			self::CAMPAIGN   => [
+				'id'    => 4,
+				'label' => __( 'Campaign', 'planet4-master-theme' ),
+			],
+			self::ARCHIVE    => [
+				'id'    => 5,
+				'label' => __( 'Archive', 'planet4-master-theme' ),
+			],
+		];
+	}
+}

--- a/src/Search/Filters/PostTypes.php
+++ b/src/Search/Filters/PostTypes.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace P4\MasterTheme\Search\Filters;
+
+use WP_Term;
+
+/**
+ * Post types used for search (Press release, News, Report, etc.).
+ * Configured in `Posts > Posts Types`
+ */
+class PostTypes {
+	/**
+	 * @return WP_Term[]
+	 */
+	public static function get_all(): array {
+		$types = get_terms(
+			[
+				'taxonomy'   => 'p4-page-type',
+				'hide_empty' => false,
+			]
+		);
+
+		if ( is_wp_error( $types )
+			|| ! is_array( $types )
+			|| empty( $types )
+			|| ! ( $types[0] instanceof WP_Term )
+		) {
+			return [];
+		}
+
+		return $types;
+	}
+
+	/**
+	 * @return array{int, array{term_id: int, name: string, results: int}}
+	 */
+	public static function get_filters(): array {
+		$post_types = self::get_all();
+		$filters    = [];
+
+		foreach ( $post_types as $post_type ) {
+			$filters[ $post_type->term_id ] = [
+				'term_id' => $post_type->term_id,
+				'name'    => $post_type->name,
+				'results' => 0,
+			];
+		}
+
+		return $filters;
+	}
+}

--- a/src/Search/Filters/Tags.php
+++ b/src/Search/Filters/Tags.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace P4\MasterTheme\Search\Filters;
+
+use WP_Term;
+
+/**
+ * Tags used for search.
+ */
+class Tags {
+	/**
+	 * @return WP_Term[]
+	 */
+	public static function get_all(): array {
+		$tags = get_terms(
+			[
+				'taxonomy'   => 'post_tag',
+				'hide_empty' => false,
+			]
+		);
+
+		if ( is_wp_error( $tags )
+			|| ! is_array( $tags )
+			|| empty( $tags )
+			|| ! ( $tags[0] instanceof WP_Term )
+		) {
+			return [];
+		}
+
+		return $tags;
+	}
+
+	/**
+	 * @return array{int, array{term_id: int, name: string, results: int}}
+	 */
+	public static function get_filters(): array {
+		$tags    = self::get_all();
+		$filters = [];
+
+		foreach ( $tags as $tag ) {
+			$filters[ $tag->term_id ] = [
+				'term_id' => $tag->term_id,
+				'name'    => $tag->name,
+				'results' => 0,
+			];
+		}
+
+		return $filters;
+	}
+}

--- a/templates/search.twig
+++ b/templates/search.twig
@@ -228,6 +228,7 @@
 									<div id="item-issue" class="collapse show" role="tabpanel">
 										<ul class="list-unstyled">
 											{% for category in categories %}
+												{% if ( category.results > 0 ) %}
 												<li>
 													<label class="custom-control">
 														<input
@@ -242,6 +243,7 @@
 														<span class="custom-control-description">{{ category.name|e('wp_kses_post')|raw }} ({{ category.results }})</span>
 													</label>
 												</li>
+												{% endif %}
 											{% endfor %}
 										</ul>
 									</div>
@@ -255,6 +257,7 @@
 									<div id="item-campaign" class="collapse {{ show }}" role="tabpanel">
 										<ul class="list-unstyled">
 											{% for tag in tags %}
+												{% if ( tag.results > 0 ) %}
 												<li>
 													<label class="custom-control">
 														<input
@@ -268,6 +271,7 @@
 														<span class="custom-control-description">{{ tag.name|e('wp_kses_post')|raw }} ({{ tag.results }})</span>
 													</label>
 												</li>
+												{% endif %}
 											{% endfor %}
 										</ul>
 									</div>
@@ -308,6 +312,7 @@
 									<div id="item-content" class="collapse {{ show }}" role="tabpanel">
 										<ul class="list-unstyled">
 											{% for id, content_type in content_types %}
+												{% if ( content_type.results > 0 ) %}
 												<li>
 													<label class="custom-control">
 														<input
@@ -322,6 +327,7 @@
 														<span class="custom-control-description">{{ content_type.name }} ({{ content_type.results }})</span>
 													</label>
 												</li>
+												{% endif %}
 											{% endfor %}
 										</ul>
 									</div>

--- a/templates/search.twig
+++ b/templates/search.twig
@@ -79,7 +79,7 @@
 													{% if ( categories|length > 0 ) %}
 														<div class="filteritem">
 															<a data-bs-toggle="collapse" href="#item-modal-issue" aria-expanded="true">
-																{{ __( 'ISSUE', 'planet4-master-theme' ) }} <span></span>
+																{{ __( 'Category', 'planet4-master-theme' ) }} <span></span>
 															</a>
 															<div id="item-modal-issue" class="collapse show" role="tabpanel">
 																<ul class="list-unstyled">
@@ -108,7 +108,7 @@
 													{% if ( page_types|length > 0 ) %}
 														<div class="filteritem">
 															<a data-bs-toggle="collapse" href="#item-modal-category" aria-expanded="true">
-																{{ __( 'CATEGORY', 'planet4-master-theme' ) }} <span></span>
+																{{ __( 'Post Type', 'planet4-master-theme' ) }} <span></span>
 															</a>
 															<div id="item-modal-category" class="collapse show" role="tabpanel">
 																<ul class="list-unstyled">
@@ -137,7 +137,7 @@
 													{% if ( content_types|length > 0 ) %}
 														<div class="filteritem">
 															<a data-bs-toggle="collapse" href="#item-modal-content" aria-expanded="true">
-																{{ __( 'CONTENT TYPES', 'planet4-master-theme' ) }} <span></span>
+																{{ __( 'Content Type', 'planet4-master-theme' ) }} <span></span>
 															</a>
 															<div id="item-modal-content" class="collapse show" role="tabpanel">
 																<ul class="list-unstyled">
@@ -169,7 +169,7 @@
 												{% if ( tags|length > 0 ) %}
 													<div class="filteritem">
 														<a data-bs-toggle="collapse" href="#item-modal-campaign" aria-expanded="true">
-															{{ __( 'CAMPAIGN', 'planet4-master-theme' ) }} <span></span>
+															{{ __( 'Campaign', 'planet4-master-theme' ) }} <span></span>
 														</a>
 														<div id="item-modal-campaign" class="collapse show" role="tabpanel">
 															<ul class="list-unstyled">
@@ -223,7 +223,7 @@
 							{% if ( categories|length > 0 ) %}
 								<div class="filteritem">
 									<a data-bs-toggle="collapse" href="#item-issue" aria-expanded="true">
-										{{ __( 'Issue', 'planet4-master-theme' ) }} <span></span>
+										{{ __( 'Category', 'planet4-master-theme' ) }} <span></span>
 									</a>
 									<div id="item-issue" class="collapse show" role="tabpanel">
 										<ul class="list-unstyled">
@@ -276,7 +276,7 @@
 							{% if ( page_types|length > 0 ) %}
 								<div class="filteritem">
 									<a data-bs-toggle="collapse" href="#item-category" class="{{ collapsed }}" aria-expanded="{{ expanded }}">
-										{{ __( 'Category', 'planet4-master-theme' ) }} <span></span>
+										{{ __( 'Post Type', 'planet4-master-theme' ) }} <span></span>
 									</a>
 									<div id="item-category" class="collapse {{ show }}" role="tabpanel">
 										<ul class="list-unstyled">
@@ -303,7 +303,7 @@
 							{% if ( content_types|length > 0 ) %}
 								<div class="filteritem">
 									<a data-bs-toggle="collapse" href="#item-content" class="{{ collapsed }}" aria-expanded="{{ expanded }}">
-										{{ __( 'Content type', 'planet4-master-theme' ) }} <span></span>
+										{{ __( 'Content Type', 'planet4-master-theme' ) }} <span></span>
 									</a>
 									<div id="item-content" class="collapse {{ show }}" role="tabpanel">
 										<ul class="list-unstyled">

--- a/templates/search.twig
+++ b/templates/search.twig
@@ -277,28 +277,30 @@
 									</div>
 								</div>
 							{% endif %}
-							{% if ( page_types|length > 0 ) %}
+							{% if ( post_types|length > 0 ) %}
 								<div class="filteritem">
 									<a data-bs-toggle="collapse" href="#item-category" class="{{ collapsed }}" aria-expanded="{{ expanded }}">
 										{{ __( 'Post Type', 'planet4-master-theme' ) }} <span></span>
 									</a>
 									<div id="item-category" class="collapse {{ show }}" role="tabpanel">
 										<ul class="list-unstyled">
-											{% for page_type in page_types %}
+											{% for post_type in post_types %}
+												{% if ( post_type.results > 0 ) %}
 												<li>
 													<label class="custom-control">
 														<input
 															type="checkbox"
-															name="f[ptype][{{ page_type.name }}]"
-															value="{{ page_type.term_id }}"
+															name="f[ptype][{{ post_type.name }}]"
+															value="{{ post_type.term_id }}"
 															class="p4-custom-control-input"
 															data-ga-category="Search Page"
 															data-ga-action="Post Type Filter"
-															data-ga-label="{{ page_type.name|e('wp_kses_post')|raw }}"
-															{{ page_type.checked }} {{ page_type.results > 0 ? '' : 'disabled' }} />
-														<span class="custom-control-description">{{ page_type.name|e('wp_kses_post')|raw }} ({{ page_type.results }})</span>
+															data-ga-label="{{ post_type.name|e('wp_kses_post')|raw }}"
+															{{ post_type.checked }} {{ post_type.results > 0 ? '' : 'disabled' }} />
+														<span class="custom-control-description">{{ post_type.name|e('wp_kses_post')|raw }} ({{ post_type.results }})</span>
 													</label>
 												</li>
+												{% endif %}
 											{% endfor %}
 										</ul>
 									</div>

--- a/templates/search.twig
+++ b/templates/search.twig
@@ -306,6 +306,35 @@
 									</div>
 								</div>
 							{% endif %}
+							{% if ( action_types|length > 0 ) %}
+								<div class="filteritem">
+									<a data-bs-toggle="collapse" href="#item-content" class="{{ collapsed }}" aria-expanded="{{ expanded }}">
+										{{ __( 'Action Type', 'planet4-master-theme' ) }} <span></span>
+									</a>
+									<div id="item-content" class="collapse {{ show }}" role="tabpanel">
+										<ul class="list-unstyled">
+											{% for id, action_type in action_types %}
+												{% if ( action_type.results > 0 ) %}
+												<li>
+													<label class="custom-control">
+														<input
+															type="checkbox"
+															name="f[atype][{{ action_type.name }}]"
+															value="{{ id }}"
+															class="p4-custom-control-input"
+															data-ga-category="Search Page"
+															data-ga-action="Content Filter"
+															data-ga-label="{{ action_type.name|e('wp_kses_post')|raw }}"
+															{{ action_type.checked }} {{ action_type.results > 0 ? '' : 'disabled' }} />
+														<span class="custom-control-description">{{ action_type.name }} ({{ action_type.results }})</span>
+													</label>
+												</li>
+												{% endif %}
+											{% endfor %}
+										</ul>
+									</div>
+								</div>
+							{% endif %}
 							{% if ( content_types|length > 0 ) %}
 								<div class="filteritem">
 									<a data-bs-toggle="collapse" href="#item-content" class="{{ collapsed }}" aria-expanded="{{ expanded }}">


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6652

> - We could re-purpose the filters to follow native taxonomies. So in the end we can have these filters:
>    "Categories" (actual categories)
>    "Tags" (actual tags) leave out for now
>    "Post Types" (eg. Stories, Publications, etc)
>    "Action Types" (eg. Petition, Event)
>    "Content Types" (WP post types. eg. pages, posts, actions, archive, document, etc)
> - Hide taxonomies and post types if there is no content

## Modifications

- Extracted filters to their own classes
- Renamed some filters to follow code taxonomy
- Implemented p4_action post type (only appears if the post type is active)

<table>
<tr>
<td><em>Master branch</em></td>
<td><em>This branch</em></td>
</tr>
<td>
<img src="https://user-images.githubusercontent.com/617346/165051375-a590aad2-eaef-4f7e-9640-93c63c4f6dcd.png" />
</td>
<td>
<img src="https://user-images.githubusercontent.com/617346/165051401-8123a78e-6dec-45d3-9e20-b54a3f72af05.png" />
</td>
</tr>
</table>


## Test

Test on [Phobos](https://www-dev.greenpeace.org/test-phobos)

Locally, run the elastic container and the indexation
```shell
> docker-compose -f docker-compose.full.yml up -d elasticsearch
> docker-compose exec php-fpm wp option update ep_host $(ELASTICSEARCH_HOST)
> docker-compose exec php-fpm wp elasticpress index --setup --quiet 
```

## Notes

Those mixed mentions are also noted in
- page.php l.25
- tag.php l.5