### PR TITLE
PLANET-6637: Create a Reviewer user role

### DIFF
--- a/load-class-aliases.php
+++ b/load-class-aliases.php
@@ -10,7 +10,7 @@ class_alias( \P4\MasterTheme\Activator::class, 'P4_Activator' );
 class_alias( \P4\MasterTheme\AnalyticsValues::class, 'P4_Analytics_Values' );
 class_alias( \P4\MasterTheme\Exporter::class, 'P4_Campaign_Exporter' );
 class_alias( \P4\MasterTheme\Importer::class, 'P4_Campaign_Importer' );
-class_alias( \P4\MasterTheme\Campaigner::class, 'P4_Campaigner' );
+class_alias( \P4\MasterTheme\Role\Campaigner::class, 'P4_Campaigner' );
 class_alias( \P4\MasterTheme\Campaigns::class, 'P4_Campaigns' );
 class_alias( \P4\MasterTheme\Context::class, 'P4_Context' );
 class_alias( \P4\MasterTheme\ControlPanel::class, 'P4_Control_Panel' );

--- a/src/Activator.php
+++ b/src/Activator.php
@@ -26,7 +26,8 @@ class Activator {
 	 * Run activation functions.
 	 */
 	public static function run(): void {
-		Campaigner::register_role_and_add_capabilities();
+		Role\Campaigner::register_role_and_add_capabilities();
+		Role\Reviewer::register_role();
 		Migrator::migrate();
 	}
 

--- a/src/Role/Campaigner.php
+++ b/src/Role/Campaigner.php
@@ -1,6 +1,8 @@
 <?php
 
-namespace P4\MasterTheme;
+namespace P4\MasterTheme\Role;
+
+use P4\MasterTheme\Capability;
 
 /**
  * Register custom 'campaigner' role and adds custom capabilities.

--- a/src/Role/Reviewer.php
+++ b/src/Role/Reviewer.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace P4\MasterTheme\Role;
+
+/**
+ * Register custom 'reviewer' role and adds its capabilities.
+ */
+class Reviewer {
+	/**
+	 * Add Reviewer role.
+	 */
+	public static function register_role() {
+		add_role(
+			'reviewer',
+			__( 'Reviewer', 'planet4-master-theme-backend' ),
+			[
+				'read_private_posts' => true,
+				'read_private_pages' => true,
+			]
+		);
+	}
+}


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6637

Add user role and capabilites

- Added _Role\Reviewer_ class
- Moved Campaigner to the `Role` namespace

## Test

Locally, run `docker-compose exec php-fpm wp p4-run-activator` to create the role.

- Create a private post/page, note the public url
- Create a user with role _Reviewer_
- Log with this user, check the private post/page
  - You should be able to read the content
  - You don't have access to anything else
  - Content is not available when you're not logged in