### PR TITLE
PLANET-6822 Fix author block image margins

### DIFF
--- a/assets/src/scss/pages/post/_author-block.scss
+++ b/assets/src/scss/pages/post/_author-block.scss
@@ -35,12 +35,15 @@
 .author-block-image {
   width: 200px;
   height: 200px;
-  margin: auto;
 
   img {
     width: 100%;
     border-radius: 50%;
     object-fit: cover;
+  }
+
+  @include small-and-less {
+    margin: auto;
   }
 }
 


### PR DESCRIPTION
### Description

See [PLANET-6822](https://jira.greenpeace.org/browse/PLANET-6822)
Without this fix, if the bio info is too short the image takes more space and the block looks weird.

### Testing

On local, you can add a short bio (such as "Morbi ac congue ipsum.") to one of your users, then go to a post written by this user. On `master` branch, in screen sizes medium and up you should see the image take too much space in the author block, whereas on this branch it should show aligned to the start as expected.
You can also compare the [broken version](https://www-dev.greenpeace.org/test-oberon/story/51096/post-title-goes-here-it-can-be-this-long/) with the [fixed version](https://www-dev.greenpeace.org/test-deimos/blog/36520/por-que-precisamos-de-um-tratado-global-dos-oceanos/) in test instances.