### PR TITLE
Fix PHP type errors

### DIFF
--- a/src/GravityFormsExtensions.php
+++ b/src/GravityFormsExtensions.php
@@ -261,12 +261,12 @@ class GravityFormsExtensions
      *
      * Return custom confirmation message for Gravity Forms.
      *
-     * @param string $confirmation The default confirmation message.
-     * @param array  $form The form properties.
+     * @param string|array $confirmation The default confirmation message.
+     * @param mixed        $form         The form properties.
      *
      * @return string The custom confirmation message.
      */
-    public function p4_gf_custom_confirmation(string $confirmation, array $form): string
+    public function p4_gf_custom_confirmation($confirmation, $form): string
     {
         // If the $confirmation object is an array, it means that it's a redirect page so we can directly use it.
         if (is_array($confirmation)) {

--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -1348,12 +1348,12 @@ class MasterSite extends TimberSite
     /**
      * Save custom media metadata fields
      *
-     * @param \WP_Post $post        The $post data for the attachment.
-     * @param array    $attachment  The $attachment part of the form $_POST ($_POST[attachments][postID]).
+     * @param array $post        The $post data for the attachment.
+     * @param array $attachment  The $attachment part of the form $_POST ($_POST[attachments][postID]).
      *
-     * @return \WP_Post $post
+     * @return array $post
      */
-    public function add_image_attachment_fields_to_save(\WP_Post $post, array $attachment): \WP_Post
+    public function add_image_attachment_fields_to_save(array $post, array $attachment): array
     {
         if (isset($attachment['credit_text'])) {
             update_post_meta($post['ID'], self::CREDIT_META_FIELD, $attachment['credit_text']);


### PR DESCRIPTION
Fix 2 type errors coming up in Sentry

Fix https://sentry.greenpeace.org/organizations/greenpeace-org/issues/1438/?project=2&query=is%3Aunresolved
Cf. https://docs.gravityforms.com/gform_confirmation/#parameters

Fix https://sentry.greenpeace.org/organizations/greenpeace-org/issues/1443/?project=2&query=is%3Aunresolved
Cf. https://developer.wordpress.org/reference/hooks/attachment_fields_to_save/#parameters
