### PR TITLE
Translate "Manage your cookies preferences" label into French (fr_CA)

### DIFF
--- a/languages/planet4-master-theme-fr_CA.po
+++ b/languages/planet4-master-theme-fr_CA.po
@@ -260,7 +260,7 @@ msgstr ""
 
 #: templates/cookies/cookies_settings.twig:11
 msgid "Manage your cookies preferences"
-msgstr ""
+msgstr "Gérez vos préférences en matière de témoins de navigation"
 
 #. Description of the theme
 msgid "Master theme for the Planet 4 Wordpress project"


### PR DESCRIPTION
Translated the "Manage your cookies preferences" label into French with "Gérez vos préférences en matière de témoins de navigation".

I came up with many options:

- [x] "Gérez vos préférences en matière de témoins de navigation" (most precise translation I could come up with)
- [ ] "Gérez vos préférences en matière de témoins" (using a shorthand)
- [ ] "Gérez vos préférences en matière de cookies" (uses the common anglicism "cookie" to appear less formal)

Let me know if I chose the wrong one or if you have a better translation to propose?