### PR TITLE
PLANET_6952: Create new class for empty pagination content

### DIFF
--- a/assets/src/scss/layout/_block-classes.scss
+++ b/assets/src/scss/layout/_block-classes.scss
@@ -29,6 +29,10 @@
   @include large-and-up {
     justify-content: center;
   }
+
+  &.is-empty {
+    display: none;
+  }
 }
 
 .wp-block-query-pagination-previous,


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6951

## Description
This is only the for the `empty` class name. 

Based on this [comment](https://github.com/greenpeace/planet4-master-theme/pull/1812#pullrequestreview-1163031084) from #1812

<img width="192" alt="199197992-3bfef910-8df1-4c77-ac0e-f3af08955d92" src="https://user-images.githubusercontent.com/77975803/199577258-bc2e740f-e4cd-4fbb-9a5a-22c66953f7d0.png">

Related Gutenberg PR: https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/965 

## Testing
Pending...