### PR TITLE
PLANET-6765 Fix slide in direction of mobile menu on RTL

### DIFF
--- a/assets/src/scss/layout/navbar/_burger-menu.scss
+++ b/assets/src/scss/layout/navbar/_burger-menu.scss
@@ -6,9 +6,12 @@ $transition-duration: .2s;
     transition-delay: 0s, $transition-duration;
     transform: translateX(-100%);
     opacity: 0;
+    left: 0;
 
     html[dir="rtl"] & {
       transform: translateX(100%);
+      left: auto;
+      right: 0;
     }
   }
 
@@ -29,7 +32,6 @@ $transition-duration: .2s;
   flex-direction: column;
   justify-content: flex-start;
   top: 0;
-  left: 0;
   padding: 18px $sp-3;
   z-index: 9999999999;
   overflow: hidden;


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6765

We previously missed the RTL version of left for the slide from start effect. As a result the menu was not off screen and covered part of it.
