### PR TITLE
PLANET-6890 Add meta field to hide page title in Actions

### DIFF
--- a/src/ActionPage.php
+++ b/src/ActionPage.php
@@ -140,5 +140,6 @@ class ActionPage {
 		];
 
 		register_post_meta( self::POST_TYPE, 'nav_type', $args );
+		register_post_meta( self::POST_TYPE, 'p4_hide_page_title_checkbox', $args );
 	}
 }


### PR DESCRIPTION
### Description

See [PLANET-6890](https://jira.greenpeace.org/browse/PLANET-6890)

**Related PR:** https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/937

### Testing

You can test the new checkbox either on local on any Action page, or on [this one](https://www-dev.greenpeace.org/test-telesto/action/the-first-action-page/) that I created for UAT. Note that just like the corresponding meta option available in pages/posts, you need to update (and not just preview) the page before you see the change applied!