### PR TITLE
PLANET-6981 Remove jQuery from post_tag.js

### DIFF
--- a/admin/css/post_tag.css
+++ b/admin/css/post_tag.css
@@ -2,3 +2,7 @@
   max-width: 150px;
   max-height: 150px;
 }
+
+.submit input#submit {
+  display: none;
+}

--- a/admin/css/post_tag.css
+++ b/admin/css/post_tag.css
@@ -1,0 +1,4 @@
+.attachment-thumbnail.size-thumbnail {
+  max-width: 150px;
+  max-height: 150px;
+}

--- a/admin/js/post_tag.js
+++ b/admin/js/post_tag.js
@@ -53,7 +53,7 @@ document.addEventListener('DOMContentLoaded', () => {
   // Clean up the custom fields, since the taxonomy save is made via ajax and the taxonomy page does not reload.
   const addTagForm = document.querySelector('#addtag');
   if (addTagForm) {
-    addTagForm.querySelector('#submit').onclick = () => {
+    addTagForm.querySelector('#addtag').onclick = () => {
       HTMLFormElement.prototype.submit.call(addTagForm);
       setTimeout(() => {
         document.querySelector('#tag_attachment_id').value = '';

--- a/src/Campaigns.php
+++ b/src/Campaigns.php
@@ -221,6 +221,9 @@ class Campaigns {
 				<p class="description"><?php esc_html_e( 'Associate this tag with an image.', 'planet4-master-theme-backend' ); ?></p>
 				<img class="attachment-thumbnail size-thumbnail" src="" />
 				<i class="dashicons dashicons-dismiss hidden" style="cursor: pointer;"></i>
+				<p class="submit">
+					<input name="submit" id="addtag" type="submit" class="button button-primary" value="<?php esc_html_e( 'Add new tag', 'planet4-master-theme-backend' ); ?>" />
+				</p>
 			</div>
 			<?php
 		}

--- a/src/Campaigns.php
+++ b/src/Campaigns.php
@@ -247,10 +247,6 @@ class Campaigns {
 		if ( $this->validate( $attachment_id ) ) {
 			update_term_meta( $term_id, $field_id, $attachment_id );
 			update_term_meta( $term_id, $field_url, $attachment_url );
-			$tag_attachment_id  = $attachment_id;
-			$tag_attachment_url = $attachment_url;
-		} else {
-			$tag_attachment_id = '';
 		}
 
 		$field_id       = 'happypoint_attachment_id';
@@ -261,9 +257,6 @@ class Campaigns {
 		if ( $this->validate( $attachment_id ) ) {
 			update_term_meta( $term_id, $field_id, $attachment_id );
 			update_term_meta( $term_id, $field_url, $attachment_url );
-			$happy_background_code = $attachment_id;
-		} else {
-			$happy_background_code = '';
 		}
 
 		$field_id              = 'happypoint_bg_opacity';
@@ -408,10 +401,16 @@ class Campaigns {
 		if ( ! is_admin() || strpos( get_current_screen()->taxonomy, $this->taxonomy ) === false ) {
 			return;
 		}
+		wp_enqueue_style(
+			'custom-login',
+			get_template_directory_uri() . '/admin/css/post_tag.css',
+			[],
+			Loader::theme_file_ver( 'admin/css/post_tag.css' )
+		);
 		wp_register_script(
 			$this->taxonomy,
 			get_template_directory_uri() . "/admin/js/$this->taxonomy.js",
-			[ 'jquery' ],
+			[],
 			Loader::theme_file_ver( "admin/js/$this->taxonomy.js" ),
 			true
 		);


### PR DESCRIPTION
### Description

See [PLANET-6981](https://jira.greenpeace.org/browse/PLANET-6981)
Ideally we want to avoid using jQuery. In this PR I've also included a small CSS fix for the tags image thumbnail size.

### Testing

Adding a post tag (for example [here](https://www-dev.greenpeace.org/test-pandora/wp-admin/edit-tags.php?taxonomy=post_tag)) or editing a post tag (for example [here](https://www-dev.greenpeace.org/test-pandora/wp-admin/term.php?taxonomy=post_tag&tag_ID=79&post_type=post&wp_http_referer=%2Ftest-pandora%2Fwp-admin%2Fedit-tags.php%3Ftaxonomy%3Dpost_tag)) should still work as expected.