### PR TITLE
PLANET-6915 Remove wp_kses_post filter from post content

### DIFF
--- a/templates/single.twig
+++ b/templates/single.twig
@@ -86,7 +86,7 @@
 		<div class="container narrow-container">
 			<div class="post-content">
 				<article class="post-details clearfix">
-					{{ post.content|e('wp_kses_post')|raw }}
+					{{ post.content|raw }}
 					{% if ( post.take_action_boxout ) %}
 						{{ fn('do_blocks', post.take_action_boxout )|raw }}
 					{% endif %}


### PR DESCRIPTION
### Description

See [PLANET-6915](https://jira.greenpeace.org/browse/PLANET-6915)
This filter was messing up Gravity Forms forms on posts.
