### PR TITLE
Check if share platforms are set for GF confirmation message

### DIFF
--- a/src/GravityFormsExtensions.php
+++ b/src/GravityFormsExtensions.php
@@ -278,11 +278,11 @@ class GravityFormsExtensions {
 		$confirmation_fields = [
 			'confirmation'    => $default_confirmation['message'],
 			'share_platforms' => [
-				'facebook' => '1' === $default_confirmation['facebook'] ?? false,
-				'twitter'  => '1' === $default_confirmation['twitter'] ?? false,
-				'whatsapp' => '1' === $default_confirmation['whatsapp'] ?? false,
-				'native'   => '1' === $default_confirmation['native'] ?? false,
-				'email'    => '1' === $default_confirmation['email'] ?? false,
+				'facebook' => $default_confirmation['facebook'] ?? true,
+				'twitter'  => $default_confirmation['twitter'] ?? true,
+				'whatsapp' => $default_confirmation['whatsapp'] ?? true,
+				'native'   => $default_confirmation['native'] ?? true,
+				'email'    => $default_confirmation['email'] ?? true,
 			],
 			'share_text'      => $default_confirmation['p4_gf_share_text_override'] ?? '',
 			'share_url'       => $default_confirmation['p4_gf_share_url_override'] ?? '',


### PR DESCRIPTION
### Description

Without this check, if editors didn't manually save the confirmation message then the buttons don't show in the frontend (and you see some warnings on local). If not defined, we set them to true since we want to show them by default. 

### Testing

You can test this behaviour on local by creating a new form and not editing/saving the confirmation message. On this branch the share buttons should then show in the confirmation message, whereas on `master` they won't. Another option to fix this issue would maybe be to set the share buttons values for new forms in [this after save function](https://github.com/greenpeace/planet4-master-theme/blob/master/src/GravityFormsExtensions.php#L167), but that wouldn't solve the problem for existing forms which is the reason why I've gone for this fix instead!