### PR TITLE
PLANET-6977 Hide WPML footer language switcher

### DIFF
--- a/admin/css/wpml.css
+++ b/admin/css/wpml.css
@@ -1,0 +1,3 @@
+div[id="wpml-language-switcher-footer"] {
+  display: none;
+}

--- a/assets/src/scss/style.scss
+++ b/assets/src/scss/style.scss
@@ -76,3 +76,8 @@ Text Domain: planet4-master-theme
 
 // CSS variables
 @import "base/css-variables";
+
+// Hide WPML footer language switcher.
+.wpml-ls-statics-footer {
+  display: none;
+}

--- a/src/ControlPanel.php
+++ b/src/ControlPanel.php
@@ -310,12 +310,26 @@ class ControlPanel
     }
 
     /**
-     * Load assets.
+     * Load admin assets.
      */
     public function enqueue_admin_assets(): void
     {
-        // Load these assets only in Dashboard.
-        if (! is_admin() || 'dashboard' !== get_current_screen()->base) {
+        if (!is_admin()) {
+            return;
+        }
+
+        $this->load_dashboard_assets();
+        $this->load_wpml_assets();
+    }
+
+    /**
+     * Load Dashboard assets.
+     */
+    public function load_dashboard_assets(): void
+    {
+        $is_dashboard = 'dashboard' === get_current_screen()->base;
+
+        if (!$is_dashboard) {
             return;
         }
 
@@ -332,6 +346,26 @@ class ControlPanel
             [],
             Loader::theme_file_ver('admin/js/dashboard.js'),
             true
+        );
+    }
+
+    /**
+     * Load WPML assets.
+     */
+    public function load_wpml_assets(): void
+    {
+        $is_wpml_active = is_plugin_active('sitepress-multilingual-cms/sitepress.php');
+
+        if (!$is_wpml_active) {
+            return;
+        }
+
+        $theme_uri = get_template_directory_uri();
+        wp_enqueue_style(
+            'wpml-style',
+            "$theme_uri/admin/css/wpml.css",
+            [],
+            Loader::theme_file_ver('admin/css/wpml.css')
         );
     }
 }


### PR DESCRIPTION
### Description

See [PLANET-6977](https://jira.greenpeace.org/browse/PLANET-6977)
We use CSS for this since it seems there's no available hook to do it

### Testing

You'll need WPML to test this, so it's probably easier to use the [rhea test instance](https://www-dev.greenpeace.org/test-rhea). There, make sure that the footer language switcher option is hidden in the backend, and even if it was checked make sure that the footer switcher doesn't show in the frontend!