### PR TITLE
PLANET-6813: (POC) Use new styles to body links 

### DIFF
--- a/assets/src/scss/base/_body.scss
+++ b/assets/src/scss/base/_body.scss
@@ -26,4 +26,8 @@ body {
 .container > * {
   position: relative;
   z-index: 2;
+
+  p > a {
+    @include links-hover-effect;
+  }
 }

--- a/assets/src/scss/base/_mixins.scss
+++ b/assets/src/scss/base/_mixins.scss
@@ -249,3 +249,15 @@ $nested-comment-left-margin: 50px;
     background: rgba(0, 0, 0, 0.2);
   }
 }
+
+@mixin links-hover-effect {
+  color: #007D49;
+  text-decoration-color: #BEE7D1;
+  box-shadow: inset 0 -2px #BEE7D1;
+  transition: 200ms cubic-bezier(0.5, 0, 0, 1);
+
+  &:hover {
+    box-shadow: inset 0 -1.1em #E4F5ED;
+    text-decoration-color: #E4F5ED;
+  }
+}


### PR DESCRIPTION
This feature has been requested by Houssam as a proof of concept since they are currently working on the new identity project.

This change should be applied only to body links, but keep the style for the category, post type, standalone, and title links.

[Demo pages](https://github.com/greenpeace/planet4-master-theme/pulls?q=is%3Aopen+is%3Apr+label%3A%22%5BTest+Env%5D+umbriel%22+)

**Please do not merge it!**