### PR TITLE
PLANET-6676 Allow default(Posts) articles bk header and btn translation

### DIFF
--- a/single.php
+++ b/single.php
@@ -74,6 +74,8 @@ if ( 'yes' === $post->include_articles ) {
 		'exclude_post_id' => $post->ID,
 		'tags'            => $tag_id_array,
 		'post_categories' => $category_id_array,
+		'article_heading' => __( 'Related Articles', 'planet4-master-theme' ),
+		'read_more_text'  => __( 'Load More', 'planet4-master-theme' ),
 	];
 
 	$post->articles = '<!-- wp:planet4-blocks/articles ' . wp_json_encode( $block_attributes, JSON_UNESCAPED_SLASHES ) . ' /-->';


### PR DESCRIPTION
Fix articles block added by 'Include related articles in the post' settings, header and Load More button string translation issue

To make it works editors need to add strings translation in LOCO plugin for strings -'Related Articles' & 'Load More'

eg. https://www-dev.greenpeace.org/brasil/blog/4-contribuicoes-da-agroecologia-para-a-saude-do-brasil/


