### PR TITLE
PLANET-6929 Fixed GF confirmation message share button issue

### DIFF
--- a/src/GravityFormsExtensions.php
+++ b/src/GravityFormsExtensions.php
@@ -266,20 +266,7 @@ class GravityFormsExtensions {
 
 		$post = Timber::query_post( false, Post::class );
 
-		$current_confirmation_array = array_filter(
-			$form['confirmations'],
-			function ( $conf ) use ( $confirmation ) {
-				// We need to strip all HTML tags for proper comparison.
-				return wp_strip_all_tags( $confirmation ) === wp_strip_all_tags( $conf['message'] );
-			}
-		);
-
-		$current_confirmation = reset( $current_confirmation_array );
-
-		// In case we don't find the current confirmation object, we return the $confirmation param.
-		if ( ! $current_confirmation ) {
-			return $confirmation;
-		}
+		$current_confirmation = $form['confirmation'];
 
 		$confirmation_fields = [
 			'confirmation'    => $confirmation,


### PR DESCRIPTION
Ref https://jira.greenpeace.org/browse/PLANET-6929

Use a `confirmation` param instead of `confirmations` from $form [Form Object](https://docs.gravityforms.com/form-object).

The `confirmation` param returns the [Confirmation Object](https://docs.gravityforms.com/confirmations-object/#confirmation-properties) being used for the current form submission.

Reference:
https://docs.gravityforms.com/form-object/

