### PR TITLE
PLANET-6970 WPML option disabling access to WordPress admin panel

### DIFF
--- a/admin/css/wpml.css
+++ b/admin/css/wpml.css
@@ -1,3 +1,4 @@
-div[id="wpml-language-switcher-footer"] {
+div[id="wpml-language-switcher-footer"],
+div[id="ml-content-setup-sec-wp-login"] {
   display: none;
 }


### PR DESCRIPTION
**Description: [PLANET-6970](https://jira.greenpeace.org/browse/PLANET-6970)**

**Testing:** 

If you got to this [test instance](https://www-dev.greenpeace.org/test-rhea/wp-admin/) and look through the WPML Settings, you should not see the option for _Login and Registration pages_


<!-- Ref: Please add a url to the ticket this change is addressing.

---

Please provide a brief summary of the change introduced to make review process easier.

Ideally this should also be part of the commit summary.
-->
