### PR TITLE
PLANET-6733: Nav search form is hidden on large screens

### DIFF
--- a/templates/navigation-bar-new.twig
+++ b/templates/navigation-bar-new.twig
@@ -84,40 +84,6 @@
 				</span>
 			</button>
 		</div>
-		<form id="search_form" class="form nav-search-form" action="{{ data_nav_bar.home_url }}">
-			{% set search_label = __( 'Search', 'planet4-master-theme' ) %}
-			<input id="{{ search_input_id }}"
-				type="search"
-				name="s"
-				class="form-control"
-				placeholder="{{ search_label }}"
-				value="{{ data_nav_bar.search_query|e('wp_kses_post')|raw }}"
-				aria-label="{{ __( 'Search input', 'planet4-master-theme' ) }}"/>
-			<input id="orderby" type="hidden" name="orderby" value="{{ selected_sort ?? default_sort }}"/>
-			<button class="nav-search-btn"
-				aria-label="{{ __( 'Press return/enter or click to search', 'planet4-master-theme' ) }}"
-				type="submit"
-				data-ga-category="Menu Navigation"
-				data-ga-action="Search"
-				data-ga-label="{{ page_category }}"
-			>
-				{{ search_icon|replace({'<svg': "<svg " ~ data_ga_attrs })|raw }}
-				<span class="visually-hidden"
-					data-ga-category="Menu Navigation"
-					data-ga-action="Search"
-					data-ga-label="{{ page_category }}"
-				>
-						{{ search_label }}
-				</span>
-			</button>
-			<button class="nav-search-clear"
-				aria-label="{{ __( 'Clear search', 'planet4-master-theme' ) }}"
-				type="button"
-				onclick="document.getElementById('{{ search_input_id }}').value=null;"
-			>
-				<span class="visually-hidden">{{ __( 'Clear search', 'planet4-master-theme' ) }}</span>
-			</button>
-		</form>
 		{% if site_languages is not empty %}
 			{% set current_lang = site_languages|filter(i => i.active)|first %}
 			<button class="nav-languages-toggle" type="button"
@@ -153,6 +119,40 @@
 			</span>
 		</button>
 	</div>
+	<form id="search_form" class="form nav-search-form" action="{{ data_nav_bar.home_url }}">
+		{% set search_label = __( 'Search', 'planet4-master-theme' ) %}
+		<input id="{{ search_input_id }}"
+			type="search"
+			name="s"
+			class="form-control"
+			placeholder="{{ search_label }}"
+			value="{{ data_nav_bar.search_query|e('wp_kses_post')|raw }}"
+			aria-label="{{ __( 'Search input', 'planet4-master-theme' ) }}"/>
+		<input id="orderby" type="hidden" name="orderby" value="{{ selected_sort ?? default_sort }}"/>
+		<button class="nav-search-btn"
+			aria-label="{{ __( 'Press return/enter or click to search', 'planet4-master-theme' ) }}"
+			type="submit"
+			data-ga-category="Menu Navigation"
+			data-ga-action="Search"
+			data-ga-label="{{ page_category }}"
+		>
+			{{ search_icon|replace({'<svg': "<svg " ~ data_ga_attrs })|raw }}
+			<span class="visually-hidden"
+				data-ga-category="Menu Navigation"
+				data-ga-action="Search"
+				data-ga-label="{{ page_category }}"
+			>
+					{{ search_label }}
+			</span>
+		</button>
+		<button class="nav-search-clear"
+			aria-label="{{ __( 'Clear search', 'planet4-master-theme' ) }}"
+			type="button"
+			onclick="document.getElementById('{{ search_input_id }}').value=null;"
+		>
+			<span class="visually-hidden">{{ __( 'Clear search', 'planet4-master-theme' ) }}</span>
+		</button>
+	</form>
 	{% if mobile_tabs_menu %}
 	<div id="nav-mobile">
 		<nav id="nav-mobile-menu">


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6733

Demo page: https://www-dev.greenpeace.org/test-neptune/

**Solution**
Moved the element outside the main nav desktop element since is not displayed on large screens because of the `ds-lg-none` class.

**Testing**
Go to international dev instance and resize the screen to <992px, then click on the search button. The search form might be visible. 