### PR TITLE
PLANET-6734 Inherit color for heading links

### DIFF
--- a/assets/src/scss/base/_typography.scss
+++ b/assets/src/scss/base/_typography.scss
@@ -35,6 +35,13 @@ h6 {
   &.has-text-align-left {
     width: 100%;
   }
+
+  a,
+  a:hover,
+  a:active,
+  a:visited {
+    color: inherit;
+  }
 }
 
 h1 {


### PR DESCRIPTION
### Description

See [PLANET-6734](https://jira.greenpeace.org/browse/PLANET-6734)
We don't want heading links to follow standalone links colors, as you can see in the [design system](https://p4-designsystem.greenpeace.org/05f6e9516/v/0/p/266986-links/t/365cab).

**Related PR:** https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/829

### Testing

You can test the new heading links on [this page](https://www-dev.greenpeace.org/test-venus/heading-links/) for example, and compare it to [the old version](https://www-dev.greenpeace.org/test-titan/51775-2/). Also make sure that our P4 Columns and Articles blocks still behave as expected too (for instance on the [homepage](https://www-dev.greenpeace.org/test-venus/)).