### PR TITLE
PLANET-6473 Add focus state to checkboxes and radio buttons

### DIFF
--- a/assets/src/scss/layout/_forms.scss
+++ b/assets/src/scss/layout/_forms.scss
@@ -4,6 +4,12 @@
     opacity: 0;
     pointer-events: none;
 
+    &:focus:focus-visible ~ label:before,
+    &:focus:focus-visible ~ .custom-control-description:before {
+      outline: 2px solid #99c3ff;
+      outline-offset: 1px;
+    }
+
     &:not(:disabled) ~ .custom-control-description:hover:before,
     &:not(:disabled) ~ label:hover:before {
       border-color: var(--body--color);
@@ -80,6 +86,12 @@
     position: absolute;
     pointer-events: none;
     opacity: 0;
+
+    &:focus:focus-visible ~ label:before,
+    &:focus:focus-visible ~ .custom-control-description:before {
+      outline: 2px solid #99c3ff;
+      outline-offset: 1px;
+    }
 
     &:not(:disabled) ~ .custom-control-description:hover:before,
     &:not(:disabled) ~ label:hover:before {


### PR DESCRIPTION
### Description

See [PLANET-6473](https://jira.greenpeace.org/browse/PLANET-6473)

**Note:** I've noticed that the Gravity Forms radio buttons are not working properly with the keyboard, I've opened a [bug ticket](https://jira.greenpeace.org/browse/PLANET-7085) to investigate that since it's not related to these style changes

### Testing

You can test the new focus styles on [this page](https://www-dev.greenpeace.org/test-rhea/new-focus-styles/), where I've added a Gravity Forms block and an EN form block with checkboxes and/or radio buttons. They should appear only for `:focus-visible`, for example when navigating with tabs.