### PR TITLE
Add setting to link to category directly

### DIFF
--- a/src/Features/PostPageCategoryLinks.php
+++ b/src/Features/PostPageCategoryLinks.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace P4\MasterTheme\Features;
+
+use P4\MasterTheme\Feature;
+use P4\MasterTheme\Settings\InformationArchitecture;
+
+/**
+ * @see description()
+ */
+class PostPageCategoryLinks extends Feature {
+
+	/**
+	 * @inheritDoc
+	 */
+	public static function id(): string {
+		return 'post_page_category_links';
+	}
+
+
+	/**
+	 * @inheritDoc
+	 */
+	protected static function name(): string {
+		return __( 'Post Page Category Links', 'planet4-master-theme-backend' );
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected static function description(): string {
+		return __(
+			'On post pages, link to the categories, instead of a page that has the same category ("issue pages").',
+			'planet4-master-theme-backend'
+		);
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected static function options_key(): string {
+		return InformationArchitecture::OPTIONS_KEY;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public static function show_toggle_production(): bool {
+		return true;
+	}
+}

--- a/src/Post.php
+++ b/src/Post.php
@@ -2,6 +2,7 @@
 
 namespace P4\MasterTheme;
 
+use P4\MasterTheme\Features\PostPageCategoryLinks;
 use Timber\Post as TimberPost;
 use Timber\Term as TimberTerm;
 use WP_Block;
@@ -177,6 +178,17 @@ class Post extends TimberPost {
 		$options         = get_option( 'planet4_options' );
 		$explore_page_id = $options['explore_page'] ?? '';
 		$categories      = get_the_category( $this->ID );
+
+		if ( PostPageCategoryLinks::is_active() ) {
+			$this->issues_nav_data = array_map(
+				fn( $category ) => [
+					'name' => $category->name,
+					'link' => get_term_link( $category ),
+				],
+				array_filter( $categories, fn( $category ) => 'uncategorised' !== $category->slug )
+			);
+			return;
+		}
 
 		// Handle navigation links.
 		if ( $categories ) {

--- a/src/Settings/Features.php
+++ b/src/Settings/Features.php
@@ -20,6 +20,7 @@ use P4\MasterTheme\Features\Dev\ListingPagePagination;
 use P4\MasterTheme\Features\NewDesignCountrySelector;
 use P4\MasterTheme\Features\NewDesignNavigationBar;
 use P4\MasterTheme\Features\PurgeOnFeatureChanges;
+use P4\MasterTheme\Features\PostPageCategoryLinks;
 use P4\MasterTheme\Loader;
 use P4\MasterTheme\Settings;
 

--- a/src/Settings/InformationArchitecture.php
+++ b/src/Settings/InformationArchitecture.php
@@ -7,6 +7,7 @@ namespace P4\MasterTheme\Settings;
 use P4\MasterTheme\Features\ActionPostType;
 use P4\MasterTheme\Features\MobileTabsMenu;
 use P4\MasterTheme\Features\DropdownMenu;
+use P4\MasterTheme\Features\PostPageCategoryLinks;
 use P4\MasterTheme\Loader;
 
 /**
@@ -48,6 +49,7 @@ class InformationArchitecture {
 			MobileTabsMenu::get_cmb_field(),
 			ActionPostType::get_cmb_field(),
 			DropdownMenu::get_cmb_field(),
+			PostPageCategoryLinks::get_cmb_field(),
 		];
 	}
 


### PR DESCRIPTION
### Ref: [PLANET-6747](https://jira.greenpeace.org/browse/PLANET-6747)

Investigate whether it's easy to replace the weird logic of which links are shown after the tags, with a simple link to the category page itself.

Note that our category page atm still needs to get pagination and a new listing style. We should also first check the content of these pages, to be sure our new alternative is sufficient.

Since the toggle is only a few lines of code, it's easy to provide already on dev envs.

There's some things an NRO should watch out for when enabling:
* "Uncategorized" is a category, and will be shown as such. Also you need to manually unassign it after assigning an actual category.
* Some categories which didn't have a page will start getting shown. They should maybe be removed if they're not intended to show up. If they can't be removed we could maybe check a visibility setting (or create one) per category.

The old mechanism does effectively the same as tag "redirect pages", with small differences:
* If no page exists, the category is not linked to by itself.
* It doesn't replace the content of the category page, but the links to it.