### PR TITLE
PLANET-6948 Increase the size of the navigation bar drop-down menu

### DIFF
--- a/assets/src/scss/layout/_navbar.scss
+++ b/assets/src/scss/layout/_navbar.scss
@@ -142,7 +142,7 @@ $navbar-default-height: 60px;
 
 .nav-submenu {
   _-- {
-    width: 193px;
+    width: 240px;
   }
   position: fixed;
   display: none;

--- a/src/AdminAssets.php
+++ b/src/AdminAssets.php
@@ -43,7 +43,7 @@ class AdminAssets {
 					],
 					1 => [
 						'maxItems' => 10,
-						'maxChars' => 18,
+						'maxChars' => 32,
 					],
 				],
 			],
@@ -56,7 +56,7 @@ class AdminAssets {
 					],
 					1 => [
 						'maxItems' => 10,
-						'maxChars' => 18,
+						'maxChars' => 32,
 					],
 				],
 			],


### PR DESCRIPTION
### Description

See [PLANET-6948](https://jira.greenpeace.org/browse/PLANET-6948)
With this change we also allow dropdown menu items to be up to 32 characters long.

### Testing

In the backend, in `Appearance > Menus`, you should now see a warning appear only when a dropdown menu item's name is longer than 32 characters. For the main menu items however the limit remains 18 characters. 
In the frontend, you should see that the dropdown menu is now `240px` wide (instead of previously `193px`).