### PR TITLE
Purge caches for posts that contain a form

### DIFF
--- a/src/GravityFormsExtensions.php
+++ b/src/GravityFormsExtensions.php
@@ -359,7 +359,7 @@ class GravityFormsExtensions
          *
          * @param array $post_types Array of post types to consider for cache clearing after form update
          */
-        $post_types = apply_filters('planet4_form_cache_purge_post_types', [ 'page', 'post', 'campaign' ]);
+        $post_types = apply_filters('planet4_form_cache_purge_post_types', [ 'page', 'post', 'campaign', 'p4_action' ]);
 
         // Get IDs of posts that contain the forms
         $posts_to_clear = $this->get_posts_by_gf_id($form['id'], $post_types);


### PR DESCRIPTION
Every time a Gravity Form is updated in wordpress, this will search all posts that contain the form and purge the page caches. It also works for posts that include the forms in a resuable block.

Some additional comments on the code choices:

- I added a filter to cutomize the post types searched for forms. That enables NROs to search custom post types they use in their child themes
- Updating the post is the most reliable way I could find to clear all caches, including Cloudflare. I couldn't find any side effects.
- I'm not sure if the functions are in the right place, mainly if `find_nested_blocks` should be in the `GravityFormsExtensions` class. It could be used in more general use cases, but for now isn't. Let me know if I should move it.
- I tried @lithrel's suggestion to use the block search implemented in the blocks plugin. In the end, I went back to the approach in this PR to use `WP_Query` and filter the form blocks by ID in code. Even though WP_Query isn't as versatile, for this particular use case it ended up being around 30x faster in my dev environment. Mostly due to the blocks plugin using regular expressions that seem to be slow in MySQL. The version using the blocks plugin search [can be found here](https://github.com/stduerre/planet4-master-theme/commit/b8d2bc9ddde41ab53be3b2e40d24deef12d67f8a) for comparison. It also [relies on this change in the blocks plugin](https://github.com/stduerre/planet4-plugin-gutenberg-blocks/commit/9280129293dc23c0f5f578e1ea3cefee4583a805) if anyone wants to test it. 


Ref: [When a GravityForm is updated, purge the page cache of pages that contain the form](https://github.com/greenpeace/planet4/issues/184)
