### PR TITLE
PLANET-6811 Remove default duotones

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -8,7 +8,7 @@
       "customGradient": false,
       "defaultGradients": false,
       "defaultPalette": false,
-      "duotone": [],
+      "duotone": null,
       "palette": [
         {
           "name": "Grey 80%",


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6811
Ref: https://github.com/WordPress/gutenberg/issues/40383

---

Our current `theme.json` option doesn't work in 6.0. You will probably see a validation error in your editor, because `null`
is not yet reflected in the official schema, but it does seem to work without issues.

### Testing

1. You need to be running Wordpress 6.0
2. While on `master` branch in the theme, add an image block. You should be seeing the Duotones button in the formatting toolbar.
3. `git checkout -t origin/duotone-false`
4. `make flush` (just in case)
5. No duotone button anymore.

I haven't tested this with 5.9 yet, but if it creates issues we can hold merging it till the actual upgrade.