### PR TITLE
PLANET-6992 Update footer background colors for new identity

### DIFF
--- a/assets/src/scss/layout/_country-selector.scss
+++ b/assets/src/scss/layout/_country-selector.scss
@@ -90,7 +90,7 @@
 
 .countries-list {
   _-- {
-    background: var(--site-footer--background, $active-blue);
+    background: $active-blue;
   }
   font-weight: 500;
   max-height: 0;

--- a/assets/src/scss/new-identity/style.scss
+++ b/assets/src/scss/new-identity/style.scss
@@ -1,3 +1,6 @@
 :root {
   --body--color: #1c1c1c;
+  --site-footer--background: #1f4912;
+  --countries-list--background: #1a3c10;
+  --site-footer--copyright--background: #1a3c10;
 }


### PR DESCRIPTION
### Description

See [PLANET-6992](https://jira.greenpeace.org/browse/PLANET-6992)
For now these are only visible when the new identity styles setting is checked

### Testing

Make sure that the new identity styles setting is enabled (`Appearance > Customize > Site identity > Enable new Greenpeace visual identity`) and then you should see the new footer background colors. Note that on local you will probably need to rebuild the theme to see the changes. You can also test the changes on the [neptune test instance](https://www-dev.greenpeace.org/test-neptune/) where I already toggled the new identity styles.