### PR TITLE
Add spacing feature to theme

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -88,6 +88,11 @@
           "radius": false
         }
       },
+      "core/group": {
+        "spacing": {
+          "padding": true
+        }
+      },
       "core/table": {
         "color": {
           "text": false,


### PR DESCRIPTION
## Description
This feature is going to be used by the [issues pattern](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/914/files#diff-48b8904c9490414ea5f81b24352f93cd7ebc7c65369ba952fbfebaa35f0d5f5fR32) among others.

Related PR: https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/914

## Testing
- Create a new page and add a `core/group`. You'll be able to see the below settings
![Screenshot 2022-08-02 at 14 30 48](https://user-images.githubusercontent.com/77975803/182437801-7c3005f0-f77f-4d3e-aef4-9363819d7d5c.png)


## Documentation
- More info about the [Wodrpress's Dimension feature](https://wordpress.com/support/wordpress-editor/blocks/row-block/)
- [Code reference](https://developer.wordpress.org/reference/classes/wp_theme_json/get_settings/)