### PR TITLE
Fix php notice when IA option unavailable

### DIFF
--- a/src/Settings/InformationArchitecture.php
+++ b/src/Settings/InformationArchitecture.php
@@ -65,6 +65,6 @@ class InformationArchitecture {
 	public static function is_active( string $name ): bool {
 		$options = get_option( self::OPTIONS_KEY );
 
-		return 'on' === $options[ $name ];
+		return isset( $options[ $name ] ) ? 'on' === $options[ $name ] : false;
 	}
 }


### PR DESCRIPTION
A PHP Notice appears when an IA option is not yet set

https://output.circle-artifacts.com/output/job/7c8a73d8-065a-4632-aa3b-b8f29ac061a3/artifacts/0/artifacts/codeception/report.html
![Screenshot from 2022-06-10 11-18-20](https://user-images.githubusercontent.com/617346/173313195-2020dcf7-9fa3-4ff1-9040-2b6e27bd978e.png)

