### PR TITLE
Remove duotone feature the proper way

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -50,11 +50,12 @@
   "settings": {
     "color": {
       "custom": false,
+      "duotone": [],
       "customDuotone": false,
       "customGradient": false,
+      "defaultDuotone": false,
       "defaultGradients": false,
       "defaultPalette": false,
-      "duotone": null,
       "palette": [
         {
           "name": "Grey 80%",

--- a/theme.json
+++ b/theme.json
@@ -9,44 +9,44 @@
     "typography": {
       "fontFamily": "Lora, serif"
     },
-		"elements": {
+    "elements": {
       "heading": {
         "typography": {
           "fontFamily": "Roboto, sans-serif",
           "fontWeight": "bold"
         }
       },
-			"link": {
+      "link": {
         "color": {
           "text": "#006dfd"
         },
-				"typography": {
-					"textDecoration": "none"
-				},
-				":hover": {
+        "typography": {
+          "textDecoration": "none"
+        },
+        ":hover": {
           "color": {
             "text": "#006dfd"
           },
-					"typography": {
-						"textDecoration": "underline"
-					}
-				},
-				":active": {
+          "typography": {
+            "textDecoration": "underline"
+          }
+        },
+        ":active": {
           "color": {
             "text": "#006dfd"
           },
-					"typography": {
-						"textDecoration": "underline"
-					}
-				},
-				":visited": {
+          "typography": {
+            "textDecoration": "underline"
+          }
+        },
+        ":visited": {
           "color": {
             "text": "#68009e"
           }
-				}
-			}
-		}
-	},
+        }
+      }
+    }
+  },
   "settings": {
     "color": {
       "custom": false,


### PR DESCRIPTION
This is a follow up from 24cc5ec49fe0cec09289deb9680e186274423104

It was breaking theme.json scheme validation. This change is how duotone feature is supposed to be disabled.

This also includes a fist commit to re-indent `theme.json` for removing tabs.

### Testing

Image block should not have the [duotone button](https://wordpress.com/go/tutorials/how-to-use-the-duotone-image-filter-with-wordpress-com/) in its toolbar