### PR TITLE
PLANET-6914 Prepare to upgrade to Wordpress 6.1.1

### DIFF
--- a/assets/src/scss/base/_typography.scss
+++ b/assets/src/scss/base/_typography.scss
@@ -106,7 +106,6 @@ h6 {
 
 a --link-- {
   color: $link-color;
-  text-decoration: none;
 
   &:focus {
     outline: 2px solid rgba(0, 106, 255, 0.4);
@@ -117,7 +116,6 @@ a --link-- {
   &:hover,
   &:active {
     color: $link-color;
-    text-decoration: underline;
   }
 
   &:visited {

--- a/assets/src/scss/editorOverrides.scss
+++ b/assets/src/scss/editorOverrides.scss
@@ -18,7 +18,7 @@
 }
 
 .editor-styles-wrapper {
-  padding: 0 1rem;
+  padding: 0 1rem !important;
 }
 
 .edit-post-visual-editor {
@@ -176,6 +176,7 @@
 
     .components-base-control__label {
       font-weight: bold;
+      text-transform: none;
     }
   }
 }

--- a/theme.json
+++ b/theme.json
@@ -1,6 +1,25 @@
 {
   "$schema": "https://schemas.wp.org/trunk/theme.json",
   "version": 2,
+  "styles": {
+		"elements": {
+			"link": {
+				"typography": {
+					"textDecoration": "none"
+				},
+				":hover": {
+					"typography": {
+						"textDecoration": "underline"
+					}
+				},
+				":active": {
+					"typography": {
+						"textDecoration": "underline"
+					}
+				}
+			}
+		}
+	},
   "settings": {
     "color": {
       "custom": false,


### PR DESCRIPTION
### Description

See [PLANET-6914](https://jira.greenpeace.org/browse/PLANET-6914)
Some small fixes were needed before the upgrade:
- remove the new `text-transform` added to labels in the editor
- force `0 1rem` padding in the editor block area
- move the `text-decoration` changes for links to `theme.json`

I've created 2 follow-up tickets that would require more work and/or some investigation:
- [PLANET-6958](https://jira.greenpeace.org/browse/PLANET-6958) to look into our RichText components that currently use the deprecated `multiline` prop, since it's probably gonna require quite a lot of changes and it's less urgent because we have until WP 6.3 before that prop is completely removed
- [PLANET-6965](https://jira.greenpeace.org/browse/PLANET-6965) to adapt the page creation modal to all post types

[The PR for the actual upgrade](https://github.com/greenpeace/planet4-base/pull/226) is in the base repo.

### Testing

You can test the changes either on local or on the [janus test instance](https://www-dev.greenpeace.org/test-janus). To see how it is before these fixes, you can compare it with the [gutenberg instance](https://www-dev.greenpeace.org/gutenberg/) which is already running WP 6.1!