### PR TITLE
PLANET-6987 Update Donate button colors for new identity

### DIFF
--- a/assets/src/scss/new-identity/style.scss
+++ b/assets/src/scss/new-identity/style.scss
@@ -25,4 +25,9 @@
   --post-tag-button--hover--border-color: var(--gp-green-200);
   --post-tag-button--hover--color: var(--grey-900);
   --post-tag-button--visited--color: var(--grey-900);
+  --button-donate--background: var(--gp-green-400);
+  --button-donate--color: var(--grey-900);
+  --button-donate--visited--color: var(--grey-900);
+  --button-donate--hover--color: var(--grey-900);
+  --button-donate--hover--background: var(--gp-green-500);
 }


### PR DESCRIPTION
### Description

See [PLANET-6987](https://jira.greenpeace.org/browse/PLANET-6987)
These changes are only visible when the new identity styles are enabled

### Testing

Make sure that the new identity styles setting is enabled (`Appearance > Customize > Site identity > Enable new Greenpeace visual identity`) and then you should see the new Donate button colors, both in the top navigation bar and in the side menu on mobile. Note that on local you will probably need to rebuild the theme to see the changes. You can also test the changes on the [rhea test instance](https://www-dev.greenpeace.org/test-rhea/) where I already toggled the new identity styles.