### PR TITLE
PLANET-6954 Adding a custom CSS class through the admin panel is not reflected in the frontend when inspecting the page

### DIFF
--- a/templates/navigation-submenu.twig
+++ b/templates/navigation-submenu.twig
@@ -1,7 +1,7 @@
 <nav class='nav-submenu'>
 	<ul>
 	{% for key,item in menu.children %}
-		<li class="nav-item {{ item == item.current ? 'active' : '' }}">
+		<li class="nav-item {{ item.class }} {{ item == item.current ? 'active' : '' }}">
 			{% if fn('get_post_meta', item.ID, '_menu_item_object_id', true ) == act_page_id %}
 				{% set link_ga_action = 'Act' %}
 			{% elseif fn('get_post_meta', item.ID, '_menu_item_object_id', true ) == explore_page_id %}


### PR DESCRIPTION
### **PLANET-6954** 
**Description** [here](https://jira.greenpeace.org/browse/PLANET-6954?atlLinkOrigin=c2xhY2staW50ZWdyYXRpb258aXNzdWU%3D)

**TESTING:**

Implementation before:
- Go to the admin dashboard and create a menu item.
- Add a submenu item under the menu item you created.
- Enable _CSS classes_ under the _screen options_ tab and add a custom CSS to your submenu.
- Save the page and got to the frontend of the webpage.
- Inspect the submenu element and you will not see the class added to the `li` element.

_After this change is implemented you can test now and the submenu links should have the custom CSS added to it now._


<!-- Ref: Please add a url to the ticket this change is addressing.

---

Please provide a brief summary of the change introduced to make review process easier.

Ideally this should also be part of the commit summary.
-->
