### PR TITLE
Apply filter to youtube embed parameters

### DIFF
--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -1345,7 +1345,7 @@ class MasterSite extends TimberSite {
 		$youtube_id = $matches[0][1] ?? null;
 
 		// For now just rel, but we can extract more from the url.
-		$query_string = 'rel=0';
+		$query_string = apply_filters( 'planet4_youtube_embed_parameters', 'rel=0' );
 
 		return [ $youtube_id, $query_string ];
 	}


### PR DESCRIPTION
Replicated from https://github.com/greenpeace/planet4-master-theme/pull/1727
Closes https://github.com/greenpeace/planet4/issues/179

Applies a filter to the parameters used to load an embedded Youtube video. Enables child themes to modify the functionality of the embedded Youtube player [using the supported parameters](https://developers.google.com/youtube/player_parameters#Parameters).

One relevant use case is to enable the JS API in order to get better video data in Google Analytics.

[Slack thread](https://greenpeace.slack.com/archives/C0151L0KKNX/p1654089635150519)