### PR TITLE
Fix PHP error on custom taxonomy

### DIFF
--- a/src/Campaigns.php
+++ b/src/Campaigns.php
@@ -57,10 +57,10 @@ class Campaigns
     /**
      * Add custom field(s) to taxonomy form.
      *
-     * @param WP_Term $wp_tag The object passed to the callback when on Edit Tag page.*
+     * @param WP_Term|string $wp_tag The object passed to the callback when on Edit Tag page.*
      * phpcs:disable Generic.Files.LineLength.MaxExceeded
      */
-    public function add_taxonomy_form_fields(WP_Term $wp_tag): void
+    public function add_taxonomy_form_fields($wp_tag): void
     {
         $this->page_types = get_terms(
             [

--- a/src/CustomTaxonomy.php
+++ b/src/CustomTaxonomy.php
@@ -512,10 +512,10 @@ class CustomTaxonomy
     /**
      * Add "Reading time" option to p4-page-type taxonomy.
      *
-     * @param WP_Term $term Current taxonomy term object.
+     * @param WP_Term|string $term Current taxonomy term object.
      * phpcs:disable Generic.Files.LineLength.MaxExceeded
      */
-    public function add_taxonomy_form_fields(WP_Term $term): void
+    public function add_taxonomy_form_fields($term): void
     {
         $use_reading_time = $term instanceof WP_Term
             ? get_term_meta($term->term_id, self::READING_TIME_FIELD, true)


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6967

Following [PHP coding standards](https://github.com/greenpeace/planet4-master-theme/pull/1880) PR

PHP error on `add_taxonomy_form_fields()` with `$term` type when adding new taxonomy (Posts Types, Page Tags, Action tags).

![Screenshot from 2023-02-03 18-18-43](https://user-images.githubusercontent.com/617346/216666416-2410ccf2-bb9a-4e8d-b586-05789ae1d329.png)

