### PR TITLE
PLANET-6325 Add padding top to pages with no title

### DIFF
--- a/assets/src/scss/pages/_page.scss
+++ b/assets/src/scss/pages/_page.scss
@@ -13,7 +13,7 @@ $min-height: 40px;
     height: auto;
   }
 
-  .page-header-hidden + &.no-page-title {
+  &.no-page-title {
     padding-top: $menu-height-small;
 
     @include medium-and-up {

--- a/templates/page.twig
+++ b/templates/page.twig
@@ -1,7 +1,7 @@
 {% extends "base.twig" %}
 
 {% block content %}
-	<div class="page-content container {% if hide_page_title %}no-page-title{% endif %}">
+	<div class="page-content container {% if hide_page_title or not header_title %}no-page-title{% endif %}">
 		{{ post.content|raw }}
 	</div>
 {% endblock %}


### PR DESCRIPTION
### Description

See [PLANET-6325](https://jira.greenpeace.org/browse/PLANET-6325)
Without this fix the navbar overlaps the page content if there is no title

### Testing

You can compare both versions on these pages I set up without title:
- [Broken](https://www-dev.greenpeace.org/test-mars/no-page-title/)
- [Fixed](https://www-dev.greenpeace.org/test-umbriel/no-page-title/)