### PR TITLE
PLANET-6552: Fix search filters to follow native taxonomies

### DIFF
--- a/templates/search.twig
+++ b/templates/search.twig
@@ -79,7 +79,7 @@
 													{% if ( categories|length > 0 ) %}
 														<div class="filteritem">
 															<a data-bs-toggle="collapse" href="#item-modal-issue" aria-expanded="true">
-																{{ __( 'ISSUE', 'planet4-master-theme' ) }} <span></span>
+																{{ __( 'Category', 'planet4-master-theme' ) }} <span></span>
 															</a>
 															<div id="item-modal-issue" class="collapse show" role="tabpanel">
 																<ul class="list-unstyled">
@@ -108,7 +108,7 @@
 													{% if ( page_types|length > 0 ) %}
 														<div class="filteritem">
 															<a data-bs-toggle="collapse" href="#item-modal-category" aria-expanded="true">
-																{{ __( 'CATEGORY', 'planet4-master-theme' ) }} <span></span>
+																{{ __( 'Post Type', 'planet4-master-theme' ) }} <span></span>
 															</a>
 															<div id="item-modal-category" class="collapse show" role="tabpanel">
 																<ul class="list-unstyled">
@@ -137,7 +137,7 @@
 													{% if ( content_types|length > 0 ) %}
 														<div class="filteritem">
 															<a data-bs-toggle="collapse" href="#item-modal-content" aria-expanded="true">
-																{{ __( 'CONTENT TYPES', 'planet4-master-theme' ) }} <span></span>
+																{{ __( 'Content Type', 'planet4-master-theme' ) }} <span></span>
 															</a>
 															<div id="item-modal-content" class="collapse show" role="tabpanel">
 																<ul class="list-unstyled">
@@ -169,7 +169,7 @@
 												{% if ( tags|length > 0 ) %}
 													<div class="filteritem">
 														<a data-bs-toggle="collapse" href="#item-modal-campaign" aria-expanded="true">
-															{{ __( 'CAMPAIGN', 'planet4-master-theme' ) }} <span></span>
+															{{ __( 'Campaign', 'planet4-master-theme' ) }} <span></span>
 														</a>
 														<div id="item-modal-campaign" class="collapse show" role="tabpanel">
 															<ul class="list-unstyled">
@@ -223,7 +223,7 @@
 							{% if ( categories|length > 0 ) %}
 								<div class="filteritem">
 									<a data-bs-toggle="collapse" href="#item-issue" aria-expanded="true">
-										{{ __( 'Issue', 'planet4-master-theme' ) }} <span></span>
+										{{ __( 'Category', 'planet4-master-theme' ) }} <span></span>
 									</a>
 									<div id="item-issue" class="collapse show" role="tabpanel">
 										<ul class="list-unstyled">
@@ -276,7 +276,7 @@
 							{% if ( page_types|length > 0 ) %}
 								<div class="filteritem">
 									<a data-bs-toggle="collapse" href="#item-category" class="{{ collapsed }}" aria-expanded="{{ expanded }}">
-										{{ __( 'Category', 'planet4-master-theme' ) }} <span></span>
+										{{ __( 'Post Type', 'planet4-master-theme' ) }} <span></span>
 									</a>
 									<div id="item-category" class="collapse {{ show }}" role="tabpanel">
 										<ul class="list-unstyled">
@@ -303,7 +303,7 @@
 							{% if ( content_types|length > 0 ) %}
 								<div class="filteritem">
 									<a data-bs-toggle="collapse" href="#item-content" class="{{ collapsed }}" aria-expanded="{{ expanded }}">
-										{{ __( 'Content type', 'planet4-master-theme' ) }} <span></span>
+										{{ __( 'Content Type', 'planet4-master-theme' ) }} <span></span>
 									</a>
 									<div id="item-content" class="collapse {{ show }}" role="tabpanel">
 										<ul class="list-unstyled">

--- a/templates/search.twig
+++ b/templates/search.twig
@@ -84,7 +84,7 @@
 															<div id="item-modal-issue" class="collapse show" role="tabpanel">
 																<ul class="list-unstyled">
 																	{% for category in categories %}
-																		{% if ( category.results >= 0 ) %}
+																		{% if ( category.results > 0 ) %}
 																			<li>
 																				<label class="custom-control">
 																					<input
@@ -113,7 +113,7 @@
 															<div id="item-modal-category" class="collapse show" role="tabpanel">
 																<ul class="list-unstyled">
 																	{% for page_type in page_types %}
-																		{% if ( page_type.results >= 0 ) %}
+																		{% if ( page_type.results > 0 ) %}
 																			<li>
 																				<label class="custom-control">
 																					<input
@@ -142,7 +142,7 @@
 															<div id="item-modal-content" class="collapse show" role="tabpanel">
 																<ul class="list-unstyled">
 																	{% for id, content_type in content_types %}
-																		{% if ( content_type.results >= 0 ) %}
+																		{% if ( content_type.results > 0 ) %}
 																			<li>
 																				<label class="custom-control">
 																					<input
@@ -174,6 +174,7 @@
 														<div id="item-modal-campaign" class="collapse show" role="tabpanel">
 															<ul class="list-unstyled">
 																{% for tag in tags %}
+																	{% if ( tag.results > 0 ) %}
 																	<li>
 																		<label class="custom-control">
 																			<input
@@ -188,6 +189,7 @@
 																			<span class="custom-control-description">{{ tag.name|e('wp_kses_post')|raw }} ({{ tag.results }})</span>
 																		</label>
 																	</li>
+																	{% endif %}
 																{% endfor %}
 															</ul>
 														</div>
@@ -228,6 +230,7 @@
 									<div id="item-issue" class="collapse show" role="tabpanel">
 										<ul class="list-unstyled">
 											{% for category in categories %}
+												{% if ( category.results > 0 ) %}
 												<li>
 													<label class="custom-control">
 														<input
@@ -242,6 +245,7 @@
 														<span class="custom-control-description">{{ category.name|e('wp_kses_post')|raw }} ({{ category.results }})</span>
 													</label>
 												</li>
+												{% endif %}
 											{% endfor %}
 										</ul>
 									</div>
@@ -255,6 +259,7 @@
 									<div id="item-campaign" class="collapse {{ show }}" role="tabpanel">
 										<ul class="list-unstyled">
 											{% for tag in tags %}
+												{% if ( tag.results > 0 ) %}
 												<li>
 													<label class="custom-control">
 														<input
@@ -268,6 +273,7 @@
 														<span class="custom-control-description">{{ tag.name|e('wp_kses_post')|raw }} ({{ tag.results }})</span>
 													</label>
 												</li>
+												{% endif %}
 											{% endfor %}
 										</ul>
 									</div>
@@ -308,6 +314,7 @@
 									<div id="item-content" class="collapse {{ show }}" role="tabpanel">
 										<ul class="list-unstyled">
 											{% for id, content_type in content_types %}
+												{% if ( content_type.results > 0 ) %}
 												<li>
 													<label class="custom-control">
 														<input
@@ -322,6 +329,7 @@
 														<span class="custom-control-description">{{ content_type.name }} ({{ content_type.results }})</span>
 													</label>
 												</li>
+												{% endif %}
 											{% endfor %}
 										</ul>
 									</div>


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6652

> - We could re-purpose the filters to follow native taxonomies. So in the end we can have these filters:
>    "Categories" (actual categories)
>    "Tags" (actual tags) leave out for now
>    "Post Types" (eg. Stories, Publications, etc)
>    "Action Types" (eg. Petition, Event)
>    "Content Types" (WP post types. eg. pages, posts, actions, archive, document, etc)
> - Hide taxonomies and post types if there is no content

<table>
<tr>
<td><em>Master branch</em></td>
<td><em>This branch</em></td>
</tr>
<td>
<img src="https://user-images.githubusercontent.com/617346/165051375-a590aad2-eaef-4f7e-9640-93c63c4f6dcd.png" />
</td>
<td>
<img src="https://user-images.githubusercontent.com/617346/165467662-23a075f6-ee7c-46ff-bb91-4031132a1fb0.png" />
</td>
</tr>
</table>


## Test

Test on [Phobos](https://www-dev.greenpeace.org/test-phobos)

Locally, run the elastic container and the indexation
```shell
> docker-compose -f docker-compose.full.yml up -d elasticsearch
> docker-compose exec php-fpm wp option update ep_host $(ELASTICSEARCH_HOST)
> docker-compose exec php-fpm wp elasticpress index --setup --quiet 
```