### PR TITLE
Fix tag creation when certain fields are missing

### DIFF
--- a/src/Campaigns.php
+++ b/src/Campaigns.php
@@ -250,7 +250,7 @@ class Campaigns
         $attachment_id = filter_input(INPUT_POST, $field_id, FILTER_VALIDATE_INT);
         $attachment_url = filter_input(INPUT_POST, $field_url, FILTER_VALIDATE_URL);
 
-        if ($this->validate($attachment_id)) {
+        if ($attachment_id && $this->validate($attachment_id)) {
             update_term_meta($term_id, $field_id, $attachment_id);
             update_term_meta($term_id, $field_url, $attachment_url);
         }
@@ -260,7 +260,7 @@ class Campaigns
         $attachment_id = filter_input(INPUT_POST, $field_id, FILTER_VALIDATE_INT);
         $attachment_url = filter_input(INPUT_POST, $field_url, FILTER_VALIDATE_URL);
 
-        if ($this->validate($attachment_id)) {
+        if ($attachment_id && $this->validate($attachment_id)) {
             update_term_meta($term_id, $field_id, $attachment_id);
             update_term_meta($term_id, $field_url, $attachment_url);
         }
@@ -268,7 +268,7 @@ class Campaigns
         $field_id = 'happypoint_bg_opacity';
         $happypoint_bg_opacity = filter_input(INPUT_POST, $field_id, FILTER_VALIDATE_INT);
 
-        if ($this->validate($happypoint_bg_opacity)) {
+        if ($happypoint_bg_opacity && $this->validate($happypoint_bg_opacity)) {
             update_term_meta($term_id, $field_id, $happypoint_bg_opacity);
         } else {
             $happypoint_bg_opacity = 30;


### PR DESCRIPTION
### Description

This was crashing, my guess is that it is due to a [recent refactor of the validate function](https://github.com/greenpeace/planet4-master-theme/commit/d8303237ece741dc19c773c4f2c2ec25e3f6c73f#diff-09f0c1569665b6a290f7d056be1cabce24a3834d7940a7c16da9817bbd0de723R353). Maybe this is a partial fix for [PLANET-7099](https://jira.greenpeace.org/browse/PLANET-7099).

### Testing

If you try creating a tag on the `main` branch without selecting a redirect page or an image, it will crash (even though on reload the tag will be there). On this branch it should work as expected.