### PR TITLE
Fix PHP error on pages rest endpoint

### DIFF
--- a/page.php
+++ b/page.php
@@ -35,7 +35,7 @@ use Timber\Timber;
 
 $context = Timber::get_context();
 $post = new Post(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-$page_meta_data = get_post_meta($post->ID);
+$page_meta_data = get_post_meta($post->ID) ?: [];
 $page_meta_data = array_map(fn($v) => reset($v), $page_meta_data);
 
 // Ensure redirect is only performed if we're not already on a tag URL. Because tag.php includes this file.

--- a/src/PostReportController.php
+++ b/src/PostReportController.php
@@ -2,6 +2,8 @@
 
 namespace P4\MasterTheme;
 
+use WP_REST_Request;
+
 /**
  * Class PostReportController
  */
@@ -38,12 +40,12 @@ class PostReportController
     /**
      * Add extra date column in post rest endpoint.
      *
-     * @param array $args Arguments array passed to endpoint.
-     * @param array $request Initial request parameters to the endpoint.
+     * @param array           $args    Array of arguments for WP_Query.
+     * @param WP_REST_Request $request The REST API request.
      *
      * @return mixed
      */
-    public function add_posts_param_to_endpoint(array $args, array $request)
+    public function add_posts_param_to_endpoint(array $args, WP_REST_Request $request)
     {
         if (! isset($request['before']) && ! isset($request['after'])) {
             return $args;


### PR DESCRIPTION
Fix error on pages rest endpoint
-  Fix type hint on second parameter for hook `rest_page_query`
Cf. Sentry issue https://sentry.greenpeace.org/organizations/greenpeace-org/issues/1323/?project=2&query=is%3Aunresolved

Fix error exception on page  
- Fix type hint on Request object
Cf. https://sentry.greenpeace.org/organizations/greenpeace-org/issues/1126/?project=2&query=is%3Aunresolved
