### PR TITLE
Add font-family css variables

### DIFF
--- a/assets/src/scss/base/_body.scss
+++ b/assets/src/scss/base/_body.scss
@@ -10,7 +10,7 @@ body {
   overflow-y: hidden;
 
   &.search {
-    font-family: $roboto;
+    font-family: var(--headings--font-family);
   }
 
   .mejs-container {

--- a/assets/src/scss/base/_variables.scss
+++ b/assets/src/scss/base/_variables.scss
@@ -1,4 +1,9 @@
 // Fonts
+:root {
+  --body--font-family: "Lora", serif;
+  --headings--font-family: "Roboto", sans-serif;
+}
+
 $roboto:     "Roboto", sans-serif;
 $lora:       "Lora", serif;
 

--- a/assets/src/scss/components/_blockquote.scss
+++ b/assets/src/scss/components/_blockquote.scss
@@ -23,7 +23,7 @@ blockquote > p {
 
 blockquote > h5 {
   @include blockquote;
-  font-family: $lora;
+  font-family: var(--body--font-family);
   color: $grey-80;
   font-size: $font-size-xxl;
 
@@ -34,7 +34,7 @@ blockquote > h5 {
 
 blockquote > h6 {
   @include blockquote;
-  font-family: $lora;
+  font-family: var(--body--font-family);
   color: $grey-80;
   font-size: $font-size-xl;
 

--- a/assets/src/scss/components/_buttons.scss
+++ b/assets/src/scss/components/_buttons.scss
@@ -5,7 +5,7 @@
 .gform_button_select_files,
 .gform_footer input[type="submit"] {
   --button-- {
-    font-family: $roboto;
+    font-family: var(--headings--font-family);
     text-align: center;
     font-weight: bold;
     border-radius: 4px;

--- a/assets/src/scss/editorOverrides.scss
+++ b/assets/src/scss/editorOverrides.scss
@@ -1,7 +1,7 @@
 // Moved from another repo, for history please see https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/blame/f5c532ed5704738136224cde305e9a0ffe614ceb/assets/src/styles/editorOverrides.scss
 .editor-post-title__block textarea.editor-post-title__input {
   --headings-- {
-    font-family: $roboto;
+    font-family: var(--headings--font-family);
   }
 
   font-size: $font-size-xl;
@@ -60,7 +60,7 @@
 .wp-block-button .wp-block-button__link[role="textbox"],
 .wp-block-file .wp-block-file__button {
   display: inline-block;
-  font-family: $roboto;
+  font-family: var(--headings--font-family);
   text-align: center;
   text-decoration: none;
   font-weight: bold;
@@ -194,7 +194,7 @@
 
   h1, h2, h3, h4, h5 {
     --headings-- {
-      font-family: $roboto;
+      font-family: var(--headings--font-family);
     }
   }
 }
@@ -234,7 +234,7 @@ input.describe[type=text][data-setting=caption] {
 }
 
 .input_error {
-  font-family: $roboto;
+  font-family: var(--headings--font-family);
   font-size: 13px;
   color: red;
 }

--- a/assets/src/scss/layout/_breadcrumbs.scss
+++ b/assets/src/scss/layout/_breadcrumbs.scss
@@ -1,7 +1,7 @@
 .top-page-tags {
   font-size: 16px;
   margin-bottom: $sp-1;
-  font-family: $roboto;
+  font-family: var(--headings--font-family);
 
   .tag-wrap {
     display: inline;

--- a/assets/src/scss/layout/_cookies.scss
+++ b/assets/src/scss/layout/_cookies.scss
@@ -1,5 +1,5 @@
 .cookie-notice {
-  font-family: $roboto;
+  font-family: var(--headings--font-family);
   z-index: 100;
   position: fixed;
   width: 100vw;

--- a/assets/src/scss/layout/_footer.scss
+++ b/assets/src/scss/layout/_footer.scss
@@ -1,6 +1,6 @@
 .site-footer {
   _-- {
-    font-family: $roboto;
+    font-family: var(--headings--font-family);
     background: $dark-blue;
     color: $white;
   }

--- a/assets/src/scss/layout/_forms.scss
+++ b/assets/src/scss/layout/_forms.scss
@@ -13,7 +13,7 @@
     & ~ label {
       position: relative;
       cursor: pointer;
-      font-family: $roboto;
+      font-family: var(--headings--font-family);
       font-size: $font-size-xxxs;
       line-height: 1rem;
       color: $grey-80;
@@ -91,7 +91,7 @@
     & ~ label {
       position: relative;
       cursor: pointer;
-      font-family: $roboto;
+      font-family: var(--headings--font-family);
       font-size: $font-size-sm;
       line-height: 1.25rem;
       color: $grey-80;
@@ -139,7 +139,7 @@
 .gfield textarea,
 .ginput_container_multiselect select {
   border-radius: 4px;
-  font-family: $roboto;
+  font-family: var(--headings--font-family);
   background-color: $white;
   border: 1px solid $grey-20;
   color: $grey-80;
@@ -210,7 +210,7 @@ textarea.form-control {
       color: $grey-40;
       padding-inline-start: 16px;
       font-size: 11px;
-      font-family: $roboto;
+      font-family: var(--headings--font-family);
       opacity: 0;
       transition: all .3s ease;
       margin-bottom: 0;
@@ -254,7 +254,7 @@ select {
     position: relative;
     pointer-events: none;
     margin-top: 6px;
-    font-family: $roboto;
+    font-family: var(--headings--font-family);
 
     &:after {
       bottom: 100%;

--- a/assets/src/scss/layout/_gravity-forms.scss
+++ b/assets/src/scss/layout/_gravity-forms.scss
@@ -5,7 +5,7 @@
 @import "../base/typography";
 
 .gform_wrapper {
-  font-family: $roboto;
+  font-family: var(--headings--font-family);
 
   &.gform_validation_error .gform_validation_errors {
     color: $dark-orange;
@@ -130,7 +130,7 @@
 }
 
 .ui-datepicker {
-  font-family: $roboto;
+  font-family: var(--headings--font-family);
 }
 
 .gform_p4_confirmation {

--- a/assets/src/scss/layout/_navbar.scss
+++ b/assets/src/scss/layout/_navbar.scss
@@ -11,7 +11,7 @@ $navbar-default-height: 60px;
     box-shadow: none;
     color: $white;
     fill: $white;
-    font-family: $roboto;
+    font-family: var(--headings--font-family);
     font-size: $font-size-sm;
   }
 

--- a/assets/src/scss/layout/_page-header.scss
+++ b/assets/src/scss/layout/_page-header.scss
@@ -140,7 +140,7 @@
 }
 
 .page-header-title _-- {
-  font-family: $roboto;
+  font-family: var(--headings--font-family);
   font-weight: bold;
   text-transform: none;
   max-width: 80%;

--- a/assets/src/scss/layout/_page-section.scss
+++ b/assets/src/scss/layout/_page-section.scss
@@ -2,7 +2,7 @@
   text-transform: none;
   color: inherit;
   font-weight: var(--headings--font-weight, bold);
-  font-family: var(--headings--font-family, $roboto);
+  font-family: var(--headings--font-family);
   font-size: 2.5rem;
   margin-bottom: $sp-2;
 }

--- a/assets/src/scss/layout/_tables.scss
+++ b/assets/src/scss/layout/_tables.scss
@@ -11,7 +11,7 @@
 
   table {
     margin-bottom: 15px;
-    font-family: $roboto;
+    font-family: var(--headings--font-family);
     width: 100%;
 
     @include mobile-only {

--- a/assets/src/scss/layout/navbar/_burger-menu.scss
+++ b/assets/src/scss/layout/navbar/_burger-menu.scss
@@ -24,7 +24,7 @@ $transition-duration: .2s;
   _-- {
     background: $white;
     color: $grey-80;
-    font-family: $roboto;
+    font-family: var(--headings--font-family);
   }
 
   position: fixed;

--- a/assets/src/scss/pages/_author.scss
+++ b/assets/src/scss/pages/_author.scss
@@ -31,7 +31,7 @@
   }
 
   .search-result-list-item {
-    font-family: $roboto;
+    font-family: var(--headings--font-family);
   }
 
   // Search uses absolutely positioned buttons, for absolutely no reason. The button effectively is

--- a/assets/src/scss/pages/_category.scss
+++ b/assets/src/scss/pages/_category.scss
@@ -1,9 +1,9 @@
 .category {
   .search-result-list-item {
-    font-family: $roboto;
+    font-family: var(--headings--font-family);
   }
 
   .search-result-item-content {
-    font-family: $lora;
+    font-family: var(--body--font-family);
   }
 }

--- a/assets/src/scss/pages/_listing-page.scss
+++ b/assets/src/scss/pages/_listing-page.scss
@@ -72,7 +72,7 @@
 .query-list-item-post-terms {
   display: flex;
   font-size: $font-size-sm;
-  font-family: $roboto;
+  font-family: var(--headings--font-family);
   line-height: 25px;
 
   .wrapper-post-tag {
@@ -143,7 +143,7 @@
 }
 
 .query-list-item-meta {
-  font-family: $roboto;
+  font-family: var(--headings--font-family);
   font-size: $font-size-xxs;
   color: $grey-40;
   line-height: 22px;
@@ -237,7 +237,7 @@
     }
   }
 
-  font-family: $roboto;
+  font-family: var(--headings--font-family);
   display: flex;
   flex-direction: row;
   justify-content: space-between;

--- a/assets/src/scss/pages/_page_type.scss
+++ b/assets/src/scss/pages/_page_type.scss
@@ -1,9 +1,9 @@
 .tax-p4-page-type {
   .search-result-list-item {
-    font-family: $roboto;
+    font-family: var(--headings--font-family);
   }
 
   .search-result-item-content {
-    font-family: $lora;
+    font-family: var(--body--font-family);
   }
 }

--- a/assets/src/scss/pages/_sitemap.scss
+++ b/assets/src/scss/pages/_sitemap.scss
@@ -3,7 +3,7 @@
 
   a {
     color: $grey-80;
-    font-family: $roboto;
+    font-family: var(--headings--font-family);
 
     &:visited {
       color: $link-color-visited;

--- a/assets/src/scss/pages/post/_article-content.scss
+++ b/assets/src/scss/pages/post/_article-content.scss
@@ -36,7 +36,7 @@
     }
 
     .cover-card-tag {
-      font-family: $roboto;
+      font-family: var(--headings--font-family);
     }
   }
 
@@ -328,7 +328,7 @@
 
   .wp-caption-text {
     font-size: $font-size-xxs;
-    font-family: $roboto;
+    font-family: var(--headings--font-family);
     line-height: 1.4;
     margin-bottom: 0;
     padding-top: $sp-1;

--- a/assets/src/scss/pages/post/_comments-block.scss
+++ b/assets/src/scss/pages/post/_comments-block.scss
@@ -8,7 +8,7 @@
 
 .single-comment {
   padding-bottom: 24px;
-  font-family: $roboto;
+  font-family: var(--headings--font-family);
 
   &:not(:first-of-type) {
     border-top: 1px solid transparentize($grey-20, 0.5);

--- a/assets/src/scss/pages/post/_comments-form.scss
+++ b/assets/src/scss/pages/post/_comments-form.scss
@@ -39,7 +39,7 @@
 }
 
 #gdpr-comments-compliance {
-  font-family: $roboto;
+  font-family: var(--headings--font-family);
   margin-bottom: 8px;
 
   #gdpr-comments-checkbox {
@@ -60,7 +60,7 @@
 
 .logged-in-as {
   font-size: 14px;
-  font-family: $roboto;
+  font-family: var(--headings--font-family);
 }
 
 #cancel-comment-reply-link {

--- a/assets/src/scss/pages/post/_post.scss
+++ b/assets/src/scss/pages/post/_post.scss
@@ -28,7 +28,7 @@
 .single-post-meta {
   color: $grey-40;
   font-size: 14px;
-  font-family: $roboto;
+  font-family: var(--headings--font-family);
   border-bottom: 1px solid transparentize($grey-20, 0.5);
   padding-bottom: 16px;
   line-height: 24px;

--- a/assets/src/scss/pages/search/_filtered-tags.scss
+++ b/assets/src/scss/pages/search/_filtered-tags.scss
@@ -1,7 +1,7 @@
 .search-info {
   font-size: $font-size-xxs;
   margin-bottom: 0;
-  font-family: $roboto;
+  font-family: var(--headings--font-family);
   font-style: italic;
   color: $grey-60;
   line-height: normal;

--- a/assets/src/scss/pages/search/_search-results.scss
+++ b/assets/src/scss/pages/search/_search-results.scss
@@ -189,7 +189,7 @@
 .search-result-item-content {
   color: $grey-80;
   font-size: $font-size-sm;
-  font-family: $lora;
+  font-family: var(--body--font-family);
   line-height: 1.6;
   margin-bottom: $sp-1;
 


### PR DESCRIPTION
Switching to css variables from scss will help us to replace those fonts easier in child themes by just overriding the variable. Same as we do for campaign themes.

I left the scss variables untouched since they may be used in other places (eg. landing page).

### Testing 

Just running `make assets` on local env with these branches should have no visual diff in the frontend.