### PR TITLE
PLANET-6961: Action Type listing page empty when no pagination

### DIFF
--- a/taxonomy.php
+++ b/taxonomy.php
@@ -13,6 +13,8 @@
 use P4\MasterTheme\Features\Dev\ListingPageGridView;
 use P4\MasterTheme\Features\ListingPagePagination;
 use P4\MasterTheme\Post;
+use P4\MasterTheme\ActionPage;
+use P4\MasterTheme\Features\ActionPostType;
 use Timber\Timber;
 
 $templates = [ 'taxonomy.twig', 'index.twig' ];
@@ -33,15 +35,30 @@ if ( ListingPagePagination::is_active() ) {
 	exit();
 }
 
-$post_args = [
-	'posts_per_page' => 10,
-	'post_type'      => 'post',
-	'paged'          => 1,
-	'p4-page-type'   => $context['taxonomy']->slug,
-	'has_password'   => false,  // Skip password protected content.
+$allowed_post_types = [
+	'post',
+	'page',
+	'campaign',
+	'attachment',
+	ActionPostType::is_active() ? ActionPage::POST_TYPE : null,
 ];
 
-$context['page_category'] = 'Post Type Page';
+$post_args = [
+	'posts_per_page' => 10,
+	'post_type'      => $allowed_post_types,
+	'paged'          => 1,
+	'has_password'   => false,  // Skip password protected content.
+	'tax_query'      => [
+		[
+			'taxonomy' => $context['taxonomy']->taxonomy,
+			'field'    => 'slug',
+			'terms'    => $context['taxonomy']->slug,
+		],
+	],
+];
+
+$context['page_category']       = 'Post Type Page';
+$context['custom_body_classes'] = 'tax-p4-page-type';
 
 if ( get_query_var( 'page' ) ) {
 	$templates          = [ 'tease-taxonomy-post.twig' ];


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6961


Queries ending up in the `taxonomy.php` template are the [Custom taxonomy](https://developer.wordpress.org/themes/template-files-section/taxonomy-templates/#custom-taxonomy) ones.
We have 2 different custom taxonomies,
- `p4-page-type` (cf. `/edit-tags.php?taxonomy=p4-page-type`) 
- `action-type` (cf. `/edit-tags.php?taxonomy=action-type`).

## Fix

- Change query args to fetch any valid post type, not only `post`
- Rebase query on taxonomy query instead of static  `p4-page-type` taxonomy
- Force `tax-p4-page-type` class [used for font-family](https://github.com/greenpeace/planet4-master-theme/blob/1dc9c0714f32112fc5a05ee433541cdc5c9e29ac/assets/src/scss/pages/_page_type.scss#L1)

## Test

- Activate option `Action post type` in _Planet 4 > Information architecture_
- Create a new Action type in _Actions > Action type_
- Create a new Action and associate it to your new Action type
- Check the listing page, with option `Listing page pagination` in _Planet 4 > Information architecture_ enabled and disabled
  - with listing disabled, you should still see some content