### PR TITLE
PLANET-6960 Add sidebar option to define canonical link

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -475,15 +475,16 @@ add_action(
 	}
 );
 
-/**
- * Adds the canonical link from the sidebar menu to the post head
- */
-function add_meta_tags() {
-	global $post;
-	if ( isset( $post->p4_seo_canonical_url ) && '' !== $post->p4_seo_canonical_url ) {
-		$url = $post->p4_seo_canonical_url;
-		echo '<link rel="canonical" href="' . $url . '">'; // phpcs:ignore
-	}
-}
-
-add_action( 'wp_head', 'add_meta_tags', 10 );
+// This filter replaces the default Canonical URL with what is set in the Sidebar Options.
+// If no URL is set for the Canonical link, the default WP url is used.
+add_filter(
+	'get_canonical_url',
+	function( $canonical_url, $post ) {
+		if ( isset( $post->p4_seo_canonical_url ) && '' !== $post->p4_seo_canonical_url ) {
+			$canonical_url = $post->p4_seo_canonical_url;
+		}
+		return $canonical_url;
+	},
+	10,
+	2
+);

--- a/functions.php
+++ b/functions.php
@@ -480,7 +480,7 @@ add_action(
  */
 function add_meta_tags() {
 	global $post;
-	if ( isset( $post->p4_seo_canonical_url ) ) {
+	if ( isset( $post->p4_seo_canonical_url ) && '' !== $post->p4_seo_canonical_url ) {
 		$url = $post->p4_seo_canonical_url;
 		echo '<link rel="canonical" href="' . $url . '">'; // phpcs:ignore
 	}

--- a/functions.php
+++ b/functions.php
@@ -474,3 +474,16 @@ add_action(
 		}
 	}
 );
+
+/**
+ * Adds the canonical link from the sidebar menu to the post head
+ */
+function add_meta_tags() {
+	global $post;
+	if ( isset( $post->p4_seo_canonical_url ) ) {
+		$url = $post->p4_seo_canonical_url;
+		echo '<link rel="canonical" href="' . $url . '">'; // phpcs:ignore
+	}
+}
+
+add_action( 'wp_head', 'add_meta_tags', 10 );

--- a/src/ActionPage.php
+++ b/src/ActionPage.php
@@ -23,6 +23,7 @@ class ActionPage {
 		'p4_og_description',
 		'p4_og_image',
 		'p4_og_image_id',
+		'p4_seo_canonical_url',
 	];
 
 	/**

--- a/src/PageMeta.php
+++ b/src/PageMeta.php
@@ -23,6 +23,7 @@ class PageMeta {
 		'p4_og_description',
 		'p4_og_image',
 		'p4_og_image_id',
+		'p4_seo_canonical_url',
 	];
 
 	/**

--- a/src/Post.php
+++ b/src/Post.php
@@ -350,7 +350,6 @@ class Post extends TimberPost {
 		return [];
 	}
 
-
 	/**
 	 * Get values for share buttons content.
 	 *

--- a/src/Post.php
+++ b/src/Post.php
@@ -350,6 +350,7 @@ class Post extends TimberPost {
 		return [];
 	}
 
+
 	/**
 	 * Get values for share buttons content.
 	 *

--- a/src/PostCampaign.php
+++ b/src/PostCampaign.php
@@ -39,6 +39,7 @@ class PostCampaign {
 		'p4_og_description',
 		'p4_og_image',
 		'p4_og_image_id',
+		'p4-seo-canonical-url',
 	];
 
 	public const LEGACY_THEMES = [

--- a/src/PostMeta.php
+++ b/src/PostMeta.php
@@ -14,6 +14,7 @@ class PostMeta {
 		'p4_og_description',
 		'p4_og_image',
 		'p4_og_image_id',
+		'p4_seo_canonical_url',
 	];
 
 	/**


### PR DESCRIPTION
**Description**

See [PLANET-6960](https://jira.greenpeace.org/browse/PLANET-6960)

Associated [PR](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/986)

### Testing
On your local or [Umbriel Test Instance](https://www-dev.greenpeace.org/test-umbriel/), you can add the Canonical link from the sidebar (_Search Engine Optimizations_ section), to any post type and update the page. On reload in the editor you should still see the data that you entered, and when inspecting the page in the frontend you should see the correct link tag added to the head.

<img width="1512" alt="Screenshot 2022-12-14 at 03 36 45" src="https://user-images.githubusercontent.com/38656549/207549187-bd27a125-1ff7-4f99-a729-58a942988961.png">

<img width="1512" alt="Screenshot 2022-12-14 at 03 41 30" src="https://user-images.githubusercontent.com/38656549/207548553-b1f1e221-5b71-4f07-9025-897609f6027a.png">

<!-- Ref: Please add a url to the ticket this change is addressing.

---

Please provide a brief summary of the change introduced to make review process easier.


Ideally this should also be part of the commit summary.
-->
