### PR TITLE
PLANET-6698: Remove the Donate button styles and classes

### DIFF
--- a/assets/src/scss/base/_colors.scss
+++ b/assets/src/scss/base/_colors.scss
@@ -35,7 +35,6 @@ $orange-hover: #ee562d;
 $x-dark-blue:  #042233;
 $dark-blue:    #074365;
 $active-blue:  #05324c;
-$aquamarine:   #68dfde;
 
 // Various reds:
 $peach:       #eaccbb;

--- a/assets/src/scss/components/_buttons.scss
+++ b/assets/src/scss/components/_buttons.scss
@@ -173,10 +173,9 @@ $primary-button-box-shadow: 0 2px 5px rgba(0, 0, 0, .25);
 
 $donate-button-box-shadow: 0 2px 5px rgba(0, 0, 0, .25);
 
-.btn-donate,
-.wp-block-button.is-style-donate a {
+.btn-donate {
   --button-donate-- {
-    background: $aquamarine;
+    background: $orange;
     color: $grey-80;
     min-width: 180px;
     padding: 2px 30px;
@@ -185,7 +184,7 @@ $donate-button-box-shadow: 0 2px 5px rgba(0, 0, 0, .25);
     border-color: transparent;
 
     &:hover {
-      background: $aquamarine;
+      background: $orange-hover;
       color: transparentize($grey-80, 0.2);
       box-shadow: $donate-button-box-shadow;
       border: 1px solid transparent;

--- a/assets/src/scss/editorOverrides.scss
+++ b/assets/src/scss/editorOverrides.scss
@@ -118,25 +118,6 @@
   }
 }
 
-.wp-block-button.is-style-donate .wp-block-button__link[role="textbox"] {
-  --button-donate-- {
-    background: $aquamarine;
-    color: $grey;
-    box-shadow: 0 2px 5px rgba(0, 0, 0, .25);
-  }
-
-  line-height: 1.65;
-  min-width: 180px;
-  margin: 0;
-  padding: 2px $sp-4;
-  transition: color background-color font-weight 100ms;
-
-  .editor-styles-wrapper & {
-    min-width: auto;
-    line-height: 3;
-  }
-}
-
 .wp-block-button.transparent-button .wp-block-button__link[role="textbox"],
 .wp-block-button.is-style-transparent .wp-block-button__link[role="textbox"] {
   --transparent-button-- {


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6698

> - Remove the Donate button style's associated CSS (class name "is-style-donate").
> - Remove the "aquamarine" color from our codebase (including theme.json) since it's used nowhere else.
> - Check existing content and maybe warn NROs that still use this style.

[`$aquamarine`](https://github.com/search?q=org%3Agreenpeace+aquamarine&type=code) and [`is-style-donate`](https://github.com/search?q=org%3Agreenpeace+is-style-donate&type=Code) are locally copied in the child-theme where they're used.
