### PR TITLE
PLANET-7011 Select one action type on action add/edit

### DIFF
--- a/tests/p4-testcase.php
+++ b/tests/p4-testcase.php
@@ -123,6 +123,29 @@ class P4_TestCase extends WP_UnitTestCase {
 			]
 		);
 
+		// Create action-type terms.
+		$this->factory->term->create(
+			[
+				'name'     => 'Event',
+				'taxonomy' => 'action-type',
+				'slug'     => 'event',
+			]
+		);
+		$this->factory->term->create(
+			[
+				'name'     => 'Petition',
+				'taxonomy' => 'action-type',
+				'slug'     => 'petion',
+			]
+		);
+		$this->factory->term->create(
+			[
+				'name'     => 'Contest',
+				'taxonomy' => 'action-type',
+				'slug'     => 'contest',
+			]
+		);
+
 		wp_set_current_user( 0 );
 	}
 }

--- a/tests/test-action-type-custom-taxonomy.php
+++ b/tests/test-action-type-custom-taxonomy.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Test action_type custom taxonomy.
+ *
+ * @package P4MT
+ */
+
+use P4\MasterTheme\ActionPage;
+
+/**
+ * Class ActionTypeCustomTaxonomyTest
+ */
+class ActionTypeCustomTaxonomyTest extends P4_TestCase {
+
+	/**
+	 * Test that a Action(Custom post type) has always a action-type term assigned to it.
+	 *
+	 * @covers P4\MasterTheme\ActionPage::save_taxonomy_action_type
+	 */
+	public function test_action_has_a_actiontype_term_assigned() {
+
+		// Get editor user.
+		$user = get_user_by( 'login', 'p4_editor' );
+		wp_set_current_user( $user->ID );
+
+		// Create a sample Action(Custom post type) without assigning a action-type 'contest' term to it.
+		$post_id = $this->factory->post->create(
+			[
+				'post_type'    => 'p4_action',
+				'post_title'   => 'The name of the place is Babylon',
+				'post_name'    => 'test-taxonomy-url',
+				'post_content' => 'test content',
+			]
+		);
+
+		$terms = wp_get_object_terms( $post_id, 'action-type' );
+
+		// Assert that the action has been assigned with a action-type term.
+		$this->assertCount( 1, $terms );
+		$this->assertInstanceOf( 'WP_Term', $terms[0] );
+
+	}
+
+	/**
+	 * Test that a Action(Custom post type) has always a single action-type term assigned to it.
+	 *
+	 * @covers P4\MasterTheme\ActionPage::save_taxonomy_action_type
+	 */
+	public function test_action_has_a_single_action_type_assigned() {
+
+		// Get editor user.
+		$user = get_user_by( 'login', 'p4_editor' );
+		wp_set_current_user( $user->ID );
+
+		// Create a sample Action(Custom post type) and assign action-type 'contest' term to it.
+		$post_id = $this->factory->post->create(
+			[
+				'post_type'    => 'p4_action',
+				'post_title'   => 'The name of the place is Babylon.',
+				'post_name'    => 'test-taxonomy-url',
+				'post_content' => 'test content',
+				'tax_input'    => [
+					'action-type' => [ 'contest', 'event', 'petition' ],
+				],
+			]
+		);
+
+		$terms = wp_get_object_terms( $post_id, 'action-type' );
+		// Assert that the Action has been assigned with a single action-type term.
+		$this->assertCount( 1, $terms );
+		$this->assertEquals( 'contest', $terms[0]->slug );
+	}
+}


### PR DESCRIPTION
Ref. https://jira.greenpeace.org/browse/PLANET-7011

**Requirements**

- When editor add a new action, by default assign a default action type* to it. 
- If user manually select multiple action type while add/edit of action, assign only first action type
- Same above behaviour should work in case of quick edit of action from admin action listing page.


The Default Action Type setting is available in WP admin >> Writing Settings page (wp-admin/options-writing.php)


**Testing:**
- Add new action, the default action type should assign to action post type
- Select multiple action type while add/edit of action, on save of action only one action type should save.
- Also check the action quick edit from admin action listing page

**Note:**
- I tried to use a `save_post` hook for both (save action /quick edit action) but the taxonomy will update after `save_post` hook execution for add/edit action.

**To run the test case on local** -
`make php-shell`
`cd public/wp-content/themes/planet4-master-theme/`
`bin/install-wp-tests.sh planet4_test planet4 Phoh4zaeshaiT9ee db`
`vendor/bin/phpunit tests/test-action-type-custom-taxonomy.php `