### PR TITLE
PLANET-6673 Burger menu fixes

### DIFF
--- a/assets/src/scss/base/_mixins.scss
+++ b/assets/src/scss/base/_mixins.scss
@@ -12,13 +12,6 @@
   }
 }
 
-// Mobile to Large (From 576px to 992px)
-@mixin small-to-large {
-  @media (min-width: #{$small-width}) and (max-width: #{$large-width - 1}) {
-    @content;
-  }
-}
-
 // Tablet & Up (greater than 768px)
 @mixin medium-and-up {
   @media (min-width: #{$medium-width}) {

--- a/assets/src/scss/layout/navbar/_burger-menu.scss
+++ b/assets/src/scss/layout/navbar/_burger-menu.scss
@@ -1,3 +1,20 @@
+@mixin slide-from-start() {
+  &:not(.open) {
+    transition: transform 0.2s ease-in, visibility;
+    transition-delay: 0s, 0.2s;
+    transform: translateX(-100%);
+    visibility: hidden;
+
+    html[dir="rtl"] & {
+      transform: translateX(100%);
+    }
+  }
+
+  &.open {
+    transition: transform 0.2s ease-out;
+  }
+}
+
 .burger-menu {
   _-- {
     background: $white;
@@ -11,28 +28,15 @@
   justify-content: flex-start;
   top: 0;
   left: 0;
-  inset-inline-start: -100%;
   padding: 18px $sp-3;
   z-index: 9999999999;
   overflow: hidden;
   height: 100%;
 
-  &.open {
-    inset-inline-start: 0;
-    transition: inset-inline-start 0.2s ease-out;
+  @include slide-from-start;
 
-    @supports not (inset-inline-start: 0) {
-      transform: translateX(0);
-      transition: transform 0.2s ease-out;
-
-      html[dir="rtl"] & {
-        transform: translateX(0);
-      }
-    }
-
-    ~ .burger-menu-overlay {
-      display: block;
-    }
+  &.open ~ .burger-menu-overlay {
+    display: block;
   }
 
   ul {
@@ -59,31 +63,10 @@
 
   @include small-and-less {
     width: 100vw;
-    inset-inline-start: -100vw;
-
-    @supports not (inset-inline-start: -100vw) {
-      transform: translateX(-100vw);
-      transition: transform 0.2s ease-in;
-
-      html[dir="rtl"] & {
-        transform: translateX(100vw);
-      }
-    }
   }
 
-  @include small-to-large {
+  @include small-and-up {
     width: 400px;
-    inset-inline-start: -400px;
-    transition: inset-inline-start 0.2s ease-in;
-
-    @supports not (inset-inline-start: -400px) {
-      transform: translateX(-400px);
-      transition: transform 0.2s ease-in;
-
-      html[dir="rtl"] & {
-        transform: translateX(400px);
-      }
-    }
   }
 }
 

--- a/assets/src/scss/layout/navbar/_burger-menu.scss
+++ b/assets/src/scss/layout/navbar/_burger-menu.scss
@@ -32,10 +32,6 @@
 
     ~ .burger-menu-overlay {
       display: block;
-
-      @include large-and-up {
-        display: none;
-      }
     }
   }
 
@@ -255,8 +251,11 @@
 }
 
 .burger-menu-overlay {
+  _-- {
+    background: $black;
+  }
+
   display: none;
-  background: var(--burger-menu-overlay--background, $black);
   opacity: 0.5;
   height: 100%;
   pointer-events: all;

--- a/templates/burger-menu.twig
+++ b/templates/burger-menu.twig
@@ -81,4 +81,4 @@
 		</div>
 	{% endif %}
 </div>
-<div class="burger-menu-overlay"></div>
+<div class="burger-menu-overlay d-lg-none"></div>


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6673

Some further low hanging fruit improvements to the code, mostly making it do the same with less lines of CSS.

I also used `d-lg-none` in favor of CSS rules to hide other elements.

~~Each commit is a separate fix, please refer to the commit messages for more detailed info.~~ I'll probably rebase it as now the latest fix supersedes some of the previous commits.

I ended up using transforms instead for the open and close animation. If you do `translateX(-100%)`, it always uses 100% of the width of that element. Whereas `inset-inline-start` needed CSS per screen size, as % there uses the parent container as a reference.