### PR TITLE
PLANET-6780 Remove unused transparent-button class

### DIFF
--- a/assets/src/scss/components/_buttons.scss
+++ b/assets/src/scss/components/_buttons.scss
@@ -295,7 +295,6 @@ button.load-more-mt {
   transition-duration: 100ms;
 }
 
-.wp-block-button.transparent-button a,
 .wp-block-button.is-style-transparent a {
   --transparent-button-- {
     border-color: $white;

--- a/assets/src/scss/editorOverrides.scss
+++ b/assets/src/scss/editorOverrides.scss
@@ -118,7 +118,6 @@
   }
 }
 
-.wp-block-button.transparent-button .wp-block-button__link[role="textbox"],
 .wp-block-button.is-style-transparent .wp-block-button__link[role="textbox"] {
   --transparent-button-- {
     border-color: $white;


### PR DESCRIPTION
### Description

See [PLANET-6780](https://jira.greenpeace.org/browse/PLANET-6780)
This was previously used in block patterns until we added the transparent style to Buttons