### PR TITLE
Fix post title declaration

### DIFF
--- a/src/Context.php
+++ b/src/Context.php
@@ -15,7 +15,10 @@ class Context {
 	 * @param String $post_title the title of the post.
 	 */
 	public static function set_header( &$context, $page_meta_data, $post_title ) {
-		$context['header_title']                = is_front_page() ? ( $page_meta_data['p4_title'] ?? '' ) : ( $page_meta_data['p4_title'] ?? $post_title );
+		$meta_data_title    = $page_meta_data['p4_title'] ?? '';
+		$post_title_to_show = $meta_data_title ? $meta_data_title : $post_title;
+
+		$context['header_title']                = is_front_page() ? $meta_data_title : $post_title_to_show;
 		$context['header_subtitle']             = $page_meta_data['p4_subtitle'] ?? '';
 		$context['header_description']          = wpautop( $page_meta_data['p4_description'] ?? '' );
 		$context['header_button_title']         = $page_meta_data['p4_button_title'] ?? '';


### PR DESCRIPTION
### Description

Since the meta data title is set to an empty string when cleared, the declaration was no longer working as expected because `$page_meta_data['p4_title'] ?? $post_title` would return an empty string instead of the actual title.

### Testing

On your local, reproduce the following steps:
1. Go to any page
2. Add a meta data header in the sidebar fields, update the page and see the meta data header show in the frontend
3. Remove the meta data header field, and update the page again
4. On `main` branch you'll see the page in the frontend show no title, whereas on this branch it should again show the actual title that is set in the editor