### PR TITLE
PLANET-4334 Allow a list of non-P4 urls not to have the :arrow_upper_right:  icon 

### DIFF
--- a/assets/src/js/external_links.js
+++ b/assets/src/js/external_links.js
@@ -13,12 +13,17 @@ export const setupExternalLinks = () => {
     // We don't want to show the icon in headings/titles,
     // or in links that are images
     const text = link.textContent || link.innerText;
-    if (['H1', 'H2', 'H3', 'H4', 'H5', 'H6'].includes(link.parentElement.nodeName) || text.trim().length === 0 || commonExternalDomains.includes(link.hostname)) {
+    if (['H1', 'H2', 'H3', 'H4', 'H5', 'H6'].includes(link.parentElement.nodeName) || text.trim().length === 0) {
       return;
     }
 
     link.target = link.target ? link.target : '';
-    link.classList.add('external-link');
+    if (!commonExternalDomains.includes(link.hostname)){
+      link.classList.add('external-link');
+    }
+    else {
+      link.target = '_blank';
+    }
 
     const url = new URL(link.href);
     const domain = url.hostname.replace('www.','');

--- a/assets/src/js/external_links.js
+++ b/assets/src/js/external_links.js
@@ -13,7 +13,7 @@ export const setupExternalLinks = () => {
     // We don't want to show the icon in headings/titles,
     // or in links that are images
     const text = link.textContent || link.innerText;
-    if (['H1', 'H2', 'H3', 'H4', 'H5', 'H6'].includes(link.parentElement.nodeName) || text.trim().length === 0) {
+    if (['H1', 'H2', 'H3', 'H4', 'H5', 'H6'].includes(link.parentElement.nodeName) || text.trim().length === 0 || commonExternalDomains.includes(link.hostname)) {
       return;
     }
 

--- a/assets/src/js/external_links.js
+++ b/assets/src/js/external_links.js
@@ -18,11 +18,9 @@ export const setupExternalLinks = () => {
     }
 
     link.target = link.target ? link.target : '';
+    link.target = '_blank';
     if (!commonExternalDomains.includes(link.hostname)){
       link.classList.add('external-link');
-    }
-    else {
-      link.target = '_blank';
     }
 
     const url = new URL(link.href);

--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -632,6 +632,16 @@ class MasterSite extends TimberSite {
 			$context['preconnect_domains'] = $preconnect_domains;
 		}
 
+		$context['common_external_domains']     = [];
+
+		if ( ! empty( $options['common_external_domains'] ) ) {
+			$common_external_domains = explode( "\n", $options['common_external_domains'] );
+			$common_external_domains = array_map( 'trim', $common_external_domains );
+			$common_external_domains = array_filter( $common_external_domains );
+
+			$context['common_external_domains'] = $common_external_domains;
+		}
+
 		// hreflang metadata.
 		if ( is_front_page() ) {
 			$context['hreflang'] = self::generate_hreflang_meta();

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -367,6 +367,15 @@ class Settings {
 							'type' => 'text',
 						],
 					],
+					[
+						'name'       => __( 'Commonly used external domains', 'planet4-master-theme-backend' ),
+						'desc'       => __( 'Links for these domains will not open in a new tab and will hide the external link icon.', 'planet4-master-theme-backend' ),
+						'id'         => 'common_external_domains',
+						'type'       => 'textarea',
+						'attributes' => [
+							'type' => 'text',
+						],
+					],
 				],
 			],
 			'planet4_settings_404_page'         => [

--- a/templates/html-header.twig
+++ b/templates/html-header.twig
@@ -37,6 +37,17 @@
 		{% endfor %}
 	{% endif %}
 
+	{% if common_external_domains %}
+		<script>
+			const commonExternalDomains = (() => {
+				const domains ={{ common_external_domains | json_encode | raw }}
+				return domains.map(domain => {
+					return new URL(domain).hostname;
+				})
+			})();
+		</script>
+	{% endif %}
+
 	{% if css_vars %}
 		{% include 'css-variables.twig' %}
 	{% endif %}


### PR DESCRIPTION
# Summary
Adds the option to define a list of "Commonly used domains" under "Social" settings.
These domains should not get the external link icon and should always open in a new tab

As discussed in: https://github.com/greenpeace/planet4/issues/174

# Testing
- Under "Social" > "Commonly used external domains" add https://www.google.com _(or another variation of the url)_
- Test with content:
```
<!-- wp:paragraph -->
<p><a href="https://www.google.com">External link marked as commonly used</a><br>
<a href="https://www.google.com/android/find">Link with path marked as commonly used</a><br>
<a href="https://www.planet4.test/privacy-and-cookies/" data-type="page" data-id="232">Internal link</a> <br>
<a href="https://www.youtube.com/">External link NOT marked as commonly used</a></p>
<!-- /wp:paragraph -->
```
_(or of course with any other content)_