### PR TITLE
PLANET-7020 Add new site identity feature toggle

### DIFF
--- a/assets/src/scss/new-identity/style.scss
+++ b/assets/src/scss/new-identity/style.scss
@@ -1,0 +1,3 @@
+:root {
+  --body--color: #1c1c1c;
+}

--- a/src/Features/NewIdentityStyles.php
+++ b/src/Features/NewIdentityStyles.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace P4\MasterTheme\Features;
+
+use P4\MasterTheme\Feature;
+use P4\MasterTheme\Settings\ExperimentalFeatures;
+
+/**
+ * @see description().
+ */
+class NewIdentityStyles extends Feature
+{
+    /**
+     * @inheritDoc
+     */
+    public static function id(): string
+    {
+        return 'new_identity_styles';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected static function name(): string
+    {
+        return __('New identity styles', 'planet4-master-theme-backend');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected static function description(): string
+    {
+        return __(
+            'Enable new Greenpeace visual identity',
+            'planet4-master-theme-backend'
+        );
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected static function options_key(): string
+    {
+        return ExperimentalFeatures::OPTIONS_KEY;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function show_toggle_production(): bool
+    {
+        return true;
+    }
+}

--- a/src/PublicAssets.php
+++ b/src/PublicAssets.php
@@ -2,6 +2,8 @@
 
 namespace P4\MasterTheme;
 
+use P4\MasterTheme\Features\NewIdentityStyles;
+
 /**
  * Wrapper class for the enqueue function because we can't autoload functions.
  */
@@ -77,6 +79,7 @@ final class PublicAssets
 
         self::conditionally_load_partials();
         self::load_blocks_assets();
+        self::load_new_identity_styles();
     }
 
     /**
@@ -103,6 +106,23 @@ final class PublicAssets
         Loader::enqueue_versioned_style(
             '/assets/build/post.min.css',
             'post-type--post',
+            [ 'parent-style' ]
+        );
+    }
+
+    /**
+     * Load any CSS for the new identity styles if the corresponding setting is on.
+     */
+    private static function load_new_identity_styles(): void
+    {
+        $new_identity_styles = NewIdentityStyles::is_active();
+        if (!$new_identity_styles) {
+            return;
+        }
+
+        Loader::enqueue_versioned_style(
+            '/assets/build/new_identity_styles.min.css',
+            'new_identity_styles',
             [ 'parent-style' ]
         );
     }

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -5,6 +5,7 @@ namespace P4\MasterTheme;
 use CMB2_Field;
 use P4\MasterTheme\Settings\Comments;
 use P4\MasterTheme\Settings\Features;
+use P4\MasterTheme\Settings\ExperimentalFeatures;
 
 /**
  * Class P4\MasterTheme\Settings
@@ -483,6 +484,7 @@ class Settings
             ],
             'planet4_settings_comments' => Comments::get_options_page(),
             'planet4_settings_features' => Features::get_options_page(),
+            'planet4_settings_experimental_features' => ExperimentalFeatures::get_options_page(),
             'planet4_settings_notifications' => [
                 'title' => 'Notifications',
                 'fields' => [

--- a/src/Settings/ExperimentalFeatures.php
+++ b/src/Settings/ExperimentalFeatures.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+namespace P4\MasterTheme\Settings;
+
+use P4\MasterTheme\Features\NewIdentityStyles;
+use P4\MasterTheme\Features\PurgeOnFeatureChanges;
+use P4\MasterTheme\Loader;
+use P4\MasterTheme\Settings;
+use P4\MasterTheme\CloudflarePurger;
+use CMB2;
+
+/**
+ * Experimental features.
+ */
+class ExperimentalFeatures
+{
+    public const OPTIONS_KEY = 'planet4_experimental_features';
+
+    /**
+     * @var bool Purge Cloudflare cache on save
+     */
+    public static bool $purge_cloudflare = false;
+
+    /**
+     * Register current options status before processing, to detect any change later.
+     *
+     * @var array $preprocess_fields
+     */
+    public static array $preprocess_fields = [];
+
+    /**
+     * Get the features options page settings.
+     *
+     * @return array Settings for the options page.
+     */
+    public static function get_options_page(): array
+    {
+        return [
+            'title' => 'Experimental features',
+            'description' => __('These features are experiments or work in progress.', 'planet4-master-theme-backend'),
+            'root_option' => self::OPTIONS_KEY,
+            'fields' => self::get_fields(),
+            'add_scripts' => static function (): void {
+                Loader::enqueue_versioned_script('/admin/js/features_save_redirect.js');
+            },
+        ];
+    }
+
+    /**
+     * Add hooks related to Experimental Features activation
+     */
+    public static function hooks(): void
+    {
+        // On field save.
+        add_action(
+            'cmb2_options-page_process_fields_' . Settings::METABOX_ID,
+            [self::class, 'on_pre_process'],
+            10,
+            2
+        );
+
+        add_action(
+            'cmb2_save_field',
+            [self::class, 'on_field_save'],
+            10,
+            4
+        );
+
+        // After all fields are saved.
+        add_action(
+            'cmb2_save_options-page_fields_' . Settings::METABOX_ID,
+            [self::class, 'on_features_saved'],
+            10,
+            4
+        );
+    }
+
+    /**
+     * Get form fields.
+     *
+     * @return array  The fields.
+     */
+    public static function get_fields(): array
+    {
+        return [
+            NewIdentityStyles::get_cmb_field(),
+        ];
+    }
+
+    /**
+     * Save options status on preprocess, to be compared later
+     *
+     * @param CMB2   $cmb       This CMB2 object.
+     * @param string $object_id The ID of the current object.
+     */
+    public static function on_pre_process(CMB2 $cmb, string $object_id): void
+    {
+        if (self::OPTIONS_KEY !== $object_id) {
+            return;
+        }
+
+        self::$preprocess_fields = array_merge(
+            ...array_map(
+                function ($f) use ($cmb) {
+                    /**
+                     * @var \CMB2_Field|bool $cmb_field
+                     */
+                    $cmb_field = $cmb->get_field($f['id']);
+
+                    if (!$cmb_field) {
+                        return [];
+                    }
+
+                    return [$f['id'] => $cmb_field->value()];
+                },
+                self::get_fields()
+            )
+        );
+    }
+
+    /**
+     * Hook running after field is saved
+     *
+     * @param string     $field_id The current field id paramater.
+     * @param bool       $updated  Whether the metadata update action occurred.
+     * @param string     $action   Action performed. Could be "repeatable", "updated", or "removed".
+     * @param CMB2_Field $field    This field object.
+     */
+    public static function on_field_save(string $field_id, bool $updated, string $action, object $field): void
+    {
+        // This requires a toggle because we may be hitting a sort of rate limit from the deploy purge alone.
+        // For now it's better to leave this off on test instances, to avoid purges failing on production because we hit
+        // the rate limit.
+        if (
+            !PurgeOnFeatureChanges::is_active() ||
+            !in_array($field_id, [NewIdentityStyles::id()], true) ||
+            $field->value() === self::$preprocess_fields[$field_id]
+        ) {
+            return;
+        }
+
+        self::$purge_cloudflare = true;
+    }
+
+    /**
+     * Hook running after all features are saved
+     */
+    public static function on_features_saved(): void
+    {
+        if (!self::$purge_cloudflare) {
+            return;
+        }
+
+        is_plugin_active('cloudflare/cloudflare.php') && (new CloudflarePurger())->purge_all();
+    }
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -29,6 +29,7 @@ module.exports = {
     "navigation-bar-dark": './assets/src/scss/partials/navigation-bar-dark.scss',
     "navigation-bar-light": './assets/src/scss/partials/navigation-bar-light.scss',
     "gravity-forms": './assets/src/scss/layout/_gravity-forms.scss',
+    new_identity_styles: './assets/src/scss/new-identity/style.scss',
     archive_picker: './assets/src/js/archive_picker.js',
     "lite-yt-embed": './node_modules/lite-youtube-embed/src/lite-yt-embed.js',
     menu_editor: './assets/src/js/menu_editor.js',


### PR DESCRIPTION
### Description

See [PLANET-7020](https://jira.greenpeace.org/browse/PLANET-7020) & [PLANET-6984](https://jira.greenpeace.org/browse/PLANET-6984)

**Notes:**
- there is [a draft PR](https://github.com/greenpeace/planet4-master-theme/pull/1914) to explore the possibility of adding this new toggle instead in `Appearance > Customize > Site identity` as it was preferred by the design team. However with that implementation I found it difficult to meet the other requirements, such as adding the value to `planet4_options` and purging the cache on change.
- there are 2 PRs ([theme](https://github.com/greenpeace/planet4-master-theme/pull/1920) and [blocks](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/1007)) for using the CSS variable `--body--color` in as many places as possible, so that the change made here for [PLANET-6984](https://jira.greenpeace.org/browse/PLANET-6984) applies everywhere needed in the frontend.

### Testing

When checking the new site identity toggle in `Planet 4 > Experimental features`, you should see in the frontend that the new value of `--body--color` is applied (#1c1c1c instead of #020202).