### PR TITLE
PLANET-7028 Add analytics feed meta on new GF form add

### DIFF
--- a/src/GravityFormsExtensions.php
+++ b/src/GravityFormsExtensions.php
@@ -179,6 +179,31 @@ class GravityFormsExtensions
         $form['is_active'] = '1';
 
         GFAPI::update_form($form);
+
+        // Default analytics feed meta.
+        $feed_meta = [
+            "feedName" => "Google Analytics",
+            "gaeventgoalid_thickbox" => "",
+            "gaeventgoal_thickbox" => "Submission: " . $form['title'],
+            "gaeventcategory_thickbox" => "",
+            "gaeventaction_thickbox" => "",
+            "gaeventlabel_thickbox" => "{form_title} ID: {form_id}",
+            "gaeventgoalid" => "",
+            "gaeventgoal" => "Submission: " . $form['title'],
+            "gaeventcategory" => "",
+            "gaeventaction" => "",
+            "gaeventlabel" => "{form_title} ID: {form_id}",
+            "gaeventvalue" => "",
+            "feed_condition_conditional_logic_object" => [],
+            "feed_condition_conditional_logic" => "0",
+            "select_goal" => "",
+            "feed_event_category" => "",
+            "feed_event_action" => "",
+            "feed_event_label" => "",
+            "conditionalLogic" => "",
+        ];
+
+        GFAPI::add_feed($form_id = $form['id'], $feed_meta, $addon_slug = 'gravityformsgoogleanalytics');
     }
 
     /**


### PR DESCRIPTION
Ref. https://jira.greenpeace.org/browse/PLANET-7028

**Testing:**
- Create a new GF form, the default feed called "Google Analytics" is created with value's specified in JIRA ticket
- On form submission, the 'formSubmission' dataLayer event will trigger (please check all 3 use case's, Confirmation type - Text, Page, Redirect)  - [example](https://www-dev.greenpeace.org/test-saturn/story/46528/test-page-redirect-dlv/)


