### PR TITLE
PLANET-6784 Remove WP default color palette

### DIFF
--- a/assets/src/scss/base/_palette.scss
+++ b/assets/src/scss/base/_palette.scss
@@ -13,6 +13,7 @@ $palette: (
   "blue": $blue,
   "orange-hover": $orange-hover,
   "yellow": $yellow,
+  "white": $white,
 );
 
 @each $name, $color in $palette {

--- a/theme.json
+++ b/theme.json
@@ -71,6 +71,11 @@
           "name": "Yellow",
           "slug": "yellow",
           "color": "#ffd204"
+        },
+        {
+          "name": "White",
+          "slug": "white",
+          "color": "#ffffff"
         }
       ]
     },

--- a/theme.json
+++ b/theme.json
@@ -1,5 +1,5 @@
 {
-  "version": 1,
+  "version": 2,
   "settings": {
     "color": {
       "custom": false,
@@ -82,7 +82,7 @@
     "blocks": {
       "core/button": {
         "border": {
-          "customRadius": false
+          "radius": false
         }
       },
       "core/table": {

--- a/theme.json
+++ b/theme.json
@@ -5,6 +5,7 @@
       "custom": false,
       "customGradient": false,
       "defaultGradients": false,
+      "defaultPalette": false,
       "palette": [
         {
           "name": "Grey 80%",
@@ -81,7 +82,6 @@
       },
       "core/table": {
         "color": {
-          "defaultPalette": false,
           "text": false,
           "palette": [
             {


### PR DESCRIPTION
### Description

See [PLANET-6784](https://jira.greenpeace.org/browse/PLANET-6784) & [PLANET-6787](https://jira.greenpeace.org/browse/PLANET-6787)
In this PR we also add the `white` color to our theme palette, since it will now be the only palette available to editors and that color might be useful to them.
There is also a small commit to update the file version number to 2, since it's the [version number that fits our current WordPress version](https://developer.wordpress.org/themes/advanced-topics/theme-json/#what-is-theme-json). Following this change we had to change the Button block border radius setting removal, from `customRadius` to just `radius`.

### Testing

Either on local or on the [titan test instance](https://www-dev.greenpeace.org/test-titan/), you can add any core block in the editor and the only color palette available for both `Text` and `Background` should be our own (with the white color added). The only exception is the `Table` block, for which we have disabled the text color and also defined some specific background colors.