### PR TITLE
PLANET-6969 Add Roboto font family to Paragraph typography options

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -141,6 +141,17 @@
             }
           ]
         }
+      },
+      "core/paragraph": {
+        "typography": {
+          "fontFamilies": [
+            {
+              "name": "Roboto",
+              "fontFamily": "Roboto, sans-serif",
+              "slug": "roboto"
+            }
+          ]
+        }
       }
     },
     "layout": {


### PR DESCRIPTION
### Description

See [PLANET-6969](https://jira.greenpeace.org/browse/PLANET-6969)
We used to do this via block styles, but this is simpler and better aligned with WP guidelines. There is a corresponding PR to remove the block style and update patterns that used it.

We probably need to update existing patterns so that they still work as expected 🤔  

### Testing