### PR TITLE
Modify Donate button functionality on Mobile

### DIFF
--- a/templates/burger-menu.twig
+++ b/templates/burger-menu.twig
@@ -60,7 +60,7 @@
 					{% include "burger-menu-items.twig" with { menu: navbar_menu_items } %}
 				{% endif %}
 
-				{% if donate_menu_items is not empty and dropdown_menu %}
+				{% if donate_menu_items is not empty and donate_menu_items[0].children|length > 1 and dropdown_menu %}
 					{% include "burger-menu-items.twig" with { menu: donate_menu_items } %}
 				{% endif %}
 			</ul>


### PR DESCRIPTION
Show only when it has **more than 1 children**.
Doing this we will avoid to have 2 donate buttons with the same link in the same template, which is not necessary.

This fix comes from this [Slack thread](https://greenpeace.slack.com/archives/C0151L0KKNX/p1650978089768639) and this is a [real example](https://www.greenpeace.org/brasil/).

![Screenshot 2022-04-26 at 12 14 45](https://user-images.githubusercontent.com/77975803/165333855-558ac85d-985f-411b-8491-9acdc490ac0a.png)

