### PR TITLE
PLANET-7020 Add new site identity feature toggle

### DIFF
--- a/assets/src/scss/base/_css-variables.scss
+++ b/assets/src/scss/base/_css-variables.scss
@@ -1,0 +1,12 @@
+:root {
+  --body--font-family: #{$lora};
+  --headings--font-family: #{$roboto};
+  --headings--font-weight: bold;
+  --body--background-color: #{$white};
+  --body--color: #{$grey-80};
+  --link--color: #{$link-color};
+  --link--hover--color: #{$link-color};
+  --link--text-decoration: none;
+  --link--hover--text-decoration: underline;
+  --link--visited--color: #{$link-color-visited};
+}

--- a/assets/src/scss/base/_variables.scss
+++ b/assets/src/scss/base/_variables.scss
@@ -30,17 +30,3 @@ $sp-6x: space(6.5);
 $sp-7: space(7);
 $sp-7x: space(7.5);
 $sp-8: space(8);
-
-// Variables
-:root {
-  --body--font-family: #{$lora};
-  --headings--font-family: #{$roboto};
-  --headings--font-weight: bold;
-  --body--background-color: #{$white};
-  --body--color: #{$grey-80};
-  --link--color: #{$link-color};
-  --link--hover--color: #{$link-color};
-  --link--text-decoration: none;
-  --link--hover--text-decoration: underline;
-  --link--visited--color: #{$link-color-visited};
-}

--- a/assets/src/scss/editorOverrides.scss
+++ b/assets/src/scss/editorOverrides.scss
@@ -279,3 +279,7 @@ input.describe[type=text][data-setting=caption] {
     margin-bottom: $sp-1;
   }
 }
+
+.customize-control[id*="new_identity_styles"] label {
+  display: inline;
+}

--- a/assets/src/scss/editorStyle.scss
+++ b/assets/src/scss/editorStyle.scss
@@ -22,3 +22,6 @@
 @import "layout/gravity-forms";
 
 @import "editorOverrides";
+
+// CSS variables
+@import "base/css-variables";

--- a/assets/src/scss/new-identity/style.scss
+++ b/assets/src/scss/new-identity/style.scss
@@ -1,0 +1,3 @@
+:root {
+  --body--color: #1c1c1c;
+}

--- a/assets/src/scss/style.scss
+++ b/assets/src/scss/style.scss
@@ -73,3 +73,6 @@ Text Domain: planet4-master-theme
 @import "vendors/usabilla";
 @import "vendors/gtm";
 @import "~lite-youtube-embed";
+
+// CSS variables
+@import "base/css-variables";

--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -14,6 +14,7 @@ use Twig_Markup;
 use Twig_SimpleFilter;
 use WP_Error;
 use WP_Post;
+use WP_Customize_Control;
 
 /**
  * Class MasterSite.
@@ -248,14 +249,27 @@ class MasterSite extends TimberSite
         // Make post tags ordered.
         add_filter('register_taxonomy_args', [ $this, 'set_post_tags_as_ordered' ], 10, 2);
 
-        // Disable CSS Customizer.
         add_action(
             'customize_register',
             function ($wp_customize): void {
+                // Add new site identity styles toggle.
+                $wp_customize->add_setting('new_identity_styles', [ 'default' => false ]);
+                $wp_customize->add_control(new WP_Customize_Control(
+                    $wp_customize,
+                    'new_identity_styles',
+                    array(
+                        'label' => __('Enable new Greenpeace visual identity', 'planet4-master-theme'),
+                        'settings' => 'new_identity_styles',
+                        'type' => 'checkbox',
+                        'section' => 'title_tagline',
+                    )
+                ));
+
                 if (!defined('WP_APP_ENV') || ( 'production' !== WP_APP_ENV && 'staging' !== WP_APP_ENV )) {
                     return;
                 }
 
+                // Disable CSS Customizer.
                 $wp_customize->remove_control('custom_css');
             }
         );
@@ -867,6 +881,17 @@ class MasterSite extends TimberSite
     public function enqueue_editor_assets(): void
     {
         Loader::enqueue_versioned_style('assets/build/editorStyle.min.css', 'planet4-editor-style');
+
+        $new_identity_styles = get_theme_mod('new_identity_styles');
+        if (!$new_identity_styles) {
+            return;
+        }
+
+        Loader::enqueue_versioned_style(
+            '/assets/build/new_identity_styles.min.css',
+            'new_identity_styles',
+            []
+        );
     }
 
     /**

--- a/src/PublicAssets.php
+++ b/src/PublicAssets.php
@@ -77,6 +77,7 @@ final class PublicAssets
 
         self::conditionally_load_partials();
         self::load_blocks_assets();
+        self::load_new_identity_styles();
     }
 
     /**
@@ -141,6 +142,23 @@ final class PublicAssets
                     ? Loader::enqueue_versioned_script($file, $handle)
                     : Loader::enqueue_versioned_style($file, $handle);
             }
+        );
+    }
+
+    /**
+     * Load any CSS for the new identity styles if the corresponding setting is on.
+     */
+    private static function load_new_identity_styles(): void
+    {
+        $new_identity_styles = get_theme_mod('new_identity_styles');
+        if (!$new_identity_styles) {
+            return;
+        }
+
+        Loader::enqueue_versioned_style(
+            '/assets/build/new_identity_styles.min.css',
+            'new_identity_styles',
+            []
         );
     }
 }

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -516,6 +516,7 @@ class Settings
         add_filter('cmb2_render_category_select_taxonomy', [ $this, 'p4_render_category_dropdown' ], 10, 2);
         add_filter('cmb2_render_pagetype_select_taxonomy', [ $this, 'p4_render_pagetype_dropdown' ], 10, 2);
         add_action('admin_enqueue_scripts', [ $this, 'enqueue_admin_assets' ]);
+        add_action('admin_init', [$this, 'add_new_identity_styles_toggle_value']);
 
         // Make settings multilingual if wpml plugin is installed and activated.
         if (function_exists('is_plugin_active') && is_plugin_active('sitepress-multilingual-cms/sitepress.php')) {
@@ -775,5 +776,18 @@ class Settings
             Loader::theme_file_ver('admin/css/options.css')
         );
         wp_enqueue_style('options-style');
+    }
+
+    /**
+     * Add new identity styles toggle value.
+     */
+    public function add_new_identity_styles_toggle_value(): void
+    {
+        $settings = get_option(self::KEY);
+
+        update_option(
+            self::KEY,
+            array_merge($settings, ['new_identity_styles' => get_theme_mod('new_identity_styles')])
+        );
     }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -29,6 +29,7 @@ module.exports = {
     "navigation-bar-dark": './assets/src/scss/partials/navigation-bar-dark.scss',
     "navigation-bar-light": './assets/src/scss/partials/navigation-bar-light.scss',
     "gravity-forms": './assets/src/scss/layout/_gravity-forms.scss',
+    new_identity_styles: './assets/src/scss/new-identity/style.scss',
     archive_picker: './assets/src/js/archive_picker.js',
     "lite-yt-embed": './node_modules/lite-youtube-embed/src/lite-yt-embed.js',
     menu_editor: './assets/src/js/menu_editor.js',


### PR DESCRIPTION
### Description

See [PLANET-7020](https://jira.greenpeace.org/browse/PLANET-7020) & [PLANET-6984](https://jira.greenpeace.org/browse/PLANET-6984)

### Testing

When checking the new site identity toggle in `Appearance > Customize > Site identity`, you should see in the frontend and in the editor that the new value of `--body--color` is applied (#1c1c1c instead of #020202). You'll need to also use [this branch](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/1014) from the blocks plugin to see the change applied properly. 