### PR TITLE
PLANET-6794: Fix languges switcher through the navigation bar

### DIFF
--- a/assets/src/js/menu_editor.js
+++ b/assets/src/js/menu_editor.js
@@ -65,6 +65,35 @@ const menuEditorRestrictions = () => {
   const disableObserver = () => { observer.disconnect(); };
 
   /**
+   * Show a notice message to inform to editors to prevent
+   * using long texts to menu items
+   */
+  const showInfoNoticeMessage = () => {
+    const menuEditorFooter = document.getElementById('nav-menu-footer');
+
+    const container = document.createElement('div');
+    container.classList.add('notice', 'notice-info', 'custom-notice-info', 'inline');
+
+    const infoText = __(
+      'Avoid using more than 5 items in the navigation menu, and limit the number of items when dealing with long text labels.',
+      'planet4-master-theme-backend'
+    );
+    container.innerHTML = `<p>${infoText}</p>
+    <style>
+      .notice.custom-notice-info {
+        background: transparent;
+        border-top: none;
+        border-right: none;
+        margin-top: 0;
+        margin-left: -10px;
+        width: calc(100% - 8px);
+      }
+    </style>`;
+
+    menuEditorFooter.insertBefore(container, menuEditorFooter.querySelector('div'));
+  }
+
+  /**
    * Toggle rules linked to location selected
    * Reset if no config available
    */
@@ -76,6 +105,8 @@ const menuEditorRestrictions = () => {
       displayErrors([]);
       return;
     }
+
+    showInfoNoticeMessage();
 
     // Define depth limit for editor
     /* global wpNavMenu */

--- a/assets/src/scss/layout/_navbar.scss
+++ b/assets/src/scss/layout/_navbar.scss
@@ -60,6 +60,7 @@ $navbar-default-height: 60px;
       color: $white;
       font-size: inherit;
       min-width: 116px;
+      padding: 2px 17px;
 
       &:hover {
         background: $orange-hover;
@@ -119,7 +120,11 @@ $navbar-default-height: 60px;
 
     & > li:not(:last-child) {
       margin-inline-start: $sp-2;
-      margin-inline-end: $sp-3;
+      margin-inline-end: $sp-2;
+
+      @include xx-large-and-up {
+        margin-inline-end: $sp-3;
+      }
     }
   }
 

--- a/assets/src/scss/layout/navbar/languages.scss
+++ b/assets/src/scss/layout/navbar/languages.scss
@@ -5,7 +5,7 @@
   display: none;
   font-size: $font-size-sm;
   font-weight: 700;
-  padding: 0 25px;
+  padding: 0 $sp-2;
 
   @include large-and-up {
     border-inline-start: var(--top-navigation--separation, 1px solid transparentize($white, 0.5));


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6794

- ~Add a new XXL screen value (1400px), based on [Bootstrap breakpoints](https://getbootstrap.com/docs/5.0/layout/breakpoints/#available-breakpoints), and don't use the [XXL P4's breakpoint](https://github.com/greenpeace/planet4-master-theme/blob/master/assets/src/scss/base/_variables.scss#L11).~
- ~Remove Bootstrap's inline classes.~
- Add a Notice info message.

Demo page: Using the [Belgium's dev instance](https://www-dev.greenpeace.org/belgium/fr/) not only because they reported the issue but also because they have a Multi language site.

Please take a look all the comments I left about to changed files explaining about some of their changes.