### PR TITLE
PLANET-6727 Update search results UI

### DIFF
--- a/assets/src/scss/pages/search/_search-results.scss
+++ b/assets/src/scss/pages/search/_search-results.scss
@@ -184,7 +184,6 @@
 }
 
 .search-result-item-info {
-  font-style: italic;
   color: $grey-60;
   line-height: normal;
   margin-bottom: 10px;
@@ -200,7 +199,7 @@
   font-size: $font-size-sm;
   font-family: $lora;
   line-height: 1.6;
-  margin: $sp-1 0 0;
+  margin-bottom: $sp-1;
 
   @include large-and-up {
     font-size: 1.125rem;

--- a/templates/tease-author.twig
+++ b/templates/tease-author.twig
@@ -43,6 +43,8 @@
 				{{ post.title|e('wp_kses_post')|raw }}
 		</a>
 
+		<p class="search-result-item-content">{{ post.post_excerpt|excerpt( 30 )|e('wp_kses_post')|raw }}</p>
+
 		<div class="search-result-item-info">
 			<span class="search-result-item-date">{{ post.post_date|date }}</span>
 			{% set reading_time = post.reading_time %}
@@ -53,8 +55,6 @@
 				</span>
 			{% endif %}
 		</div>
-
-		<p class="search-result-item-content">{{ post.post_excerpt|excerpt( 30 )|e('wp_kses_post')|raw }}</p>
 
 	</div>
 </li>

--- a/templates/tease-search.twig
+++ b/templates/tease-search.twig
@@ -109,12 +109,6 @@
 								{{ post.post_title|e('wp_kses_post')|raw }}
 						</a>
 					{% endif %}
-
-					{% if ( 'page' != post.post_type ) %}
-						<div class="search-result-item-info">
-							<span class="search-result-item-date">{{ post.post_date|date('d/m/Y') }}</span>
-						</div>
-					{% endif %}
 				</div>
 				<div>
 					{% if ( is_document ) %}
@@ -137,6 +131,12 @@
 			<p class="search-result-item-content">
 				{{ post.post_excerpt|default(post.post_content)|excerpt( 30 )|raw }}
 			</p>
+			{% endif %}
+
+			{% if ( 'page' != post.post_type ) %}
+				<div class="search-result-item-info">
+					<span class="search-result-item-date">{{ post.post_date|date('d/m/Y') }}</span>
+				</div>
 			{% endif %}
 
 			{% if ( is_action ) %}

--- a/templates/tease-taxonomy-post.twig
+++ b/templates/tease-taxonomy-post.twig
@@ -43,6 +43,8 @@
 				{{ post.title|e('wp_kses_post')|raw }}
 		</a>
 
+		<p class="search-result-item-content">{{ post.post_excerpt|excerpt( 30 )|e('wp_kses_post')|raw }}</p>
+
 		<div class="search-result-item-info">
 			{% if ( post.author ) %}
 				<span class="search-result-item-author">
@@ -62,8 +64,6 @@
 				</span>
 			{% endif %}
 		</div>
-
-		<p class="search-result-item-content">{{ post.post_excerpt|excerpt( 30 )|e('wp_kses_post')|raw }}</p>
 
 	</div>
 </li>


### PR DESCRIPTION
### Description

See [PLANET-6727](https://jira.greenpeace.org/browse/PLANET-6727)
We want to apply there some of the changes that we recently made for the Articles block, mainly moving the meta information below the excerpt and removing the italic font style.

### Testing

You can see the changes on the leda test instance, for example:
- [author listing pages](https://www-dev.greenpeace.org/test-leda/author/admin/)
- [search results](https://www-dev.greenpeace.org/test-leda/?s=lorem&orderby=_score)
- [post type listing pages](https://www-dev.greenpeace.org/test-leda/story/)