### PR TITLE
PLANET-6887 Fix placeholder color for Button block

### DIFF
--- a/assets/src/scss/editorOverrides.scss
+++ b/assets/src/scss/editorOverrides.scss
@@ -74,6 +74,10 @@
   transition-duration: 150ms;
   transition-timing-function: linear;
   font-size: $font-size-sm;
+
+  [data-rich-text-placeholder]::after {
+    color: inherit;
+  }
 }
 
 .wp-block-button .wp-block-button__link[role="textbox"],


### PR DESCRIPTION
### Description

See [PLANET-6687](https://jira.greenpeace.org/browse/PLANET-6687)
Without this fix, the placeholder is white regardless of the actual text color.

### Testing

On local, you can test the fix with any empty Button block (without text) by changing the style (esp. `secondary` since it doesn't have white text color) or by picking a new text color from the palette. On this branch you should see the text color always being applied to the placeholder, whereas on `master` branch it would remain white.