### PR TITLE
Decrease Google login font-size to fix overflow

### DIFF
--- a/admin/css/login.css
+++ b/admin/css/login.css
@@ -25,11 +25,6 @@ body.login h1 a {
   display: block;
 }
 
-body.login div#login form#loginform h3.galogin-or {
-  text-transform: uppercase;
-  font-weight: normal;
-}
-
 body.login div#login form#loginform {
   background: #e7e8ea;
 }
@@ -40,6 +35,10 @@ form#loginform p.galogin {
 
 form#loginform p.galogin a {
   line-height: initial;
+}
+
+form#loginform p.galogin .google-apps-header {
+  font-size: 0.7rem;
 }
 
 body.login #login_error, body.login .message, body.login .success {


### PR DESCRIPTION
This was probably caused by a recent plugin upgrade.

### Testing

#### Current login form

<img src="https://user-images.githubusercontent.com/939357/219599504-0a7773cc-afeb-4698-a61c-0d77219a5c6d.png" width="350">

#### Fixed login form

<img src="https://user-images.githubusercontent.com/939357/219599543-7acc0fb9-d63f-4ead-be20-e74794d00faa.png" width="350">