### PR TITLE
PLANET-6712 Add transparent style to core Button block

### DIFF
--- a/assets/src/scss/components/_buttons.scss
+++ b/assets/src/scss/components/_buttons.scss
@@ -296,7 +296,8 @@ button.load-more-mt {
   transition-duration: 100ms;
 }
 
-.wp-block-button.transparent-button a {
+.wp-block-button.transparent-button a,
+.wp-block-button.is-style-transparent a {
   --transparent-button-- {
     border-color: $white;
     color: $white;

--- a/assets/src/scss/editorOverrides.scss
+++ b/assets/src/scss/editorOverrides.scss
@@ -133,7 +133,8 @@
   }
 }
 
-.wp-block-button.transparent-button .wp-block-button__link[role="textbox"] {
+.wp-block-button.transparent-button .wp-block-button__link[role="textbox"],
+.wp-block-button.is-style-transparent .wp-block-button__link[role="textbox"] {
   --transparent-button-- {
     border-color: $white;
     color: $white;
@@ -266,4 +267,8 @@ input.describe[type=text][data-setting=caption] {
 .CodeMirror-code {
   font-size: $font-size-xs;
   line-height: 1rem;
+}
+
+.block-editor-block-preview__content-iframe .wp-block-button.is-style-transparent {
+  background: $dark-blue;
 }


### PR DESCRIPTION
### Description

See [PLANET-6712](https://jira.greenpeace.org/browse/PLANET-6712)
This is needed for some block patterns, for now only the Highlighted CTA

**Related PR**: https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/849

### Testing

You can test both the Highlighted CTA pattern and regular buttons on this [page](https://www-dev.greenpeace.org/test-titan/transparent-buttons/) I made for UAT, with several background colors from our palette.