### PR TITLE
PLANET-6908 Remove Cookies box slide animation

### DIFF
--- a/assets/src/scss/layout/_cookies.scss
+++ b/assets/src/scss/layout/_cookies.scss
@@ -1,21 +1,3 @@
-@mixin slide-from($direction, $margin) {
-  $animation-name: unique-id() !global;
-
-  @keyframes #{$animation-name} {
-    0% {
-      #{$direction}: -100%;
-    }
-
-    100% {
-      #{$direction}: $margin;
-    }
-  }
-
-  &.shown {
-    animation: 1s $animation-name;
-  }
-}
-
 .cookie-notice {
   font-family: $roboto;
   z-index: 100;
@@ -31,7 +13,6 @@
   box-shadow: 0 0 12px rgba(0, 0, 0, 0.15);
   bottom: 0;
   color: $grey-80;
-  @include slide-from(bottom, 0);
 
   &.shown {
     opacity: 1;
@@ -46,23 +27,19 @@
     border-radius: 4px;
     padding: $sp-3 $sp-4;
     box-shadow: 0 3px 12px rgba(0, 0, 0, 0.15);
-    @include slide-from(right, $sp-2);
 
     html[dir="rtl"] & {
       right: auto;
       left: $sp-2;
-      @include slide-from(left, $sp-2);
     }
   }
 
   @include large-and-up {
     bottom: $sp-3;
     right: $sp-3;
-    @include slide-from(right, $sp-3);
 
     html[dir="rtl"] & {
       left: $sp-3;
-      @include slide-from(left, $sp-3);
     }
   }
 }


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6908

---

To avoid Cookie Box contributing to CLS metrics, we remove the slide animation
and instead show the Cookie Box directly in its final position.