### PR TITLE
PLANET-6931 Navigation submenu items that are anchors are not clickable

### DIFF
--- a/assets/src/scss/layout/_navbar.scss
+++ b/assets/src/scss/layout/_navbar.scss
@@ -201,7 +201,7 @@ $navbar-default-height: 60px;
     }
 
     &.active {
-      pointer-events: none;
+      pointer-events: inherit;
     }
 
     &.active a.nav-link {

--- a/assets/src/scss/layout/navbar/_burger-menu.scss
+++ b/assets/src/scss/layout/navbar/_burger-menu.scss
@@ -154,7 +154,7 @@ $transition-duration: .2s;
   padding-block-end: $sp-1x;
 
   .nav-item.active {
-    pointer-events: none;
+    pointer-events: inherit;
 
     a.nav-link {
       font-weight: bold;


### PR DESCRIPTION
**Description**: 

[See PLANET-6931](https://jira.greenpeace.org/browse/PLANET-6931)

Changed behaviour of submenu links with the **_active_** class to allow pointer-events.



**Testing**:

- Make sure menu items with dropdown for submenus it active, create a menu item and add submenus. 
- On the frontend, inspect the submenu items and use the style panel to add the **_active_** class to the _li_ element.
- The item should now have a font bold, but also allow you to click the link. Previously the link was not clickable, (Test [here](https://www-dev.greenpeace.org/denmark/about-greenpeace/) under the About Us menu).
<!-- Ref: Please add a url to the ticket this change is addressing.

---

Please provide a brief summary of the change introduced to make review process easier.

Ideally this should also be part of the commit summary.
-->
