### PR TITLE
PLANET-6805: Change donate button text through the burger menu

### DIFF
--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -583,22 +583,27 @@ class MasterSite extends TimberSite {
 			}
 		);
 
-		// Donate button menu dropdown.
-		// If no Donate menu is defined, we use the old settings from Planet 4 > Donate.
-		$donate_menu_items[] = [
+		$donate_menu_default[] = [
 			'link'  => planet4_get_option( 'donate_button', '#' ),
 			'title' => planet4_get_option( 'donate_text', __( 'Donate', 'planet4-master-theme' ) ),
 		];
 
+		// Donate button menu dropdown.
+		// If no Donate menu is defined, we use the old settings from Planet 4 > Donate.
+		$donate_menu_items = $donate_menu_default;
+
+		// Check if the menu has been created.
 		if ( has_nav_menu( 'donate-menu' ) ) {
 			$donate_menu = new TimberMenu( 'donate-menu' );
 
+			// Check if it has at least 1 item added into the menu.
 			if ( ! empty( $donate_menu->get_items() ) ) {
 				$donate_menu_items = $donate_menu->get_items();
 			}
 		}
 
-		$context['donate_menu_items'] = $donate_menu_items;
+		$context['donate_menu_default'] = $donate_menu_default;
+		$context['donate_menu_items']   = $donate_menu_items;
 
 		$languages                 = function_exists( 'icl_get_languages' ) ? icl_get_languages() : [];
 		$context['site_languages'] = $languages;

--- a/templates/burger-menu.twig
+++ b/templates/burger-menu.twig
@@ -47,11 +47,11 @@
 			<ul id="accordion-list" class="accordion">
 				<li class="burger-menu-item nav-item">
 					<a
-							class="nav-link"
-							href="{{ site.url }}"
-							data-ga-category="Menu Navigation"
-							data-ga-action="Home"
-							data-ga-label="{{ page_category }}">
+						class="nav-link"
+						href="{{ site.url }}"
+						data-ga-category="Menu Navigation"
+						data-ga-action="Home"
+						data-ga-label="{{ page_category }}">
 						{{ __( 'Home', 'planet4-master-theme' ) }}
 					</a>
 				</li>
@@ -60,25 +60,22 @@
 					{% include "burger-menu-items.twig" with { menu: navbar_menu_items } %}
 				{% endif %}
 
-				{% if donate_menu_items is not empty and donate_menu_items[0].children|length > 1 and dropdown_menu %}
+				{% if donate_menu_items is not empty and donate_menu_items[0].children|length >= 1 and dropdown_menu %}
 					{% include "burger-menu-items.twig" with { menu: donate_menu_items } %}
 				{% endif %}
 			</ul>
 		</nav>
 	</div>
 
-	{% if donate_menu_items|first is not null %}
-		{% set donate_menu = donate_menu_items|first %}
-		<div class="burger-menu-footer">
-			<a
-					class="btn btn-donate"
-					href="{{ donate_menu.link }}"
-					data-ga-category="Menu Navigation"
-					data-ga-action="Donate"
-					data-ga-label="{{ page_category }}">
-				{{ __( 'Make a donation', 'planet4-master-theme' ) }}
-			</a>
-		</div>
-	{% endif %}
+	<div class="burger-menu-footer">
+		<a
+			class="btn btn-donate"
+			href="{{ donate_menu_default[0].link }}"
+			data-ga-category="Menu Navigation"
+			data-ga-action="Donate"
+			data-ga-label="{{ page_category }}">
+			{{ donate_menu_default[0].title }}
+		</a>
+	</div>
 </div>
 <div class="burger-menu-overlay d-lg-none"></div>


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6805

Use the default provided from Planet4 > Donate button instead the "Make a donation" text. It avoids to use a duplicated donate button into the burger menu.

**New Logic**

- If the Donate button has not been created, then use the default one through the `navbar` and burger menu.
- If the donate button has been created, then show on the `navbar`. And if it has at least one item, then show it also in the burger menu.
- The "Make a donation" button is now replaced by the default settings.

**How to test**
Play around within the donate dropdown menu (Appearance > Menu) and the default donate button (Planet4 > Donate Button).
