### PR TITLE
PLANET-6695 Always show scroll bar in cookies settings

### DIFF
--- a/assets/src/scss/layout/_cookies-settings.scss
+++ b/assets/src/scss/layout/_cookies-settings.scss
@@ -52,7 +52,7 @@
 
 .cookies-settings-details {
   max-height: 40vh;
-  overflow-y: auto;
+  overflow-y: scroll;
   overflow-x: hidden;
   width: calc(100% + 2 * #{$sp-3});
   margin-inline-start: -$sp-3;


### PR DESCRIPTION
### Description

See [PLANET-6695](https://jira.greenpeace.org/browse/PLANET-6695)
This fix will not work everywhere, in particular not in MacOS where scroll bars are shown/hidden based on system settings (see screenshot), but it's an easy fix for at least some browsers/OS!

<img width="438" alt="Screenshot 2022-04-14 at 13 57 35" src="https://user-images.githubusercontent.com/6949075/163392492-19e93ab7-d2d7-41ac-82b2-310a19e32f63.png">