### PR TITLE
PLANET-7005: Analytics sidebar in native UI

### DIFF
--- a/assets/src/scss/editorOverrides.scss
+++ b/assets/src/scss/editorOverrides.scss
@@ -175,6 +175,12 @@
     text-transform: none;
   }
 
+  .components-input-control__label {
+    font-size: 13px !important;
+    font-weight: bold !important;
+    text-transform: none !important;
+  }
+
   // By default all but the first .component-base-control have margin-bottom, causing weird spacing.
   .components-base-control {
     margin-bottom: 0;

--- a/src/ActionPage.php
+++ b/src/ActionPage.php
@@ -24,6 +24,10 @@ class ActionPage
         'p4_og_image',
         'p4_og_image_id',
         'p4_seo_canonical_url',
+        'p4_campaign_name',
+        'p4_local_project',
+        'p4_basket_name',
+        'p4_department',
     ];
 
     /**

--- a/src/AnalyticsValues.php
+++ b/src/AnalyticsValues.php
@@ -335,6 +335,24 @@ final class AnalyticsValues
     }
 
     /**
+     * Analytics baskets
+     */
+    public function basket_options(): array
+    {
+        return [
+            'not set' => __('- Select Basket -', 'planet4-master-theme-backend'),
+            'Forests' => 'Forests',
+            'Oceans' => 'Oceans',
+            'Good Life' => 'Good Life',
+            'Food' => 'Food',
+            'Climate &amp; Energy' => 'Climate & Energy',
+            'Oil' => 'Oil',
+            'Plastics' => 'Plastics',
+            'Political &amp; Business' => 'Political & Business',
+        ];
+    }
+
+    /**
      * Look up a project by its name and get its ID.
      *
      * @param string $global_project_name The unique name of the project.

--- a/src/MetaboxRegister.php
+++ b/src/MetaboxRegister.php
@@ -38,7 +38,6 @@ class MetaboxRegister
     public function register_p4_meta_box(): void
     {
         $this->register_meta_box_post();
-        $this->register_meta_box_campaign();
     }
 
     /**
@@ -97,90 +96,6 @@ class MetaboxRegister
     }
 
     /**
-     * Register Campaign Information meta box.
-     */
-    public function register_meta_box_campaign(): void
-    {
-        $post_types = [ 'page', 'campaign', 'post' ];
-        $analytics_values = AnalyticsValues::from_cache_or_api_or_hardcoded();
-
-        // P4 Datalayer/Campaign fields.
-        $p4_campaign_fields = new_cmb2_box(
-            [
-                'id' => 'p4_campaign_fields',
-                'title' => __('Analytics & Tracking', 'planet4-master-theme-backend'),
-                'object_types' => $post_types, // Post type.
-                'closed' => true, // Keep the metabox closed by default.
-                'context' => 'side', // show cmb2box in right sidebar.
-                'priority' => 'low',
-                'show_names' => false, // Hide the labels.
-            ]
-        );
-
-        $global_project_options = self::maybe_add_current_post_value(
-            $analytics_values->global_projects_options(),
-            'p4_campaign_name'
-        );
-
-        $p4_campaign_fields->add_field(
-            [
-                'name' => __('Global Project', 'planet4-master-theme-backend'),
-                'id' => 'p4_campaign_name',
-                'type' => 'select',
-                'options' => $global_project_options,
-                'attributes' => [
-                    'data-validation' => 'required',
-                ],
-            ]
-        );
-
-        $local_projects_options = self::maybe_add_current_post_value(
-            $analytics_values->local_projects_options(),
-            'p4_local_project'
-        );
-        $p4_campaign_fields->add_field(
-            [
-                'name' => __('Local Projects', 'planet4-master-theme-backend'),
-                'id' => 'p4_local_project',
-                'type' => 'select',
-                'options' => $local_projects_options,
-            ]
-        );
-
-        $basket_options = [
-            'not set' => __('- Select Basket -', 'planet4-master-theme-backend'),
-            'Forests' => 'Forests',
-            'Oceans' => 'Oceans',
-            'Good Life' => 'Good Life',
-            'Food' => 'Food',
-            'Climate &amp; Energy' => 'Climate & Energy',
-            'Oil' => 'Oil',
-            'Plastics' => 'Plastics',
-            'Political &amp; Business' => 'Political & Business',
-        ];
-
-        $p4_campaign_fields->add_field(
-            [
-                'name' => __('Basket Name', 'planet4-master-theme-backend'),
-                'id' => 'p4_basket_name',
-                'type' => 'select',
-                'options' => $basket_options,
-            ]
-        );
-
-        $p4_campaign_fields->add_field(
-            [
-                'name' => __('Department', 'planet4-master-theme-backend'),
-                'id' => 'p4_department',
-                'type' => 'text_medium',
-                'attributes' => [
-                    'placeholder' => __('Add Department', 'planet4-master-theme-backend'),
-                ],
-            ]
-        );
-    }
-
-    /**
      * Look up the ID of the global campaign and save it on the post.
      *
      * @param bool       $updated Whether the field is being updated.
@@ -200,40 +115,5 @@ class MetaboxRegister
 
         $project_id = AnalyticsValues::from_cache_or_api_or_hardcoded()->get_id_for_global_project($field->value());
         update_post_meta($field->object_id, 'p4_global_project_tracking_id', $project_id);
-    }
-
-    /**
-     * If the post has a value that is not in the sheet, keep it in the dropdown so that metaboxes save doesn't set
-     * it to another value, but mark it with `[DEPRECATED]` prefix.
-     *
-     * @param array  $options_array The list of supported global/local projects.
-     * @param string $field_name The meta field name.
-     * @return array The list with maybe the current post value.
-     */
-    private static function maybe_add_current_post_value(array $options_array, string $field_name): array
-    {
-        // Not pretty but will work for now.
-		// phpcs:disable WordPress.Security.NonceVerification.Recommended
-        $post_id = $_GET['post'] ?? null;
-        if (! $post_id) {
-            return $options_array;
-        }
-
-        $current_post_meta_value = get_post_meta($post_id, $field_name);
-
-        if (
-            isset($current_post_meta_value[0])
-            && ! ( array_key_exists(
-                $current_post_meta_value[0],
-                $options_array
-            ) )
-        ) {
-            $options_array = [
-                $current_post_meta_value[0] => __('[DEPRECATED] ', 'planet4-master-theme-backend')
-                    . $current_post_meta_value[0],
-            ] + $options_array;
-        }
-
-        return $options_array;
     }
 }

--- a/src/PageMeta.php
+++ b/src/PageMeta.php
@@ -24,6 +24,10 @@ class PageMeta
         'p4_og_image',
         'p4_og_image_id',
         'p4_seo_canonical_url',
+        'p4_campaign_name',
+        'p4_local_project',
+        'p4_basket_name',
+        'p4_department',
     ];
 
     /**

--- a/src/PostCampaign.php
+++ b/src/PostCampaign.php
@@ -19,6 +19,9 @@ class PostCampaign
 
     public const META_FIELDS = [
         'p4_campaign_name',
+        'p4_local_project',
+        'p4_basket_name',
+        'p4_department',
         'theme',
         'campaign_logo',
         'campaign_logo_color',

--- a/src/PostMeta.php
+++ b/src/PostMeta.php
@@ -15,6 +15,10 @@ class PostMeta
         'p4_og_image',
         'p4_og_image_id',
         'p4_seo_canonical_url',
+        'p4_campaign_name',
+        'p4_local_project',
+        'p4_basket_name',
+        'p4_department',
     ];
 
     /**


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-7005
Requires: https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/1005

> As we recently moved Opengraph and Page Header option on the sidebar, it's a good opportunity to refactor Analytics section too to match the same UI.

This PR :
- removes the Metabox for Analytics & tracking
- adds relevant fields to meta fields declaration, so that they are readable/editable through the REST API used by our Sidebar system