### PR TITLE
Add rel="me" on footer social icon links

### DIFF
--- a/templates/footer_social_media.twig
+++ b/templates/footer_social_media.twig
@@ -24,7 +24,7 @@
           {% endif %}
         {% endfor %}
         <li>
-          <a href="{{ social.url }}"
+          <a href="{{ social.url }}" rel="me"
             data-ga-category="Footer Navigation"
             data-ga-action="Social Icons"
             data-ga-label="{{ social.title }}">


### PR DESCRIPTION
This is being used by some social media platforms to verify website url.

### Testing

Just verify that all links for footer social media icons now also contain `rel="me"` as part of the `href` tag.

Already deployed on eu-unit website since they were eager to test it out. And the website link looks verified now in their [Mastodon profile page](https://eupolicy.social/@GreenpeaceEU).
