### PR TITLE
PLANET-6845: Fix menu config loading

### DIFF
--- a/src/AdminAssets.php
+++ b/src/AdminAssets.php
@@ -26,7 +26,9 @@ class AdminAssets {
 		$navbar_location = 'navigation-bar-menu';
 		$donate_location = 'donate-menu';
 
-		if ( ! isset( $menus[ $navbar_location ] ) || ! isset( $menus[ $donate_location ] ) ) {
+		if ( ! isset( $menus[ $navbar_location ] )
+			&& ! isset( $menus[ $donate_location ] )
+		) {
 			return;
 		}
 


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6845

> Houssam and I noticed that WPML sites, such as Belgium or MENA, has the Menu restrictions not working as expected.

Because of a mistake in a condition, if the Donate menu location doesn't exist on the instance, the menu configuration limitations are not applied to the editor.
Fixing the condition to work if at least one of the menus location exists.
