### PR TITLE
Allow box-orient to be vendor prefixed

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -88,6 +88,6 @@
     "no-invalid-double-slash-comments": true,
     "no-missing-end-of-source-newline": true,
     "max-empty-lines": 1,
-    "property-no-vendor-prefix": true
+    "property-no-vendor-prefix": [true, {"ignoreProperties": ["box-orient"]}]
   }
 }

--- a/assets/src/js/menu_editor.js
+++ b/assets/src/js/menu_editor.js
@@ -91,7 +91,7 @@ const menuEditorRestrictions = () => {
     </style>`;
 
     menuEditorFooter.insertBefore(container, menuEditorFooter.querySelector('div'));
-  }
+  };
 
   /**
    * Toggle rules linked to location selected


### PR DESCRIPTION
Making `stylelint` happy, since this property is needed for `line-clamp`.

And adding a missing semicolon to make `eslint` also happy.

Frontend tests are [currently failing](https://app.circleci.com/pipelines/github/greenpeace/planet4-master-theme/5942/workflows/688bf238-d345-4785-8d11-e8377d154e08/jobs/37372/parallel-runs/0/steps/0-102) because of [-webkit-box-orient](https://github.com/greenpeace/planet4-master-theme/blob/61ba0e0f6e32c1a40fdebe8ce2d33689ad313b93/assets/src/scss/pages/post/_article-content.scss#L255).