### PR TITLE
PLANET-7056 Change form attributes to enforce Ajax submission

### DIFF
--- a/src/GravityFormsExtensions.php
+++ b/src/GravityFormsExtensions.php
@@ -101,6 +101,7 @@ class GravityFormsExtensions {
 		add_filter( 'gform_confirmation_settings_fields', [ $this, 'p4_gf_confirmation_settings' ], 10, 3 );
 		add_filter( 'gform_confirmation', [ $this, 'p4_gf_custom_confirmation' ], 10, 3 );
 		add_filter( 'gform_field_css_class', [ $this, 'p4_gf_custom_field_class' ], 10, 3 );
+		add_filter( 'gform_form_args', [ $this, 'p4_gf_enforce_ajax' ], 10, 3 );
 	}
 
 	/**
@@ -308,5 +309,19 @@ class GravityFormsExtensions {
 			$classes .= ' custom-control';
 		}
 		return $classes;
+	}
+
+	/**
+	 *
+	 * Enforces Ajax submission on all forms.
+	 *
+	 * @param array $form_args form arguments when adding it to a page/post.
+	 *
+	 * @return array The updated form arguments.
+	 */
+	public function p4_gf_enforce_ajax( $form_args ) {
+		$form_args['ajax'] = true;
+
+		return $form_args;
 	}
 }


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-7056
Ref: https://docs.gravityforms.com/gform_form_args/

---

Using `gform_form_args` to enforce Ajax submission.
Leaving the filter introduced at [this commit](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/commit/121f22428c1c457d3482a8e048b4237fe233370b) intact, since it's needed for visually changing the toggle option in the editor.

### Testing

This can be tested by adding a form to a page and submitting it while having he Network tab in the Browser Web Console open. Looking at the requests on submission before and after the change, it should be obcious that before this fix the page is being reloaded on submission.