### PR TITLE
PLANET-6760 Restore search bar position

### DIFF
--- a/assets/src/scss/layout/_navbar.scss
+++ b/assets/src/scss/layout/_navbar.scss
@@ -95,14 +95,14 @@ $navbar-default-height: 60px;
   @include large-and-up {
     flex-grow: 1;
     width: auto;
+  }
+}
 
-    .nav-languages {
-      display: none;
+#header > .nav-languages {
+  display: none;
 
-      &.open {
-        display: flex;
-      }
-    }
+  &.open {
+    display: flex;
   }
 }
 

--- a/templates/desktop-menu.twig
+++ b/templates/desktop-menu.twig
@@ -58,5 +58,4 @@
 				</span>
 		</button>
 	</div>
-	{% include 'language-switcher.twig' %}
 </div>

--- a/templates/navigation-bar-new.twig
+++ b/templates/navigation-bar-new.twig
@@ -40,6 +40,7 @@
 		</button>
 	</div>
 	{% include 'search-form.twig' %}
+	{% include 'language-switcher.twig' %}
 	{% if mobile_tabs_menu %}
 	<div id="nav-mobile">
 		<nav id="nav-mobile-menu">


### PR DESCRIPTION
[PLANET-6760](https://jira.greenpeace.org/browse/PLANET-6760)

After clearing the ground in https://github.com/greenpeace/planet4-master-theme/pull/1700 and https://github.com/greenpeace/planet4-master-theme/pull/1701, it's now a lot easier to address the position issue.

* By adding a second language switcher, and adjusting CSS slightly to account for new position on desktop. On mobile the new switcher is hidden.
* Seems to need no other changes as on mobile it's a fixed element.