### PR TITLE
PLANET-7027: Fix tag listing page

### DIFF
--- a/tag.php
+++ b/tag.php
@@ -41,26 +41,10 @@ if ( is_tag() ) {
 
 		$templates = [ 'tag.twig', 'archive.twig', 'index.twig' ];
 
-		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-		$posts = get_posts(
-			[
-				'posts_per_page'   => 1,
-				'offset'           => 0,
-				'post_parent'      => $explore_page_id,
-				'post_type'        => 'page',
-				'post_status'      => 'publish',
-				'suppress_filters' => false,
-				'tag_slug__in'     => [ $context['tag']->slug ],
-			]
-		);
-
-		$context['custom_body_classes'] = 'white-bg page-issue-page';
-		$context['category_name']       = $posts[0]->post_title ?? '';
-		$context['category_link']       = isset( $posts[0] ) ? get_permalink( $posts[0] ) : '';
-		$context['tag_name']            = single_tag_title( '', false );
-		$context['tag_description']     = wpautop( $context['tag']->description );
-		$context['tag_image']           = get_term_meta( $context['tag']->term_id, 'tag_attachment', true );
-		$tag_image_id                   = get_term_meta( $context['tag']->term_id, 'tag_attachment_id', true );
+		$context['tag_name']        = single_tag_title( '', false );
+		$context['tag_description'] = wpautop( $context['tag']->description );
+		$context['tag_image']       = get_term_meta( $context['tag']->term_id, 'tag_attachment', true );
+		$tag_image_id               = get_term_meta( $context['tag']->term_id, 'tag_attachment_id', true );
 
 		$context['og_description'] = $context['tag_description'];
 		if ( $tag_image_id ) {
@@ -80,6 +64,23 @@ if ( is_tag() ) {
 			$campaign->view();
 			exit();
 		}
+
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		$posts = get_posts(
+			[
+				'posts_per_page'   => 1,
+				'offset'           => 0,
+				'post_parent'      => $explore_page_id,
+				'post_type'        => 'page',
+				'post_status'      => 'publish',
+				'suppress_filters' => false,
+				'tag_slug__in'     => [ $context['tag']->slug ],
+			]
+		);
+
+		$context['custom_body_classes'] = 'white-bg page-issue-page';
+		$context['category_name']       = $posts[0]->post_title ?? '';
+		$context['category_link']       = isset( $posts[0] ) ? get_permalink( $posts[0] ) : '';
 
 		$campaign = new TaxonomyCampaign( $templates, $context );
 


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-7027

## About the issue
This issue has been reported by Greenpeace Denmark.
 
Here is a very useful description taken from the ticket:
> Sup! It seems I need your help debugging the
> listing pages. We may lack to do something for them to work, but I can’t
> tell what. We are redirecting the tags for FI and NO right now, but I’d
> prefer implementing/piloting the listing pages.
> 
> What I did so far:
> I enabled the “Use the new paginated tag, category, author, post & action
> type listing pages.” option.
> Randomly selected the Fiskeri (37) tag to test with. Initially it only
> showed the title/description.
> Toggled the IA setting off/on again like proper IT. It then started
> showing the <li> elements, but they remain empty of content.
> Reproduced the issue on other tag pages. (see link to Energi down below)
> Confirmed author listing pages work. (the elements are dramatically
> oversized, but listing does work, see author link down below)

## Testing
I've set the [current branch to their repository](https://github.com/greenpeace/planet4-denmark/blob/main/composer-local.json#L7) and validate directly against [their dev instance](https://www-dev.greenpeace.org/denmark/tag/fiskeri/).

Example page of the current issue: https://www-dev.greenpeace.org/international/tag/consumption/

## To Do
Don't forget to update their repository whenever this fix is merged.