### PR TITLE
PLANET-7073: Fix custom taxonomy pagination

### DIFF
--- a/src/CustomTaxonomy.php
+++ b/src/CustomTaxonomy.php
@@ -350,7 +350,9 @@ class CustomTaxonomy
 
         if ($terms_slugs) {
             foreach ($terms_slugs as $slug) {
-                $rules[ $slug . '/?$' ] = 'index.php?' . self::TAXONOMY . '=' . $slug;
+                $rules[ $slug . '(/page/([0-9]+)?)?/?$' ] = 'index.php?'
+                    . self::TAXONOMY . '=' . $slug
+                    . '&paged=$matches[2]';
             }
         }
 


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-7073

> Posts listing page pagination redirects to an article that has a title which starts with the same number

## Fix
Pagination handling is missing from the rewrite rule for Custom taxonomy.  
Adding pagination to rewrite rules fixes the issue.

## Test

Locally, using the `query-monitor` plugin simplifies debugging the matching rules
```
wp install --activate query-monitor
```

![Screenshot from 2023-02-08 14-30-21](https://user-images.githubusercontent.com/617346/217545254-5bc2dade-7992-4992-93d7-800fd0910a9c.png)


On [Oberon](https://www-dev.greenpeace.org/test-oberon/press-release/page/3/), check Posts Types listing pages and their pagination.