### PR TITLE
PLANET-6808 Update Gravity Forms thank you message

### DIFF
--- a/assets/src/scss/layout/_gravity-forms.scss
+++ b/assets/src/scss/layout/_gravity-forms.scss
@@ -152,3 +152,13 @@
 .ui-datepicker {
   font-family: $roboto;
 }
+
+.gform_p4_confirmation {
+  .share-buttons {
+    margin-top: $sp-3;
+  }
+
+  hr {
+    margin: $sp-5 0;
+  }
+}

--- a/functions.php
+++ b/functions.php
@@ -217,22 +217,60 @@ add_filter(
  *
  * Add CSS classes to Gravity Forms fields.
  */
-add_filter( 'gform_field_css_class', 'custom_class', 10, 3 );
+add_filter( 'gform_field_css_class', 'gform_custom_field_class', 10, 3 );
 
 /**
  *
  * Add CSS classes to some Gravity Forms fields: checkboxes and radio buttons.
  *
  * @param string $classes The existing field classes.
- * @param string $field The field name.
+ * @param object $field The field.
  *
  * @return string The updated field classes.
  */
-function custom_class( $classes, $field ) {
+function gform_custom_field_class( $classes, $field ) {
 	if ( 'checkbox' === $field->type || 'radio' === $field->type || 'consent' === $field->type ) {
 		$classes .= ' custom-control';
 	}
 	return $classes;
+}
+
+/**
+ *
+ * Update confirmation message for Gravity Forms.
+ */
+add_filter( 'gform_confirmation', 'gform_custom_confirmation', 10, 3 );
+
+/**
+ *
+ * Return custom confirmation message for Gravity Forms.
+ *
+ * @param string $confirmation The default confirmation message.
+ * @param array  $form The form properties.
+ * @param array  $entry The form data.
+ *
+ * @return string The custom confirmation message.
+ */
+function gform_custom_confirmation( $confirmation, $form, $entry ) {
+	$first_name_field = array_filter(
+		$form['fields'],
+		function( $field ) {
+			return 'name' === $field->type;
+		}
+	)[0];
+
+	$first_name = rgar( $entry, '' . $first_name_field->id . '.3' );
+
+	$post = Timber::query_post( false, Post::class );
+
+	$confirmation_fields = [
+		'first_name'       => $first_name ?? '',
+		'post'             => $post,
+		'form_title'       => $form['title'] ?? '',
+		'form_description' => $form['description'] ?? '',
+	];
+
+	return Timber::compile( [ 'gravity_forms_confirmation.twig' ], $confirmation_fields );
 }
 
 /**

--- a/functions.php
+++ b/functions.php
@@ -252,25 +252,31 @@ add_filter( 'gform_confirmation', 'gform_custom_confirmation', 10, 3 );
  * @return string The custom confirmation message.
  */
 function gform_custom_confirmation( $confirmation, $form, $entry ) {
-	$first_name_field = array_filter(
-		$form['fields'],
-		function( $field ) {
-			return 'name' === $field->type;
-		}
-	)[0];
+	$form_confirmation_option = $form['p4_gf_confirmation'] ?? 'planet4';
 
-	$first_name = rgar( $entry, '' . $first_name_field->id . '.3' );
+	if ( 'planet4' === $form_confirmation_option ) {
+		$first_name_field = array_filter(
+			$form['fields'],
+			function( $field ) {
+				return 'name' === $field->type;
+			}
+		)[0];
 
-	$post = Timber::query_post( false, Post::class );
+		$first_name = rgar( $entry, '' . $first_name_field->id . '.3' );
 
-	$confirmation_fields = [
-		'first_name'       => $first_name ?? '',
-		'post'             => $post,
-		'form_title'       => $form['title'] ?? '',
-		'form_description' => $form['description'] ?? '',
-	];
+		$post = Timber::query_post( false, Post::class );
 
-	return Timber::compile( [ 'gravity_forms_confirmation.twig' ], $confirmation_fields );
+		$confirmation_fields = [
+			'first_name'       => $first_name ?? '',
+			'post'             => $post,
+			'form_title'       => $form['title'] ?? '',
+			'form_description' => $form['description'] ?? '',
+		];
+
+		return Timber::compile( [ 'gravity_forms_confirmation.twig' ], $confirmation_fields );
+	} else {
+		return $confirmation;
+	}
 }
 
 /**

--- a/src/GravityFormsExtensions.php
+++ b/src/GravityFormsExtensions.php
@@ -51,6 +51,25 @@ class GravityFormsExtensions {
 	];
 
 	/**
+	 * @var string The default gravity form confirmation message.
+	 */
+	public const DEFAULT_GF_CONFIRMATION = 'planet4';
+
+	/**
+	 * @var array The Planet4 Gravity form confirmation messages.
+	 */
+	public const P4_GF_CONFIRMATIONS = [
+		[
+			'label' => 'Planet 4 message',
+			'value' => 'planet4',
+		],
+		[
+			'label' => 'Custom message',
+			'value' => 'custom',
+		],
+	];
+
+	/**
 	 * The constructor.
 	 */
 	public function __construct() {
@@ -61,18 +80,18 @@ class GravityFormsExtensions {
 	 * Class hooks.
 	 */
 	private function hooks() {
-		add_filter( 'gform_form_settings_fields', [ $this, 'p4_gf_type_setting' ], 5, 2 );
+		add_filter( 'gform_form_settings_fields', [ $this, 'p4_gf_settings' ], 5, 2 );
 	}
 
 	/**
-	 * Add a setting to gravity Forms to set the type of form.
+	 * Add settings to Gravity Forms: one to set the type of form, one to choose the confirmation message.
 	 *
 	 * @param array  $fields The form settings fields.
 	 * @param object $form The Gravity form Object.
 	 *
 	 * @return array The new fields array.
 	 */
-	public function p4_gf_type_setting( $fields, $form ) {
+	public function p4_gf_settings( $fields, $form ) {
 
 		if ( ! array_key_exists( 'p4_options', $fields ) ) {
 			$new_fields['p4_options'] = [
@@ -91,6 +110,16 @@ class GravityFormsExtensions {
 			'required'       => true,
 			'default_value ' => self::DEFAULT_GF_TYPE,
 			'choices'        => self::P4_GF_TYPES,
+		];
+
+		$fields['p4_options']['fields'][] = [
+			'type'           => 'select',
+			'name'           => 'p4_gf_confirmation',
+			'label'          => __( 'Confirmation message', 'planet4-master-theme-backend' ),
+			'tooltip'        => __( 'If you use the Planet 4 confirmation message, you will not be able to see it and edit it via the Confirmations menu item', 'planet4-master-theme-backend' ),
+			'required'       => true,
+			'default_value ' => self::DEFAULT_GF_CONFIRMATION,
+			'choices'        => self::P4_GF_CONFIRMATIONS,
 		];
 
 		return $fields;

--- a/templates/gravity_forms_confirmation.twig
+++ b/templates/gravity_forms_confirmation.twig
@@ -1,0 +1,18 @@
+<div class="gform_p4_confirmation">
+	{% if form_title %}
+		<h2>{{ form_title }}</h2>
+	{% endif %}
+	{% if form_description %}
+		<p>{{ form_description }}</p>
+	{% endif %}
+	{% if form_title or form_description %}
+		<hr>
+	{% endif %}
+	{% if first_name %}
+		<h3>{{ __( first_name ~ ', thanks for signing!', 'planet4-master-theme', first_name ) }}</h3>
+	{% else %}
+		<h3>{{ __( 'Thanks for signing!', 'planet4-master-theme' ) }}</h3>
+	{% endif %}
+	<p>{{ __( 'Share this petition to increase your global impact', 'planet4-master-theme' ) }}</p>
+	{% include "blocks/share_buttons.twig" with { social: post.share_meta } %}
+</div>


### PR DESCRIPTION
### Description

See [PLANET-6808](https://jira.greenpeace.org/browse/PLANET-6808)

### Testing

You can test the new confirmation message either on this [page](https://www-dev.greenpeace.org/test-neptune/33089-2/) that I created for UAT, or on your local using any GF form. I also added a Planet 4 option to Gravity Forms to allow editors to choose whether or not they want to use our message or create a custom one! I've added a tooltip to explain that it's not possible to see or edit it via the Confirmations tab if they select the P4 one. You can test that new setting [here](https://www-dev.greenpeace.org/test-neptune/wp-admin/admin.php?page=gf_edit_forms&view=settings&id=1) for example 🙂 