### PR TITLE
PLANET-6767: Remove control panel overlay blocking clicks

### DIFF
--- a/admin/css/dashboard.css
+++ b/admin/css/dashboard.css
@@ -1,5 +1,14 @@
+.cp-item {
+  font-size:  14px;
+  padding:  5px 0;
+}
+
 .cp-item div {
   background-color: rgb(250, 250, 250);
+}
+
+#dashboard-widgets .cp-item h3 {
+  font-weight: bold;
 }
 
 .cp-subitem-response {

--- a/src/ControlPanel.php
+++ b/src/ControlPanel.php
@@ -114,7 +114,7 @@ class ControlPanel {
 	 */
 	public function add_item( $data ) {
 		echo '<div class="cp-item">
-				<div class="welcome-panel"><span><strong>' . esc_html( $data['title'] ) . '</strong></span>';
+				<div><h3>' . esc_html( $data['title'] ) . '</h3>';
 		foreach ( $data['subitems'] as $subitem ) {
 			echo '<div>
 					<a href="' . esc_url( $subitem['url'] ?? '#' ) . '" class="btn btn-cp-action ' . esc_attr( $subitem['action'] ?? '' ) . '" data-action="' . esc_attr( $subitem['action'] ?? '' ) . '" data-confirm="' . esc_attr( $subitem['confirm'] ?? '' ) . '">' . esc_html( $subitem['title'] ) . '</a>


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6767

> Icons on dashboard (flush part) are so big, I can't flush the cache anymore.

WP 5.9 background image is displayed over our links and prevent clicks. It is because we use the `.welcome-panel` class, that WP uses to display its "welcome new 5.9 version" background.

<table>
<tr><td>Before fix</td><td>After fix</td></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/617346/168778839-90e680e9-7087-4f57-8c5a-48fbe29d4ebb.png" /></td>
<td><img src="https://user-images.githubusercontent.com/617346/168778366-bef766a7-5eea-479a-b86a-d4be93ab5dfb.png" /></td>
</tr></table>

- Removing this class fixes the issue
- Changing markup a bit to fit other panel boxes 

## Test

On the admin dashboard, check the Planet4 Control Panel.
- Links should be visible and clickable