### PR TITLE
DoD experiment: Load script on demand in page

### DIFF
--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -301,6 +301,24 @@ class MasterSite extends TimberSite {
 			}
 		);
 
+		add_action( 'the_title', function ( $title ): string {
+			global $post;
+
+			if( 'page' === $post->post_type ) {
+				// Used only for testing
+				wp_register_script(
+					'underscore',
+					'https://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.9.1/underscore.js',
+					[],
+					'1.9.1',
+					true
+				);
+				wp_enqueue_script( 'underscore' );
+			}
+
+			return $title;
+		}, 10, 1);
+
 		$this->register_meta_fields();
 	}
 


### PR DESCRIPTION
This implementation has been asked by GPBR because they want to load specific scripts (underscore is used as an example) in post types as "page".

### **Test**

#### Case #1: The Javascript **should** be loaded
1. Create a new page
2. Add dummy content
3. Publish it
4. Check if the underscore script has been loaded.

Demo page: https://www-dev.greenpeace.org/test-leda/the_title-hook-from-page/

![Screenshot 2022-06-03 at 10 29 27](https://user-images.githubusercontent.com/77975803/171864119-843bcf4f-a1d6-46f7-a556-10c98e8c98ad.png)

#### Case #2: The Javascript **shouldn't** be loaded
1. Create a new post
2. Add dummy content
3. Publish it
4. Check if the underscore script has been loaded.

Demo page: https://www-dev.greenpeace.org/test-leda/story/1116/the_title-hook-from-post/

![Screenshot 2022-06-03 at 10 29 36](https://user-images.githubusercontent.com/77975803/171864132-4a064e91-9fb7-41cb-8a58-5402efce7bdc.png)

