### PR TITLE
PLANET-7029 Add default action type, if no action type added

### DIFF
--- a/src/ActionPage.php
+++ b/src/ActionPage.php
@@ -272,7 +272,7 @@ class ActionPage {
 		wp_dropdown_categories(
 			[
 				'hide_empty' => 0,
-				'taxonomy'   => 'action-type',
+				'taxonomy'   => self::TAXONOMY,
 				'selected'   => $value,
 				'name'       => 'p4_default_action_type',
 				'id'         => 'p4_default_action_type',

--- a/src/Migrations/M016CreateDefaultActionType.php
+++ b/src/Migrations/M016CreateDefaultActionType.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace P4\MasterTheme\Migrations;
+
+use P4\MasterTheme\MigrationRecord;
+use P4\MasterTheme\MigrationScript;
+use P4\MasterTheme\ActionPage;
+
+/**
+ * If No Action type added, Create "Petitions" (with slug petitions) Action type and set it as the default.
+ */
+class M016CreateDefaultActionType extends MigrationScript {
+	private const DEFAULT_ACTION_TYPE      = 'Petitions';
+	private const DEFAULT_ACTION_TYPE_SLUG = 'petitions';
+
+	/**
+	 * Perform the actual migration.
+	 *
+	 * @param MigrationRecord $record Information on the execution, can be used to add logs.
+	 *
+	 * @return void
+	 */
+	protected static function execute( MigrationRecord $record ): void {
+
+		// Get planet4 action type taxonomy terms.
+		$action_terms = get_terms(
+			[
+				'fields'     => 'all',
+				'hide_empty' => false,
+				'taxonomy'   => ActionPage::TAXONOMY,
+			]
+		);
+
+		if ( 0 === count( $action_terms ) ) {
+			// Insert new action type term.
+			$new_action_type = wp_insert_term(
+				self::DEFAULT_ACTION_TYPE,
+				ActionPage::TAXONOMY,
+				[
+					'slug' => self::DEFAULT_ACTION_TYPE_SLUG,
+				]
+			);
+			if ( ! is_wp_error( $new_action_type ) && isset( $new_action_type['term_id'] ) ) {
+				$term_id = $new_action_type['term_id'];
+				// Update default action type.
+				update_option( 'p4_default_action_type', $term_id );
+			}
+		}
+	}
+}

--- a/src/Migrator.php
+++ b/src/Migrator.php
@@ -17,6 +17,7 @@ use P4\MasterTheme\Migrations\M012RemoveThemeEditorOption;
 use P4\MasterTheme\Migrations\M013RemoveDuplicatedOptions;
 use P4\MasterTheme\Migrations\M014RemoveDropdownNavigationMenusOption;
 use P4\MasterTheme\Migrations\M015RemoveListingPagesBackgroundImage;
+use P4\MasterTheme\Migrations\M016CreateDefaultActionType;
 
 
 /**
@@ -51,6 +52,7 @@ class Migrator {
 			M013RemoveDuplicatedOptions::class,
 			M014RemoveDropdownNavigationMenusOption::class,
 			M015RemoveListingPagesBackgroundImage::class,
+			M016CreateDefaultActionType::class,
 		];
 
 		// Loop migrations and run those that haven't run yet.


### PR DESCRIPTION
Ref. https://jira.greenpeace.org/browse/PLANET-7029

**Testing:** 
- Ensure the action post type is action on local, and No action type terms.
- To run the migration script on local env. connect to PHP container
`make php-shell`
- Run migration script - `wp p4-run-activator`
-  Check action type terms - The "Petitions" action term is added and set as default.

The migration script tested on [test-umbriel](https://www-dev.greenpeace.org/test-umbriel/wp-admin/edit-tags.php?taxonomy=action-type&post_type=p4_action) instance. (The test-oberon instance was updated in first commit of PR)