### PR TITLE
PLANET-6981 Remove jQuery from dashboard.js

### DIFF
--- a/src/ControlPanel.php
+++ b/src/ControlPanel.php
@@ -117,7 +117,7 @@ class ControlPanel {
 				<div><h3>' . esc_html( $data['title'] ) . '</h3>';
 		foreach ( $data['subitems'] as $subitem ) {
 			echo '<div>
-					<a href="' . esc_url( $subitem['url'] ?? '#' ) . '" class="btn btn-cp-action ' . esc_attr( $subitem['action'] ?? '' ) . '" data-action="' . esc_attr( $subitem['action'] ?? '' ) . '" data-confirm="' . esc_attr( $subitem['confirm'] ?? '' ) . '">' . esc_html( $subitem['title'] ) . '</a>
+				<a data-ajaxurl="' . esc_url( admin_url( 'admin-ajax.php' ) ) . '" href="' . esc_url( $subitem['url'] ?? '#' ) . '" class="btn btn-cp-action ' . esc_attr( $subitem['action'] ?? '' ) . '" data-action="' . esc_attr( $subitem['action'] ?? '' ) . '" data-confirm="' . esc_attr( $subitem['confirm'] ?? '' ) . '">' . esc_html( $subitem['title'] ) . '</a>
 					<span class="cp-subitem-response"></span>
 				</div>';
 		}
@@ -292,7 +292,7 @@ class ControlPanel {
 		wp_enqueue_script(
 			'dashboard-script',
 			"$theme_uri/admin/js/dashboard.js",
-			[ 'jquery' ],
+			[],
 			Loader::theme_file_ver( 'admin/js/dashboard.js' ),
 			true
 		);


### PR DESCRIPTION
### Description

This is to eventually completely stop using jQuery

### Testing

These functionalities in the dashboard should still work as expected:
<img width="438" alt="Screenshot 2022-11-30 at 15 04 07" src="https://user-images.githubusercontent.com/6949075/204816529-ce686a41-2c3c-45ce-ac3b-de3288e872cd.png">
