### PR TITLE
PLANET-4444 Add meta field for Action button text

### DIFF
--- a/src/ActionPage.php
+++ b/src/ActionPage.php
@@ -139,7 +139,14 @@ class ActionPage {
 			'single'       => true,
 		];
 
+		$options = get_option( 'planet4_options' );
+
 		register_post_meta( self::POST_TYPE, 'nav_type', $args );
 		register_post_meta( self::POST_TYPE, 'p4_hide_page_title_checkbox', $args );
+		register_post_meta(
+			self::POST_TYPE,
+			'action_button_text',
+			array_merge( $args, [ 'default' => $options['take_action_covers_button_text'] ?? __( 'Take action', 'planet4-master-theme' ) ] )
+		);
 	}
 }

--- a/src/Search.php
+++ b/src/Search.php
@@ -393,6 +393,17 @@ abstract class Search {
 				$template_post->tags          = self::filter_existing_terms( $tags );
 				$template_post->p4_page_types = self::filter_existing_terms( $p4_page_types );
 
+				if ( 'p4_action' === $post->post_type ) {
+					$options   = get_option( 'planet4_options' );
+					$post_meta = get_post_meta( $post->ID );
+
+					if ( isset( $post_meta['action_button_text'] ) && $post_meta['action_button_text'][0] ) {
+						$template_post->button_text = $post_meta['action_button_text'][0];
+					} else {
+						$template_post->button_text = $options['take_action_covers_button_text'] ?? __( 'Take action', 'planet4-master-theme' );
+					}
+				}
+
 				$template_posts[] = $template_post;
 			}
 		}
@@ -964,8 +975,6 @@ abstract class Search {
 	public function view_paged_posts() {
 		// TODO - The $paged_context related code should be transferred to set_results_context method for better separation of concerns.
 		if ( $this->paged_posts ) {
-			$paged_context['settings'] = get_option( 'planet4_options' );
-
 			$paged_context['dummy_thumbnail'] = get_template_directory_uri() . self::DUMMY_THUMBNAIL;
 
 			foreach ( $this->paged_posts as $index => $post ) {

--- a/templates/tease-search.twig
+++ b/templates/tease-search.twig
@@ -141,14 +141,13 @@
 
 			{% if ( is_action ) %}
 			<div>
-				{%  set link_text = settings['take_action_covers_button_text'] %}
 				<a
 					href="{{ post_link }}"
 					class="btn btn-primary btn-small"
 					data-ga-category="Search Results"
 					data-ga-action="Call to Action"
 					data-ga-label="{{ ga_page_type }}">
-						{{ link_text ?: __( 'Take action', 'planet4-master-theme' ) }}
+						{{ post.button_text }}
 				</a>
 			</div>
 			{% endif %}


### PR DESCRIPTION
### Description

See [PLANET-4444](https://jira.greenpeace.org/browse/PLANET-4444)
This text will be shown in the Covers block, the Take Action boxout and in search results.

**Related PR:** https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/957

### Testing

You can test the 3 possibilities (no button text, default button text, and custom button text)

- in the Covers block on [this page](https://www-dev.greenpeace.org/test-titan/text-actions-button-texts/) for example
- in the Search page [here](https://www-dev.greenpeace.org/test-titan/?s=button+text&orderby=_score) for example

You can also test changing the default text in the [P4 settings](https://www-dev.greenpeace.org/test-titan/wp-admin/admin.php?page=planet4_settings_defaults_content) to see how the block and search results are impacted!