### PR TITLE
PLANET-6959 Fix possible overflow in comment text

### DIFF
--- a/assets/src/scss/pages/post/_comments-block.scss
+++ b/assets/src/scss/pages/post/_comments-block.scss
@@ -20,6 +20,7 @@
   font-size: 16px;
   line-height: 1.5;
   margin-bottom: 8px;
+  overflow-wrap: break-word;
 }
 
 .single-comment-meta {


### PR DESCRIPTION
### Description

See [PLANET-6959](https://jira.greenpeace.org/browse/PLANET-6959)
We need this in case comments contain a really long word or URL

### Testing

You can compare the broken version [here](https://www.greenpeace.org/international/story/55533/amazon-rainforest-fires-2022-brazil-causes-climate/) to the fixed version [here](https://www-dev.greenpeace.org/test-pandora/story/52154/africa-waste-colonialism-plastic-treaty/#comment-33844).