### PR TITLE
Add Grey 5% to our color palette

### DIFF
--- a/assets/src/scss/base/_palette.scss
+++ b/assets/src/scss/base/_palette.scss
@@ -1,10 +1,11 @@
-// Allower colors for blocks palette
+// Allow colors for blocks palette
 $palette: (
   "grey-80": $grey-80,
   "grey-60": $grey-60,
   "grey-40": $grey-40,
   "grey-20": $grey-20,
   "grey-10": $grey-10,
+  "grey-05": $grey-05,
   "grey": $grey,
   "gp-green": $gp-green,
   "x-dark-blue": $x-dark-blue,


### PR DESCRIPTION
### Description

This is needed for some block patterns, for their background color, for example the [Deep Dive](https://jira.greenpeace.org/browse/PLANET-6534) or the [Quick Links](https://jira.greenpeace.org/browse/PLANET-6520).

**Related PR:** https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/856

### Testing

You can see the new color used in both text color and background color on [this page](https://www-dev.greenpeace.org/test-iocaste/new-grey-5-color/) for example!