### PR TITLE
Return current GF confirmation if no corresponding one is found

### DIFF
--- a/src/GravityFormsExtensions.php
+++ b/src/GravityFormsExtensions.php
@@ -275,6 +275,11 @@ class GravityFormsExtensions {
 
 		$default_confirmation = reset( $default_confirmation_array );
 
+		// In case we don't find the corresponding confirmation, we return the current one.
+		if ( ! $default_confirmation ) {
+			return $confirmation;
+		}
+
 		$confirmation_fields = [
 			'confirmation'    => $default_confirmation['message'],
 			'share_platforms' => [


### PR DESCRIPTION
### Description

Since we check for the message string it's possible that if the string is too complicated (seems the problem is when there's a line break) then the corresponding object is not found.
I think this would solve the issue [GP Brazil is having at the moment](https://greenpeace.slack.com/archives/C0151L0KKNX/p1664374752896649?thread_ts=1663783124.723999&cid=C0151L0KKNX).

**Note:** I'm checking for the message in order to find the right confirmation object, because editors can add several confirmation messages and also add share buttons there. However, depending on how often this happens, maybe it would make sense to only allow the share buttons for the default confirmation, in that case we could check for `isDefault` which would always return something since it's mandatory... Maybe we could even force having only one confirmation message per form by finding a way to hide this `Add new` button via CSS 🤔 

<img width="603" alt="Screenshot 2022-09-28 at 17 01 53" src="https://user-images.githubusercontent.com/6949075/192814330-65bb3f1c-d1b7-4fa5-93cc-f85366438acb.png">
