### PR TITLE
PLANET-6861 Add tooltip to P4 form type setting for Gravity Forms

### DIFF
--- a/src/GravityFormsExtensions.php
+++ b/src/GravityFormsExtensions.php
@@ -87,6 +87,7 @@ class GravityFormsExtensions {
 			'type'           => 'select',
 			'name'           => 'p4_gf_type',
 			'label'          => __( 'Form Type', 'planet4-master-theme-backend' ),
+			'tooltip'        => __( 'Please select a form type below so you can track and analyze each form type separately', 'planet4-master-theme-backend' ),
 			'required'       => true,
 			'default_value ' => self::DEFAULT_GF_TYPE,
 			'choices'        => self::P4_GF_TYPES,


### PR DESCRIPTION
### Description

See [PLANET-6861](https://jira.greenpeace.org/browse/PLANET-6861)
This is to clarify what this setting is for.

### Testing

You can check out this new tooltip in any Gravity Forms form's settings (or on the [test instance](https://www-dev.greenpeace.org/test-umbriel/wp-admin/admin.php?page=gf_edit_forms&view=settings&id=1)!)