### PR TITLE
PLANET-6844: Anti-flicker snippet does not load properly

### DIFF
--- a/templates/blocks/google_antiflicker.twig
+++ b/templates/blocks/google_antiflicker.twig
@@ -1,0 +1,20 @@
+{#
+  Anti-flicker is used to hide some portions of the page until Optimize container is ready
+  Cf. https://developers.google.com/optimize/devguides/antiflicker?hl=en
+  This version uses a non-standard configuration variable,
+  so that it doesn't show an error in the Optimize installation check (only a warning).
+  It also logs the duration of the anti-flicker, in dataLayer.hide.duration.
+  If this duration is >= to the timeout configured, then Optimize probably wasn't triggered.
+#}
+{% if google_tag_value and ab_hide_selector %}
+	<style>.google-optimize-loading {{ ab_hide_selector }} { opacity: 0 !important; }</style>
+	<script>
+		var antiflickerConf = {'{{ google_tag_value }}':true};
+		(function(a,s,y,n,c,h,i,d,e){
+			s.className+=' '+y; h.start=1*new Date; h.end=i=function(){
+				s.className=s.className.replace(RegExp(' ?'+y),'');
+				h.duration=h.duration || (1*new Date)-h.start;
+			}; (a[n]=a[n]||[]).hide=h; setTimeout(function(){i();h.end=null},c); h.timeout=c;
+		})(window, document.documentElement, 'google-optimize-loading', 'dataLayer', 4000, antiflickerConf);
+	</script>
+{% endif %}

--- a/templates/blocks/google_tag_manager.twig
+++ b/templates/blocks/google_tag_manager.twig
@@ -1,13 +1,8 @@
 {% if google_tag_value %}
-  {% if ab_hide_selector %}
-  <style>
-    .google-optimize-loading {{ ab_hide_selector }} {
-      opacity: 0 !important;
-    }
-  </style>
-  {% endif %}
   <script>
+    var google_tag_value = '{{ google_tag_value }}';
     window.dataLayer = window.dataLayer || [];
+
     function gtag() { dataLayer.push(arguments); };
 
     var cookie_content = document.cookie.split(';').map(s => s.trim());
@@ -49,8 +44,6 @@
     }
     {% endif %}
 
-    var google_tag_value = '{{ google_tag_value }}';
-
     dataLayer.push({
       'pageType' : '{{ page_category }}',
       'signedIn' : '{{ p4_signedin_status }}',
@@ -59,12 +52,6 @@
       'post_tags': '{{ post_tags }}',
       'gPlatform': 'Planet 4'
     });
-
-    (function(a,s,y,n,c,h,i,d,e){s.className+=' '+y;h.start=1*new Date;
-    h.end=i=function(){s.className=s.className.replace(RegExp(' ?'+y),'')};
-    (a[n]=a[n]||[]).hide=h;setTimeout(function(){i();h.end=null},c);h.timeout=c;
-    })(window,document.documentElement,'google-optimize-loading','dataLayer',4000,
-    {'{{ google_tag_value }}':true});
 
     {% if not post.password_required %}
       var cf_campaign_name = '{% if cf_campaign_name is defined and cf_campaign_name is not null %}{{ cf_campaign_name|raw }}{% endif %}';
@@ -91,10 +78,7 @@
     if ( google_tag_value && gtm_allow ) {
       (function (w, d, s, l, i) {
         w[l] = w[l] || [];
-        w[l].push({
-          'gtm.start':
-          new Date().getTime(), event: 'gtm.js'
-        });
+        w[l].push({'gtm.start': new Date().getTime(), event: 'gtm.js'});
         var f = d.getElementsByTagName(s)[0],
             j = d.createElement(s), dl = l != 'dataLayer' ? '&l=' + l : '';
         j.async = true;

--- a/templates/html-header.twig
+++ b/templates/html-header.twig
@@ -1,12 +1,13 @@
 <!DOCTYPE html>
 <html {{ fn('language_attributes', 'html') }} data-base="{{ data_nav_bar.home_url }}">
 <head>
+	{% include 'blocks/google_antiflicker.twig' %}
+	{% include 'blocks/google_tag_manager.twig' %}
+
 	<meta charset="{{ site.charset }}">
 	{% include 'blocks/title.twig' %}
 
 	{% include 'blocks/meta_fields.twig' %}
-
-	{% include 'blocks/google_tag_manager.twig' %}
 
 	{% if hubspot_active %}
 		{% include 'head/hubspot.twig' %}


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6844

> Check relevant discussions [here](https://greenpeace-gpi.slack.com/archives/C0151L0KKNX/p1656962941586809) and [here](https://greenpeace-gpi.slack.com/archives/C0151L0KKNX/p1656510365584269).
> Google Optimize reports (see screenshot) that the snippet is not installed in the right place or not installed at all.


![Screenshot from 2022-07-06 17-48-53](https://user-images.githubusercontent.com/617346/178563117-1dc0373b-5ea4-4315-9b53-9db2a1d7d3bc.png)

## Fixes
- Re order scripts
- Extract anti-flicker to its own template, to make it easier to modify/edit/remove
- Change anti-flicker last parameter to make it appear "non-standard" and avoid installation check error in Optimize
- Add anti-flicker duration log to check for good run or timeout
- Include anti-flicker only if an a/b selector is configured

Optimize installation check now reports only a Warning, instead of various errors.
![Screenshot from 2022-07-08 12-03-25](https://user-images.githubusercontent.com/617346/178563017-24bf4326-6ca5-41e7-b387-1d5edbd16f27.png)


These fixes come with a proper configuration in Tag manager Trigger related to the Optimize container.
![gpi](https://user-images.githubusercontent.com/617346/178565158-a96df221-dc50-46d7-af9a-efe061fb5c2f.png)

_It was confirmed to work on Brasil dev site and is currently running and working on Brasil prod site._