### PR TITLE
Fix notice on undefined $filename variable

### DIFF
--- a/src/PublicAssets.php
+++ b/src/PublicAssets.php
@@ -147,7 +147,7 @@ final class PublicAssets {
 			function ( $asset_data ): void {
 				$handle = $asset_data[0];
 				$file   = '/assets/build/' . $asset_data[1];
-				'js' === pathinfo( $filename, \PATHINFO_EXTENSION )
+				'js' === pathinfo( $file, \PATHINFO_EXTENSION )
 					? Loader::enqueue_versioned_script( $file, $handle )
 					: Loader::enqueue_versioned_style( $file, $handle );
 			}


### PR DESCRIPTION
Variable `$filename` generates a Notice because it's not defined

Typo on filename -> file
