### PR TITLE
PLANET-6928: Create a new listing page stylesheet

### DIFF
--- a/assets/src/scss/pages/_listing-page.scss
+++ b/assets/src/scss/pages/_listing-page.scss
@@ -1,0 +1,192 @@
+@mixin render-bullet($spacing: $sp-1) {
+  &:before {
+    display: block;
+    margin: 0 $spacing;
+    color: $link-color;
+    content: "•";
+  }
+}
+
+.query-list-item {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  margin-top: var(--query-list--item--margin-top, $sp-4);
+
+  @include medium-and-up {
+    flex-direction: row;
+  }
+}
+
+.query-list-item-image {
+  flex-basis: 30%;
+
+  &.query-list-item-image-max-width {
+    img {
+      width: 100%;
+      height: 190px;
+      object-fit: cover;
+      object-position: 50% 50%;
+      margin-right: $sp-2;
+
+      html[dir="rtl"] & {
+        margin-right: 0;
+        margin-left: $sp-2;
+      }
+
+      @include medium-and-up {
+        height: 200px;
+      }
+
+      @include large-and-up {
+        height: 210px;
+      }
+    }
+  }
+
+  .wp-post-image {
+    height: 100%;
+  }
+}
+
+.query-list-item-body {
+  flex-basis: 70%;
+  flex-shrink: 0;
+  margin-top: $sp-1x;
+
+  header {
+    margin-top: $sp-1;
+  }
+
+  // Chrome and Safari
+  // :has is not fully support for now.
+  // https://developer.mozilla.org/en-US/docs/Web/CSS/:has
+  &:has(.taxonomy-action-type):has(.taxonomy-post_tag) {
+    .wrapper-post-tag {
+      display: flex;
+      @include render-bullet;
+    }
+  }
+}
+
+.query-list-item-post-terms {
+  display: flex;
+  font-size: $font-size-sm;
+  font-family: $roboto;
+  line-height: 25px;
+
+  .wp-block-post-terms__separator {
+    visibility: hidden;
+  }
+
+  // Firefox
+  .wrapper-action-type:not(:-moz-only-whitespace) {
+    display: flex;
+
+    & ~ .wrapper-post-tag:not(:-moz-only-whitespace) {
+      display: flex;
+      @include render-bullet;
+    }
+  }
+}
+
+.query-list-item-headline a,
+.query-list-item-content p {
+  display: -webkit-box !important;
+  overflow: hidden;
+  -webkit-box-orient: vertical;
+}
+
+.query-list-item-content p {
+  font-size: $font-size-sm;
+  margin-bottom: $sp-1;
+  line-height: 25px;
+  -webkit-line-clamp: 3;
+
+  @include medium-and-up {
+    -webkit-line-clamp: 2;
+  }
+
+  @include large-and-up {
+    -webkit-line-clamp: 3;
+  }
+}
+
+.query-list-item-headline {
+  font-size: $font-size-lg !important;
+  font-weight: var(--query-list-item-headline--font-weight, bold) !important;
+
+  a {
+    -webkit-line-clamp: 6;
+
+    @include medium-and-up {
+      -webkit-line-clamp: 2;
+    }
+  }
+}
+
+.query-list-item-meta {
+  font-family: $roboto;
+  font-size: $font-size-xxs;
+  color: $grey-40;
+  line-height: 22px;
+
+  .query-list-item-bullet {
+    display: inline-block;
+    padding: 0 $sp-x;
+  }
+
+  .article-list-item-author a {
+    color: $grey-40;
+  }
+
+  .article-list-item-readtime {
+    display: flex;
+    @include render-bullet(4px);
+  }
+}
+
+.wp-block-query {
+  &.wp-block-query--list {
+    .query-list-item-body {
+      @include medium-and-up {
+        padding: 0 0 0 $sp-2x;
+      }
+    }
+  }
+
+  .wp-block-query-pagination:last-child {
+    margin-top: $sp-6;
+  }
+
+  &:not(.wp-block-query--list) {
+    // Only applied to "grid" layout
+    .wp-block-post-template {
+      li {
+        @include small-and-up {
+          width: calc((100% / 2) - 1.25em + (1.25em / 2)) !important;
+        }
+
+        @include large-and-up {
+          width: calc((100% / 3) - 1.25em + (1.25em / 3)) !important;
+        }
+
+        @include x-large-and-up {
+          width: calc((100% / 4) - 1.25em + (1.25em / 4)) !important;
+        }
+      }
+    }
+
+    .query-list-item-meta {
+      @include small-and-up {
+        .article-list-item-author a {
+          overflow: hidden;
+          max-width: 100px;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+          display: inline-block;
+        }
+      }
+    }
+  }
+}

--- a/assets/src/scss/style.scss
+++ b/assets/src/scss/style.scss
@@ -57,6 +57,7 @@ Text Domain: planet4-master-theme
 @import "pages/author";
 @import "pages/page_type";
 @import "pages/category";
+@import "pages/listing-page";
 
 // Search
 @import "pages/search/search";


### PR DESCRIPTION
Ref: [PLANET-6928](https://jira.greenpeace.org/browse/PLANET-6928)

## Description
Since we're having a couple of listing pages (default, category, action, among others), the idea is to standardize their styles by using the same style sheet.

This pull request it's blocked by https://github.com/greenpeace/planet4-master-theme/pull/1812
