### PR TITLE
PLANET-6895: Use open graph title for title tag

### DIFF
--- a/templates/blocks/title.twig
+++ b/templates/blocks/title.twig
@@ -2,6 +2,8 @@
 	{% if post.password_required %}
 		{{ site.name }}
 		{% set post_tags = '' %}
+	{% elseif og_title %}
+		{{ og_title|e('esc_html')|raw }} - {{ site.name }}
 	{% elseif wp_title %}
 		{{ wp_title|e('esc_html')|raw }} - {{ site.name }}
 	{% else %}


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6895

> If Opengraph title has been set, [we use](https://github.com/greenpeace/planet4-master-theme/blob/aa58c884132cbe4cfe8a01194a1953ceb06d38ff/templates/blocks/meta_fields.twig#L18-L24) that to override the meta title tag (same for description).
We should do the same for the actual [title tag](https://github.com/greenpeace/planet4-master-theme/blob/aa58c884132cbe4cfe8a01194a1953ceb06d38ff/templates/blocks/title.twig). That would allow editors to have a more SEO-friendly title for search bots while using a slightly different/bigger for the actual content.

Prioritize Open graph title if it exists as `<title>` tag.

## Test

- create a page with a specific title
- add a different title in the _Open Graph > Title_ field, at the bottom of the editor
- check that the page title tag has the Open Graph title on the frontend
- check that it still displays the page title if no OG Title is specified