### PR TITLE
PLANET-6708: Fix page padding with mobile tabs menu

### DIFF
--- a/assets/src/js/header.js
+++ b/assets/src/js/header.js
@@ -120,11 +120,22 @@ const setMobileTabsMenuScroll = () => {
     return;
   }
 
-  const distToClose = 50;
+  const distToClose = 100;
   const distToOpen = 50;
   let lastScrollDir = null;
   let lastScrollTop = window.pageYOffset || document.documentElement.scrollTop;
   let lastScrollRef = lastScrollTop;
+
+  // Check support for eventlistener opts (passive option)
+  // Cf. https://github.com/WICG/EventListenerOptions/blob/gh-pages/explainer.md#feature-detection
+  let supportsPassive = false;
+  try {
+    const opts = Object.defineProperty({}, 'passive', {
+      get: function() { supportsPassive = true; } // eslint-disable-line getter-return
+    });
+    window.addEventListener('testPassive', null, opts);
+    window.removeEventListener('testPassive', null, opts);
+  } catch (e) {} // eslint-disable-line no-empty
 
   /**
    * Get scroll direction, distance from the lastScrollTop, and distance from a reference point
@@ -172,7 +183,11 @@ const setMobileTabsMenuScroll = () => {
   };
 
   ['touchmove', 'scroll'].forEach((eventName) => {
-    document.addEventListener(eventName, toggleMobileTabsMenu);
+    document.addEventListener(
+      eventName,
+      toggleMobileTabsMenu,
+      supportsPassive ? {passive: true} : false
+    );
   });
 };
 

--- a/assets/src/js/header.js
+++ b/assets/src/js/header.js
@@ -160,8 +160,16 @@ const setMobileTabsMenuScroll = () => {
    * Update reference point and reference direction only on state change
    */
   const toggleMobileTabsMenu = () => {
-    const {dir, ref} = scrollData();
+    const {dir, pos, ref} = scrollData();
     if (!dir || dir === lastScrollDir) {
+      return;
+    }
+
+    // Keep open, avoid glitches when scrolling up at max top
+    if (pos < distToOpen) {
+      lastScrollDir = 'up';
+      lastScrollRef = lastScrollTop;
+      menu.classList.remove('mobile-menu-hidden');
       return;
     }
 

--- a/assets/src/scss/pages/_page.scss
+++ b/assets/src/scss/pages/_page.scss
@@ -50,7 +50,7 @@ $min-height: 40px;
   }
 }
 
-.with-mobile-tabs + .page-content {
+.with-mobile-tabs ~ :not(.page-header) + .page-content {
   @include medium-and-less {
     padding-top: calc(#{$menu-height-small} + 50px);
   }


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6708

> The mobile tabs menu makes it impossible to see the top part of the first block.

The rule adding a padding to a page without header became irrelevant since divs now exist between section#header and div.page-content

<table>
<tr>
<td>
<img src="https://user-images.githubusercontent.com/617346/163406601-3e508cea-fbec-4b28-933d-c79c9e1b2955.png"  />
</td>
<td>
<img src="https://user-images.githubusercontent.com/617346/163406622-aa4ae7c0-ecbe-4715-85dd-b028384bee35.png"  />
</td></tr></table>


## Fixes

- Fix padding rule to apply to page-content
- Add `passive` option to event listener (Cf. https://www.digitalocean.com/community/tutorials/js-speed-up-scroll-events)
- Fix menu glitch when scrolling up while already at the top of the page (browser sometimes does a down-and-up jump)


## Test

Check on [Tavros](https://www-dev.greenpeace.org/test-tavros/)
Locally, 
- Activate the mobile tabs menu (Planet 4 > Information Architecture)
- Get your window to mobile size
- Check a page without header (usually front page, or a page without any title)
- Its content should be fully visible, not hidden behind the mobile tabs menu