### PR TITLE
PLANET-7055 Setup Playwright

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,8 @@ tests/backstop/
 
 # Built css and js assets
 assets/build/*
+
+# Playwright
+/e2e-results/
+/e2e-report/
+/playwright/.cache/

--- a/package-lock.json
+++ b/package-lock.json
@@ -2543,6 +2543,24 @@
       "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
       "dev": true
     },
+    "@playwright/test": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.30.0.tgz",
+      "integrity": "sha512-SVxkQw1xvn/Wk/EvBnqWIq6NLo1AppwbYOjNLmyU0R1RoQ3rLEBtmjTnElcnz8VEtn11fptj1ECxK0tgURhajw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "playwright-core": "1.30.0"
+      },
+      "dependencies": {
+        "playwright-core": {
+          "version": "1.30.0",
+          "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.30.0.tgz",
+          "integrity": "sha512-7AnRmTCf+GVYhHbLJsGUtskWTE33SwMZkybJ0v6rqR1boxq2x36U7p1vDRV7HO2IwTZgmycracLxPEJI49wu4g==",
+          "dev": true
+        }
+      }
+    },
     "@popperjs/core": {
       "version": "2.4.4",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.4.4.tgz",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "author": "Greenpeace International",
   "license": "MIT",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
     "start": "wp-scripts start --config webpack.config.js",
     "build": "wp-scripts build --config webpack.config.js --mode production",
     "lint:css": "wp-scripts lint-style"
@@ -13,6 +12,7 @@
   "devDependencies": {
     "@commitlint/cli": "^12.1.1",
     "@greenpeace/dashdash": "^1.1.2",
+    "@playwright/test": "^1.30.0",
     "@wordpress/components": "^8.3.2",
     "@wordpress/scripts": "3.3.0",
     "autoprefixer": "^9.6.1",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,101 @@
+const { devices } = require('@playwright/test');
+
+/**
+ * @see https://playwright.dev/docs/test-configuration
+ */
+const config = {
+  testDir: './tests/e2e',
+  /* Maximum time one test can run for. */
+  timeout: 30 * 1000,
+  expect: {
+    /**
+     * Maximum time expect() should wait for the condition to be met.
+     * For example in `await expect(locator).toHaveText();`
+     */
+    timeout: 5000
+  },
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: [['html', { outputFolder: 'e2e-report' }]],
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
+    actionTimeout: 0,
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    baseURL: 'http://www.planet4.test',
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+      },
+    },
+
+    {
+      name: 'firefox',
+      use: {
+        ...devices['Desktop Firefox'],
+      },
+    },
+
+    {
+      name: 'webkit',
+      use: {
+        ...devices['Desktop Safari'],
+      },
+    },
+
+    /* Test against mobile viewports. */
+    // {
+    //   name: 'Mobile Chrome',
+    //   use: {
+    //     ...devices['Pixel 5'],
+    //   },
+    // },
+    // {
+    //   name: 'Mobile Safari',
+    //   use: {
+    //     ...devices['iPhone 12'],
+    //   },
+    // },
+
+    /* Test against branded browsers. */
+    // {
+    //   name: 'Microsoft Edge',
+    //   use: {
+    //     channel: 'msedge',
+    //   },
+    // },
+    // {
+    //   name: 'Google Chrome',
+    //   use: {
+    //     channel: 'chrome',
+    //   },
+    // },
+  ],
+
+  /* Folder for test artifacts such as screenshots, videos, traces, etc. */
+  outputDir: 'e2e-results/',
+
+  /* Run your local dev server before starting the tests */
+  // webServer: {
+  //   command: 'npm run start',
+  //   port: 3000,
+  // },
+};
+
+module.exports = config;

--- a/tests/e2e/404.spec.js
+++ b/tests/e2e/404.spec.js
@@ -1,0 +1,22 @@
+const { test, expect } = require('@playwright/test');
+
+test('check the 404 page', async ({ page }) => {
+  const response = await page.goto('/thispagereallywillnotexist');
+
+  // Check the page status.
+  expect(response.status()).toEqual(404);
+
+  // Check the page text.
+  const settingsText = await page.evaluate('window.p4bk_vars.page_text_404');
+  await expect(settingsText).toBeDefined();
+  const pageContent = await page.locator('.speech-bubble').innerHTML();
+  await expect(pageContent).toContain(settingsText.replace(/[\r]/g, ''));
+
+  // Check the page image background.
+  const settingsImage = await page.evaluate('window.p4bk_vars.page_bg_image_404');
+  await expect(settingsImage).toBeDefined();
+  await expect(page.locator('.page-header-background img')).toHaveAttribute('src', settingsImage);
+
+  // Make sure the search input is there.
+  await expect(page.locator('input[aria-label="Search"]')).toBeVisible();
+});

--- a/tests/e2e/cookies-banner.spec.js
+++ b/tests/e2e/cookies-banner.spec.js
@@ -1,0 +1,20 @@
+const { test, expect } = require('@playwright/test');
+
+test('check cookies banner', async ({ page }) => {
+  await page.goto('/');
+
+  // Check that cookies banner is present.
+  const cookiesBanner = page.locator('#set-cookie');
+  await expect(cookiesBanner).toBeVisible();
+
+  // Check that the text is the one from the P4 settings.
+  const cookiesText = await page.evaluate('window.p4bk_vars.cookies_field');
+  await expect(cookiesText).toBeDefined();
+  await expect(cookiesBanner.locator('.cookies-text')).toHaveText(cookiesText);
+
+  // Accept all cookies.
+  await cookiesBanner.getByText('Accept all cookies').click();
+
+  // Check that the cookies banner disappears.
+  await expect(cookiesBanner).toBeHidden();
+});


### PR DESCRIPTION
### Description

See [PLANET-7055](https://jira.greenpeace.org/browse/PLANET-7055)

**Related PR:** https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/1001

### Testing

On local, run `npm install` to install Playwright and its needed dependencies, and then to run the tests you can use the following commands:
- `npx playwright test` for all tests
- `npx playwright test tests/e2e/404.spec.js` for individual tests