### PR TITLE
PLANET-6527: Style the default 'all posts' listing page

### DIFF
--- a/assets/src/js/load_more.js
+++ b/assets/src/js/load_more.js
@@ -14,7 +14,7 @@ function handler(e) {
   const content_elt = document.querySelector( this.dataset.content );
   const next_page = parseInt( this.dataset.page, 10 ) + 1;
   const total_pages = parseInt( this.dataset.total, 10 );
-  const url = this.dataset.url + `?page=${ next_page }`;
+  const url = this.dataset.url + `?page=${ next_page }&page_num=${ next_page }`;
   this.dataset.page = next_page;
 
   fetch(url)

--- a/functions.php
+++ b/functions.php
@@ -477,7 +477,8 @@ add_filter(
 	3
 );
 
-// This action overrides the [WordPress functionality for adding a notice message](https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-admin/edit-form-blocks.php#L303-L305)
+// This action overrides the WordPress functionality for adding a notice message
+// https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-admin/edit-form-blocks.php#L303-L305
 // When it's a page for posts.
 add_action(
 	'admin_enqueue_scripts',

--- a/functions.php
+++ b/functions.php
@@ -476,3 +476,38 @@ add_filter(
 	100,
 	3
 );
+
+// This action overrides the [WordPress functionality for adding a notice message](https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-admin/edit-form-blocks.php#L303-L305)
+// When it's a page for posts.
+add_action(
+	'admin_enqueue_scripts',
+	function() {
+		global $post;
+
+		if ( $post && (int) get_option( 'page_for_posts' ) === $post->ID ) {
+			// Adding this style, it works as a workaround for editors
+			// To disable the ability to edit the content of the listing page.
+			echo '<style>
+			.edit-post-header-toolbar,
+			.block-list-appender {
+				pointer-events: none;
+				opacity: 0;
+			}
+
+			.block-editor-block-list__layout {
+				display: none;
+			}
+		</style>';
+
+			wp_add_inline_script(
+				'wp-notices',
+				sprintf(
+					'wp.data.dispatch( "core/notices" ).createWarningNotice( "%s", { isDismissible: false } )',
+					__( 'Custom P4 message', 'planet4-master-theme' )
+				),
+				'after'
+			);
+		}
+	},
+	100
+);

--- a/functions.php
+++ b/functions.php
@@ -512,3 +512,14 @@ add_action(
 	},
 	100
 );
+
+// The new `pagenum` query_var is used ONLY trough the default listing pages (index.php),
+// when the Load more feature is enabled.
+// Also added in replacement of the `page` query_var since that param is returning always zero.
+add_filter(
+	'query_vars',
+	function( $vars ) {
+		$vars[] = 'page_num';
+		return $vars;
+	}
+);

--- a/functions.php
+++ b/functions.php
@@ -489,24 +489,29 @@ add_action(
 			// Adding this style, it works as a workaround for editors
 			// To disable the ability to edit the content of the listing page.
 			echo '<style>
-			.edit-post-header-toolbar,
-			.block-list-appender {
-				pointer-events: none;
-				opacity: 0;
-			}
+				.edit-post-header-toolbar,
+				.block-list-appender {
+					pointer-events: none;
+					opacity: 0;
+				}
 
-			.block-editor-block-list__layout {
-				display: none;
-			}
-		</style>';
+				.block-editor-block-list__layout {
+					display: none;
+				}
+
+				.components-notice__actions {
+					display: inline-flex !important;
+					margin-left: 5px;
+				}
+			</style>';
 
 			wp_add_inline_script(
 				'wp-notices',
 				sprintf(
-					'wp.data.dispatch( "core/notices" ).createWarningNotice( "%s", { isDismissible: false } )',
-					__( 'Custom P4 message', 'planet4-master-theme' )
-				),
-				'after'
+					'wp.data.dispatch( "core/notices" ).createNotice("warning", "%s" , { isDismissible: false, actions: [ { label: "%s", url: "/wp-admin/options-reading.php"} ] } )',
+					__( 'The content on this page is hidden because this page is being used as your \"All Posts\" listing page. You can disable this by un-setting the \"Posts page\"', 'planet4-master-theme' ),
+					__( 'here', 'planet4-master-theme' )
+				)
 			);
 		}
 	},

--- a/index.php
+++ b/index.php
@@ -13,6 +13,7 @@
  * @since   Timber 0.1
  */
 
+use P4\MasterTheme\Context;
 use P4\MasterTheme\Features\Dev\ListingPageGridView;
 use P4\MasterTheme\Features\ListingPagePagination;
 use P4\MasterTheme\Post;
@@ -22,11 +23,21 @@ $context   = Timber::get_context();
 $templates = [ 'index.twig' ];
 
 if ( is_home() ) {
-	$post             = new Post(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-	$page_meta_data   = get_post_meta( $post->ID );
-	$page_meta_data   = array_map( 'reset', $page_meta_data );
-	$context['posts'] = Timber::get_posts();
+	$post = new Post(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+	$post->set_data_layer();
+	$data_layer = $post->get_data_layer();
+
+	$page_meta_data = get_post_meta( $post->ID );
+	$page_meta_data = array_map( 'reset', $page_meta_data );
+
 	$context['title'] = ( $page_meta_data['p4_title'] ?? '' ) ? ( $page_meta_data['p4_title'] ?? '' ) : html_entity_decode( $context['wp_title'] ?? '' );
+	$context['posts'] = Timber::get_posts();
+
+	Context::set_header( $context, $page_meta_data, $context['title'] );
+	Context::set_background_image( $context );
+	Context::set_og_meta_fields( $context, $post );
+	Context::set_campaign_datalayer( $context, $page_meta_data );
+	Context::set_utm_params( $context, $post );
 
 	array_unshift( $templates, 'all-posts.twig' );
 

--- a/index.php
+++ b/index.php
@@ -36,6 +36,11 @@ if ( is_home() ) {
 		$context['query_loop'] = $content;
 		Timber::render( $templates, $context );
 		exit();
+	} else {
+		// Only applied to the "Load More" feature.
+		if ( null !== get_query_var( 'page_num' ) ) {
+			$wp_query->query_vars['page'] = get_query_var( 'page_num' );
+		}
 	}
 
 	$post_args = [
@@ -62,4 +67,3 @@ if ( is_home() ) {
 } else {
 	Timber::render( $templates, $context );
 }
-

--- a/index.php
+++ b/index.php
@@ -37,6 +37,29 @@ if ( is_home() ) {
 		Timber::render( $templates, $context );
 		exit();
 	}
+
+	$post_args = [
+		'posts_per_page' => 10,
+		'post_type'      => 'post',
+		'paged'          => 1,
+		'has_password'   => false,  // Skip password protected content.
+	];
+
+	if ( get_query_var( 'page' ) ) {
+		$templates          = [ 'tease-taxonomy-post.twig' ];
+		$post_args['paged'] = get_query_var( 'page' );
+		$pagetype_posts     = new \Timber\PostQuery( $post_args, Post::class );
+		foreach ( $pagetype_posts as $pagetype_post ) {
+			$context['post'] = $pagetype_post;
+			Timber::render( $templates, $context );
+		}
+	} else {
+		$pagetype_posts   = new \Timber\PostQuery( $post_args, Post::class );
+		$context['posts'] = $pagetype_posts;
+		$context['url']   = home_url( $wp->request );
+		Timber::render( $templates, $context );
+	}
+} else {
+	Timber::render( $templates, $context );
 }
 
-Timber::render( $templates, $context );

--- a/index.php
+++ b/index.php
@@ -13,11 +13,30 @@
  * @since   Timber 0.1
  */
 
+use P4\MasterTheme\Features\Dev\ListingPageGridView;
+use P4\MasterTheme\Features\ListingPagePagination;
+use Timber\Timber;
+
 $context          = Timber::get_context();
 $context['posts'] = Timber::get_posts();
+$context['title'] = html_entity_decode( $context['wp_title'] );
 
 $templates = [ 'index.twig' ];
+
 if ( is_home() ) {
-	array_unshift( $templates, 'home.twig' );
+	array_unshift( $templates, 'all-posts.twig' );
+
+	if ( ListingPagePagination::is_active() ) {
+		$view = ListingPageGridView::is_active() ? 'grid' : 'list';
+
+		$query_template = file_get_contents( get_template_directory() . "/parts/query-$view.html" );
+
+		$content = do_blocks( $query_template );
+
+		$context['query_loop'] = $content;
+		Timber::render( $templates, $context );
+		exit();
+	}
 }
+
 Timber::render( $templates, $context );

--- a/index.php
+++ b/index.php
@@ -15,15 +15,19 @@
 
 use P4\MasterTheme\Features\Dev\ListingPageGridView;
 use P4\MasterTheme\Features\ListingPagePagination;
+use P4\MasterTheme\Post;
 use Timber\Timber;
 
-$context          = Timber::get_context();
-$context['posts'] = Timber::get_posts();
-$context['title'] = html_entity_decode( $context['wp_title'] );
-
+$context   = Timber::get_context();
 $templates = [ 'index.twig' ];
 
 if ( is_home() ) {
+	$post             = new Post(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+	$page_meta_data   = get_post_meta( $post->ID );
+	$page_meta_data   = array_map( 'reset', $page_meta_data );
+	$context['posts'] = Timber::get_posts();
+	$context['title'] = ( $page_meta_data['p4_title'] ?? '' ) ? ( $page_meta_data['p4_title'] ?? '' ) : html_entity_decode( $context['wp_title'] ?? '' );
+
 	array_unshift( $templates, 'all-posts.twig' );
 
 	if ( ListingPagePagination::is_active() ) {

--- a/src/Search.php
+++ b/src/Search.php
@@ -225,6 +225,15 @@ abstract class Search {
 				2
 			);
 		}
+		// Only invoked if the page for posts is set.
+		if ( null !== get_option( 'page_for_posts' ) ) {
+			add_filter(
+				'pre_get_posts',
+				[ self::class, 'exclude_page_for_posts' ],
+				10,
+				1
+			);
+		}
 		remove_filter(
 			'pre_get_posts',
 			[ Features::factory()->get_registered_feature( 'documents' ), 'setup_document_search' ],
@@ -1001,6 +1010,23 @@ abstract class Search {
 		$args['post__not_in'] = $unwanted_attachment_ids;
 
 		return $args;
+	}
+
+	/**
+	 * Exclude the page for posts set through the Settings > Reading page.
+	 *
+	 * @param query $query The Query ElasticPress will use to fetch the ids of posts.
+	 *
+	 * @return query The Query with exclusion of the page for posts.
+	 */
+	public static function exclude_page_for_posts( $query ) {
+		$page_for_posts = get_option( 'page_for_posts' );
+
+		if ( $page_for_posts ) {
+			$query->set( 'post__not_in', [ $page_for_posts ] );
+		}
+
+		return $query;
 	}
 
 	/**

--- a/templates/all-posts.twig
+++ b/templates/all-posts.twig
@@ -1,8 +1,6 @@
 {% extends "base.twig" %}
 
-
 {% block content %}
-
 	<div class="clearfix"></div>
 	<div class="skewed-overlay"></div>
 
@@ -32,14 +30,14 @@
 				<div class="row">
 					<div class="col-md-12 col-lg-5 col-xl-5 mt-3">
 						<button
-								data-content=".multiple-search-result .list-unstyled"
-								data-page="1"
-								data-total="{{ posts.pagination.total }}"
-								data-url="{{ fn('get_term_link', taxonomy.term_id ) }}"
-								class="load-more-mt btn btn-small btn-secondary mb-5"
-								data-ga-category="Articles List"
-								data-ga-action="Load More Button"
-								data-ga-label="n/a">
+							data-content=".multiple-search-result .list-unstyled"
+							data-page="1"
+							data-total="{{ posts.pagination.total }}"
+							data-url="{{ url }}"
+							class="load-more-mt btn btn-small btn-secondary mb-5"
+							data-ga-category="Articles List"
+							data-ga-action="Load More Button"
+							data-ga-label="n/a">
 							{{ __( 'Load More', 'planet4-master-theme' ) }}
 						</button>
 					</div>

--- a/templates/all-posts.twig
+++ b/templates/all-posts.twig
@@ -1,0 +1,50 @@
+{% extends "base.twig" %}
+
+
+{% block content %}
+
+	<div class="clearfix"></div>
+	<div class="skewed-overlay"></div>
+
+	<header class="page-header">
+		<div class="container">
+			<h1 class="page-header-title">{{ title }}</h1>
+		</div>
+	</header>
+
+	<div class="page-content container">
+		{% if query_loop %}
+			{{ query_loop|raw }}
+		{% else %}
+			<h3>{{ __( 'Results', 'planet4-master-theme' ) }}</h3>
+
+			<div class="row">
+				<div class="col-lg-8 multiple-search-result">
+					<ul class="list-unstyled">
+						{% for post in posts %}
+							{% include 'tease-taxonomy-post.twig' %}
+						{% endfor %}
+					</ul>
+				</div>
+			</div>
+
+			{% if posts.pagination.total > 1 %}
+				<div class="row">
+					<div class="col-md-12 col-lg-5 col-xl-5 mt-3">
+						<button
+								data-content=".multiple-search-result .list-unstyled"
+								data-page="1"
+								data-total="{{ posts.pagination.total }}"
+								data-url="{{ fn('get_term_link', taxonomy.term_id ) }}"
+								class="load-more-mt btn btn-small btn-secondary mb-5"
+								data-ga-category="Articles List"
+								data-ga-action="Load More Button"
+								data-ga-label="n/a">
+							{{ __( 'Load More', 'planet4-master-theme' ) }}
+						</button>
+					</div>
+				</div>
+			{% endif %}
+		{% endif %}
+	</div>
+{% endblock %}

--- a/templates/all-posts.twig
+++ b/templates/all-posts.twig
@@ -4,12 +4,6 @@
 	<div class="clearfix"></div>
 	<div class="skewed-overlay"></div>
 
-	<header class="page-header">
-		<div class="container">
-			<h1 class="page-header-title">{{ title }}</h1>
-		</div>
-	</header>
-
 	<div class="page-content container">
 		{% if query_loop %}
 			{{ query_loop|raw }}


### PR DESCRIPTION
Ref: [PLANET-6527](https://jira.greenpeace.org/browse/PLANET-6527)
Demo page: https://www-dev.greenpeace.org/test-tavros/news-stories/

## Description
This is the new default listing page when the "Posts page" setting From Reading Settings is changed.
The UI should be similar to the [Category page](https://www-dev.greenpeace.org/test-rhea/category/issues/energy/) but without the description.

Other features that we would have to include: (taken from the ticket's description)
- Check if we can disable the ability to add blocks/content on the page that is set as 'posts page', to minimize editor confusion.
- Check if we can update the warning text that shows up in the yellow box at the top. If we can, I (suzi) will provide text for it.

This is how the editor looks like 👇 and there is no possibility to add content and also it's added a P4 message at the top of the page.
 <img width="1416" alt="Screenshot 2022-08-29 at 22 49 38" src="https://user-images.githubusercontent.com/77975803/187330234-c2d9e71a-092e-4970-9a69-717fe729057e.png">

We need also to exclude the page for posts (all posts) from the search result

**Before**
![Screenshot 2022-09-15 at 14 45 35](https://user-images.githubusercontent.com/77975803/190474640-bb9fcf24-24b9-40b8-993d-817a6c3b79c1.png)

**After**
![Screenshot 2022-09-15 at 14 52 52](https://user-images.githubusercontent.com/77975803/190475603-38477696-a9ef-4ce5-902e-4b6d1bf83454.png)

https://user-images.githubusercontent.com/77975803/190476812-8eff8988-a757-4741-9ffb-1fb30ec8c4e3.mov

## Testing
1. Create a new page
2. Then go to Settings > Reading and set a Posts Page.

If you chose the "Your latest post", you'll see the default created page.

![Screenshot 2022-08-22 at 13 42 25](https://user-images.githubusercontent.com/77975803/185975081-33c14e2b-570a-4598-be59-fe022b54c693.png)

But if you set "A static page" you would need to find your created page through the "Posts Page" dropdown, then you'll see the default "All posts" listing page .

![Screenshot 2022-08-22 at 13 40 50](https://user-images.githubusercontent.com/77975803/185975030-4f9452b7-eb82-4d65-9401-8defee22325c.png)



