### PR TITLE
Fix type error on author page

### DIFF
--- a/author.php
+++ b/author.php
@@ -35,7 +35,7 @@ if (isset($wp_query->query_vars['author'])) {
 
     $context['page_category'] = 'Author Page';
 
-    $context['social_accounts'] = Post::filter_social_accounts($context['footer_social_menu']);
+    $context['social_accounts'] = Post::filter_social_accounts($context['footer_social_menu'] ?: []);
     $context['og_title'] = $author->name;
     $context['og_description'] = get_the_author_meta('description', $author->ID);
     $context['og_image_data'] = [

--- a/single-attachment.php
+++ b/single-attachment.php
@@ -22,6 +22,6 @@ $context = Timber::get_context();
  */
 $post = Timber::query_post(false, Post::class); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 $context['post'] = $post;
-$context['social_accounts'] = Post::filter_social_accounts($context['footer_social_menu']);
+$context['social_accounts'] = Post::filter_social_accounts($context['footer_social_menu'] ?: []);
 
 Timber::render([ 'single-' . $post->ID . '.twig', 'single-' . $post->post_type . '.twig', 'single.twig' ], $context);


### PR DESCRIPTION
Cf. https://sentry.greenpeace.org/organizations/greenpeace-org/issues/1381/?project=2&query=is%3Aunresolved Generates an error on some author pages like https://www-dev.gcef.ca/en/author/admin/ if no `footer_social_menu` is defined

