### PR TITLE
PLANET-7050: Fix classic listing pages UI

### DIFF
--- a/templates/author.twig
+++ b/templates/author.twig
@@ -25,8 +25,8 @@
             {{ query_loop|raw }}
         {% else %}
             <div class="row">
-                <div class="col-lg-8 multiple-search-result">
-                    <ul class="list-unstyled">
+                <div class="is-layout-flow wp-block-query wp-block-query--list">
+                    <ul class="is-layout-flow wp-block-post-template">
                         {% for post in posts %}
                             {% include 'tease-author.twig' %}
                         {% endfor %}

--- a/templates/taxonomy.twig
+++ b/templates/taxonomy.twig
@@ -1,7 +1,6 @@
 {% extends "base.twig" %}
 
 {% block content %}
-
     <div class="clearfix"></div>
     <div class="skewed-overlay"></div>
 
@@ -22,8 +21,8 @@
             <h3>{{ __( 'Results', 'planet4-master-theme' ) }}</h3>
 
             <div class="row">
-                <div class="col-lg-8 multiple-search-result">
-                    <ul class="list-unstyled">
+                <div class="is-layout-flow wp-block-query wp-block-query--list">
+                    <ul class="is-layout-flow wp-block-post-template">
                         {% for post in posts %}
                             {% include 'tease-taxonomy-post.twig' %}
                         {% endfor %}

--- a/templates/tease-author.twig
+++ b/templates/tease-author.twig
@@ -1,60 +1,73 @@
-<li id="result-row-{{ post.ID }}" class="d-flex search-result-list-item">
-    {% include "blocks/image.twig" with {post:post, dummy_thumbnail:dummy_thumbnail} %}
+<li id="result-row-{{ post.ID }}" class="wp-block-post post-{{ post.ID }} post type-post status-publish format-standard hentry">
+    <article class="query-list-item">
+        <div class="query-list-item-image query-list-item-image-max-width">
+        <a href="{{ post.link() }}">
+            {{ fn('get_the_post_thumbnail', post.ID, null, {'sizes': '(min-width: 1600px) 389px, (min-width: 1200px) 335px, (min-width: 1000px) 281px, (min-width: 780px) 209px, (min-width: 580px) 516px, calc(100vw - 24px)', 'data-ga-category': data_ga_category ?? 'Articles List', 'data-ga-action': "Image", 'data-ga-label': "n/a", 'alt': fn('esc_attr', post.thumbnail_alt|default( post.post_title )|striptags ) })|raw }}
+        </a>
+        </div>
 
-    <div id="tease-{{ post.ID }}" class="search-result-item-body tease tease-{{ post.post_type }}">
-        <div class="search-result-tags top-page-tags">
-            {% for page_type in post.get_custom_terms %}
-                <a
-                    href="{{ fn('get_term_link', page_type.term_id, 'p4-page-type') }}"
-                    class="search-result-item-head no-btn tag-item tag-item--main page-type"
-                    data-ga-category="Articles List"
-                    data-ga-action="Post Type Tag"
-                    data-ga-label="n/a">
-                        {{ page_type.name|e('wp_kses_post')|raw }}
-                </a>
-            {% endfor %}
+        <div id="tease-{{ post.ID }}" class="query-list-item-body">
+            <div class="query-list-item-post-terms">
+                <div class="wrapper-post-term">
+                {% for page_type in post.get_custom_terms %}
+                    <div class="taxonomy-p4-page-type wp-block-post-terms">
+                    <a
+                        href="{{ fn('get_term_link', page_type.term_id, 'p4-page-type') }}"
+                        data-ga-category="Articles List"
+                        data-ga-action="Post Type Tag"
+                        data-ga-label="n/a">
+                            {{ page_type.name|e('wp_kses_post')|raw }}
+                    </a>
+                    </div>
+                {% endfor %}
+                </div>
 
-            {% if ( post.get_custom_terms and post.tags ) %}
-                <span class="tag-wrap-bullet" aria-hidden="true">&#8226;</span>
-            {% endif %}
-
-            {% if (post.tags) %}
-                <div class="tag-wrap tags">
+                {% if (post.tags) %}
+                <div class="wrapper-post-tag">
+                    <div class="taxonomy-post_tag wp-block-post-terms">
+                    {% apply spaceless %}
                     {% for tag in post.tags %}
                         <a
                             href="{{ tag.link }}"
-                            class="search-result-item-tag tag-item tag"
                             data-ga-category="Articles List"
                             data-ga-action="Navigation Tag"
-                            data-ga-label="n/a">
-                                <span aria-label="hashtag">#</span>{{ tag.name|e('wp_kses_post')|raw }}
+                            data-ga-label="n/a"
+                            rel="tag">{{ tag.name|e('wp_kses_post')|raw }}
                         </a>
+                        </a><span class="wp-block-post-terms__separator">, </span>
                     {% endfor %}
+                    {% endapply %}
+                    </div>
                 </div>
-            {% endif %}
+                {% endif %}
+            </div>
+
+            <header>
+                <h4 class="query-list-item-headline wp-block-post-title">
+                <a
+                    href="{{ post.link() }}"
+                    data-ga-category="Articles List"
+                    data-ga-action="Title"
+                    data-ga-label="n/a">
+                        {{ post.title|e('wp_kses_post')|raw }}
+                </a>
+                </h4>
+            </header>
+
+            <div class="query-list-item-content wp-block-post-excerpt">
+                <p class="wp-block-post-excerpt__excerpt">{{ post.post_excerpt|excerpt( 30 )|e('wp_kses_post')|raw }}</p>
+            </div>
+
+            <div class="query-list-item-meta d-flex">
+                <span class="wp-block-post-date">{{ post.post_date|date }}</span>
+                {% set reading_time = post.reading_time %}
+                {% if reading_time %}
+                    <span class="article-list-item-readtime">
+                        {{ __( '%d min read', 'planet4-master-theme' )|format(reading_time) }}
+                    </span>
+                {% endif %}
+            </div>
+
         </div>
-
-        <a
-            href="{{ post.link() }}"
-            class="search-result-item-headline"
-            data-ga-category="Articles List"
-            data-ga-action="Title"
-            data-ga-label="n/a">
-                {{ post.title|e('wp_kses_post')|raw }}
-        </a>
-
-        <p class="search-result-item-content">{{ post.post_excerpt|excerpt( 30 )|e('wp_kses_post')|raw }}</p>
-
-        <div class="search-result-item-info">
-            <span class="search-result-item-date">{{ post.post_date|date }}</span>
-            {% set reading_time = post.reading_time %}
-            {% if reading_time %}
-                <span class="single-post-meta-bullet" aria-hidden="true">&#8226;</span>
-                <span class="single-post-meta-readtime">
-                    {{ __( '%d min read', 'planet4-master-theme' )|format(reading_time) }}
-                </span>
-            {% endif %}
-        </div>
-
-    </div>
+    </article>
 </li>

--- a/templates/tease-taxonomy-post.twig
+++ b/templates/tease-taxonomy-post.twig
@@ -1,69 +1,83 @@
-<li id="result-row-{{ post.ID }}" class="d-flex search-result-list-item">
-    {% include "blocks/image.twig" with {post:post, dummy_thumbnail:dummy_thumbnail} %}
+<li id="result-row-{{ post.ID }}" class="wp-block-post post-{{ post.ID }} post type-post status-publish format-standard hentry">
+    <article class="query-list-item">
+        <div class="query-list-item-image query-list-item-image-max-width">
+        <a href="{{ post.link() }}">
+            {{ fn('get_the_post_thumbnail', post.ID, null, {'sizes': '(min-width: 1600px) 389px, (min-width: 1200px) 335px, (min-width: 1000px) 281px, (min-width: 780px) 209px, (min-width: 580px) 516px, calc(100vw - 24px)', 'data-ga-category': data_ga_category ?? 'Articles List', 'data-ga-action': "Image", 'data-ga-label': "n/a", 'alt': fn('esc_attr', post.thumbnail_alt|default( post.post_title )|striptags ) })|raw }}
+        </a>
+        </div>
 
-    <div id="tease-{{ post.ID }}" class="search-result-item-body tease tease-{{ post.post_type }}">
-        <div class="search-result-tags top-page-tags">
-            {% if (post.page_types is not empty) %}
-                <a
-                    href="{{ fn('get_term_link', post.page_types.0.term_id) }}"
-                    class="search-result-item-head no-btn tag-item tag-item--main page-type"
-                    data-ga-category="Articles List"
-                    data-ga-action="Post Type Tag"
-                    data-ga-label="n/a">
-                        {{ post.get_page_types.0.name|e('wp_kses_post')|raw }}
-                </a>
-            {% endif %}
+        <div id="tease-{{ post.ID }}" class="query-list-item-body">
+            <div class="query-list-item-post-terms">
+                {% if (post.page_types is not empty) %}
+                <div class="wrapper-post-term">
+                    <div class="taxonomy-p4-page-type wp-block-post-terms">
+                    <a
+                        href="{{ fn('get_term_link', post.page_types.0.term_id) }}"
+                        data-ga-category="Articles List"
+                        data-ga-action="Post Type Tag"
+                        data-ga-label="n/a"
+                        rel="tag">
+                            {{ post.get_page_types.0.name|e('wp_kses_post')|raw }}
+                    </a>
+                    </div>
+                </div>
+                {% endif %}
 
-            {% if ( (post.page_types is not empty) and post.tags ) %}
-                <span class="tag-wrap-bullet" aria-hidden="true">&#8226;</span>
-            {% endif %}
-
-            {% if (post.tags) %}
-                <div class="tag-wrap tags">
+                {% if (post.tags) %}
+                <div class="wrapper-post-tag">
+                    <div class="taxonomy-post_tag wp-block-post-terms">
+                    {% apply spaceless %}
                     {% for tag in post.tags %}
                         <a
                             href="{{ tag.link }}"
-                            class="search-result-item-tag tag-item tag"
                             data-ga-category="Articles List"
                             data-ga-action="Navigation Tag"
-                            data-ga-label="n/a">
-                            <span aria-label="hashtag">#</span>{{ tag.name|e('wp_kses_post')|raw }}
-                        </a>
+                            data-ga-label="n/a"
+                            rel="tag">{{ tag.name|e('wp_kses_post')|raw }}
+                        </a><span class="wp-block-post-terms__separator">, </span>
                     {% endfor %}
+                    {% endapply %}
+                    </div>
                 </div>
-            {% endif %}
+                {% endif %}
+            </div>
+
+            <header>
+                <h4 class="query-list-item-headline wp-block-post-title">
+                <a
+                    href="{{ post.link() }}"
+                    data-ga-category="Articles List"
+                    data-ga-action="Title"
+                    data-ga-action-label="n/a">
+                        {{ post.title|e('wp_kses_post')|raw }}
+                </a>
+                </h4>
+            </header>
+
+            <div class="query-list-item-content wp-block-post-excerpt">
+                <p class="wp-block-post-excerpt__excerpt">{{ post.post_excerpt|excerpt( 30 )|e('wp_kses_post')|raw }}</p>
+            </div>
+
+            <div class="query-list-item-meta d-flex">
+                {% if ( post.author ) %}
+                    <span class="article-list-item-author">
+                        {% if not ( post.get_author_override ) %}
+                            <a href="{{ post.author.path }}">{{ post.author }}</a>
+                        {% else %}
+                            {{ post.author.name }}
+                        {% endif %}
+                    </span>
+                <span class="query-list-item-bullet" aria-hidden="true">•</span>
+                {% endif %}
+                <span class="wp-block-post-date">{{ post.post_date|date }}</span>
+                {% set reading_time = post.reading_time %}
+                {% if reading_time %}
+                    <span class="article-list-item-readtime">
+                        {{ __( '%d min read', 'planet4-master-theme' )|format(reading_time) }}
+                    </span>
+                {% endif %}
+            </div>
+
         </div>
-
-        <a
-            href="{{ post.link() }}"
-            class="search-result-item-headline"
-            data-ga-category="Articles List"
-            data-ga-action="Title"
-            data-ga-label="n/a">
-                {{ post.title|e('wp_kses_post')|raw }}
-        </a>
-
-        <p class="search-result-item-content">{{ post.post_excerpt|excerpt( 30 )|e('wp_kses_post')|raw }}</p>
-
-        <div class="search-result-item-info">
-            {% if ( post.author ) %}
-                <span class="search-result-item-author">
-                    {% if not ( post.get_author_override ) %}
-                        <a href="{{ post.author.path }}">{{ post.author }}</a>
-                    {% else %}
-                        {{ post.author.name }}
-                    {% endif %}
-                </span>
-            {% endif %}
-            <span class="search-result-item-date">{{ post.post_date|date }}</span>
-            {% set reading_time = post.reading_time %}
-            {% if reading_time %}
-                <span class="single-post-meta-bullet" aria-hidden="true">&#8226;</span>
-                <span class="single-post-meta-readtime">
-                    {{ __( '%d min read', 'planet4-master-theme' )|format(reading_time) }}
-                </span>
-            {% endif %}
-        </div>
-
-    </div>
+    </article>
 </li>

--- a/tests/test-category-page.php
+++ b/tests/test-category-page.php
@@ -55,7 +55,7 @@ class CategoryPageTest extends P4TestCase
 
         // Test tag markup.
         $this->assertContainsSelector(
-            'a.search-result-item-tag',
+            '.taxonomy-post_tag > a',
             $output,
             'The template does not contain tag markup'
         );
@@ -63,7 +63,7 @@ class CategoryPageTest extends P4TestCase
         // Test page type markup.
         $this->assertElementContains(
             'Story',
-            'a.page-type',
+            '.taxonomy-p4-page-type > a',
             $output,
             'The template does not contain page type markup'
         );
@@ -92,14 +92,18 @@ class CategoryPageTest extends P4TestCase
 
         // Test tag markup.
         $this->assertContainsSelector(
-            'a.search-result-item-tag',
+            '.taxonomy-post_tag > a',
             $output,
             'The template does not contain tag markup'
         );
 
         // Test page type markup.
         // Should assert true, every post gets a p4 page type term assigned to it.
-        $this->assertContainsSelector('a.page-type', $output, 'Did not find an image in the page body.');
+        $this->assertContainsSelector(
+            '.taxonomy-p4-page-type a',
+            $output,
+            'Did not find a page type in the page body.'
+        );
     }
 
     /**
@@ -131,7 +135,7 @@ class CategoryPageTest extends P4TestCase
         );
 
         // Test that contains 10 posts in the markup.
-        $this->assertSelectorCount(10, 'li.search-result-list-item', $output);
+        $this->assertSelectorCount(10, 'li.wp-block-post', $output);
     }
 
     /**
@@ -143,7 +147,6 @@ class CategoryPageTest extends P4TestCase
     {
 
         return [
-
             'post_with_category_tag_custom_term' => [
                 'post_type' => 'post',
                 'post_title' => 'The name of the place is Babylon',


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-7050

> On listing pages, the post loop UI looks different depending on whether pagination is turned on from Planet 4 > Information architecture. When pagination is on the UI seems to follow the new designs, but when it's off at least the thumbnails are using different aspect ratio.
> Requirements
> - Fix template UI so listing pages look identical regardless of pagination feature flag.
> - This has been verified at least for Author and Category listing page, but potentially affects all listing pages.


Fix classic listing page to match new IA design.

## Fix

Match classic listing structure with HTML structure of new IA listing.

<table>
<tr>
<td><img src="https://user-images.githubusercontent.com/617346/218490658-7517091f-ad34-4b54-a7fd-336ba4d559e3.png" /></td>
<td><img src="https://user-images.githubusercontent.com/617346/218490651-0dc72104-3399-456c-a704-7000f7f6c82d.png" /></td>
</tr></table>

## Test

On Venus, check [Categories](https://www-dev.greenpeace.org/test-venus/story/) and [Authors](https://www-dev.greenpeace.org/test-venus/author/amelekou/) pages with and without the option _Planet 4 > Navigation > New Information Architecture_ activated.
