### PR TITLE
PLANET-6773: Fix WP importer fetches media along with posts

### DIFF
--- a/exporter-helper.php
+++ b/exporter-helper.php
@@ -23,6 +23,12 @@ function get_attachments_used_in_content( string $content ): array {
 				$attachment_ids[] = $block['attrs']['background'] ?? '';
 				break;
 
+			case 'core/media-text':
+				$attachment_ids[] = $block['attrs']['mediaId'] ?? '';
+				$attachment_ids[] = $block['attrs']['mediaLink'] ?? '';
+				$attachment_ids[] = $block['attrs']['mediaType'] ?? '';
+				break;
+
 			case 'core/image':
 			case 'planet4-blocks/happypoint':
 				$attachment_ids[] = $block['attrs']['id'] ?? '';

--- a/src/Importer.php
+++ b/src/Importer.php
@@ -108,6 +108,20 @@ class Importer {
 						$filter_data[] = 'wp-image-' . $block['attrs']['id'];
 					}
 					break;
+
+				case 'core/media-text':
+					if ( isset( $block['attrs']['mediaId'] ) ) {
+						$filter_data[] = 'mediaId":' . $block['attrs']['mediaId'];
+					}
+
+					if ( isset( $block['attrs']['mediaLink'] ) ) {
+						$filter_data[] = 'mediaLink":' . $block['attrs']['mediaLink'];
+					}
+
+					if ( isset( $block['attrs']['mediaType'] ) ) {
+						$filter_data[] = 'mediaType":' . $block['attrs']['mediaType'];
+					}
+					break;
 			}
 		}
 


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6773

### About the issue
Taken from the ticket:
> From the recent experience of Brasil migration, we noticed that the imported posts in production kept their dev-site media url.

![Screenshot 2022-05-31 at 08 55 38](https://user-images.githubusercontent.com/77975803/171167546-e0e3d641-a793-4e0f-b79c-9cd68a2160ab.png)

**In the above image you see that the page is on `www-stage` and the image is taken from `www-dev`.**

_Since we haven't changed a lot of part of the code, the solutions seems to be an easy fix. However, the hardest and tedious part was the analysis and the way of testing it._

### What is fixed
The page would render correctly the `<img>` with all the correct values and don't render anything related to the previous exported instance. For example, if you create a post from `-dev` and export it and then import it to `-stage` you wouldn't see any URL related to `-dev` and vice-versa.

I used the Argentina dev's instance for testing -> https://github.com/greenpeace/planet4-argentina/commit/c2d116606b490147e80995d18c490d9ba5cccb55#diff-98da95bd9dbd4979eaef5e00a61c00e5bb41f0342443a250923582923fadca48R3

### Demo page
**Argentina's dev instance**
https://www-dev.greenpeace.org/argentina/story/uncategorized/test/

**here is the uploaded image in GCP** `planet4-argentina-stateless-develop` 
https://console.cloud.google.com/storage/browser/_details/planet4-argentina-stateless-develop/2022/05/bcc2c211-bb1bd6_f221ad0f4d6f4103bf1d37b68b04492emv2.png;tab=live_object?authuser=1&project=planet-4-151612

**Argentina's stage instance**
https://www-stage.greenpeace.org/argentina/story/uncategorized/test/

**here is the uploaded image in GCP** `planet4-argentina-stateless-release` 
https://console.cloud.google.com/storage/browser/_details/planet4-argentina-stateless-release/2022/05/bcc2c211-bb1bd6_f221ad0f4d6f4103bf1d37b68b04492emv2.png;tab=live_object?authuser=1&project=planet-4-151612


This is an image from `dev`
```
<img
  src="https://www.greenpeace.org/static/planet4-argentina-stateless-develop/2022/05/bcc2c211-bb1bd6_f221ad0f4d6f4103bf1d37b68b04492emv2.png"
  alt=""
  sizes="(min-width: 1600px) calc((1320px - 24px) / 2),(min-width: 1200px) calc((1140px - 24px) / 2),(min-width: 992px) calc((960px - 24px) / 2),(min-width: 768px) calc((720px - 24px) / 2),(min-width: 601px) calc((540px - 24px) / 2),(min-width: 577px) calc((540px - 24px) / 1), calc(100vw - 24px)"
  srcset="
    https://www.greenpeace.org/static/planet4-argentina-stateless-develop/2022/05/bcc2c211-bb1bd6_f221ad0f4d6f4103bf1d37b68b04492emv2.png         1000w,
    https://www.greenpeace.org/static/planet4-argentina-stateless-develop/2022/05/bcc2c211-bb1bd6_f221ad0f4d6f4103bf1d37b68b04492emv2-300x171.png  300w,
    https://www.greenpeace.org/static/planet4-argentina-stateless-develop/2022/05/bcc2c211-bb1bd6_f221ad0f4d6f4103bf1d37b68b04492emv2-768x439.png  768w,
    https://www.greenpeace.org/static/planet4-argentina-stateless-develop/2022/05/bcc2c211-bb1bd6_f221ad0f4d6f4103bf1d37b68b04492emv2-510x291.png  510w
  "
  class="wp-image-15888 size-full"
  width="1000"
  height="571"
/>
```

And this is the same image imported to `stage`

```
<img
  src="https://www-stage.greenpeace.org/argentina/wp-content/uploads/2022/05/bcc2c211-bb1bd6_f221ad0f4d6f4103bf1d37b68b04492emv2.png"
  alt=""
  sizes="(min-width: 1600px) calc((1320px - 24px) / 2),(min-width: 1200px) calc((1140px - 24px) / 2),(min-width: 992px) calc((960px - 24px) / 2),(min-width: 768px) calc((720px - 24px) / 2),(min-width: 601px) calc((540px - 24px) / 2),(min-width: 577px) calc((540px - 24px) / 1), calc(100vw - 24px)"
  srcset="
    https://www.greenpeace.org/static/planet4-argentina-stateless-release/2022/05/bcc2c211-bb1bd6_f221ad0f4d6f4103bf1d37b68b04492emv2.png         1000w,
    https://www.greenpeace.org/static/planet4-argentina-stateless-release/2022/05/bcc2c211-bb1bd6_f221ad0f4d6f4103bf1d37b68b04492emv2-300x171.png  300w,
    https://www.greenpeace.org/static/planet4-argentina-stateless-release/2022/05/bcc2c211-bb1bd6_f221ad0f4d6f4103bf1d37b68b04492emv2-768x439.png  768w,
    https://www.greenpeace.org/static/planet4-argentina-stateless-release/2022/05/bcc2c211-bb1bd6_f221ad0f4d6f4103bf1d37b68b04492emv2-510x291.png  510w
  "
  class="wp-image-15888 size-full"
  width="1000"
  height="571"
/>
```
You see that all the values are correctly set and don't see any value linked to the other instance (`www-dev` or `www-stage`).

### How to test

1. Go to any NRO instance and login (`www-dev` or `www-stage` it's fine). **Don't use the Argentina's instance since it's using this branch.**
2. Create a new page.
3. On that page add a `core/media-text` block and upload a new image.
4. Publish page.
5. Go to pages.
6. Search the page you've just created and export it.
8. Go to the other instance (If you've created in `www-stage` then go to `www-dev` or vice-versa).
9. Import the exported page. Don't forget to check the "Download and import file attachments" option.
10. Check from WP > Media that the image is correctly uploaded.
11. After the page is imported, publish it and export it.
12. Compare these XML files with an online editor. I use [diffchecker](https://www.diffchecker.com/diff).

You'll get something like this: 

![Screenshot 2022-05-24 at 17 31 45](https://user-images.githubusercontent.com/77975803/170126912-b898238a-b924-47bc-a5fc-7fd079ccc9c0.png)

Also the `img` tag hasn't set the `srcset` attribute when it's imported and published.

![Screenshot 2022-05-27 at 16 01 52](https://user-images.githubusercontent.com/77975803/170774566-75ab23fc-fd74-44c1-b4c9-d89185775adb.png)

If you want to repeat this test, you'll need to delete the post and all its images, then import it again (or rename them from the XML file).

### Useful links
- [WP stateless plugin](https://wordpress.org/plugins/wp-stateless/)
- [Google Cloud Platform](https://console.cloud.google.com)
