### PR TITLE
Add command for WPML media path migration

### DIFF
--- a/src/Commands.php
+++ b/src/Commands.php
@@ -10,6 +10,7 @@ use P4\MasterTheme\Commands\RunActivator;
 use P4\MasterTheme\Commands\SaveCloudflareKey;
 use P4\MasterTheme\Commands\FixOrphans;
 use P4\MasterTheme\Commands\GFAddonsDisconnect;
+use P4\MasterTheme\Migrations;
 
 /**
  * Class with a static function just because PHP can't autoload functions.
@@ -27,5 +28,14 @@ class Commands {
 		CloudflarePurge::register();
 		FixOrphans::register();
 		GFAddonsDisconnect::register();
+
+		\WP_CLI::add_command(
+			'p4-update-missing-media-path',
+			function () {
+				$record = MigrationRecord::start( static::class );
+				Migrations\M004UpdateMissingMediaPath::execute( $record );
+			},
+			[ 'shortdesc' => 'Updates missing media path after WPML activation.' ]
+		);
 	}
 }

--- a/src/Migrations/M004UpdateMissingMediaPath.php
+++ b/src/Migrations/M004UpdateMissingMediaPath.php
@@ -17,7 +17,7 @@ class M004UpdateMissingMediaPath extends MigrationScript {
 	 *
 	 * @return void
 	 */
-	protected static function execute( MigrationRecord $record ): void {
+	public static function execute( MigrationRecord $record ): void {
 
 		// Check if WPML plugin is active.
 		if ( function_exists( 'is_plugin_active' ) && ! is_plugin_active( 'sitepress-multilingual-cms/sitepress.php' ) ) {


### PR DESCRIPTION
Adding this command to be able to re-run the media path fix migration after WPML activation on site the migration has already run.

### Testing

I couldn't reproduce Aotearoa's issue locally even with their latest production db. So the command does run properly locally but didn't see any visible changes.

I'll deploy this branch in Aotearoa's dev site, so we can test it before merge.
