### PR TITLE
PLANET-6913 Show button in search results for Actions

### DIFF
--- a/assets/src/scss/pages/search/_search-results.scss
+++ b/assets/src/scss/pages/search/_search-results.scss
@@ -47,14 +47,6 @@
         }
       }
 
-      .btn {
-        margin-top: 24px;
-
-        @include small-and-up {
-          width: max-content;
-        }
-      }
-
       .search-result-item-image:hover ~ * .search-result-item-headline {
         text-decoration: underline;
       }
@@ -82,23 +74,23 @@
     }
   }
 
-  .btn-secondary {
+  .btn {
+    margin-top: $sp-3;
     width: 100%;
 
     @include medium-and-up {
       width: auto;
-      position: relative;
-      top: 5px;
-      padding: 0 15px;
-      margin-left: 12px;
     }
 
-    i {
-      font-size: $font-size-sm;
-      font-weight: bold;
-      margin-right: 10px;
-      float: left;
-      line-height: 2.2rem;
+    &.btn-secondary {
+      margin-bottom: $sp-3;
+      white-space: nowrap;
+
+      @include medium-and-up {
+        padding: 0 $sp-2;
+        margin-left: $sp-2;
+        margin-top: 0;
+      }
     }
   }
 

--- a/templates/tease-search.twig
+++ b/templates/tease-search.twig
@@ -1,6 +1,6 @@
 {% set ga_page_type = post.post_type|capitalize %}
 {% set post_link = post.link %}
-{% if ( 'action' == post.post_type ) %}
+{% if ( 'p4_action' == post.post_type ) %}
 	{% set is_action = true %}
 	{% set ga_page_type = 'Take Action' %}
 {% elseif ( 'attachment' == post.post_type ) %}
@@ -112,7 +112,7 @@
 				</div>
 				<div>
 					{% if ( is_document ) %}
-						<a href="{{ post_link }}" download class="btn btn-small btn-secondary pdf-link" title={{__('This link will open a PDF file', 'planet4-master-theme')}}>
+						<a href="{{ post_link }}" download class="btn btn-small btn-secondary pdf-link" title="{{__('This link will open a PDF file', 'planet4-master-theme')}}">
 							{{ __( 'Download', 'planet4-master-theme' ) }}
 						</a>
 					{% elseif ( is_campaign or is_archive ) %}


### PR DESCRIPTION
### Description

See [PLANET-6913](https://jira.greenpeace.org/browse/PLANET-6913)
This PR also includes small design fixes for search results that have buttons (PDF documents and now Actions)

### Testing

You can test the changes on [this page](https://www-dev.greenpeace.org/test-pluto/?s=greenpeace&orderby=_score) for example where the search parameters show you both an Action page and a Document. Make sure to test in all screen sizes 🙂 