### PR TITLE
PLANET-6918: Implement actions listing page

### DIFF
--- a/archive-p4_action.php
+++ b/archive-p4_action.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * The template for displaying P4 Action pages.
+ *
+ * Learn more: http://codex.wordpress.org/Template_Hierarchy
+ *
+ * @package  WordPress
+ * @subpackage  Timber
+ */
+
+use P4\MasterTheme\Features\Dev\ListingPageGridView;
+use P4\MasterTheme\Features\ListingPagePagination;
+use P4\MasterTheme\Post;
+use Timber\Timber;
+
+$templates = [ 'all-actions.twig', 'archive.twig', 'index.twig' ];
+
+$context = Timber::get_context();
+
+$context['custom_body_classes'] = 'tax-p4-page-type';
+$context['header_title']        = post_type_archive_title( '', false );
+
+if ( ListingPagePagination::is_active() ) {
+	$view = ListingPageGridView::is_active() ? 'grid' : 'list';
+
+	$query_template = file_get_contents( get_template_directory() . "/parts/action/query-$view.html" );
+
+	$content = do_blocks( $query_template );
+
+	$context['query_loop'] = $content;
+	Timber::render( $templates, $context );
+	exit();
+} else {
+	// Only applied to the "Load More" feature.
+	if ( null !== get_query_var( 'page_num' ) ) {
+		$wp_query->query_vars['page'] = get_query_var( 'page_num' );
+	}
+
+	$post_args = [
+		'posts_per_page' => 10,
+		'post_type'      => 'p4_action',
+		'paged'          => 1,
+		'has_password'   => false,  // Skip password protected content.
+	];
+
+	if ( get_query_var( 'page' ) ) {
+		$templates          = [ 'tease-taxonomy-action.twig' ];
+		$post_args['paged'] = get_query_var( 'page' );
+		$pagetype_posts     = new \Timber\PostQuery( $post_args, Post::class );
+		foreach ( $pagetype_posts as $pagetype_post ) {
+			$context['post'] = $pagetype_post;
+		}
+	} else {
+		$pagetype_posts   = new \Timber\PostQuery( $post_args, Post::class );
+		$context['posts'] = $pagetype_posts;
+		$context['url']   = home_url( $wp->request );
+	}
+
+	Timber::render( $templates, $context );
+	exit();
+}

--- a/archive.php
+++ b/archive.php
@@ -14,6 +14,8 @@
  * @since   Timber 0.2
  */
 
+use Timber\Timber;
+
 $templates = [ 'archive.twig', 'index.twig' ];
 
 $context = Timber::get_context();

--- a/parts/action/query-grid.html
+++ b/parts/action/query-grid.html
@@ -1,0 +1,37 @@
+<!-- wp:query { "query":{ "inherit": true }, "displayLayout": { "type": "flex", "columns":4 } } -->
+<div class="wp-block-query">
+
+	<!-- wp:post-template -->
+
+	<div class="query-list-item-image query-list-item-image-max-width">
+		<!-- wp:post-featured-image {"isLink":true} /-->
+	</div>
+	<div class="query-list-item-body">
+
+		<div class="query-list-item-post-terms">
+			<div class="wrapper-post-tag">
+				<!-- wp:post-terms {"term":"post_tag"} /-->
+			</div>
+		</div>
+
+		<header>
+			<!-- wp:post-title {"isLink":true, "level":4, "className": "query-list-item-headline"} /-->
+		</header>
+		<!-- wp:post-excerpt {"className": "query-list-item-content"} /-->
+
+		<div class="query-list-item-meta d-flex">
+			<!-- wp:p4/post-author-name /-->
+			<span class="query-list-item-bullet" aria-hidden="true">•</span>
+			<!-- wp:post-date /-->
+			<!-- wp:p4/reading-time /-->
+		</div>
+	</div>
+	<!-- /wp:post-template -->
+
+	<!-- wp:query-pagination -->
+		<!-- wp:query-pagination-previous /-->
+		<!-- wp:query-pagination-numbers /-->
+		<!-- wp:query-pagination-next /-->
+	<!-- /wp:query-pagination -->
+</div>
+<!-- /wp:query -->

--- a/parts/action/query-list.html
+++ b/parts/action/query-list.html
@@ -1,0 +1,37 @@
+<!-- wp:query { "query":{ "inherit": true } } -->
+<div class="wp-block-query wp-block-query--list">
+	<!-- wp:post-template -->
+	  <article class="query-list-item">
+			<div class="query-list-item-image query-list-item-image-max-width">
+				<!-- wp:p4/post-featured-image /-->
+			</div>
+			<div class="query-list-item-body">
+
+				<div class="query-list-item-post-terms">
+					<div class="wrapper-post-tag">
+						<!-- wp:post-terms {"term":"post_tag"} /-->
+					</div>
+				</div>
+
+				<header>
+					<!-- wp:post-title {"isLink":true, "level":4, "className": "query-list-item-headline"} /-->
+				</header>
+				<!-- wp:post-excerpt {"className": "query-list-item-content"} /-->
+
+				<div class="query-list-item-meta d-flex">
+					<!-- wp:p4/post-author-name /-->
+					<span class="query-list-item-bullet" aria-hidden="true">•</span>
+					<!-- wp:post-date /-->
+					<!-- wp:p4/reading-time /-->
+				</div>
+			</div>
+		</article>
+	<!-- /wp:post-template -->
+
+	<!-- wp:query-pagination -->
+		<!-- wp:query-pagination-previous /-->
+		<!-- wp:query-pagination-numbers /-->
+		<!-- wp:query-pagination-next /-->
+	<!-- /wp:query-pagination -->
+</div>
+<!-- /wp:query -->

--- a/src/Features/ListingPagePagination.php
+++ b/src/Features/ListingPagePagination.php
@@ -28,7 +28,7 @@ class ListingPagePagination extends Feature {
 	 * @inheritDoc
 	 */
 	protected static function description(): string {
-		return __( 'Use the new paginated tag, category, author & post type listing pages.', 'planet4-master-theme-backend' );
+		return __( 'Use the new paginated tag, category, author, post & action type listing pages.', 'planet4-master-theme-backend' );
 	}
 
 	/**

--- a/src/Post.php
+++ b/src/Post.php
@@ -513,8 +513,7 @@ class Post extends TimberPost {
 	 */
 	public static function reading_time_block( array $attributes, $content, $block ) {
 		$time = ( new self( $block->context['postId'] ?? null ) )->reading_time();
-
-		return "<span class='article-list-item-readtime'>$time min read</span>";
+		return $time ? '<span class="article-list-item-readtime">$time min read</span>' : '';
 	}
 
 	/**

--- a/templates/all-actions.twig
+++ b/templates/all-actions.twig
@@ -1,0 +1,42 @@
+{% extends "base.twig" %}
+
+{% block content %}
+	<div class="clearfix"></div>
+	<div class="skewed-overlay"></div>
+
+	<div class="page-content container">
+		{% if query_loop %}
+			{{ query_loop|raw }}
+		{% else %}
+			<h3>{{ __( 'Results', 'planet4-master-theme' ) }}</h3>
+
+			<div class="row">
+				<div class="col-lg-8 multiple-search-result">
+					<ul class="list-unstyled">
+						{% for post in posts %}
+							{% include 'tease-taxonomy-action.twig' %}
+						{% endfor %}
+					</ul>
+				</div>
+			</div>
+
+			{% if posts.pagination.total > 1 %}
+				<div class="row">
+					<div class="col-md-12 col-lg-5 col-xl-5 mt-3">
+						<button
+							data-content=".multiple-search-result .list-unstyled"
+							data-page="1"
+							data-total="{{ posts.pagination.total }}"
+							data-url="{{ url }}"
+							class="load-more-mt btn btn-small btn-secondary mb-5"
+							data-ga-category="Actions List"
+							data-ga-action="Load More Button"
+							data-ga-label="n/a">
+							{{ __( 'Load More', 'planet4-master-theme' ) }}
+						</button>
+					</div>
+				</div>
+			{% endif %}
+		{% endif %}
+	</div>
+{% endblock %}

--- a/templates/blocks/image.twig
+++ b/templates/blocks/image.twig
@@ -1,8 +1,8 @@
 <img
-	class="d-flex search-result-item-image"
+	class="d-flex {{ classname ?? 'search-result-item-image' }}"
 	src="{{ post.thumbnail.src('thumbnail') ?? dummy_thumbnail }}"
 	loading="lazy"
 	alt="{{ fn('esc_attr', post.thumbnail.alt|default( post.title ) )|raw }}"
-	data-ga-category="Articles List"
+	data-ga-category="{{ data_ga_category ?? 'Articles List' }}"
 	data-ga-action="Image"
 	data-ga-label="n/a" />

--- a/templates/tease-taxonomy-action.twig
+++ b/templates/tease-taxonomy-action.twig
@@ -1,0 +1,59 @@
+<li id="result-row-{{ post.ID }}" class="d-flex search-result-list-item">
+	<div class="search-result-item-image search-result-item-image-max-width">
+		{% include "blocks/image.twig" with { post: post, dummy_thumbnail: dummy_thumbnail, data_ga_category: 'Actions List', classname: '' } %}
+	</div>
+
+	<div id="tease-{{ post.ID }}" class="search-result-item-body tease tease-{{ post.post_type }}">
+		<div class="search-result-tags top-page-tags">
+			{% if (post.tags) %}
+				<div class="tag-wrap tags">
+					{% for tag in post.tags %}
+						<a
+							href="{{ tag.link }}"
+							class="search-result-item-tag tag-item tag"
+							data-ga-category="Actions List"
+							data-ga-action="Navigation Tag"
+							data-ga-label="n/a">
+							<span aria-label="hashtag">#</span>{{ tag.name|e('wp_kses_post')|raw }}
+						</a>
+					{% endfor %}
+				</div>
+			{% endif %}
+		</div>
+
+		<a
+			href="{{ post.link() }}"
+			class="search-result-item-headline"
+			data-ga-category="Actions List"
+			data-ga-action="Title"
+			data-ga-label="n/a">
+				{{ post.title|e('wp_kses_post')|raw }}
+		</a>
+
+		<div class="search-result-item-content">
+			<p>{{ post.post_excerpt|excerpt( 30 )|e('wp_kses_post')|raw }}</p>
+		</div>
+
+		<div class="search-result-item-info">
+			{% if ( post.author ) %}
+				<span class="search-result-item-author">
+					{% if not ( post.get_author_override ) %}
+						<a href="{{ post.author.path }}">{{ post.author }}</a>
+					{% else %}
+						{{ post.author.name }}
+					{% endif %}
+				</span>
+			{% endif %}
+
+			<span class="search-result-item-date">{{ post.post_date|date }}</span>
+			{% set reading_time = post.reading_time %}
+			{% if reading_time %}
+				<span class="single-post-meta-bullet" aria-hidden="true">&#8226;</span>
+				<span class="single-post-meta-readtime">
+					{{ __( '%d min read', 'planet4-master-theme' )|format(reading_time) }}
+				</span>
+			{% endif %}
+		</div>
+
+	</div>
+</li>


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6918

### Description
New UI applied to the default Actions listing page. We should take action listing pages as a reference with the other listing pages. 
I've also left some comments (for more description) in files changed.

### Testing
Navigate to the [actions page](https://www-dev.greenpeace.org/test-sinope/action/) and compare previous layout against the [unstyled Neptune's instance](https://www-dev.greenpeace.org/test-neptune/action/). Also compare against the one reported by [Nordics](https://www-dev.greenpeace.org/denmark/action/).
Don't forget to `enable|disable` the `Listing page pagination` feature from `Planet 4 > Information architecture`