### PR TITLE
Harmonize Features titles and descriptions

### DIFF
--- a/src/Feature.php
+++ b/src/Feature.php
@@ -91,7 +91,7 @@ abstract class Feature {
 		return [
 			'id'   => static::id(),
 			'name' => self::dev_prefix( '👷' ) . static::name(),
-			'desc' => self::dev_prefix( '(dev only)' ) . static::description(),
+			'desc' => static::description(),
 			'type' => 'checkbox',
 		];
 	}

--- a/src/Features/ActionPostType.php
+++ b/src/Features/ActionPostType.php
@@ -29,7 +29,7 @@ class ActionPostType extends Feature {
 	 */
 	protected static function description(): string {
 		return __(
-			'Enable Action post type',
+			'Enable <a href="https://jira.greenpeace.org/browse/PLANET-6515" target="_blank">Action post type</a> and Action Type taxonomy. Actions will also be selectable in Take Action Boxout and Covers blocks.',
 			'planet4-master-theme-backend'
 		);
 	}

--- a/src/Features/CloudflareDeployPurge.php
+++ b/src/Features/CloudflareDeployPurge.php
@@ -20,7 +20,7 @@ class CloudflareDeployPurge extends Feature {
 	 * @inheritDoc
 	 */
 	protected static function name(): string {
-		return __( 'Purge HTML from Cloudflare on deploy', 'planet4-master-theme-backend' );
+		return __( 'Purge Cloudflare HTML cache on deploy', 'planet4-master-theme-backend' );
 	}
 
 	/**
@@ -28,7 +28,7 @@ class CloudflareDeployPurge extends Feature {
 	 */
 	protected static function description(): string {
 		return __(
-			'Whether to purge all pages from Cloudflare cache when changing features.<br>Only enable on production, on test instances it results in too many purge requests.',
+			'Purges all pages from Cloudflare cache on deploy.<br>Only enable on production (in consultation with P4 team).',
 			'planet4-master-theme-backend'
 		);
 	}

--- a/src/Features/Dev/AllowAllBlocks.php
+++ b/src/Features/Dev/AllowAllBlocks.php
@@ -20,7 +20,7 @@ class AllowAllBlocks extends Feature {
 	 * @inheritDoc
 	 */
 	protected static function name(): string {
-		return __( 'Allow all blocks', 'planet4-master-theme-backend' );
+		return __( 'All blocks', 'planet4-master-theme-backend' );
 	}
 
 	/**

--- a/src/Features/Dev/BetaBlocks.php
+++ b/src/Features/Dev/BetaBlocks.php
@@ -20,7 +20,7 @@ class BetaBlocks extends Feature {
 	 * @inheritDoc
 	 */
 	protected static function name(): string {
-		return __( 'Allow Beta Blocks in post editor', 'planet4-master-theme-backend' );
+		return __( 'Beta blocks', 'planet4-master-theme-backend' );
 	}
 
 	/**
@@ -28,7 +28,7 @@ class BetaBlocks extends Feature {
 	 */
 	protected static function description(): string {
 		return __(
-			'If enabled, you can use early or unstable versions of blocks in the post editor.<br>These will be in the "Planet 4 Blocks - BETA" category.',
+			'Enable early or unstable versions of blocks in the editor (grouped under "Planet 4 Blocks - BETA" category).',
 			'planet4-master-theme-backend'
 		);
 	}

--- a/src/Features/Dev/CoreBlockPatterns.php
+++ b/src/Features/Dev/CoreBlockPatterns.php
@@ -20,7 +20,7 @@ class CoreBlockPatterns extends Feature {
 	 * @inheritDoc
 	 */
 	protected static function name(): string {
-		return __( 'Enable core block patterns', 'planet4-master-theme-backend' );
+		return __( 'Core block patterns', 'planet4-master-theme-backend' );
 	}
 
 	/**
@@ -28,7 +28,7 @@ class CoreBlockPatterns extends Feature {
 	 */
 	protected static function description(): string {
 		return __(
-			'Allows using the default block patterns that come with WordPress.',
+			'Enable default block patterns that come with WordPress.',
 			'planet4-master-theme-backend'
 		);
 	}

--- a/src/Features/Dev/DisableTagRedirectPages.php
+++ b/src/Features/Dev/DisableTagRedirectPages.php
@@ -27,7 +27,7 @@ class DisableTagRedirectPages extends Feature {
 	 */
 	protected static function description(): string {
 		return __(
-			'Prevent redirect mechanism so that the original auto generated content is always shown. Prevents having to disable many pages to see the auto generated page.',
+			'Use default auto-generated tag listing page.',
 			'planet4-master-theme-backend'
 		);
 	}

--- a/src/Features/Dev/ListingPagePagination.php
+++ b/src/Features/Dev/ListingPagePagination.php
@@ -20,7 +20,7 @@ class ListingPagePagination extends Feature {
 	 * @inheritDoc
 	 */
 	protected static function name(): string {
-		return __( 'Listing Page Pagination', 'planet4-master-theme-backend' );
+		return __( 'Listing pages pagination', 'planet4-master-theme-backend' );
 	}
 
 	/**

--- a/src/Features/Dev/WPTemplateEditor.php
+++ b/src/Features/Dev/WPTemplateEditor.php
@@ -20,7 +20,7 @@ class WPTemplateEditor extends Feature {
 	 * @inheritDoc
 	 */
 	protected static function name(): string {
-		return __( 'Enable WordPress template editor', 'planet4-master-theme-backend' );
+		return __( 'WordPress template editor', 'planet4-master-theme-backend' );
 	}
 
 	/**

--- a/src/Features/DropdownMenu.php
+++ b/src/Features/DropdownMenu.php
@@ -21,7 +21,7 @@ class DropdownMenu extends Feature {
 	 * @inheritDoc
 	 */
 	protected static function name(): string {
-		return __( 'Enable dropdown menu', 'planet4-master-theme-backend' );
+		return __( 'Dropdown navigation menus', 'planet4-master-theme-backend' );
 	}
 
 	/**
@@ -29,7 +29,7 @@ class DropdownMenu extends Feature {
 	 */
 	protected static function description(): string {
 		return __(
-			'Display subitems through a list.',
+			'Display menu subitems on <a href="https://p4-designsystem.greenpeace.org/05f6e9516/p/106cdb-navigation-bar" target="_blank">top navigation bar</a>.',
 			'planet4-master-theme-backend'
 		);
 	}

--- a/src/Features/EngagingNetworks.php
+++ b/src/Features/EngagingNetworks.php
@@ -28,7 +28,7 @@ class EngagingNetworks extends Feature {
 	 */
 	protected static function description(): string {
 		return __(
-			'Enable the Engaging Networks integration.<br>If turned on you will be able to use the EN Form block, as well as the "Progress Bar inside EN Form" Counter block style.',
+			'Activate the EN Form block, as well as the "Progress Bar inside EN Form" Counter block style.',
 			'planet4-master-theme-backend'
 		);
 	}

--- a/src/Features/GdprCheckbox.php
+++ b/src/Features/GdprCheckbox.php
@@ -21,7 +21,7 @@ class GdprCheckbox extends Feature {
 	 * @inheritDoc
 	 */
 	protected static function name(): string {
-		return __( 'Display Opt-in checkbox', 'planet4-master-theme-backend' );
+		return __( 'Comments opt-in checkbox', 'planet4-master-theme-backend' );
 	}
 
 	/**
@@ -29,7 +29,7 @@ class GdprCheckbox extends Feature {
 	 */
 	protected static function description(): string {
 		return __(
-			'This will display an opt-in checkbox in the Comments form which will be mandatory for submitting the form (GDPR requirement).',
+			'Display a mandatory opt-in checkbox in the Comments form (GDPR requirement).',
 			'planet4-master-theme-backend'
 		);
 	}

--- a/src/Features/GoogleSheetReplacesSmartsheet.php
+++ b/src/Features/GoogleSheetReplacesSmartsheet.php
@@ -20,7 +20,7 @@ class GoogleSheetReplacesSmartsheet extends Feature {
 	 * @inheritDoc
 	 */
 	protected static function name(): string {
-		return __( 'Google Sheets replaces Smartsheet', 'planet4-master-theme-backend' );
+		return __( 'Google Sheets instead of Smartsheet', 'planet4-master-theme-backend' );
 	}
 
 	/**
@@ -28,7 +28,7 @@ class GoogleSheetReplacesSmartsheet extends Feature {
 	 */
 	protected static function description(): string {
 		return __(
-			'Toggle whether to use Google Sheets to fetch the list of analytics options.',
+			'Use Google Sheets to fetch the <a href="https://jira.greenpeace.org/browse/PLANET-6452" target="_blank">local</a> and <a href="https://jira.greenpeace.org/browse/PLANET-6451" target="_blank">global</a> projects.',
 			'planet4-master-theme-backend'
 		);
 	}

--- a/src/Features/ImageArchive.php
+++ b/src/Features/ImageArchive.php
@@ -31,7 +31,7 @@ class ImageArchive extends Feature {
 	 */
 	protected static function description(): string {
 		return __(
-			'Beta test the new Image Archive. This will replace the GPI Media Library plugin.',
+			'Drop-in replacement for the GPI Media Library plugin. If enabled, the plugin can be disabled.',
 			'planet4-master-theme-backend'
 		);
 	}

--- a/src/Features/LazyYoutubePlayer.php
+++ b/src/Features/LazyYoutubePlayer.php
@@ -28,7 +28,7 @@ class LazyYoutubePlayer extends Feature {
 	 */
 	protected static function description(): string {
 		return __(
-			'Only load the YouTube player after clicking a video.',
+			'Only load the YouTube player after clicking on a video (<a href="https://jira.greenpeace.org/browse/PLANET-5959" target="_blank">details</a>).<br>Disabling it will have a big performance impact.',
 			'planet4-master-theme-backend'
 		);
 	}

--- a/src/Features/MobileTabsMenu.php
+++ b/src/Features/MobileTabsMenu.php
@@ -21,7 +21,7 @@ class MobileTabsMenu extends Feature {
 	 * @inheritDoc
 	 */
 	protected static function name(): string {
-		return __( 'Enable mobile tabs menu', 'planet4-master-theme-backend' );
+		return __( 'Mobile tabs menu', 'planet4-master-theme-backend' );
 	}
 
 	/**

--- a/src/Features/NewDesignCountrySelector.php
+++ b/src/Features/NewDesignCountrySelector.php
@@ -20,7 +20,7 @@ class NewDesignCountrySelector extends Feature {
 	 * @inheritDoc
 	 */
 	protected static function name(): string {
-		return __( 'Enable new Country selector design', 'planet4-master-theme-backend' );
+		return __( 'New Country selector design', 'planet4-master-theme-backend' );
 	}
 
 	/**
@@ -28,7 +28,7 @@ class NewDesignCountrySelector extends Feature {
 	 */
 	protected static function description(): string {
 		return __(
-			'Enable the new Country selector design as described in the <a href="https://p4-designsystem.greenpeace.org/05f6e9516/v/0/p/16a899-footer" target="_blank">design system</a>.<br/>This might break your child theme, depending on how you extended the main templates and CSS.<br/>Changing this option will take a bit of time, as it also attempts to clear the Cloudflare cache.',
+			'Enables the new Country selector design as described in the <a href="https://p4-designsystem.greenpeace.org/05f6e9516/v/0/p/16a899-footer" target="_blank">design system</a>.<br>This might need changes in your child theme code.',
 			'planet4-master-theme-backend'
 		);
 	}

--- a/src/Features/NewDesignNavigationBar.php
+++ b/src/Features/NewDesignNavigationBar.php
@@ -20,7 +20,7 @@ class NewDesignNavigationBar extends Feature {
 	 * @inheritDoc
 	 */
 	protected static function name(): string {
-		return __( 'Enable new Navigation bar design', 'planet4-master-theme-backend' );
+		return __( 'New Navigation bar design', 'planet4-master-theme-backend' );
 	}
 
 	/**
@@ -28,7 +28,7 @@ class NewDesignNavigationBar extends Feature {
 	 */
 	protected static function description(): string {
 		return __(
-			'Enable the new Navigation bar design as described in the <a href="https://p4-designsystem.greenpeace.org/05f6e9516/p/106cdb-navigation-bar" target="_blank">design system</a>.<br/>This might break your child theme, depending on how you extended the main templates and CSS.<br/>Changing this option will take a bit of time, as it also attempts to clear the Cloudflare cache.',
+			'Enables the new Navigation bar design as described in the <a href="https://p4-designsystem.greenpeace.org/05f6e9516/p/106cdb-navigation-bar" target="_blank">design system</a>.<br>This might need changes in your child theme code.',
 			'planet4-master-theme-backend'
 		);
 	}

--- a/src/Features/PostPageCategoryLinks.php
+++ b/src/Features/PostPageCategoryLinks.php
@@ -22,7 +22,7 @@ class PostPageCategoryLinks extends Feature {
 	 * @inheritDoc
 	 */
 	protected static function name(): string {
-		return __( 'Post Page Category Links', 'planet4-master-theme-backend' );
+		return __( 'Category links on Posts', 'planet4-master-theme-backend' );
 	}
 
 	/**
@@ -30,7 +30,7 @@ class PostPageCategoryLinks extends Feature {
 	 */
 	protected static function description(): string {
 		return __(
-			'On post pages, link to the categories, instead of a page that has the same category ("issue pages").',
+			'On Posts, link to the catagories, instead of issue pages. (<a href="https://jira.greenpeace.org/browse/PLANET-6747" target="_blank">details</a>)',
 			'planet4-master-theme-backend'
 		);
 	}

--- a/src/Features/PurgeOnFeatureChanges.php
+++ b/src/Features/PurgeOnFeatureChanges.php
@@ -20,7 +20,7 @@ class PurgeOnFeatureChanges extends Feature {
 	 * @inheritDoc
 	 */
 	protected static function name(): string {
-		return __( 'Purge all HTML on feature changes', 'planet4-master-theme-backend' );
+		return __( 'Purge Cloudflare HTML cache on feature changes', 'planet4-master-theme-backend' );
 	}
 
 	/**
@@ -28,7 +28,7 @@ class PurgeOnFeatureChanges extends Feature {
 	 */
 	protected static function description(): string {
 		return __(
-			'Whether to purge all pages from Cloudflare cache when changing features.<br>Only enable on production, on test instances it results in too many purge requests.',
+			'Purges all pages from Cloudflare cache on feature changes.<br>Only enable on production (in consultation with P4 team).',
 			'planet4-master-theme-backend'
 		);
 	}

--- a/src/Settings/Features.php
+++ b/src/Settings/Features.php
@@ -51,12 +51,29 @@ class Features {
 	public static function get_options_page(): array {
 		return [
 			'title'       => 'Features',
+			'description' => self::get_description(),
 			'root_option' => self::OPTIONS_KEY,
 			'fields'      => self::get_fields(),
 			'add_scripts' => static function () {
 				Loader::enqueue_versioned_script( '/admin/js/features_save_redirect.js' );
 			},
 		];
+	}
+
+	/**
+	 * Get description based on environment.
+	 *
+	 * @return string description string.
+	 */
+	public static function get_description(): string {
+		$description = 'Enable or disable specific Planet 4 features.';
+		$dev_flags   = '<br>Options with the 👷 icon are only available in dev sites.';
+
+		$dev_site = in_array( WP_APP_ENV, [ 'local', 'development' ], true );
+
+		return $dev_site
+			? $description . $dev_flags
+			: $description;
 	}
 
 	/**


### PR DESCRIPTION
- Avoid using "Enable" or "Activate" on titles, just on descriptions.
- Use imperative on descriptions.
- Add dev-sites memo on Features descriptions to de-clutter checkbox descriptions.
- Link to certain tickets or design system where applicable.