### PR TITLE
PLANET-6968 Move some typography settings to theme.json

### DIFF
--- a/assets/src/scss/base/_body.scss
+++ b/assets/src/scss/base/_body.scss
@@ -6,11 +6,6 @@ body {
 }
 
 body {
-  _-- {
-    color: $grey-80;
-    font-family: $lora;
-    background-color: $white;
-  }
   position: relative;
   overflow-y: hidden;
 

--- a/assets/src/scss/base/_typography.scss
+++ b/assets/src/scss/base/_typography.scss
@@ -25,11 +25,6 @@ h3,
 h4,
 h5,
 h6 {
-  --headings-- {
-    font-family: $roboto;
-    font-weight: bold;
-  }
-
   &.has-text-align-center,
   &.has-text-align-right,
   &.has-text-align-left {
@@ -105,21 +100,10 @@ h6 {
 }
 
 a --link-- {
-  color: $link-color;
-
   &:focus {
     outline: 2px solid rgba(0, 106, 255, 0.4);
     outline-offset: 2px;
     border-radius: 4px;
-  }
-
-  &:hover,
-  &:active {
-    color: $link-color;
-  }
-
-  &:visited {
-    color: $link-color-visited;
   }
 }
 

--- a/functions.php
+++ b/functions.php
@@ -220,7 +220,7 @@ add_filter(
 add_filter(
 	'block_editor_settings_all',
 	function ( array $editor_settings, WP_Block_Editor_Context $block_editor_context ) {
-		if ( 'post' !== $block_editor_context->post->post_type ) {
+		if ( isset( $block_editor_context->post ) && 'post' !== $block_editor_context->post->post_type ) {
 			$editor_settings['__experimentalFeatures']['layout']['contentSize'] = '1320px';
 		}
 

--- a/theme.json
+++ b/theme.json
@@ -2,20 +2,47 @@
   "$schema": "https://schemas.wp.org/trunk/theme.json",
   "version": 2,
   "styles": {
+    "color": {
+      "background": "#ffffff",
+      "text": "#020202"
+    },
+    "typography": {
+      "fontFamily": "Lora, serif"
+    },
 		"elements": {
+      "heading": {
+        "typography": {
+          "fontFamily": "Roboto, sans-serif",
+          "fontWeight": "bold"
+        }
+      },
 			"link": {
+        "color": {
+          "text": "#006dfd"
+        },
 				"typography": {
 					"textDecoration": "none"
 				},
 				":hover": {
+          "color": {
+            "text": "#006dfd"
+          },
 					"typography": {
 						"textDecoration": "underline"
 					}
 				},
 				":active": {
+          "color": {
+            "text": "#006dfd"
+          },
 					"typography": {
 						"textDecoration": "underline"
 					}
+				},
+				":visited": {
+          "color": {
+            "text": "#68009e"
+          }
 				}
 			}
 		}


### PR DESCRIPTION
### Description

See [PLANET-6968](https://jira.greenpeace.org/browse/PLANET-6968)
This is to simplify our code and follow WP guidelines. Options moved include:
- link colors
- heading font family and font weight
- body text/background color and font family

### Testing

You can make sure (on local or on the [sinope test instance](https://www-dev.greenpeace.org/test-sinope/)) that links and headings still look as expected. Note that you need WordPress 6.1 or up for the changes to work!