### PR TITLE
Fix some links hover/visited/active color

### DIFF
--- a/assets/src/scss/pages/_sitemap.scss
+++ b/assets/src/scss/pages/_sitemap.scss
@@ -5,8 +5,10 @@
     color: $grey-80;
     font-family: var(--headings--font-family);
 
-    &:visited {
-      color: $link-color-visited;
+    &:visited,
+    &:active,
+    &:hover {
+      color: inherit;
     }
   }
 

--- a/assets/src/scss/pages/post/_post.scss
+++ b/assets/src/scss/pages/post/_post.scss
@@ -39,6 +39,12 @@
 
   a {
     color: inherit;
+
+    &:visited,
+    &:active,
+    &:hover {
+      color: inherit;
+    }
   }
 }
 


### PR DESCRIPTION
### Description

These should always be the same color regardless of their state (I double-checked with the design team)

### Testing

You can see the broken versions on the GPI site:
- [Sitemap](https://www.greenpeace.org/international/sitemap/)
- [Post](https://www.greenpeace.org/international/press-release/58205/after-13-days-and-nearly-4000km-greenpeace-occupation-of-shell-oil-platform-ends-with-no-arrests/)

On local you can test the fixed versions in the Sitemap page and in any post.