### PR TITLE
PLANET-6697: Fire consent before gtm starts

### DIFF
--- a/assets/src/js/cookies.js
+++ b/assets/src/js/cookies.js
@@ -25,16 +25,6 @@ export const setupCookies = () => {
     });
   };
 
-  const defaultGoogleConsent = () => {
-    updateGoogleConsent(
-      {
-        ad_storage: 'denied',
-        ...ENABLE_ANALYTICAL_COOKIES && {'analytics_storage': 'denied'},
-      },
-      'default'
-    );
-  };
-
   const createCookie = (name, value, days) => {
     let date = new Date();
     date.setTime(date.getTime() + (days * 24 * 60 * 60 * 1000));
@@ -65,26 +55,6 @@ export const setupCookies = () => {
   const previousNRO = readCookie('gp_nro');
   const greenpeace = readCookie('greenpeace');
   const noTrack = readCookie('no_track');
-
-  // If Google Consent Mode is enabled,
-  // set default ad storage and analytics storage to 'denied' as first action on every page until consent is given.
-  // If consent given, update consent on every page.
-  if (ENABLE_GOOGLE_CONSENT_MODE) {
-    const marketing_consent = noTrack === null
-      && cookie !== null
-      && [NECESSARY_MARKETING, NECESSARY_ANALYTICAL_MARKETING].includes(greenpeace);
-
-    if (marketing_consent) {
-      // If user consents, update on every page.
-      updateGoogleConsent({
-        'ad_storage': 'granted',
-        ...ENABLE_ANALYTICAL_COOKIES && {'analytics_storage': 'granted'}
-      });
-    } else {
-      // If user has not, default to denied on every page.
-      defaultGoogleConsent();
-    }
-  }
 
   const showCookiesBox = () => {
     if (cookiesBox) {

--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -545,10 +545,11 @@ class MasterSite extends TimberSite {
 		global $wp;
 
 		$context['cookies']      = [
-			'text'                      => planet4_get_option( 'cookies_field' ),
-			'enable_analytical_cookies' => planet4_get_option( 'enable_analytical_cookies' ),
-			'enable_reject_all_cookies' => planet4_get_option( 'enable_reject_all_cookies' ),
-			'settings_copy'             => [
+			'text'                       => planet4_get_option( 'cookies_field' ),
+			'enable_analytical_cookies'  => planet4_get_option( 'enable_analytical_cookies' ),
+			'enable_reject_all_cookies'  => planet4_get_option( 'enable_reject_all_cookies' ),
+			'enable_google_consent_mode' => planet4_get_option( 'enable_google_consent_mode' ),
+			'settings_copy'              => [
 				'necessary_cookies_name'         => planet4_get_option( 'necessary_cookies_name', '' ),
 				'necessary_cookies_description'  => planet4_get_option( 'necessary_cookies_description', '' ),
 				'analytical_cookies_name'        => planet4_get_option( 'analytical_cookies_name', '' ),

--- a/templates/blocks/google_tag_manager.twig
+++ b/templates/blocks/google_tag_manager.twig
@@ -7,9 +7,50 @@
   </style>
   {% endif %}
   <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag() { dataLayer.push(arguments); };
+
+    var cookie_content = document.cookie.split(';').map(s => s.trim());
+    function cookie_contains(value) {
+      return cookie_content.indexOf(value) !== -1;
+    };
+    var no_track = cookie_contains('no_track=1');
+    var active_consent = cookie_contains('active_consent_choice=1');
+    var marketing_consent = !no_track && active_consent
+      && (cookie_contains('greenpeace=2') || cookie_contains('greenpeace=4'));
+    var analytical_consent = !no_track && active_consent
+      && (cookie_contains('greenpeace=3') || cookie_contains('greenpeace=4'));
+    var cookie_consent = marketing_consent || analytical_consent;
+
+    {#
+      If Google Consent Mode is enabled,
+      set default ad storage and analytics storage to 'denied' as first action on every page until consent is given.
+      If consent given, update consent on every page.
+    #}
+    {% if cookies.enable_google_consent_mode %}
+    if ( cookie_consent ) {
+      var capabilities = {
+        ad_storage: marketing_consent ? 'granted' : 'denied',
+        {% if cookies.enable_analytical_cookies %}
+        ...{'analytics_storage': analytical_consent ? 'granted' : 'denied'}
+        {% endif %}
+      };
+      gtag('consent', 'update', capabilities);
+      dataLayer.push({event: 'updateConsent', ...capabilities});
+    } else {
+      var capabilities = {
+        ad_storage: 'denied',
+        {% if cookies.enable_analytical_cookies %}
+        ...{'analytics_storage': 'denied'}
+        {% endif %}
+      };
+      gtag('consent', 'default', capabilities);
+      dataLayer.push({event: 'defaultConsent', ...capabilities});
+    }
+    {% endif %}
+
     var google_tag_value = '{{ google_tag_value }}';
 
-    window.dataLayer = window.dataLayer || [];
     dataLayer.push({
       'pageType' : '{{ page_category }}',
       'signedIn' : '{{ p4_signedin_status }}',
@@ -45,19 +86,9 @@
       }
     {% endif %}
 
-    var cookie_consent = document.cookie.split(';').filter(function(c) {
-      return c.indexOf('greenpeace=2') >= 0
-        || c.indexOf('greenpeace=3') >= 0
-        || c.indexOf('greenpeace=4') >= 0;
-    }).length;
-    var enforce_cookies_policy = '{{ enforce_cookies_policy }}';
-    var gtm_allow = true;
+    var gtm_allow = '{{ enforce_cookies_policy }}' ? cookie_consent : true;
 
-    if ( enforce_cookies_policy && 1 !== parseInt( cookie_consent ) ) {
-      gtm_allow = false;
-    }
-
-    if ( google_tag_value && gtm_allow) {
+    if ( google_tag_value && gtm_allow ) {
       (function (w, d, s, l, i) {
         w[l] = w[l] || [];
         w[l].push({


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6697

>  “Take a note that Page View event fires on the gtm.js event which fires before the consent event. That's why the first collect? hit doesn't have gcs a parameter and  gid is the same on any page. Let's try to fire event with consent before gtm.js - it should help”
> Can we send the ‘consent’ arguments before the GTM script is loaded? That should fix our last issue. 

Consent should fire before gtm starts.

Sending the consent before gtm starts requires to read cookies early. This involves some code duplication, that we try to keep minimal.

![Screenshot from 2022-04-26 10-23-38](https://user-images.githubusercontent.com/617346/165256109-1cf600cf-f5b4-4ec4-8966-36a7220b7419.png)

## Test

Waiting for UAT on [tavros](https://www-dev.greenpeace.org/test-tavros).

Testing there or locally, the event `defaultConsent` or `updateConsent` triggered on page load should fire before `gtm.start`