### PR TITLE
PLANET-6775: Add chevron icon to the languages nav

### DIFF
--- a/assets/src/scss/layout/navbar/languages.scss
+++ b/assets/src/scss/layout/navbar/languages.scss
@@ -12,11 +12,28 @@
     display: inline-block;
     line-height: $menu-height;
 
+    &::after {
+      content: "";
+      display: inline-block;
+      width: 10px;
+      height: 10px;
+      margin-inline-start: $sp-x;
+      mask: url("../../images/chevron.svg") 0 0/10px 10px;
+      transform: rotate(90deg);
+      transition: transform 150ms linear;
+      background-color: $white;
+      background-repeat: no-repeat;
+    }
+
     .nav-languages {
       display: none;
     }
 
     &:hover {
+      &::after {
+        transform: rotate(-90deg);
+      }
+
       .nav-languages {
         display: block;
       }

--- a/assets/src/scss/partials/navigation-bar-light.scss
+++ b/assets/src/scss/partials/navigation-bar-light.scss
@@ -23,3 +23,11 @@
   --nav-link--active--color: #{$black};
   --nav-link--opacity: 1;
 }
+
+.nav-languages-toggle {
+  @include large-and-up {
+    &::after {
+      background-color: $grey-80;
+    }
+  }
+}


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6775

Mena's dev instance: https://www-dev.greenpeace.org/mena

Follow up a design issue.

The chevron icon was not added previously to the [navigation bar mockup](https://www.figma.com/file/Gn8wyqgto7608rlESePXZE/Foundations-%26-Components?node-id=0%3A103) and that was the reason we removed that. We noticed the inconsistent design, because the [search form mockup](https://www.figma.com/file/Gn8wyqgto7608rlESePXZE/Foundations-%26-Components?node-id=665%3A2301) had the chevron, after we merged the code.

