### PR TITLE
PLANET-6900 Remove Open Graph metabox

### DIFF
--- a/src/ActionPage.php
+++ b/src/ActionPage.php
@@ -3,7 +3,6 @@
 namespace P4\MasterTheme;
 
 use P4\MasterTheme\Features\ActionPostType;
-use P4\MasterTheme\Settings\InformationArchitecture as IA;
 
 /**
  * Class P4\MasterTheme\ActionPage
@@ -16,6 +15,15 @@ class ActionPage {
 	public const TAXONOMY           = 'action-type';
 	public const TAXONOMY_PARAMETER = 'action_type';
 	public const TAXONOMY_SLUG      = 'action-type';
+
+	public const META_FIELDS = [
+		'nav_type',
+		'p4_hide_page_title_checkbox',
+		'p4_og_title',
+		'p4_og_description',
+		'p4_og_image',
+		'p4_og_image_id',
+	];
 
 	/**
 	 * The constructor.
@@ -141,12 +149,14 @@ class ActionPage {
 
 		$options = get_option( 'planet4_options' );
 
-		register_post_meta( self::POST_TYPE, 'nav_type', $args );
-		register_post_meta( self::POST_TYPE, 'p4_hide_page_title_checkbox', $args );
 		register_post_meta(
 			self::POST_TYPE,
 			'action_button_text',
 			array_merge( $args, [ 'default' => $options['take_action_covers_button_text'] ?? __( 'Take action', 'planet4-master-theme' ) ] )
 		);
+
+		foreach ( self::META_FIELDS as $field ) {
+			register_post_meta( self::POST_TYPE, $field, $args );
+		}
 	}
 }

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -74,7 +74,8 @@ final class Loader {
 			MasterSite::class,
 			HttpHeaders::class,
 			ActionPage::class,
-			Page::class,
+			PageMeta::class,
+			PostMeta::class,
 			GravityFormsExtensions::class,
 		];
 

--- a/src/MetaboxRegister.php
+++ b/src/MetaboxRegister.php
@@ -35,7 +35,6 @@ class MetaboxRegister {
 	 */
 	public function register_p4_meta_box() {
 		$this->register_meta_box_post();
-		$this->register_meta_box_open_graph();
 		$this->register_meta_box_campaign();
 	}
 
@@ -84,58 +83,6 @@ class MetaboxRegister {
 				],
 				'text'         => [
 					'add_upload_file_text' => __( 'Add Image', 'planet4-master-theme-backend' ),
-				],
-				'preview_size' => 'large',
-			]
-		);
-	}
-
-	/**
-	 * Register Open Graph meta box.
-	 */
-	public function register_meta_box_open_graph() {
-
-		$p4_open_graph = new_cmb2_box(
-			[
-				'id'           => 'p4_metabox_og',
-				'title'        => __( 'Open Graph/Social Fields', 'planet4-master-theme-backend' ),
-				'object_types' => [ 'page', 'post', 'campaign', 'p4_action' ],
-				'closed'       => true,  // Keep the metabox closed by default.
-			]
-		);
-
-		$p4_open_graph->add_field(
-			[
-				'name' => __( 'Title', 'planet4-master-theme-backend' ),
-				'desc' => __( 'Enter title if you want to override the open graph title', 'planet4-master-theme-backend' ),
-				'id'   => 'p4_og_title',
-				'type' => 'text_medium',
-			]
-		);
-
-		$p4_open_graph->add_field(
-			[
-				'name' => __( 'Description', 'planet4-master-theme-backend' ),
-				'desc' => __( 'Enter description if you want to override the open graph description', 'planet4-master-theme-backend' ),
-				'id'   => 'p4_og_description',
-				'type' => 'textarea_small',
-			]
-		);
-
-		$p4_open_graph->add_field(
-			[
-				'name'         => __( 'Image Override', 'planet4-master-theme-backend' ),
-				'desc'         => __( 'Upload an image or select one from the media library to override the open graph image', 'planet4-master-theme-backend' ),
-				'id'           => 'p4_og_image',
-				'type'         => 'file',
-				'options'      => [
-					'url' => false,
-				],
-				'text'         => [
-					'add_upload_file_text' => __( 'Add Image', 'planet4-master-theme-backend' ),
-				],
-				'query_args'   => [
-					'type' => 'image',
 				],
 				'preview_size' => 'large',
 			]

--- a/src/PageMeta.php
+++ b/src/PageMeta.php
@@ -3,9 +3,9 @@
 namespace P4\MasterTheme;
 
 /**
- * Class P4\MasterTheme\Page
+ * Class P4\MasterTheme\PageMeta
  */
-class Page {
+class PageMeta {
 
 	public const POST_TYPE = 'page';
 
@@ -19,6 +19,10 @@ class Page {
 		'p4_button_title',
 		'p4_button_link',
 		'p4_button_link_checkbox',
+		'p4_og_title',
+		'p4_og_description',
+		'p4_og_image',
+		'p4_og_image_id',
 	];
 
 	/**

--- a/src/PostCampaign.php
+++ b/src/PostCampaign.php
@@ -35,6 +35,10 @@ class PostCampaign {
 		'p4_description',
 		'background_image_id',
 		'background_image',
+		'p4_og_title',
+		'p4_og_description',
+		'p4_og_image',
+		'p4_og_image_id',
 	];
 
 	public const LEGACY_THEMES = [

--- a/src/PostMeta.php
+++ b/src/PostMeta.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace P4\MasterTheme;
+
+/**
+ * Class P4\MasterTheme\PostMeta
+ */
+class PostMeta {
+
+	public const POST_TYPE = 'post';
+
+	public const META_FIELDS = [
+		'p4_og_title',
+		'p4_og_description',
+		'p4_og_image',
+		'p4_og_image_id',
+	];
+
+	/**
+	 * The constructor.
+	 */
+	public function __construct() {
+		$this->hooks();
+	}
+
+	/**
+	 * Class hooks.
+	 */
+	private function hooks() {
+		add_action( 'init', [ $this, 'register_post_meta' ] );
+	}
+
+	/**
+	 * Register page meta data.
+	 */
+	public function register_post_meta() {
+		$args = [
+			'show_in_rest' => true,
+			'type'         => 'string',
+			'single'       => true,
+		];
+
+		foreach ( self::META_FIELDS as $field ) {
+			register_post_meta( self::POST_TYPE, $field, $args );
+		}
+	}
+}


### PR DESCRIPTION
### Description

See [PLANET-6900](https://jira.greenpeace.org/browse/PLANET-6900)
These fields are now moved to the sidebar (see [related PR](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/954))

### Testing

On your local or on the [mars test instance](https://www-dev.greenpeace.org/test-mars/), you can add the Open Graph meta fields from the sidebar to any post/campaign/page/action and update the page. On reload in the editor you should still see the data that you entered, and when inspecting the page in the frontend you should see the correct meta fields added to the `head`:

<img width="396" alt="Screenshot 2022-10-17 at 10 56 49" src="https://user-images.githubusercontent.com/6949075/196134852-97c9fe4e-886a-4162-8134-cfea858b772c.png">

You can also test the fields using this tool: https://www.opengraph.xyz/