### PR TITLE
GITS00130982: Autor image on posts scaling weird

### DIFF
--- a/assets/src/scss/pages/post/_post.scss
+++ b/assets/src/scss/pages/post/_post.scss
@@ -54,7 +54,6 @@
 .author-pic {
   border-radius: 50%;
   object-fit: cover;
-  max-height: 50px;
 }
 
 .single-post-author {


### PR DESCRIPTION
### Reference: [PLANET-7098](https://jira.greenpeace.org/browse/PLANET-7098?atlLinkOrigin=c2xhY2staW50ZWdyYXRpb258aXNzdWU%3D)

**Description:**
Removed max-height value affecting Author profile image in post pages.

<!-- Ref: Please add a url to the ticket this change is addressing.

---

Please provide a brief summary of the change introduced to make review process easier.

Ideally this should also be part of the commit summary.
-->
