### PR TITLE
PLANET-6852: Remove features fallback and deduplicate p4 features in options

### DIFF
--- a/src/Feature.php
+++ b/src/Feature.php
@@ -67,15 +67,10 @@ abstract class Feature {
 		if ( static::is_generally_available() ) {
 			return true;
 		}
+
 		$features = get_option( static::options_key() );
-
-		// Temporary fallback to ensure it works before migration runs.
-		if ( ! $features ) {
-			$features = get_option( Settings::KEY );
-		}
-
-		$id     = static::id();
-		$active = isset( $features[ $id ] ) && $features[ $id ];
+		$id       = static::id();
+		$active   = isset( $features[ $id ] ) && $features[ $id ];
 
 		// Filter to allow setting a feature from code, to avoid chicken and egg problem when releasing adaptions to a
 		// new feature.

--- a/src/Migrations/M013RemoveDuplicatedOptions.php
+++ b/src/Migrations/M013RemoveDuplicatedOptions.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace P4\MasterTheme\Migrations;
+
+use P4\MasterTheme\MigrationRecord;
+use P4\MasterTheme\MigrationScript;
+
+/**
+ * Remove duplicated Planet 4 features comparing to options.
+ */
+class M013RemoveDuplicatedOptions extends MigrationScript {
+	/**
+	 * Perform the actual migration.
+	 *
+	 * @param MigrationRecord $record Information on the execution, can be used to add logs.
+	 *
+	 * @return void
+	 */
+	protected static function execute( MigrationRecord $record ): void {
+		$features = get_option( 'planet4_features' );
+		$options  = get_option( 'planet4_options' );
+
+		foreach ( array_keys( $features ) as $feature ) {
+			if ( array_key_exists( $feature, $options ) ) {
+				unset( $features[ $feature ] );
+			}
+		}
+
+		update_option( 'planet4_features', $features );
+	}
+}

--- a/src/Migrations/M013RemoveDuplicatedOptions.php
+++ b/src/Migrations/M013RemoveDuplicatedOptions.php
@@ -22,10 +22,10 @@ class M013RemoveDuplicatedOptions extends MigrationScript {
 
 		foreach ( array_keys( $features ) as $feature ) {
 			if ( array_key_exists( $feature, $options ) ) {
-				unset( $features[ $feature ] );
+				unset( $options[ $feature ] );
 			}
 		}
 
-		update_option( 'planet4_features', $features );
+		update_option( 'planet4_options', $options );
 	}
 }

--- a/src/Migrator.php
+++ b/src/Migrator.php
@@ -14,6 +14,7 @@ use P4\MasterTheme\Migrations\M009PopulateCookiesFields;
 use P4\MasterTheme\Migrations\M010RemoveGdprPluginOptions;
 use P4\MasterTheme\Migrations\M011RemoveSmartsheetOption;
 use P4\MasterTheme\Migrations\M012RemoveThemeEditorOption;
+use P4\MasterTheme\Migrations\M013RemoveDuplicatedOptions;
 
 
 /**
@@ -45,6 +46,7 @@ class Migrator {
 			M010RemoveGdprPluginOptions::class,
 			M011RemoveSmartsheetOption::class,
 			M012RemoveThemeEditorOption::class,
+			M013RemoveDuplicatedOptions::class,
 		];
 
 		// Loop migrations and run those that haven't run yet.

--- a/src/Settings/Features.php
+++ b/src/Settings/Features.php
@@ -128,11 +128,6 @@ class Features {
 	public static function is_active( string $name ): bool {
 		$features = get_option( self::OPTIONS_KEY );
 
-		// Temporary fallback to ensure it works before migration runs.
-		if ( ! $features ) {
-			$features = get_option( Settings::KEY );
-		}
-
 		$active = isset( $features[ $name ] ) && $features[ $name ];
 
 		// Filter to allow setting a feature from code, to avoid chicken and egg problem when releasing adaptions to a


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6852

## Description

Removed features fallback and deduplicate options. Also created new Migration to clean up code

## Testing
Ideally and easy to check, I'd suggest to run the full version of `docker-compose` to compare against the table `wp_options` from the [Database](/sql.php?db=planet4_dev&table=wp_options&token=08db792cbdf739020c6f613c43dcc251). 
1. Comment the rest of migrations except the one you want to run.
2. `make php-shell`
3. `wp p4-run-activator`
