### PR TITLE
PLANET-6873: Fix the color of links from footer

### DIFF
--- a/assets/src/scss/layout/_footer.scss
+++ b/assets/src/scss/layout/_footer.scss
@@ -13,9 +13,17 @@
   line-height: 0;
 
   a _-- {
-    color: inherit;
+    color: $white;
+
+    &:visited {
+      color: $white;
+    }
 
     &:hover {
+      color: $white;
+    }
+
+    &:active {
       color: $white;
     }
   }


### PR DESCRIPTION
Ref: [PLANET-6873](https://jira.greenpeace.org/browse/)

The color must be always in white in all its states (active, hover, etc).

Demo page: Just visit the [current instance](https://www-dev.greenpeace.org/test-janus)