### PR TITLE
Fix reading time value

### DIFF
--- a/src/Post.php
+++ b/src/Post.php
@@ -513,7 +513,7 @@ class Post extends TimberPost {
 	 */
 	public static function reading_time_block( array $attributes, $content, $block ) {
 		$time = ( new self( $block->context['postId'] ?? null ) )->reading_time();
-		return $time ? '<span class="article-list-item-readtime">$time min read</span>' : '';
+		return $time ? '<span class="article-list-item-readtime">' . $time . ' min read</span>' : '';
 	}
 
 	/**


### PR DESCRIPTION
## Description
I've noticed this issue after we merged [this code](https://github.com/greenpeace/planet4-master-theme/pull/1812/files#diff-5568aa3d3d5790f0967a994f11836016ec5d67d74c37cc62dc84ea56b39a8181R516). It's never been detected since the Action pages doesn't have already implemented the `Reading time` feature.

## Testing
[Check it out the default listing pages](https://www-dev.greenpeace.org/test-pandora/default-listing-page/) 

Before
![Screenshot 2022-11-09 at 09 56 47](https://user-images.githubusercontent.com/77975803/200836286-46306f33-7119-4a25-908d-a6856449d035.png)

After
![Screenshot 2022-11-09 at 09 56 03](https://user-images.githubusercontent.com/77975803/200836307-6174a309-4f40-4758-b874-8769a4104c91.png)