### PR TITLE
PLANET-6955 ErrorException: Warning: uasort() expects parameter 1 to be array, null given

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -468,6 +468,9 @@ add_action(
 	'admin_head',
 	function() {
 		global $submenu;
-		uasort( $submenu['planet4_settings_navigation'], fn ( $a, $b ) => $a[0] <=> $b[0] );
+
+		if ( isset( $submenu['planet4_settings_navigation'] ) ) {
+			uasort( $submenu['planet4_settings_navigation'], fn ( $a, $b ) => $a[0] <=> $b[0] );
+		}
 	}
 );


### PR DESCRIPTION
PLANET-6955 ErrorException: Warning: uasort() expects parameter 1 to be array, null given

- Added a condition to check if planet 4 settings array returns a value before sorting, to avoid sentry error.

Ticket [here](https://jira.greenpeace.org/browse/PLANET-6955)


<!-- Ref: Please add a url to the ticket this change is addressing.

---

Please provide a brief summary of the change introduced to make review process easier.

Ideally this should also be part of the commit summary.
-->
