### PR TITLE
PLANET-6784 Remove color duotone functionality

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -3,9 +3,11 @@
   "settings": {
     "color": {
       "custom": false,
+      "customDuotone": false,
       "customGradient": false,
       "defaultGradients": false,
       "defaultPalette": false,
+      "duotone": [],
       "palette": [
         {
           "name": "Grey 80%",


### PR DESCRIPTION
### Description

See [PLANET-6784](https://jira.greenpeace.org/browse/PLANET-6784)
This allowed editors to add colored filters to certain core blocks:

<img width="1053" alt="Screenshot 2022-05-23 at 16 25 49" src="https://user-images.githubusercontent.com/6949075/169993235-6397cf54-23d1-4931-a299-25c97c0fca2e.png">

We should remove this functionality as part of our WP core color palette removal. 

### Testing

Either on local or on the [titan test instance](https://www-dev.greenpeace.org/test-titan/), when adding certain core blocks (such as Image) in the editor you should no longer see the controls associated to this duotone functionality.