### PR TITLE
Ensure unique HTTPS URLs get purged

### DIFF
--- a/src/CloudflarePurger.php
+++ b/src/CloudflarePurger.php
@@ -53,8 +53,10 @@ class CloudflarePurger {
 	 * @return Generator [(bool) result, (string[]) urls chunk]
 	 */
 	public function purge( array $urls ): Generator {
-		// 30 is Cloudflare's purge api limit.
-		$chunks = array_chunk( $urls, 30 );
+		// Ensure HTTPS on all URLs.
+		$urls = array_map( fn( $url ) => str_replace( 'http://', 'https://', $url ), $urls );
+		// 30 is Cloudflare's purge API limit.
+		$chunks = array_chunk( array_unique( $urls ), 30 );
 
 		foreach ( $chunks as $chunk ) {
 			yield [


### PR DESCRIPTION
[PLANET-6770](https://jira.greenpeace.org/browse/PLANET-6770)

* We hit the rate limit and are still sending batches with http URLs.
It's unclear if it would even still send the HTTPS URL.

Tested locally by commenting out [this code](https://github.com/greenpeace/planet4-master-theme/blob/0259049bab34a55957c023b59c0c547e6d0921ff/src/CloudflarePurger.php#L32-L45), so that it also works without having the plugin setup.