### PR TITLE
Use opacity instead of visibility for better performance

### DIFF
--- a/assets/src/scss/layout/navbar/_burger-menu.scss
+++ b/assets/src/scss/layout/navbar/_burger-menu.scss
@@ -1,9 +1,11 @@
 @mixin slide-from-start() {
+  $duration: .2s;
+
   &:not(.open) {
-    transition: transform 0.2s ease-in, visibility;
-    transition-delay: 0s, 0.2s;
+    transition: transform $duration ease-in, opacity;
+    transition-delay: 0s, $duration;
     transform: translateX(-100%);
-    visibility: hidden;
+    opacity: 0;
 
     html[dir="rtl"] & {
       transform: translateX(100%);
@@ -11,7 +13,7 @@
   }
 
   &.open {
-    transition: transform 0.2s ease-out;
+    transition: transform $duration ease-out;
   }
 }
 

--- a/assets/src/scss/layout/navbar/_burger-menu.scss
+++ b/assets/src/scss/layout/navbar/_burger-menu.scss
@@ -1,9 +1,9 @@
-@mixin slide-from-start() {
-  $duration: .2s;
+$transition-duration: .2s;
 
+@mixin slide-from-start() {
   &:not(.open) {
-    transition: transform $duration ease-in, opacity;
-    transition-delay: 0s, $duration;
+    transition: transform $transition-duration ease-in, opacity;
+    transition-delay: 0s, $transition-duration;
     transform: translateX(-100%);
     opacity: 0;
 
@@ -13,7 +13,7 @@
   }
 
   &.open {
-    transition: transform $duration ease-out;
+    transition: transform $transition-duration ease-out;
   }
 }
 
@@ -36,10 +36,6 @@
   height: 100%;
 
   @include slide-from-start;
-
-  &.open ~ .burger-menu-overlay {
-    display: block;
-  }
 
   ul {
     padding: 0;
@@ -240,12 +236,22 @@
     background: $black;
   }
 
-  display: none;
-  opacity: 0.5;
+  transition: opacity $transition-duration ease-in, z-index;
+
+  .burger-menu.open ~ & {
+    z-index: 99;
+    opacity: 0.5;
+  }
+
+  .burger-menu:not(.open) ~ & {
+    z-index: -1;
+    opacity: 0;
+    transition: z-index $transition-duration step-end, opacity $transition-duration linear;
+  }
+
   height: 100%;
   pointer-events: all;
   position: fixed;
   top: 0;
   width: 100vw;
-  z-index: 99;
 }


### PR DESCRIPTION
Follow up on https://github.com/greenpeace/planet4-master-theme/pull/1673 and https://jira.greenpeace.org/browse/PLANET-6673

* This way the off screen element is still not visibile while the screen
size is changing. Opacity has better render performance.

I also added a transition of this opacity for better performance. It should be safe, as it will be below each element unless it has a lower z index.

You can't animate opacity if the element is `display: none`, so I had to move the overlay under all elements with `z-index`. So far this seemed reliable.

### Before

https://user-images.githubusercontent.com/7604138/164056181-1f350e07-0425-4596-bc17-6470cde32ddc.mp4

### After

https://user-images.githubusercontent.com/7604138/164056216-f224128b-14e7-4df3-a0f1-f6f93608144d.mp4

