### PR TITLE
PLANET-6831: Fix PDF attachment links missing in attachment pages

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -416,3 +416,19 @@ add_action(
 	},
 	99
 );
+
+// WP Stateless plugin short-circuits the image_downsize() process
+// with wpCloud\StatelessMedia\Bootstrap::image_downsize().
+// Contrary to the native function, it will return attachment data
+// even if the attachment is not an image.
+// The attachment is then treated as an image by the function
+// wp_get_attachment_link() generating the link, even for a PDF.
+// We overrule wp-stateless response if file is not an image.
+add_filter(
+	'image_downsize',
+	function ( $downsize, $id, $size ) {
+		return wp_attachment_is_image( $id ) ? $downsize : false;
+	},
+	100,
+	3
+);


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6831

WP stateless plugin short-circuits the [image_downsize()](https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-includes/media.php#L191) process with [wpCloud\StatelessMedia\Bootstrap::image_downsize()](https://github.com/udx/wp-stateless/blob/b685a67f2961d1459874da461586b4ae1bde853d/lib/classes/class-bootstrap.php#L1322).
Contrary to [the native function](https://github.com/WordPress/wordpress-develop/blob/0abc2b2a5bbc6737a7c31d28456037be91a0bfa7/src/wp-includes/media.php#L222-L229), it will return attachment data [even if the attachment is not an image](https://github.com/udx/wp-stateless/blob/b685a67f2961d1459874da461586b4ae1bde853d/lib/classes/class-bootstrap.php#L1385-L1390).
The attachment is then treated as an image by the function [wp_get_attachment_link()](https://github.com/WordPress/wordpress-develop/blob/0abc2b2a5bbc6737a7c31d28456037be91a0bfa7/src/wp-includes/post-template.php#L1616-L1632) generating the link, even for a PDF.

## Fix

We overrule wp-stateless response if the attachment is not an image.
_Depending on if we think it's a wp-stateless bug, we will report it to their repo, so this might be a temporary fix._

## Test

Test on [Phobos](https://www-dev.greenpeace.org/test-phobos/)
- Find documents pages through [Media library](https://www-dev.greenpeace.org/test-phobos/wp-admin/upload.php) filter
- Verify PDF file page (ex: https://www-dev.greenpeace.org/test-phobos/pan-african-plastics-policy-consultant/ )