### PR TITLE
Set CSS variables defaults and remove them from theme file

### DIFF
--- a/assets/src/scss/base/_variables.scss
+++ b/assets/src/scss/base/_variables.scss
@@ -1,9 +1,4 @@
 // Fonts
-:root {
-  --body--font-family: "Lora", serif;
-  --headings--font-family: "Roboto", sans-serif;
-}
-
 $roboto:     "Roboto", sans-serif;
 $lora:       "Lora", serif;
 
@@ -35,3 +30,17 @@ $sp-6x: space(6.5);
 $sp-7: space(7);
 $sp-7x: space(7.5);
 $sp-8: space(8);
+
+// Variables
+:root {
+  --body--font-family: $lora;
+  --headings--font-family: $roboto;
+  --headings--font-weight: bold;
+  --body--background-color: $white;
+  --body--color: $grey-80;
+  --link--color: $link-color;
+  --link--hover--color: $link-color;
+  --link--text-decoration: none;
+  --link--hover--text-decoration: underline;
+  --link--visited--color: $link-color-visited;
+}

--- a/assets/src/scss/base/_variables.scss
+++ b/assets/src/scss/base/_variables.scss
@@ -33,14 +33,14 @@ $sp-8: space(8);
 
 // Variables
 :root {
-  --body--font-family: $lora;
-  --headings--font-family: $roboto;
+  --body--font-family: #{$lora};
+  --headings--font-family: #{$roboto};
   --headings--font-weight: bold;
-  --body--background-color: $white;
-  --body--color: $grey-80;
-  --link--color: $link-color;
-  --link--hover--color: $link-color;
+  --body--background-color: #{$white};
+  --body--color: #{$grey-80};
+  --link--color: #{$link-color};
+  --link--hover--color: #{$link-color};
   --link--text-decoration: none;
   --link--hover--text-decoration: underline;
-  --link--visited--color: $link-color-visited;
+  --link--visited--color: #{$link-color-visited};
 }

--- a/assets/src/scss/components/_blockquote.scss
+++ b/assets/src/scss/components/_blockquote.scss
@@ -24,7 +24,6 @@ blockquote > p {
 blockquote > h5 {
   @include blockquote;
   font-family: var(--body--font-family);
-  color: $grey-80;
   font-size: $font-size-xxl;
 
   @include medium-and-up {
@@ -35,7 +34,6 @@ blockquote > h5 {
 blockquote > h6 {
   @include blockquote;
   font-family: var(--body--font-family);
-  color: $grey-80;
   font-size: $font-size-xl;
 
   @include medium-and-up {

--- a/assets/src/scss/components/_buttons.scss
+++ b/assets/src/scss/components/_buttons.scss
@@ -176,7 +176,7 @@ $donate-button-box-shadow: 0 2px 5px rgba(0, 0, 0, .25);
 .btn-donate {
   --button-donate-- {
     background: $orange;
-    color: $grey-80;
+    color: $white;
     min-width: 180px;
     padding: 2px 30px;
     box-shadow: $donate-button-box-shadow;
@@ -185,7 +185,7 @@ $donate-button-box-shadow: 0 2px 5px rgba(0, 0, 0, .25);
 
     &:hover {
       background: $orange-hover;
-      color: transparentize($grey-80, 0.2);
+      color: $white;
       box-shadow: $donate-button-box-shadow;
       border: 1px solid transparent;
     }
@@ -269,22 +269,22 @@ button.load-more-mt {
 
 .post-tag-button {
   _-- {
-    border-color: $link-color;
-    color: $link-color;
+    border-color: var(--link--color);
+    color: var(--link--color);
     background-color: $white;
     font-weight: 500;
 
     &:visited {
-      color: $link-color;
+      color: var(--link--color);
     }
 
     &:hover {
-      background-color: $link-color;
+      background-color: var(--link--color);
       color: $white;
     }
 
     &:active {
-      background-color: $link-color;
+      background-color: var(--link--color);
       color: $white;
     }
   }
@@ -304,7 +304,7 @@ button.load-more-mt {
     &:hover,
     &:active {
       background: $white;
-      color: $grey-80;
+      color: var(--body--color);
     }
   }
 }

--- a/assets/src/scss/editorOverrides.scss
+++ b/assets/src/scss/editorOverrides.scss
@@ -144,7 +144,7 @@
   background: $white;
   border-radius: 0;
   border: none;
-  color: $grey-80 !important;
+  color: var(--body--color) !important;
 }
 
 // The color picker cannot be configured to show a clear button without giving the ability to enter any color with its
@@ -268,7 +268,7 @@ input.describe[type=text][data-setting=caption] {
   flex-direction: column-reverse;
 
   .block-editor-block-patterns-list__item-title {
-    color: $grey-80;
+    color: var(--body--color);
     font-weight: bold;
     margin-bottom: $sp-1;
   }

--- a/assets/src/scss/editorStyle.scss
+++ b/assets/src/scss/editorStyle.scss
@@ -4,8 +4,8 @@
 @import "~bootstrap/scss/tooltip";
 @import "~bootstrap/scss/buttons";
 
-@import "base/variables";
 @import "base/colors";
+@import "base/variables";
 @import "base/palette";
 @import "base/functions";
 @import "base/mixins";

--- a/assets/src/scss/layout/_breadcrumbs.scss
+++ b/assets/src/scss/layout/_breadcrumbs.scss
@@ -13,7 +13,7 @@
     pointer-events: none;
     font-weight: 400;
     margin-inline-end: $sp-1;
-    color: $link-color;
+    color: var(--top-page-tags--tag-item--color, var(--link--color));
   }
 
   .tag-wrap-bullet {
@@ -22,11 +22,11 @@
 
   .tag-item {
     _-- {
-      color: $link-color;
+      color: var(--link--color);
       font-weight: 500;
 
       &:visited {
-        color: $link-color-visited;
+        color: var(--link--visited--color);
       }
     }
     display: inline-block;
@@ -46,7 +46,7 @@
     mask-size: contain;
     mask-position: center;
     background-repeat: no-repeat;
-    background-color: $link-color;
+    background-color: var(--top-page-tags--tag-item--color, var(--link--color));
     display: inline-block;
   }
 }

--- a/assets/src/scss/layout/_cookies-settings.scss
+++ b/assets/src/scss/layout/_cookies-settings.scss
@@ -18,7 +18,7 @@
 }
 
 .close-cookies-settings {
-  background-color: $grey-80;
+  background-color: var(--body--color);
   cursor: pointer;
   height: 16px;
   width: 16px;
@@ -77,7 +77,7 @@
 }
 
 .always-enabled {
-  background: $grey-80;
+  background: var(--body--color);
   color: white;
   font-weight: 700;
   border-radius: 4px;

--- a/assets/src/scss/layout/_cookies.scss
+++ b/assets/src/scss/layout/_cookies.scss
@@ -12,7 +12,6 @@
   border-top-right-radius: 4px;
   box-shadow: 0 0 12px rgba(0, 0, 0, 0.15);
   bottom: 0;
-  color: $grey-80;
 
   &.shown {
     opacity: 1;
@@ -54,7 +53,6 @@
   font-size: 14px;
   margin-bottom: $sp-3;
   font-weight: 400;
-  color: $grey-80;
   line-height: 1.5rem;
   width: 100%;
 }

--- a/assets/src/scss/layout/_country-selector.scss
+++ b/assets/src/scss/layout/_country-selector.scss
@@ -13,7 +13,7 @@
   }
 
   button:hover {
-    text-decoration: var(--link--hover--text-decoration, underline);
+    text-decoration: var(--link--hover--text-decoration);
   }
 
   button:focus {

--- a/assets/src/scss/layout/_forms.scss
+++ b/assets/src/scss/layout/_forms.scss
@@ -6,7 +6,7 @@
 
     &:not(:disabled) ~ .custom-control-description:hover:before,
     &:not(:disabled) ~ label:hover:before {
-      border-color: $grey-80;
+      border-color: var(--body--color);
     }
 
     & ~ .custom-control-description,
@@ -16,12 +16,11 @@
       font-family: var(--headings--font-family);
       font-size: $font-size-xxxs;
       line-height: 1rem;
-      color: $grey-80;
       display: inline-block;
       padding-inline-start: 36px;
 
       a {
-        color: $grey-80;
+        color: inherit;
         font-weight: bold;
       }
 
@@ -46,15 +45,15 @@
     &:checked ~ .custom-control-description,
     &:checked ~ label {
       &:before {
-        border-color: $grey-80;
+        border-color: var(--body--color);
       }
 
       &:after {
         content: "";
         position: absolute;
         transform: rotate(-45deg) scale(-1, 1);
-        border-bottom: 2px solid $grey-80;
-        border-right: 2px solid $grey-80;
+        border-bottom: 2px solid var(--body--color);
+        border-right: 2px solid var(--body--color);
         top: calc(((100% - 20px) / 2) + 5px);
         left: 4px;
         height: 8px;
@@ -84,7 +83,7 @@
 
     &:not(:disabled) ~ .custom-control-description:hover:before,
     &:not(:disabled) ~ label:hover:before {
-      border-color: $grey-80;
+      border-color: var(--body--color);
     }
 
     & ~ .custom-control-description,
@@ -94,11 +93,10 @@
       font-family: var(--headings--font-family);
       font-size: $font-size-sm;
       line-height: 1.25rem;
-      color: $grey-80;
       padding-inline-start: 36px;
 
       a {
-        color: $grey-80;
+        color: inherit;
         font-weight: bold;
       }
 
@@ -122,9 +120,9 @@
 
     &:checked ~ .custom-control-description:before,
     &:checked ~ label:before {
-      background: $grey-80;
+      background: var(--body--color);
       box-shadow: inset 0 0 0 2px $white;
-      border-color: $grey-80;
+      border-color: var(--body--color);
     }
   }
 }
@@ -142,7 +140,7 @@
   font-family: var(--headings--font-family);
   background-color: $white;
   border: 1px solid $grey-20;
-  color: $grey-80;
+  color: var(--body--color);
   padding: 0 16px;
   font-size: $font-size-sm;
 
@@ -162,7 +160,7 @@
 
   &:focus {
     box-shadow: 0 0 0 2px rgba(0, 109, 253, 0.4);
-    color: $grey-80;
+    color: var(--body--color);
     border-color: transparent;
     outline: 0;
   }

--- a/assets/src/scss/layout/_gravity-forms.scss
+++ b/assets/src/scss/layout/_gravity-forms.scss
@@ -1,5 +1,5 @@
-@import "../base/variables";
 @import "../base/colors";
+@import "../base/variables";
 @import "../base/mixins";
 @import "../base/fonts";
 @import "../base/typography";
@@ -77,7 +77,7 @@
 
   &.gfield_error {
     .gfield_label {
-      color: $grey-80;
+      color: var(--body--color);
     }
 
     input:not([type="file"]):not(:disabled),
@@ -88,7 +88,7 @@
       background-image: none;
 
       ~ label {
-        color: $grey-80;
+        color: var(--body--color);
       }
 
       &:focus {

--- a/assets/src/scss/layout/_navbar.scss
+++ b/assets/src/scss/layout/_navbar.scss
@@ -54,19 +54,15 @@ $navbar-default-height: 60px;
 
   .btn-donate {
     _-- {
-      background: $orange;
       border: none;
       box-shadow: none;
-      color: $white;
       font-size: inherit;
       min-width: 116px;
       padding: 2px 17px;
 
       &:hover {
-        background: $orange-hover;
         border: none;
         box-shadow: none;
-        color: $white;
       }
     }
 
@@ -168,19 +164,16 @@ $navbar-default-height: 60px;
   .nav-item {
     width: 100%;
     text-align: left;
-    color: $grey-80;
     margin-inline: 0;
 
     a.nav-link {
       --submenu-nav-link-- {
-        color: $grey-80;
+        color: var(--body--color);
         font-size: $font-size-sm;
         font-weight: 500;
 
         &:hover {
-          _-- {
-            color: $grey-80;
-          }
+          color: var(--body--color);
         }
       }
       text-decoration: none;

--- a/assets/src/scss/layout/_page-header.scss
+++ b/assets/src/scss/layout/_page-header.scss
@@ -24,7 +24,7 @@
 
 .page-header {
   _-- {
-    color: $grey-80;
+    color: var(--body--color);
     background: inherit;
     padding-top: 90px;
     padding-bottom: 0;

--- a/assets/src/scss/layout/_page-section.scss
+++ b/assets/src/scss/layout/_page-section.scss
@@ -1,7 +1,7 @@
 .page-section-header _-- {
   text-transform: none;
   color: inherit;
-  font-weight: var(--headings--font-weight, bold);
+  font-weight: var(--headings--font-weight);
   font-family: var(--headings--font-family);
   font-size: 2.5rem;
   margin-bottom: $sp-2;

--- a/assets/src/scss/layout/navbar/_burger-menu.scss
+++ b/assets/src/scss/layout/navbar/_burger-menu.scss
@@ -23,7 +23,7 @@ $transition-duration: .2s;
 .burger-menu {
   _-- {
     background: $white;
-    color: $grey-80;
+    color: var(--body--color);
     font-family: var(--headings--font-family);
   }
 
@@ -45,7 +45,7 @@ $transition-duration: .2s;
   }
 
   a.nav-link {
-    color: $grey-80;
+    color: var(--body--color);
     width: auto;
   }
 
@@ -126,8 +126,6 @@ $transition-duration: .2s;
     width: 100%;
     padding-top: $sp-1x;
     padding-bottom: $sp-1x;
-    background: $orange;
-    color: $white;
   }
 }
 
@@ -200,7 +198,7 @@ $transition-duration: .2s;
     background-color: currentColor;
     transform: rotate(-90deg);
     transition: transform 0.3s linear;
-    color: $grey-80;
+    color: var(--body--color);
   }
 
   &.collapsed {
@@ -219,7 +217,7 @@ $transition-duration: .2s;
   height: 16px;
   width: 16px;
   mask: url("../../images/cross.svg") 50% 50%/16px 16px no-repeat;
-  background-color: $grey-80;
+  background-color: var(--body--color);
   z-index: 5;
 
   @supports not (inset-inline-end: $sp-3) {

--- a/assets/src/scss/layout/navbar/_search.scss
+++ b/assets/src/scss/layout/navbar/_search.scss
@@ -1,5 +1,5 @@
 .nav-search-form {
-  background-color: var(--body--background-color, $white);
+  background-color: var(--body--background-color);
   border: none;
   border-top: 1px solid #c4c4c4;
   box-shadow: 0 2px 4px transparentize($black, 0.85);
@@ -78,7 +78,7 @@
   border: none;
   border-radius: unset;
   box-shadow: none;
-  color: var(--top-navigation--color, $grey-80);
+  color: var(--top-navigation--color, var(--body--color));
   display: inline-block;
   flex-grow: 1;
   font-size: $font-size-sm;

--- a/assets/src/scss/layout/navbar/languages.scss
+++ b/assets/src/scss/layout/navbar/languages.scss
@@ -128,7 +128,7 @@
     }
 
     a.nav-link {
-      color: $grey-80;
+      color: var(--body--color);
       display: inline-block;
       padding-inline: 16px 12px;
       text-decoration: none;
@@ -140,7 +140,7 @@
     }
 
     .current-language a::after {
-      background-color: $grey-80;
+      background-color: var(--body--color);
       content: "";
       float: right;
       height: 48px;

--- a/assets/src/scss/pages/_evergreen.scss
+++ b/assets/src/scss/pages/_evergreen.scss
@@ -9,7 +9,6 @@
     }
 
     h1 {
-      color: $grey-80;
       hyphens: none;
       line-height: 1.2;
     }

--- a/assets/src/scss/pages/_listing-page.scss
+++ b/assets/src/scss/pages/_listing-page.scss
@@ -76,7 +76,7 @@
   line-height: 25px;
 
   .wrapper-post-tag {
-    color: $link-color;
+    color: var(--link--color);
 
     a {
       display: inline-block;

--- a/assets/src/scss/pages/_sitemap.scss
+++ b/assets/src/scss/pages/_sitemap.scss
@@ -2,7 +2,7 @@
   margin-bottom: 100px;
 
   a {
-    color: $grey-80;
+    color: var(--body--color);
     font-family: var(--headings--font-family);
 
     &:visited,

--- a/assets/src/scss/pages/post/_article-content.scss
+++ b/assets/src/scss/pages/post/_article-content.scss
@@ -1,5 +1,4 @@
 .post-content {
-  color: $grey-80;
   margin: 24px 0;
   z-index: 3;
 

--- a/assets/src/scss/pages/post/_author-block.scss
+++ b/assets/src/scss/pages/post/_author-block.scss
@@ -78,7 +78,7 @@
   border: none;
   padding: 0;
   display: block;
-  color: $link-color;
+  color: var(--link--color);
 
   .show-less {
     display: none;
@@ -113,7 +113,7 @@
   }
 
   &:hover {
-    color: $link-color;
+    color: var(--link--hover--color);
 
     span {
       text-decoration: underline;

--- a/assets/src/scss/pages/post/_comments-block.scss
+++ b/assets/src/scss/pages/post/_comments-block.scss
@@ -19,7 +19,6 @@
 .single-comment-text {
   font-size: 16px;
   line-height: 1.5;
-  color: $grey-80;
   margin-bottom: 8px;
 }
 

--- a/assets/src/scss/pages/post/_post.scss
+++ b/assets/src/scss/pages/post/_post.scss
@@ -18,7 +18,6 @@
 }
 
 .page-header-title {
-  color: $grey-80;
   hyphens: none;
   max-width: none;
   margin-bottom: 8px;

--- a/assets/src/scss/pages/search/_filter-sidebar.scss
+++ b/assets/src/scss/pages/search/_filter-sidebar.scss
@@ -16,7 +16,7 @@
       padding: 11px $sp-4;
       text-transform: uppercase;
       text-decoration: none;
-      color: $grey-80;
+      color: var(--body--color);
       font-weight: bold;
       position: relative;
       font-size: $font-size-sm;
@@ -51,7 +51,7 @@
         &:after {
           content: "";
           position: absolute;
-          background-color: $grey-80;
+          background-color: var(--body--color);
           transition: transform 0.25s ease-out;
         }
 
@@ -130,7 +130,7 @@
       }
 
       &:hover {
-        color: $grey-80;
+        background: $orange-hover;
         cursor: pointer;
       }
 
@@ -144,11 +144,6 @@
         height: 48px;
         width: 150px;
         line-height: 48px;
-
-        &:hover {
-          background: $orange-hover;
-          color: $white;
-        }
       }
 
       &.disabled {

--- a/assets/src/scss/pages/search/_search-results.scss
+++ b/assets/src/scss/pages/search/_search-results.scss
@@ -105,7 +105,7 @@
     text-align: center;
     background: #97ed90;
     border-radius: 8px;
-    color: $grey-80;
+    color: var(--body--color);
     word-break: keep-all;
 
     &.search-results-alternative-label-mobile {
@@ -153,7 +153,7 @@
 
 .search-result-item-headline {
   font-size: 1.125rem;
-  color: $grey-80;
+  color: var(--body--color);
   text-decoration: none;
   font-weight: 500;
   display: block;
@@ -171,7 +171,7 @@
   &:visited,
   &:hover,
   &:active {
-    color: $grey-80;
+    color: inherit;
   }
 }
 
@@ -187,7 +187,6 @@
 }
 
 .search-result-item-content {
-  color: $grey-80;
   font-size: $font-size-sm;
   font-family: var(--body--font-family);
   line-height: 1.6;

--- a/assets/src/scss/partials/country-selector.scss
+++ b/assets/src/scss/partials/country-selector.scss
@@ -1,6 +1,6 @@
 @import "../base/mixins";
-@import "../base/variables";
 @import "../base/colors";
+@import "../base/variables";
 @import "../base/fonts";
 
 @import "../layout/country-selector";

--- a/assets/src/scss/partials/navigation-bar.scss
+++ b/assets/src/scss/partials/navigation-bar.scss
@@ -1,6 +1,6 @@
 @import "../base/mixins";
-@import "../base/variables";
 @import "../base/colors";
+@import "../base/variables";
 @import "../base/fonts";
 
 @import "../layout/navbar";

--- a/assets/src/scss/post.scss
+++ b/assets/src/scss/post.scss
@@ -1,5 +1,5 @@
-@import "base/variables";
 @import "base/colors";
+@import "base/variables";
 @import "base/fonts";
 @import "base/functions";
 @import "base/mixins";

--- a/assets/src/scss/style.scss
+++ b/assets/src/scss/style.scss
@@ -12,8 +12,8 @@ Text Domain: planet4-master-theme
 */
 
 // Base
-@import "base/variables";
 @import "base/colors";
+@import "base/variables";
 @import "base/palette";
 @import "base/functions";
 @import "base/mixins";

--- a/theme.json
+++ b/theme.json
@@ -3,45 +3,45 @@
   "version": 2,
   "styles": {
     "color": {
-      "background": "var(--body--background-color, #ffffff)",
-      "text": "var(--body--color, #020202)"
+      "background": "var(--body--background-color)",
+      "text": "var(--body--color)"
     },
     "typography": {
-      "fontFamily": "var(--body--font-family, Lora, serif)"
+      "fontFamily": "var(--body--font-family)"
     },
     "elements": {
       "heading": {
         "typography": {
-          "fontFamily": "var(--headings--font-family, Roboto, sans-serif)",
-          "fontWeight": "var(--headings--font-weight, bold)"
+          "fontFamily": "var(--headings--font-family)",
+          "fontWeight": "var(--headings--font-weight)"
         }
       },
       "link": {
         "color": {
-          "text": "var(--link--color, #006dfd)"
+          "text": "var(--link--color)"
         },
         "typography": {
-          "textDecoration": "var(--link--text-decoration, none)"
+          "textDecoration": "var(--link--text-decoration)"
         },
         ":hover": {
           "color": {
-            "text": "var(--link--hover--color, #006dfd)"
+            "text": "var(--link--hover--color)"
           },
           "typography": {
-            "textDecoration": "var(--link--hover--text-decoration, underline)"
+            "textDecoration": "var(--link--hover--text-decoration)"
           }
         },
         ":active": {
           "color": {
-            "text": "var(--link--hover--color, #006dfd)"
+            "text": "var(--link--hover--color)"
           },
           "typography": {
-            "textDecoration": "var(--link--hover--text-decoration, underline)"
+            "textDecoration": "var(--link--hover--text-decoration)"
           }
         },
         ":visited": {
           "color": {
-            "text": "var(--link--visited--color, #68009e)"
+            "text": "var(--link--visited--color)"
           }
         }
       }


### PR DESCRIPTION
### Description

This way we can override them more easily, and the theme file is clearer. It's also in preparation of [PLANET-6984](https://jira.greenpeace.org/browse/PLANET-6984) and other tickets related to the new identity, which should be faster to implement using CSS variables! In some cases I was able to completely remove the usage of `$grey-80` since it was applied from somewhere else anyway.

**Related PR:** https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/1007

### Testing

Everything should still look the same.