### PR TITLE
PLANET-6678 Alphabetically order Planet 4 settings menu

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -462,3 +462,12 @@ add_filter(
 		return $vars;
 	}
 );
+
+// Action to filter P4 settings menu.
+add_action(
+	'admin_head',
+	function() {
+		global $submenu;
+		uasort( $submenu['planet4_settings_navigation'], fn ( $a, $b ) => $a[0] <=> $b[0] );
+	}
+);


### PR DESCRIPTION
**Description**

See [PLANET-6678](https://jira.greenpeace.org/browse/PLANET-6678)

This PR adds a filter to alphabetically sort the Planet 4 settings menu.

<!-- Ref: Please add a url to the ticket this change is addressing.

---

Please provide a brief summary of the change introduced to make review process easier.

Ideally this should also be part of the commit summary.
-->
