### PR TITLE
PLANET-6652: Extract search filters

### DIFF
--- a/src/ElasticSearch.php
+++ b/src/ElasticSearch.php
@@ -27,6 +27,7 @@ class ElasticSearch extends Search {
 						case 'cat':
 						case 'tag':
 						case 'ptype':
+						case 'atype':
 							break;
 						case 'ctype':
 							switch ( $filter['id'] ) {
@@ -72,6 +73,7 @@ class ElasticSearch extends Search {
 									);
 									break;
 								case 5:
+								case 6:
 									break;
 								default:
 									throw new UnexpectedValueException( 'Unexpected content type!' );
@@ -212,29 +214,34 @@ class ElasticSearch extends Search {
 			'with_post_filter' => [
 				'filter' => $formatted_args['post_filter'],
 				'aggs'   => [
-					'post_type'    => [
+					'post_type'          => [
 						'terms' => [
 							'field' => 'post_type.raw',
 						],
 					],
-					'post_parent'  => [
+					'post_parent'        => [
 						'terms' => [
 							'field' => 'post_parent',
 						],
 					],
-					'categories'   => [
+					'categories'         => [
 						'terms' => [
 							'field' => 'terms.category.term_id',
 						],
 					],
-					'tags'         => [
+					'tags'               => [
 						'terms' => [
 							'field' => 'terms.post_tag.term_id',
 						],
 					],
-					'p4-page-type' => [
+					'p4-page-type'       => [
 						'terms' => [
 							'field' => 'terms.p4-page-type.term_id',
+						],
+					],
+					ActionPage::TAXONOMY => [
+						'terms' => [
+							'field' => 'terms.' . ActionPage::TAXONOMY . '.term_id',
 						],
 					],
 				],

--- a/src/ElasticSearch.php
+++ b/src/ElasticSearch.php
@@ -33,25 +33,7 @@ class ElasticSearch extends Search {
 							switch ( $filter['id'] ) {
 								case 0:
 								case 1:
-									break;
 								case 2:
-									// Workaround for making 'post_parent__not_in' to work with ES.
-									add_filter(
-										'ep_formatted_args',
-										function ( $formatted_args ) use ( $args ) {
-											// Make sure it is not an Action page.
-											if ( ! empty( $args['post_parent__not_in'] ) ) {
-												$formatted_args['post_filter']['bool']['must_not'][] = [
-													'terms' => [
-														'post_parent' => array_values( (array) $args['post_parent__not_in'] ),
-													],
-												];
-											}
-											return $formatted_args;
-										},
-										10,
-										1
-									);
 									break;
 								case 3:
 								case 4:

--- a/src/ElasticSearch.php
+++ b/src/ElasticSearch.php
@@ -176,21 +176,6 @@ class ElasticSearch extends Search {
 			],
 		);
 
-		$act_page = planet4_get_option( 'act_page', null );
-		if ( $act_page ) {
-			array_push(
-				$formatted_args['query']['function_score']['functions'],
-				[
-					'filter' => [
-						'term' => [
-							'post_parent' => esc_sql( $act_page ),
-						],
-					],
-					'weight' => self::DEFAULT_ACTION_WEIGHT,
-				],
-			);
-		}
-
 		// Specify how the computed scores are combined.
 		$formatted_args['query']['function_score']['score_mode'] = 'sum';
 

--- a/src/Search.php
+++ b/src/Search.php
@@ -533,6 +533,10 @@ abstract class Search {
 			$types[] = PostArchive::POST_TYPE;
 		}
 
+		if ( ActionPostType::is_active() ) {
+			$types[] = ActionPage::POST_TYPE;
+		}
+
 		return $types;
 	}
 
@@ -853,32 +857,15 @@ abstract class Search {
 			}
 		}
 
+		$content_types = Search\Filters\ContentTypes::get_filters();
 		foreach ( (array) $posts as $post ) {
-			// Post Type (+Action) <-> Content Type.
-			switch ( $post->post_type ) {
-				case 'page':
-					$content_type_text = __( 'PAGE', 'planet4-master-theme' );
-					$content_type      = 'page';
-					break;
-				case 'campaign':
-					$content_type_text = __( 'CAMPAIGN', 'planet4-master-theme' );
-					$content_type      = 'campaign';
-					break;
-				case 'attachment':
-					$content_type_text = __( 'DOCUMENT', 'planet4-master-theme' );
-					$content_type      = 'document';
-					break;
-				case 'post':
-					$content_type_text = __( 'POST', 'planet4-master-theme' );
-					$content_type      = 'post';
-					break;
-				case PostArchive::POST_TYPE:
-					$content_type_text = __( 'Archive', 'planet4-master-theme' );
-					$content_type      = 'archive';
-					break;
-				default:
-					continue 2;     // Ignore other post_types and continue with next $post.
+			$type = $content_types[ $post->post_type ] ?? null;
+			if ( ! $type ) {
+				continue;
 			}
+
+			$content_type_text = $type ? $type['label'] : $post->post_type;
+			$content_type      = 'attachment' === $post->post_type ? 'document' : $post->post_type;
 
 			if ( ! isset( $post->ID ) ) {
 				$post->ID = $post->link;

--- a/src/Search.php
+++ b/src/Search.php
@@ -727,85 +727,21 @@ abstract class Search {
 	 * @throws UnexpectedValueException When filter type is not recognized.
 	 */
 	protected function set_filters_context( &$context ) {
-		// Retrieve P4 settings in order to check that we add only categories that are children of the Issues category.
-		$options = get_option( 'planet4_options' );
+		// Categories.
+		$context['categories'] = Search\Filters\Categories::get_filters();
+		uasort( $context['categories'], fn ( $a, $b ) => strcmp( $a['name'], $b['name'] ) );
 
-		// Category <-> Issue.
-		// Consider Issues that have multiple Categories.
-		$categories = get_categories( [ 'child_of' => $options['issues_parent_category'] ] );
-		if ( $categories ) {
-			foreach ( $categories as $category ) {
-				$context['categories'][ $category->term_id ] = [
-					'term_id' => $category->term_id,
-					'name'    => $category->name,
-					'results' => 0,
-				];
-			}
-		}
+		// Post Types.
+		$context['post_types'] = Search\Filters\PostTypes::get_filters();
+
+		// Content Types.
+		$context['content_types'] = Search\Filters\ContentTypes::get_filters(
+			self::should_include_archive()
+		);
 
 		// Tag <-> Campaign.
-		$tags = get_terms(
-			[
-				'taxonomy'   => 'post_tag',
-				'hide_empty' => false,
-			]
-		);
-		if ( $tags ) {
-			foreach ( (array) $tags as $tag ) {
-				// Tag filters.
-				$context['tags'][ $tag->term_id ] = [
-					'term_id' => $tag->term_id,
-					'name'    => $tag->name,
-					'results' => 0,
-				];
-			}
-		}
-
-		// Page Type <-> Category.
-		$page_types = get_terms(
-			[
-				'taxonomy'   => 'p4-page-type',
-				'hide_empty' => false,
-			]
-		);
-		if ( $page_types ) {
-			foreach ( (array) $page_types as $page_type ) {
-				// p4-page-type filters.
-				$context['page_types'][ $page_type->term_id ] = [
-					'term_id' => $page_type->term_id,
-					'name'    => $page_type->name,
-					'results' => 0,
-				];
-			}
-		}
-
-		// Post Type (+Action) <-> Content Type.
-		$context['content_types']['0'] = [
-			'name'    => __( 'Action', 'planet4-master-theme' ),
-			'results' => 0,
-		];
-		$context['content_types']['4'] = [
-			'name'    => __( 'Campaign', 'planet4-master-theme' ),
-			'results' => 0,
-		];
-		$context['content_types']['1'] = [
-			'name'    => __( 'Document', 'planet4-master-theme' ),
-			'results' => 0,
-		];
-		$context['content_types']['2'] = [
-			'name'    => __( 'Page', 'planet4-master-theme' ),
-			'results' => 0,
-		];
-		$context['content_types']['3'] = [
-			'name'    => __( 'Post', 'planet4-master-theme' ),
-			'results' => 0,
-		];
-		if ( self::should_include_archive() ) {
-			$context['content_types']['5'] = [
-				'name'    => __( 'Archive', 'planet4-master-theme' ),
-				'results' => 0,
-			];
-		}
+		$context['tags'] = Search\Filters\Tags::get_filters();
+		uasort( $context['tags'], fn ( $a, $b ) => strcmp( $a['name'], $b['name'] ) );
 
 		// Keep track of which filters are already checked.
 		if ( $this->filters ) {
@@ -819,7 +755,7 @@ abstract class Search {
 							$context['tags'][ $filter['id'] ]['checked'] = 'checked';
 							break;
 						case 'ptype':
-							$context['page_types'][ $filter['id'] ]['checked'] = 'checked';
+							$context['post_types'][ $filter['id'] ]['checked'] = 'checked';
 							break;
 						case 'ctype':
 							$context['content_types'][ $filter['id'] ]['checked'] = 'checked';
@@ -830,33 +766,10 @@ abstract class Search {
 				}
 			}
 		}
-
-		// Sort associative array with filters alphabetically.
-		if ( $context['categories'] ?? false ) {
-			uasort(
-				$context['categories'],
-				function ( $a, $b ) {
-					return strcmp( $a['name'], $b['name'] );
-				}
-			);
-		}
-		if ( $context['tags'] ?? false ) {
-			uasort(
-				$context['tags'],
-				function ( $a, $b ) {
-					return strcmp( $a['name'], $b['name'] );
-				}
-			);
-		}
 	}
 
 	/**
 	 * Sets the context for the results of the Search.
-	 *
-	 * Categories are Issues.
-	 * Tags       are Campaigns.
-	 * Page types are Categories.
-	 * Post_types are Content Types.
 	 *
 	 * @param array $context Associative array with the data to be passed to the view.
 	 */
@@ -908,33 +821,24 @@ abstract class Search {
 			}
 
 			foreach ( $aggs['p4-page-type']['buckets'] as $p4_post_type_agg ) {
-				$p4_post_type_id = (int) $p4_post_type_agg['key'];
-
-				$p4_post_type = self::get_p4_post_type( $p4_post_type_id );
-
-				$context['page_types'][ $p4_post_type_id ] = [
-					'term_id' => $p4_post_type_id,
-					'name'    => $p4_post_type->name ?? null,
-					'results' => $p4_post_type_agg['doc_count'],
-				];
+				if ( ! isset( $context['post_types'][ $p4_post_type_agg['key'] ] ) ) {
+					continue;
+				}
+				$context['post_types'][ $p4_post_type_agg['key'] ]['results'] = $p4_post_type_agg['doc_count'];
 			}
 
 			foreach ( $aggs['categories']['buckets'] as $category_agg ) {
-				// TODO get the parent from ES so no fetch is needed here.
-				$category = get_category( $category_agg['key'] );
-
-				// Category <-> Issue.
-				// Consider Issues that have multiple Categories.
-				if ( $category->parent === (int) $options['issues_parent_category'] ) {
-					$context['categories'][ $category->term_id ]['results'] = $category_agg['doc_count'];
+				if ( ! isset( $context['categories'][ $category_agg['key'] ] ) ) {
+					continue;
 				}
+				$context['categories'][ $category_agg['key'] ]['results'] = $category_agg['doc_count'];
 			}
 
 			foreach ( $aggs['tags']['buckets'] as $tag_agg ) {
-				// Tag filters.
-				$tag = get_tag( $tag_agg['key'] );
-
-				$context['tags'][ $tag->term_id ]['results'] = $tag_agg['doc_count'];
+				if ( ! isset( $context['tags'][ $tag_agg['key'] ] ) ) {
+					continue;
+				}
+				$context['tags'][ $tag_agg['key'] ]['results'] = $tag_agg['doc_count'];
 			}
 		}
 

--- a/src/Search/Filters/ActionTypes.php
+++ b/src/Search/Filters/ActionTypes.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace P4\MasterTheme\Search\Filters;
+
+use P4\MasterTheme\ActionPage;
+
+/**
+ * Action types used for search (Petition, Event, etc.).
+ */
+class ActionTypes {
+	/**
+	 * Get all content types.
+	 *
+	 * @return array<WP_Post_Type>
+	 */
+	public static function get_all(): array {
+		return get_terms(
+			[
+				'taxonomy'   => ActionPage::TAXONOMY,
+				'hide_empty' => false,
+			]
+		);
+	}
+
+	/**
+	 * @return array{int, array{term_id: int, name: string, results: int}}
+	 */
+	public static function get_filters(): array {
+		$types   = self::get_all();
+		$filters = [];
+
+		foreach ( $types as $type ) {
+			$filters[ $type->term_id ] = [
+				'term_id' => $type->term_id,
+				'name'    => $type->name,
+				'results' => 0,
+			];
+		}
+
+		return $filters;
+	}
+}

--- a/src/Search/Filters/Categories.php
+++ b/src/Search/Filters/Categories.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace P4\MasterTheme\Search\Filters;
+
+/**
+ * Categories used for search.
+ */
+class Categories {
+	/**
+	 * @return array<WP_Term>
+	 */
+	public static function get_all(): array {
+		return get_categories();
+	}
+
+	/**
+	 * @return array{int, array{term_id: int, name: string, results: int}}
+	 */
+	public static function get_filters(): array {
+		$categories = self::get_all();
+		$filters    = [];
+
+		foreach ( $categories as $category ) {
+			if ( 'uncategorised' === $category->slug ) {
+				continue;
+			}
+
+			$filters[ $category->term_id ] = [
+				'term_id' => $category->term_id,
+				'name'    => $category->name,
+				'results' => 0,
+			];
+		}
+
+		return $filters;
+	}
+}

--- a/src/Search/Filters/ContentTypes.php
+++ b/src/Search/Filters/ContentTypes.php
@@ -10,7 +10,6 @@ namespace P4\MasterTheme\Search\Filters;
  * Custom types (p4_action, etc.).
  */
 class ContentTypes {
-	public const ACT_PAGE   = 'action';
 	public const POST       = 'post';
 	public const PAGE       = 'page';
 	public const ACTION     = 'p4_action';
@@ -54,15 +53,6 @@ class ContentTypes {
 		$types  = self::get_all();
 		$config = self::get_config();
 
-		// ACT_PAGE are sub-pages of the Act page and not a real type, adding manually.
-		$filters = [
-			0 => [
-				'id'      => 0,
-				'name'    => __( 'Action', 'planet4-master-theme' ),
-				'results' => 0,
-			],
-		];
-
 		foreach ( $types as $name => $type ) {
 			if ( self::ARCHIVE === $name && ! $include_archive ) {
 				continue;
@@ -94,10 +84,6 @@ class ContentTypes {
 	 */
 	public static function get_config(): array {
 		return [
-			self::ACT_PAGE   => [
-				'id'    => 0,
-				'label' => __( 'Action', 'planet4-master-theme' ),
-			],
 			self::ATTACHMENT => [
 				'id'    => 1,
 				'label' => __( 'Document', 'planet4-master-theme' ),

--- a/src/Search/Filters/ContentTypes.php
+++ b/src/Search/Filters/ContentTypes.php
@@ -13,6 +13,7 @@ class ContentTypes {
 	public const ACT_PAGE   = 'action';
 	public const POST       = 'post';
 	public const PAGE       = 'page';
+	public const ACTION     = 'p4_action';
 	public const CAMPAIGN   = 'campaign';
 	public const ATTACHMENT = 'attachment';
 	public const ARCHIVE    = 'archive';
@@ -42,11 +43,13 @@ class ContentTypes {
 
 	/**
 	 * @param bool $include_archive Include archive type.
+	 * @param bool $include_action Include p4_action type.
 	 *
 	 * @return array{string, array{id: int, name: string, results: int}}
 	 */
 	public static function get_filters(
-		bool $include_archive = false
+		bool $include_archive = false,
+		bool $include_action = false
 	): array {
 		$types  = self::get_all();
 		$config = self::get_config();
@@ -62,6 +65,10 @@ class ContentTypes {
 
 		foreach ( $types as $name => $type ) {
 			if ( self::ARCHIVE === $name && ! $include_archive ) {
+				continue;
+			}
+
+			if ( self::ACTION === $name && ! $include_action ) {
 				continue;
 			}
 
@@ -110,6 +117,10 @@ class ContentTypes {
 			self::ARCHIVE    => [
 				'id'    => 5,
 				'label' => __( 'Archive', 'planet4-master-theme' ),
+			],
+			self::ACTION     => [
+				'id'    => 6,
+				'label' => __( 'Action', 'planet4-master-theme' ),
 			],
 		];
 	}

--- a/src/Search/Filters/ContentTypes.php
+++ b/src/Search/Filters/ContentTypes.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace P4\MasterTheme\Search\Filters;
+
+/**
+ * Content type used for search.
+ * Native types (post, page, attachment, etc.).
+ * Custom types (p4_action, etc.).
+ */
+class ContentTypes {
+	public const ACT_PAGE   = 'action';
+	public const POST       = 'post';
+	public const PAGE       = 'page';
+	public const CAMPAIGN   = 'campaign';
+	public const ATTACHMENT = 'attachment';
+	public const ARCHIVE    = 'archive';
+
+	/**
+	 * Get all content types.
+	 *
+	 * @return array<WP_Post_Type>
+	 */
+	public static function get_all(): array {
+		$config = self::get_config();
+		$types  = get_post_types(
+			[
+				'public'              => true,
+				'exclude_from_search' => false,
+			],
+			false
+		);
+
+		return array_filter(
+			$types,
+			function ( $type ) use ( $config ) {
+				return isset( $config[ $type->name ] );
+			}
+		);
+	}
+
+	/**
+	 * @param bool $include_archive Include archive type.
+	 *
+	 * @return array{string, array{id: int, name: string, results: int}}
+	 */
+	public static function get_filters(
+		bool $include_archive = false
+	): array {
+		$types  = self::get_all();
+		$config = self::get_config();
+
+		// ACT_PAGE are sub-pages of the Act page and not a real type, adding manually.
+		$filters = [
+			0 => [
+				'id'      => 0,
+				'name'    => __( 'Action', 'planet4-master-theme' ),
+				'results' => 0,
+			],
+		];
+
+		foreach ( $types as $name => $type ) {
+			if ( self::ARCHIVE === $name && ! $include_archive ) {
+				continue;
+			}
+
+			$type_data = $config[ $type->name ] ?? null;
+			if ( ! $type_data ) {
+				continue;
+			}
+
+			$filters[ $type_data['id'] ] = [
+				'id'      => $type_data['id'],
+				'name'    => $type_data['label'],
+				'results' => 0,
+			];
+		}
+
+		return $filters;
+	}
+
+	/**
+	 * Get all content type config for search
+	 *
+	 * @return array{string, array{id: int, label: string}}
+	 */
+	public static function get_config(): array {
+		return [
+			self::ACT_PAGE   => [
+				'id'    => 0,
+				'label' => __( 'Action', 'planet4-master-theme' ),
+			],
+			self::ATTACHMENT => [
+				'id'    => 1,
+				'label' => __( 'Document', 'planet4-master-theme' ),
+			],
+			self::PAGE       => [
+				'id'    => 2,
+				'label' => __( 'Page', 'planet4-master-theme' ),
+			],
+			self::POST       => [
+				'id'    => 3,
+				'label' => __( 'Post', 'planet4-master-theme' ),
+			],
+			self::CAMPAIGN   => [
+				'id'    => 4,
+				'label' => __( 'Campaign', 'planet4-master-theme' ),
+			],
+			self::ARCHIVE    => [
+				'id'    => 5,
+				'label' => __( 'Archive', 'planet4-master-theme' ),
+			],
+		];
+	}
+}

--- a/src/Search/Filters/PostTypes.php
+++ b/src/Search/Filters/PostTypes.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace P4\MasterTheme\Search\Filters;
+
+use WP_Term;
+
+/**
+ * Post types used for search (Press release, News, Report, etc.).
+ * Configured in `Posts > Posts Types`
+ */
+class PostTypes {
+	/**
+	 * @return WP_Term[]
+	 */
+	public static function get_all(): array {
+		$types = get_terms(
+			[
+				'taxonomy'   => 'p4-page-type',
+				'hide_empty' => false,
+			]
+		);
+
+		if ( is_wp_error( $types )
+			|| ! is_array( $types )
+			|| empty( $types )
+			|| ! ( $types[0] instanceof WP_Term )
+		) {
+			return [];
+		}
+
+		return $types;
+	}
+
+	/**
+	 * @return array{int, array{term_id: int, name: string, results: int}}
+	 */
+	public static function get_filters(): array {
+		$post_types = self::get_all();
+		$filters    = [];
+
+		foreach ( $post_types as $post_type ) {
+			$filters[ $post_type->term_id ] = [
+				'term_id' => $post_type->term_id,
+				'name'    => $post_type->name,
+				'results' => 0,
+			];
+		}
+
+		return $filters;
+	}
+}

--- a/src/Search/Filters/Tags.php
+++ b/src/Search/Filters/Tags.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace P4\MasterTheme\Search\Filters;
+
+use WP_Term;
+
+/**
+ * Tags used for search.
+ */
+class Tags {
+	/**
+	 * @return WP_Term[]
+	 */
+	public static function get_all(): array {
+		$tags = get_terms(
+			[
+				'taxonomy'   => 'post_tag',
+				'hide_empty' => false,
+			]
+		);
+
+		if ( is_wp_error( $tags ) ) {
+			return [];
+		}
+
+		return $tags;
+	}
+
+	/**
+	 * @return array{int, array{term_id: int, name: string, results: int}}
+	 */
+	public static function get_filters(): array {
+		$tags    = self::get_all();
+		$filters = [];
+
+		foreach ( $tags as $tag ) {
+			$filters[ $tag->term_id ] = [
+				'term_id' => $tag->term_id,
+				'name'    => $tag->name,
+				'results' => 0,
+			];
+		}
+
+		return $filters;
+	}
+}

--- a/templates/search.twig
+++ b/templates/search.twig
@@ -249,6 +249,35 @@
 									</div>
 								</div>
 							{% endif %}
+							{% if ( action_types|length > 0 ) %}
+								<div class="filteritem">
+									<a data-bs-toggle="collapse" href="#item-content" class="{{ collapsed }}" aria-expanded="{{ expanded }}">
+										{{ __( 'Action Type', 'planet4-master-theme' ) }} <span></span>
+									</a>
+									<div id="item-content" class="collapse {{ show }}" role="tabpanel">
+										<ul class="list-unstyled">
+											{% for id, action_type in action_types %}
+												{% if ( action_type.results > 0 ) %}
+												<li>
+													<label class="custom-control">
+														<input
+															type="checkbox"
+															name="f[atype][{{ action_type.name }}]"
+															value="{{ id }}"
+															class="p4-custom-control-input"
+															data-ga-category="Search Page"
+															data-ga-action="Content Filter"
+															data-ga-label="{{ action_type.name|e('wp_kses_post')|raw }}"
+															{{ action_type.checked }} {{ action_type.results > 0 ? '' : 'disabled' }} />
+														<span class="custom-control-description">{{ action_type.name }} ({{ action_type.results }})</span>
+													</label>
+												</li>
+												{% endif %}
+											{% endfor %}
+										</ul>
+									</div>
+								</div>
+							{% endif %}
 							{% if ( content_types|length > 0 ) %}
 								<div class="filteritem">
 									<a data-bs-toggle="collapse" href="#item-content" class="{{ collapsed }}" aria-expanded="{{ expanded }}">

--- a/templates/search.twig
+++ b/templates/search.twig
@@ -165,37 +165,6 @@
 													{% endif %}
 												</div>
 											</div>
-											<div class="col-md-6">
-												{% if ( tags|length > 0 ) %}
-													<div class="filteritem">
-														<a data-bs-toggle="collapse" href="#item-modal-campaign" aria-expanded="true">
-															{{ __( 'Campaign', 'planet4-master-theme' ) }} <span></span>
-														</a>
-														<div id="item-modal-campaign" class="collapse show" role="tabpanel">
-															<ul class="list-unstyled">
-																{% for tag in tags %}
-																	{% if ( tag.results > 0 ) %}
-																	<li>
-																		<label class="custom-control">
-																			<input
-																				type="checkbox"
-																				name="f[tag][{{ tag.name }}]"
-																				value="{{ tag.term_id }}"
-																				class="p4-custom-control-input modal-checkbox"
-																				data-ga-category="Search Page"
-																				data-ga-action="Tag Filter"
-																				data-ga-label="{{ tag.name|e('wp_kses_post')|raw }}"
-																				{{ tag.checked }} {{ tag.results > 0 ? '' : 'disabled' }} />
-																			<span class="custom-control-description">{{ tag.name|e('wp_kses_post')|raw }} ({{ tag.results }})</span>
-																		</label>
-																	</li>
-																	{% endif %}
-																{% endfor %}
-															</ul>
-														</div>
-													</div>
-												{% endif %}
-											</div>
 										</div>
 										<div class="btnact">
 											<button type="button" class="btn btn-action btn-small cancelbtn" data-bs-dismiss="modal">{{ __( 'Cancel', 'planet4-master-theme' ) }}</button>
@@ -243,34 +212,6 @@
 																data-ga-label="{{ category.name|e('wp_kses_post')|raw }}"
 																{{ category.checked }} {{ category.results > 0 ? '' : 'disabled' }} />
 														<span class="custom-control-description">{{ category.name|e('wp_kses_post')|raw }} ({{ category.results }})</span>
-													</label>
-												</li>
-												{% endif %}
-											{% endfor %}
-										</ul>
-									</div>
-								</div>
-							{% endif %}
-							{% if ( tags|length > 0 ) %}
-								<div class="filteritem">
-									<a data-bs-toggle="collapse" href="#item-campaign" class="{{ collapsed }}" aria-expanded="{{ expanded }}">
-										{{ __( 'Campaign', 'planet4-master-theme' ) }} <span></span>
-									</a>
-									<div id="item-campaign" class="collapse {{ show }}" role="tabpanel">
-										<ul class="list-unstyled">
-											{% for tag in tags %}
-												{% if ( tag.results > 0 ) %}
-												<li>
-													<label class="custom-control">
-														<input
-															type="checkbox"
-															name="f[tag][{{ tag.name }}]"
-															value="{{ tag.term_id }}"
-															class="p4-custom-control-input" {{ tag.checked }} {{ tag.results > 0 ? '' : 'disabled' }}
-															data-ga-category="Search Page"
-															data-ga-action="Tag Filter"
-															data-ga-label="{{ tag.name|e('wp_kses_post')|raw }}" />
-														<span class="custom-control-description">{{ tag.name|e('wp_kses_post')|raw }} ({{ tag.results }})</span>
 													</label>
 												</li>
 												{% endif %}

--- a/templates/search.twig
+++ b/templates/search.twig
@@ -279,28 +279,30 @@
 									</div>
 								</div>
 							{% endif %}
-							{% if ( page_types|length > 0 ) %}
+							{% if ( post_types|length > 0 ) %}
 								<div class="filteritem">
 									<a data-bs-toggle="collapse" href="#item-category" class="{{ collapsed }}" aria-expanded="{{ expanded }}">
 										{{ __( 'Post Type', 'planet4-master-theme' ) }} <span></span>
 									</a>
 									<div id="item-category" class="collapse {{ show }}" role="tabpanel">
 										<ul class="list-unstyled">
-											{% for page_type in page_types %}
+											{% for post_type in post_types %}
+												{% if ( post_type.results > 0 ) %}
 												<li>
 													<label class="custom-control">
 														<input
 															type="checkbox"
-															name="f[ptype][{{ page_type.name }}]"
-															value="{{ page_type.term_id }}"
+															name="f[ptype][{{ post_type.name }}]"
+															value="{{ post_type.term_id }}"
 															class="p4-custom-control-input"
 															data-ga-category="Search Page"
 															data-ga-action="Post Type Filter"
-															data-ga-label="{{ page_type.name|e('wp_kses_post')|raw }}"
-															{{ page_type.checked }} {{ page_type.results > 0 ? '' : 'disabled' }} />
-														<span class="custom-control-description">{{ page_type.name|e('wp_kses_post')|raw }} ({{ page_type.results }})</span>
+															data-ga-label="{{ post_type.name|e('wp_kses_post')|raw }}"
+															{{ post_type.checked }} {{ post_type.results > 0 ? '' : 'disabled' }} />
+														<span class="custom-control-description">{{ post_type.name|e('wp_kses_post')|raw }} ({{ post_type.results }})</span>
 													</label>
 												</li>
+												{% endif %}
 											{% endfor %}
 										</ul>
 									</div>


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6652
Ref: https://jira.greenpeace.org/browse/PLANET-6797
Ref/ https://jira.greenpeace.org/browse/PLANET-6578

Clarify search code by matching native taxonomy with class structure 
- Extract search filters to their own classes
- Rename page_types to post_types
- Hide tags search
- Add p4_action type to search