### PR TITLE
Add border radius feature to core/image

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -169,7 +169,12 @@
             }
           ]
         }
-      }
+      },
+      "core/image": {
+        "border": {
+          "radius": true
+        }
+      },
     },
     "layout": {
       "contentSize": "736px"


### PR DESCRIPTION
By Doing this we'll be able to potentially remove some custom classes for borders from [here](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/blob/main/assets/src/styles/blocks/core-overrides/Image.scss#L1-L12).

```sass
@mixin rounded-image-size($size) {
  figure,
  img {
    border-radius: 50%
    height: $size
    width: $size
  }

  img {
    object-fit: cover
  }
}
```
and
```sass
&.is-style-rounded-180 {
    @include rounded-image-size(180px)
  }

  &.is-style-rounded-90 {
    @include rounded-image-size(90px)
  }
```
## What to do?
1) Merge this feature
2) Open a new PR removing all the appearances of those classes. For example from the [Quick Links block pattern](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/blob/main/assets/src/block-templates/quick-links/template.js#L8).