### PR TITLE
PLANET-6950: Add new visited pseudo class style

### DIFF
--- a/assets/src/scss/layout/_navbar.scss
+++ b/assets/src/scss/layout/_navbar.scss
@@ -213,6 +213,10 @@ $navbar-default-height: 60px;
 a.nav-link {
   --nav-link-- {
     color: $white;
+
+    &:visited {
+      color: $white;
+    }
   }
 
   opacity: 1;

--- a/assets/src/scss/partials/navigation-bar-light.scss
+++ b/assets/src/scss/partials/navigation-bar-light.scss
@@ -11,6 +11,7 @@
   --nav-link--hover--color: #{$black};
   --nav-link-active--color: #{$black};
   --nav-link-active--hover--color: #{$black};
+  --nav-link--visited--color: #{$black};
 }
 
 #nav-mobile-menu {


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6950

## Description
Fix the visited color and set to the default one. Now it's set to purple.

Example of issues:
- [GPI Take Action page](https://www.greenpeace.org/international/act/stop-deep-sea-mining/)
- [GPGR Take Action page](https://www.greenpeace.org/greece/epirease/receptionist-secretarial-assistant-on-site/)

[The Greece dev site is using this branch](https://github.com/greenpeace/planet4-greece/commit/e094426189c9fc80bb34244665250f14f10bde51), don't test through the current instance (Phobos).
Remember to test the light and dark mode too ⚠️ 

**Demo page** 👉  https://www-dev.greenpeace.org/greece/epirease/receptionist-secretarial-assistant-on-site/