### PR TITLE
PLANET-6789 Add pointer-events none to animated form field labels

### DIFF
--- a/assets/src/scss/layout/_forms.scss
+++ b/assets/src/scss/layout/_forms.scss
@@ -201,6 +201,7 @@ textarea.form-control {
     position: relative;
 
     label {
+      pointer-events: none;
       position: absolute;
       left: 0;
       top: 16px;


### PR DESCRIPTION
### Description

See [PLANET-6789](https://jira.greenpeace.org/browse/PLANET-6789)
Without this, the label sometimes blocks clicking on the field to start typing.

### Testing

You can test the fix with any EN form block.