### PR TITLE
PLANET-6755 Update GF forms max width specification

### DIFF
--- a/assets/src/scss/layout/_gravity-forms.scss
+++ b/assets/src/scss/layout/_gravity-forms.scss
@@ -12,6 +12,14 @@
       color: $dark-orange;
     }
   }
+
+  @include large-and-up {
+    max-width: 600px;
+  }
+
+  @include x-large-and-up {
+    max-width: 800px;
+  }
 }
 
 .gfield {
@@ -131,16 +139,6 @@
           right: $sp-2;
         }
       }
-    }
-  }
-
-  @include medium-and-up {
-    .gfield_validation_message,
-    .ginput_container,
-    select,
-    textarea,
-    input {
-      max-width: 400px;
     }
   }
 }


### PR DESCRIPTION
### Description

See [PLANET-6755](https://jira.greenpeace.org/browse/PLANET-6755)
We move it from the inputs to the form wrapper, to make sure fields are aligned even if side by side

### Testing

You can test the new GF forms' max width in all screen sizes on this [page](https://www-dev.greenpeace.org/test-saturn/new-gravity-forms-width/) I created for UAT 🙂 