### PR TITLE
PLANET-7077: Featured img not picked up/ missing when sharing on socials

### DIFF
--- a/src/Post.php
+++ b/src/Post.php
@@ -345,7 +345,7 @@ class Post extends TimberPost
         $image_id = null;
         $image_metas = [ 'p4_og_image_id', '_thumbnail_id', 'background_image_id' ];
         foreach ($image_metas as $image_meta) {
-            if (isset($meta[ $image_meta ][0])) {
+            if (!empty($meta[ $image_meta ][0])) {
                 $image_id = $meta[ $image_meta ][0];
                 break;
             }


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-7077

> On some posts the set featured image is not picked up and missing when sharing on socials

The loop going through post images can return an empty result in some cases.

A request in DB `select * from wp_postmeta where meta_key = 'p4_og_image_id'` will return some rows with empty `meta_value`; in the current loop, `isset` will return true and `get_og_image()` will return nothing, even if a featured image (thumbnail_id) is set.