### PR TITLE
PLANET-6936 Remove jQuery from frontend

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12525,11 +12525,6 @@
         }
       }
     },
-    "jquery": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.1.tgz",
-      "integrity": "sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg=="
-    },
     "js-base64": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.5.1.tgz",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
   "dependencies": {
     "bootstrap": "^5.1.3",
     "classnames": "^2.2.6",
-    "jquery": "^3.5.1",
     "lite-youtube-embed": "^0.1.3",
     "popper.js": "^1.15.0"
   }

--- a/src/PublicAssets.php
+++ b/src/PublicAssets.php
@@ -12,20 +12,6 @@ final class PublicAssets {
 	public static function enqueue_js() {
 		$js_creation = filectime( get_template_directory() . '/assets/build/index.js' );
 
-		$jquery_should_wait = is_plugin_active( 'planet4-plugin-gutenberg-blocks/planet4-gutenberg-blocks.php' ) && ! is_user_logged_in();
-
-		$jquery_deps = $jquery_should_wait ? [ 'planet4-blocks-script' ] : [];
-
-		// JS files.
-		wp_deregister_script( 'jquery' );
-		wp_register_script(
-			'jquery',
-			'https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js',
-			$jquery_deps,
-			'3.3.1',
-			true
-		);
-
 		$theme_dir = get_template_directory_uri();
 		// Variables reflected from PHP to the JS side.
 		$localized_variables = [


### PR DESCRIPTION
### Description

See [PLANET-6936](https://jira.greenpeace.org/browse/PLANET-6936)
This should not cause any issues.
I've opened some follow-up PRs to stop using jQuery in a few other places in the admin area (so not totally related to this ticket):
- [dashboard.js](https://github.com/greenpeace/planet4-master-theme/pull/1853)
- [addButtonLinkPasteWarning.js](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/977)
- [menu_editor.js](https://github.com/greenpeace/planet4-master-theme/pull/1851)

### Testing

All should still work as expected in the site (blocks, admin code, plugins, etc)