### PR TITLE
Enable Opengraph metadata for tag listing pages

### DIFF
--- a/languages/planet4-master-theme-backend.pot
+++ b/languages/planet4-master-theme-backend.pot
@@ -792,10 +792,6 @@ msgstr ""
 msgid "Listing page pagination"
 msgstr ""
 
-#: src/Features/HideListingPagesBackground.php:25
-msgid "Listing pages background"
-msgstr ""
-
 #: assets/src/js/Components/ArchivePicker.js:74
 msgid "Loading..."
 msgstr ""
@@ -1149,10 +1145,6 @@ msgstr ""
 
 #: src/Settings.php:316
 msgid "Reject all cookies"
-msgstr ""
-
-#: src/Features/HideListingPagesBackground.php:32
-msgid "Remove background image and skewed overlay on all listing pages."
 msgstr ""
 
 #: src/Role/Reviewer.php:17

--- a/tag.php
+++ b/tag.php
@@ -44,7 +44,13 @@ if ( is_tag() ) {
 
 		$context['og_description'] = $context['tag_description'];
 		if ( $tag_image_id ) {
-			$context['og_image_data'] = wp_get_attachment_image_src( $tag_image_id, 'full' );
+			$tag_image = wp_get_attachment_image_src( $tag_image_id, 'full' );
+
+			$context['og_image_data'] = [
+				'url'    => $tag_image[0],
+				'width'  => $tag_image[1],
+				'height' => $tag_image[2],
+			];
 		}
 		$context['page_category'] = 'Tag Page';
 

--- a/templates/blocks/meta_fields.twig
+++ b/templates/blocks/meta_fields.twig
@@ -1,4 +1,4 @@
-{% if ((post and (1 != fn('post_password_required', post))) or author is defined) %}
+{% if ((post and (1 != fn('post_password_required', post))) or author is defined) or tag_name is defined %}
 	{% if (author.description is defined and author.description) %}
 		{% set meta_description = author.description|striptags %}
 	{% elseif (post.post_excerpt is defined and post.post_excerpt) %}


### PR DESCRIPTION
This adds metadata tags on Tag auto-generated listing pages. Adjusted also the relevant context variables to get [proper values](https://developer.wordpress.org/reference/functions/wp_get_attachment_image_src/) for url and size.

### Testing

- While on `main` branch, remove the redirection page from any tag and then check the frontend source code. Opengraph metadata are completely missing so the image selected on Tag edit is not being used anywhere.
- Switch to this branch and refresh. Now you should be seing proper `og:image` meta tag on the frontend source code.