### PR TITLE
Use Query Loop on posts page if feature enabled

### DIFF
--- a/index.php
+++ b/index.php
@@ -13,11 +13,21 @@
  * @since   Timber 0.1
  */
 
-$context          = Timber::get_context();
-$context['posts'] = Timber::get_posts();
+use P4\MasterTheme\Features\Dev\ListingPageGridView;
+use P4\MasterTheme\Features\Dev\ListingPagePagination;
 
-$templates = [ 'index.twig' ];
-if ( is_home() ) {
-	array_unshift( $templates, 'home.twig' );
+$context = Timber::get_context();
+
+if ( ListingPagePagination::is_active() ) {
+	$view = ListingPageGridView::is_active() ? 'grid' : 'list';
+
+	$query_template = file_get_contents( get_template_directory() . "/parts/query-$view.html" );
+
+	$content = do_blocks( $query_template );
+
+	$context['query_loop'] = $content;
+} else {
+	$context['posts'] = Timber::get_posts();
 }
-Timber::render( $templates, $context );
+
+Timber::render( [ 'index.twig' ], $context );

--- a/src/Post.php
+++ b/src/Post.php
@@ -508,8 +508,12 @@ class Post extends TimberPost {
 	 *
 	 * @return string Formatted reading time.
 	 */
-	public static function reading_time_block( array $attributes, $content, $block ) {
+	public static function reading_time_block( array $attributes, $content, $block ): string {
 		$time = ( new self( $block->context['postId'] ?? null ) )->reading_time();
+
+		if ( ! $time ) {
+			return '';
+		}
 
 		return "<span class='article-list-item-readtime'>$time min read</span>";
 	}

--- a/templates/index.twig
+++ b/templates/index.twig
@@ -1,7 +1,18 @@
 {% extends "base.twig" %}
-
 {% block content %}
-	{% for post in posts %}
-		{% include ['tease-'~post.post_type~'.twig', 'tease.twig'] %}
-	{% endfor %}
+	<div class="page-content container">
+		<br>
+		<br>
+		<br>
+		<br>
+		<br>
+		<br>
+		{{ query_loop|raw }}
+		{# Need to check as posts doesn't need to be assigned in context, it's always going to forward to get_posts() #}
+		{% if not query_loop %}
+			{% for post in posts %}
+				{% include ['tease-'~post.post_type~'.twig', 'tease.twig'] %}
+			{% endfor %}
+		{% endif %}
+	</div>
 {% endblock %}


### PR DESCRIPTION
* This index template is only used on the posts page, which nobody
likely uses as it missed styles for the page width and a few more
things. I now added the same container as on pages.
* Check feature toggle for listing pages and use a listing page if
enabled.
* Quick workaround with <br> tags to fix topbar covering things.

<!-- Ref: Please add a url to the ticket this change is addressing.

---

Please provide a brief summary of the change introduced to make review process easier.

Ideally this should also be part of the commit summary.
-->
