### PR TITLE
PLANET-6671: Log large cookie content

### DIFF
--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -318,7 +318,12 @@ class MasterSite extends TimberSite {
 			return;
 		}
 
-		\Sentry\captureMessage( 'Large cookies detected' );
+		\Sentry\withScope(
+			function ( \Sentry\State\Scope $scope ): void {
+				$scope->setContext( 'cookie_content', [ 'content' => $_SERVER['HTTP_COOKIE'] ] );
+				\Sentry\captureMessage( 'Large cookies detected' );
+			}
+		);
 	}
 
 	/**


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6671

Cookie content is filtered on the events currently logged.
Trying to log content explicitly to bypass the filter
