### PR TITLE
Fix form token field label text transform

### DIFF
--- a/assets/src/scss/editorOverrides.scss
+++ b/assets/src/scss/editorOverrides.scss
@@ -170,6 +170,11 @@
     display: none;
   }
 
+  .components-form-token-field__label {
+    font-weight: bold;
+    text-transform: none;
+  }
+
   // By default all but the first .component-base-control have margin-bottom, causing weird spacing.
   .components-base-control {
     margin-bottom: 0;


### PR DESCRIPTION
### Description

This is used in the editor in some blocks such as Articles, it should have the same styles as the other labels.

### Testing

In the editor, add an Articles block and check the sidebar. On the `main` branch you should see some labels in uppercase:
<img width="278" alt="Screenshot 2022-12-20 at 10 53 58" src="https://user-images.githubusercontent.com/6949075/208637703-e7a1702c-6f98-404d-ba34-18609583a087.png">
On this branch it should be fixed 🙂 
