### PR TITLE
PLANET-6725 Remove listing pages background and overlay

### DIFF
--- a/src/Campaigns.php
+++ b/src/Campaigns.php
@@ -3,6 +3,7 @@
 namespace P4\MasterTheme;
 
 use WP_Term;
+use P4\MasterTheme\Features\HideListingPagesBackground;
 
 /**
  * Class Campaigns
@@ -95,6 +96,8 @@ class Campaigns {
 
 			$page           = $redirect_page ? get_post( $redirect_page ) : null;
 			$redirect_title = $page ? $page->post_title : null;
+
+			$hide_background = HideListingPagesBackground::is_active();
 			?>
 
 			<tr class="form-field edit-wrap">
@@ -146,21 +149,23 @@ class Campaigns {
 					</td>
 				</tr>
 			<?php } ?>
-			<tr class="form-field edit-wrap term-image-wrap">
-				<th>
-					<label><?php esc_html_e( 'Image', 'planet4-master-theme-backend' ); ?></label>
-				</th>
-				<td>
-					<input type="hidden" name="tag_attachment_id" id="tag_attachment_id" class="tag-attachment-id field-id" value="<?php echo esc_attr( $attachment_id ); ?>" />
-					<input type="hidden" name="tag_attachment" id="tag_attachment" class="tag-attachment-url field-url" value="<?php echo esc_url( $attachment_url ); ?>" />
-					<button class="button insert-media add_media" name="insert_image_tag_button" id="insert_image_tag_button" type="button">
-						<?php esc_html_e( 'Select/Upload Image', 'planet4-master-theme-backend' ); ?>
-					</button>
-					<p class="description"><?php esc_html_e( 'Associate this tag with an image.', 'planet4-master-theme-backend' ); ?></p>
-					<img class="attachment-thumbnail size-thumbnail" src="<?php echo esc_url( $attachment_url ); ?>"/>
-					<i class="dashicons dashicons-dismiss <?php echo $image_attributes ? '' : 'hidden'; ?>" style="cursor: pointer;"></i>
-				</td>
-			</tr>
+			<?php if ( ! $hide_background ) { ?>
+				<tr class="form-field edit-wrap term-image-wrap">
+					<th>
+						<label><?php esc_html_e( 'Image', 'planet4-master-theme-backend' ); ?></label>
+					</th>
+					<td>
+						<input type="hidden" name="tag_attachment_id" id="tag_attachment_id" class="tag-attachment-id field-id" value="<?php echo esc_attr( $attachment_id ); ?>" />
+						<input type="hidden" name="tag_attachment" id="tag_attachment" class="tag-attachment-url field-url" value="<?php echo esc_url( $attachment_url ); ?>" />
+						<button class="button insert-media add_media" name="insert_image_tag_button" id="insert_image_tag_button" type="button">
+							<?php esc_html_e( 'Select/Upload Image', 'planet4-master-theme-backend' ); ?>
+						</button>
+						<p class="description"><?php esc_html_e( 'Associate this tag with an image.', 'planet4-master-theme-backend' ); ?></p>
+						<img class="attachment-thumbnail size-thumbnail" src="<?php echo esc_url( $attachment_url ); ?>"/>
+						<i class="dashicons dashicons-dismiss <?php echo $image_attributes ? '' : 'hidden'; ?>" style="cursor: pointer;"></i>
+					</td>
+				</tr>
+			<?php } ?>
 			<tr class="form-field edit-wrap term-happypoint-wrap">
 				<th>
 					<label><?php esc_html_e( 'Image Subscribe', 'planet4-master-theme-backend' ); ?></label>

--- a/src/Features/HideListingPagesBackground.php
+++ b/src/Features/HideListingPagesBackground.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace P4\MasterTheme\Features;
+
+use P4\MasterTheme\Feature;
+use P4\MasterTheme\Settings\InformationArchitecture;
+
+/**
+ * @see description()
+ */
+class HideListingPagesBackground extends Feature {
+
+	/**
+	 * @inheritDoc
+	 */
+	public static function id(): string {
+		return 'hide_listing_pages_background';
+	}
+
+
+	/**
+	 * @inheritDoc
+	 */
+	protected static function name(): string {
+		return __( 'Listing pages background', 'planet4-master-theme-backend' );
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected static function description(): string {
+		return __(
+			'Remove background image and skewed overlay on all listing pages.',
+			'planet4-master-theme-backend'
+		);
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected static function options_key(): string {
+		return InformationArchitecture::OPTIONS_KEY;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public static function show_toggle_production(): bool {
+		return true;
+	}
+}

--- a/src/Settings/InformationArchitecture.php
+++ b/src/Settings/InformationArchitecture.php
@@ -8,6 +8,7 @@ use P4\MasterTheme\Features\ActionPostType;
 use P4\MasterTheme\Features\MobileTabsMenu;
 use P4\MasterTheme\Features\DropdownMenu;
 use P4\MasterTheme\Features\PostPageCategoryLinks;
+use P4\MasterTheme\Features\HideListingPagesBackground;
 use P4\MasterTheme\Loader;
 
 /**
@@ -50,6 +51,7 @@ class InformationArchitecture {
 			ActionPostType::get_cmb_field(),
 			DropdownMenu::get_cmb_field(),
 			PostPageCategoryLinks::get_cmb_field(),
+			HideListingPagesBackground::get_cmb_field(),
 		];
 	}
 

--- a/tag.php
+++ b/tag.php
@@ -12,12 +12,15 @@
 use P4\MasterTheme\Features\Dev\DisableTagRedirectPages;
 use P4\MasterTheme\Features\Dev\ListingPageGridView;
 use P4\MasterTheme\Features\Dev\ListingPagePagination;
+use P4\MasterTheme\Features\HideListingPagesBackground;
 use P4\MasterTheme\TaxonomyCampaign;
 use Timber\Timber;
 use P4GBKS\Blocks\Articles;
 use P4GBKS\Blocks\HappyPoint;
 
 $context = Timber::get_context();
+
+$context['hide_background'] = HideListingPagesBackground::is_active();
 
 if ( is_tag() ) {
 	$context['tag']  = get_queried_object();

--- a/templates/blocks/header.twig
+++ b/templates/blocks/header.twig
@@ -1,8 +1,10 @@
 {% if ( header_title ) %}
-	<div class="skewed-overlay"></div>
+	{% if not hide_background %}
+		<div class="skewed-overlay"></div>
+	{% endif %}
 	{% set page_header_show = ( header_subtitle or header_description or not hide_page_title )  %}
 	<div class="page-header {% if not page_header_show %}page-header-hidden{% endif %}">
-		{% if ( background_image ) %}
+		{% if ( background_image and not hide_background ) %}
 			<div class="page-header-background">
 				<img src="{{ background_image }}"
 					{% if ( background_image_srcset ) %}

--- a/templates/tag.twig
+++ b/templates/tag.twig
@@ -1,9 +1,11 @@
 {% extends "base.twig" %}
 
 {% block content %}
-	<div class="skewed-overlay"></div>
+	{% if not hide_background %}
+		<div class="skewed-overlay"></div>
+	{% endif %}
 	<div class="page-header">
-		{% if ( tag_image ) %}
+		{% if ( tag_image and not hide_background ) %}
 			<div class="page-header-background">
 				<img src="{{ tag_image }}" class="page-header-image">
 			</div>


### PR DESCRIPTION
### Description

See [PLANET-6725](https://jira.greenpeace.org/browse/PLANET-6725)

### Testing

In order to test this behaviour, you need to toggle the new `Planet 4 > Information Architecture > Listing pages background` feature. Then you should no longer see the background and skewed overlay in the tag pages (it seems other listing pages such as author, category/issue and post type don't support adding a background image). You can check this on the pluto test instance, for example with this [tag page](https://www-dev.greenpeace.org/test-pluto/tag/health/).
Please make sure you also test the tag page with the new paginated list enabled (`Planet 4 > Features > Use a paginated list of posts`), both versions should no longer have the background!