### PR TITLE
PLANET-6676 Fix articles block strings text-domain

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -17,7 +17,7 @@
     <!-- Add rule for theme's textdomains -->
     <rule ref="WordPress.WP.I18n">
         <properties>
-            <property name="text_domain" type="array" value="planet4-master-theme,planet4-master-theme-backend"/>
+            <property name="text_domain" type="array" value="planet4-master-theme,planet4-master-theme-backend,planet4-blocks"/>
         </properties>
     </rule>
 

--- a/single.php
+++ b/single.php
@@ -74,8 +74,8 @@ if ( 'yes' === $post->include_articles ) {
 		'exclude_post_id' => $post->ID,
 		'tags'            => $tag_id_array,
 		'post_categories' => $category_id_array,
-		'article_heading' => __( 'Related Articles', 'planet4-master-theme' ),
-		'read_more_text'  => __( 'Load More', 'planet4-master-theme' ),
+		'article_heading' => __( 'Related Articles', 'planet4-blocks' ),
+		'read_more_text'  => __( 'Load more', 'planet4-blocks' ),
 	];
 
 	$post->articles = '<!-- wp:planet4-blocks/articles ' . wp_json_encode( $block_attributes, JSON_UNESCAPED_SLASHES ) . ' /-->';


### PR DESCRIPTION
- Follow up fix from https://github.com/greenpeace/planet4-master-theme/pull/1804 PR
- By using the same text domain no need to add a translation twice

eg.
...