### PR TITLE
Move desktop styles to a file

### DIFF
--- a/assets/src/scss/layout/_navbar.scss
+++ b/assets/src/scss/layout/_navbar.scss
@@ -91,13 +91,6 @@ $navbar-default-height: 60px;
   }
 }
 
-#nav-main-desktop {
-  @include large-and-up {
-    flex-grow: 1;
-    width: auto;
-  }
-}
-
 .nav-menu {
   background: var(--top-navigation--background, $dark-blue);
   height: 100%;
@@ -329,3 +322,4 @@ a.nav-link:hover:before,
 @import "navbar/search";
 @import "navbar/mobile";
 @import "navbar/burger-menu";
+@import "navbar/desktop-menu";

--- a/assets/src/scss/layout/navbar/_desktop-menu.scss
+++ b/assets/src/scss/layout/navbar/_desktop-menu.scss
@@ -1,0 +1,6 @@
+#nav-main-desktop {
+  @include large-and-up {
+    flex-grow: 1;
+    width: auto;
+  }
+}


### PR DESCRIPTION
This change it's very helpful to understand the styles related to the desktop menu template, all of those [are currently added within the navbar](https://github.com/greenpeace/planet4-master-theme/blob/master/assets/src/scss/layout/_navbar.scss#L94-L99) and doesn't seem to be helpful.

We should do the same as we did with the burger menu. (template + styles). 

This is also a preparation of this [ticket](https://jira.greenpeace.org/browse/PLANET-6794)