### PR TITLE
Remove Campaign tags from Action Pages

### DIFF
--- a/single-p4_action.php
+++ b/single-p4_action.php
@@ -20,23 +20,6 @@ $post           = new Post(); // phpcs:ignore WordPress.WP.GlobalVariablesOverri
 $page_meta_data = get_post_meta( $post->ID );
 $page_meta_data = array_map( 'reset', $page_meta_data );
 
-// Set Navigation Issues links.
-$post->set_issues_links();
-
-// Get Navigation Campaigns links.
-$page_tags = wp_get_post_tags( $post->ID );
-$tags      = [];
-
-if ( is_array( $page_tags ) && $page_tags ) {
-	foreach ( $page_tags as $page_tag ) {
-		$tags[] = [
-			'name' => $page_tag->name,
-			'link' => get_tag_link( $page_tag ),
-		];
-	}
-	$context['campaigns'] = $tags;
-}
-
 // Set GTM Data Layer values.
 $post->set_data_layer();
 $data_layer = $post->get_data_layer();


### PR DESCRIPTION
Ref: [PLANET-6983](https://jira.greenpeace.org/browse/PLANET-6983)

## Description
This the [Slack thread](https://greenpeace-gpi.slack.com/archives/G015K63081W/p1667920973170169) with more information.

## Testing 
Go to this [demo page](https://www-dev.greenpeace.org/test-titan/action/the-second-action-custom-button-text/) and you wouldn't see any link, categories or tags, at the top of the page. Even you've already set them (1) and enabled the **Category links on Posts** feature from [Planet 4 > Information architecture](https://www-dev.greenpeace.org/test-titan/wp-admin/admin.php?page=planet4_settings_ia) (2).  Also compare with the [current behavior](https://www-dev.greenpeace.org/international/action/action-demo-page/)
(1)
![Screenshot 2022-12-21 at 07 55 57](https://user-images.githubusercontent.com/77975803/208889269-5e8ad084-cb00-434c-ac5e-4520f367a4b4.png)
(2)
![Screenshot 2022-12-21 at 08 01 27](https://user-images.githubusercontent.com/77975803/208890088-2e1e6433-e560-4977-b25e-106710d42bc0.png)
