### PR TITLE
PLANET-6744 Make listing pages author name bold

### DIFF
--- a/assets/src/scss/pages/search/_search-results.scss
+++ b/assets/src/scss/pages/search/_search-results.scss
@@ -207,6 +207,8 @@
 }
 
 .search-result-item-author {
+  font-weight: 500;
+
   &:after {
     content: "\2022";
     display: inline-block;


### PR DESCRIPTION
### Description

See [PLANET-6744](https://jira.greenpeace.org/browse/PLANET-6744)
This is to comply with the new designs.

### Testing

On local, you can check any post type listing page (such as [Story](http://www.planet4.test/story/) or [Publication](http://www.planet4.test/publication/)) and compare both versions: on `master` branch you'll see the author name is not bold, whereas on this branch it should be.
Or you can see the fix on the test instance, on the [Story](https://www-dev.greenpeace.org/test-pluto/story/) or [Publication](https://www-dev.greenpeace.org/test-pluto/publication/) listing pages for example.