### PR TITLE
Fix copyright values from Media Library

### DIFF
--- a/src/ImageArchive/ApiClient.php
+++ b/src/ImageArchive/ApiClient.php
@@ -27,7 +27,7 @@ class ApiClient {
 
 	private const DEFAULT_PARAMS = [
 		'query'        => '(Mediatype:Image)',
-		'fields'       => 'MediaEncryptedIdentifier,Title,Caption,copyright,Path_TR1,Path_TR1_COMP_SMALL,Path_TR7,Path_TR4,Path_TR1_COMP,Path_TR2,Path_TR3,SystemIdentifier,original-language-title,original-language-description,original-language,restrictions,copyright,MediaDate,CreatedDate,EditDate',
+		'fields'       => 'MediaEncryptedIdentifier,Title,Caption,CoreField.Copyright,Path_TR1,Path_TR1_COMP_SMALL,Path_TR7,Path_TR4,Path_TR1_COMP,Path_TR2,Path_TR3,SystemIdentifier,original-language-title,original-language-description,original-language,restrictions,MediaDate,CreatedDate,EditDate',
 		'countperpage' => self::MEDIAS_PER_PAGE,
 		'format'       => 'json',
 		'pagenumber'   => 1,

--- a/src/ImageArchive/Image.php
+++ b/src/ImageArchive/Image.php
@@ -94,7 +94,7 @@ class Image implements JsonSerializable {
 		$image->archive_id   = $data['SystemIdentifier'];
 		$image->title        = $data['Title'];
 		$image->caption      = $data['Caption'];
-		$image->credit       = trim( $data['copyright'] ?? '' );
+		$image->credit       = trim( $data['CoreField.Copyright'] ?? '' );
 		$image->restrictions = $data['restrictions'] ?? [];
 		$image->sizes        = ImageSize::all_from_api_response( $data );
 


### PR DESCRIPTION
As a part of [#49](https://github.com/greenpeace/planet4-plugin-medialibrary/pull/49)

![Screenshot 2023-01-23 at 11 52 18](https://user-images.githubusercontent.com/77975803/214070431-98b74365-f04e-45f0-a773-91c17cd69af8.png)

