### PR TITLE
PLANET-6847: Improve the Page Create Patterns modal layout 

### DIFF
--- a/assets/src/scss/editorOverrides.scss
+++ b/assets/src/scss/editorOverrides.scss
@@ -276,3 +276,14 @@ input.describe[type=text][data-setting=caption] {
 .block-editor-block-preview__content-iframe .wp-block-button.is-style-transparent {
   background: $dark-blue;
 }
+
+.block-editor-block-patterns-list__item {
+  display: flex;
+  flex-direction: column-reverse;
+
+  .block-editor-block-patterns-list__item-title {
+    color: $grey-80;
+    font-weight: bold;
+    margin-bottom: $sp-1;
+  }
+}


### PR DESCRIPTION
**Description**
The intention is to show the pattern description above the pattern preview for a better readability. 
This change has been suggested by Suzi, here is the [Slack's thread](https://greenpeace-gpi.slack.com/archives/G014JEXDUHJ/p1657303099711689?thread_ts=1657291502.321389&cid=G014JEXDUHJ).

Ref: https://jira.greenpeace.org/browse/PLANET-6847

**Test**
1. create a new page
2. Then see how the modal looks like. The title must be above the pattern preview