### PR TITLE
PLANET-6897 Fix scroll to top bug when opening side menu

### DIFF
--- a/assets/src/js/header.js
+++ b/assets/src/js/header.js
@@ -54,7 +54,8 @@ const toggleNavElement = element => {
 
   // Lock scroll when navigation menu is open
   if (element.classList.contains('nav-menu-toggle')) {
-    document.body.classList.toggle('no-scroll-nav-open', !wasExpanded);
+    const htmlElement = document.getElementsByTagName('html')[0];
+    htmlElement.style.overflowY = wasExpanded ? 'auto' : 'hidden';
   }
 
   // Toggle data-ga-action attribute used in GTM tracking.

--- a/assets/src/scss/layout/_navbar.scss
+++ b/assets/src/scss/layout/_navbar.scss
@@ -313,14 +313,6 @@ a.nav-link:hover:before,
   }
 }
 
-.no-scroll-nav-open {
-  @include medium-and-less {
-    overflow-y: hidden;
-    position: fixed;
-    width: 100%;
-  }
-}
-
 // I'll include these at the end for now because they depend on CSS order.
 @import "navbar/site-logo";
 @import "navbar/languages";


### PR DESCRIPTION
### Description

See [PLANET-6897](https://jira.greenpeace.org/browse/PLANET-6897)
We don't want the page to scroll back to top when toggling the burger menu

### Testing

Either on local or on the [oberon test instance](https://www-dev.greenpeace.org/test-oberon/), when opening the side menu on mobile/tablet devices after scrolling down the page a bit, the page should no longer scroll back to top. On tablets make sure that you also cannot scroll through the page when the side menu is open!