### PR TITLE
For now only style this on the tag pages

### DIFF
--- a/assets/src/scss/layout/_block-classes.scss
+++ b/assets/src/scss/layout/_block-classes.scss
@@ -24,27 +24,32 @@
   }
 }
 
-.wp-block-post-terms {
-  font-weight: 500;
-}
-
-.taxonomy-post_tag a {
-  display: inline-block;
-
-  &:before {
-    content: "#";
-    speak: none;
+// For now only apply on tag pages.
+// Will adjust the selector once there are more types of listing pages.
+// Or perhaps this can be converted to block styles.
+body.tag {
+  .wp-block-post-terms {
+    font-weight: 500;
   }
-}
 
-.wp-block-post {
-  margin-bottom: 32px;
+  .taxonomy-post_tag a {
+    display: inline-block;
 
-  figure {
-    margin-bottom: 0;
+    &:before {
+      content: "#";
+      speak: none;
+    }
   }
-}
 
-.wp-block-post-excerpt__excerpt {
-  font-size: 1rem;
+  .wp-block-post {
+    margin-bottom: 32px;
+
+    figure {
+      margin-bottom: 0;
+    }
+  }
+
+  .wp-block-post-excerpt__excerpt {
+    font-size: 1rem;
+  }
 }


### PR DESCRIPTION
* CSS was written assuming it's the only usage of the block, but now
people are starting to allow it in the editor. Ensure the CSS doesn't
conflict anymore.
* I didn't change the pagination style, because that one definitely
should not be used in regular pages.

It's just a quick fix, we can later properly register this as block styles.

Example tag page on the instance https://www-dev.greenpeace.org/test-oberon/tag/50-years/ Styles should still be applied there.