### PR TITLE
PLANET-6405 Fix download icon not showing in later search results

### DIFF
--- a/assets/src/js/pdf_icon.js
+++ b/assets/src/js/pdf_icon.js
@@ -2,7 +2,7 @@ const { __ } = wp.i18n;
 
 // Add pdf icon to pdf links
 export const setupPDFIcon = () => {
-  const links = [...document.querySelectorAll('a[href*=".pdf"]:not(.search-result-item-headline):not(.cover-card-heading)')];
+  const links = [...document.querySelectorAll('a[href*=".pdf"]:not(.search-result-item-headline):not(.cover-card-heading):not(.pdf-link)')];
 
   links.forEach(link => {
     // We don't want to show the icon in headings/titles,

--- a/src/Search.php
+++ b/src/Search.php
@@ -864,14 +864,9 @@ abstract class Search {
 				continue;
 			}
 
-			$content_type_text = $type ? $type['label'] : $post->post_type;
-			$content_type      = 'attachment' === $post->post_type ? 'document' : $post->post_type;
-
 			if ( ! isset( $post->ID ) ) {
 				$post->ID = $post->link;
 			}
-			$post->content_type_text = $content_type_text;
-			$post->content_type      = $content_type;
 
 			// Page Type <-> Category. This taxonomy is used only for Posts.
 			if ( 'post' === $post->post_type && ! empty( $post->terms['p4-page-type'] ) ) {

--- a/templates/tease-search.twig
+++ b/templates/tease-search.twig
@@ -1,13 +1,13 @@
 {% set ga_page_type = post.post_type|capitalize %}
 {% set post_link = post.link %}
-{% if ( 'action' == post.content_type ) %}
+{% if ( 'action' == post.post_type ) %}
 	{% set is_action = true %}
 	{% set ga_page_type = 'Take Action' %}
-{% elseif ( 'document' == post.content_type ) %}
+{% elseif ( 'attachment' == post.post_type ) %}
 	{% set is_document = true %}
 	{% set ga_page_type = 'Document' %}
 	{% set post_link = fn('wp_get_attachment_url', post.id) %}
-{% elseif ( 'campaign' == post.content_type ) %}
+{% elseif ( 'campaign' == post.post_type ) %}
 	{% set is_campaign = true %}
 {% elseif ( 'archive' == post.post_type ) %}
 	{% set is_archive = true %}
@@ -112,7 +112,7 @@
 				</div>
 				<div>
 					{% if ( is_document ) %}
-						<a href="{{ post_link }}" download class="btn btn-small btn-secondary">
+						<a href="{{ post_link }}" download class="btn btn-small btn-secondary pdf-link" title={{__('This link will open a PDF file', 'planet4-master-theme')}}>
 							{{ __( 'Download', 'planet4-master-theme' ) }}
 						</a>
 					{% elseif ( is_campaign or is_archive ) %}


### PR DESCRIPTION
### Description

See [PLANET-6405](https://jira.greenpeace.org/browse/PLANET-6405)
This PR also includes a small refactoring to get rid of some unnecessary/unused variables.

### Testing

On the pluto test instance, you can [search for documents](https://www-dev.greenpeace.org/test-pluto/?s=&orderby=_score&f%5Bctype%5D%5BDocument%5D=1) and make sure that the download buttons with PDF icons are shown for all the corresponding results (even the ones after clicking the "show more" button)