### PR TITLE
PLANET-6985 Update primary buttons colors for new identity

### DIFF
--- a/assets/src/scss/components/_buttons.scss
+++ b/assets/src/scss/components/_buttons.scss
@@ -99,7 +99,7 @@ $primary-button-box-shadow: 0 2px 5px rgba(0, 0, 0, .25);
     &:active {
       background: $orange-hover;
       color: $white;
-      border: 1px solid $orange-hover;
+      border: 1px solid transparent;
       box-shadow: $primary-button-box-shadow;
     }
 

--- a/assets/src/scss/editorOverrides.scss
+++ b/assets/src/scss/editorOverrides.scss
@@ -108,7 +108,7 @@
 .wp-block-button.is-style-cta .wp-block-button__link[role="textbox"] {
   --button-primary-- {
     background: $orange;
-    border-color: $orange;
+    border-color: transparent;
     color: $white;
     box-shadow: 0 2px 5px rgba(0, 0, 0, .25);
   }

--- a/assets/src/scss/new-identity/style.scss
+++ b/assets/src/scss/new-identity/style.scss
@@ -9,4 +9,10 @@
   --block-columns--step-number--background: var(--gp-green-100);
   --block-columns--step-number--color: var(--grey-900);
   --block-columns--card-header--background: var(--p4-dark-green-800);
+  --button-primary--background: var(--p4-action-yellow-500);
+  --button-primary--disabled--background: var(--p4-action-yellow-500);
+  --button-primary--hover--background: var(--p4-action-yellow-600);
+  --button-primary--color: var(--grey-900);
+  --button-primary--visited--color: var(--grey-900);
+  --button-primary--hover--color: var(--grey-900);
 }

--- a/assets/src/scss/pages/search/_filter-sidebar.scss
+++ b/assets/src/scss/pages/search/_filter-sidebar.scss
@@ -120,18 +120,11 @@
       height: 40px;
       width: 130px;
       line-height: 40px;
-      background: $orange;
       padding: 0 $sp-1;
-      color: $white;
 
       svg {
         margin-right: 4px;
         vertical-align: baseline;
-      }
-
-      &:hover {
-        background: $orange-hover;
-        cursor: pointer;
       }
 
       .icon-cross {
@@ -144,15 +137,6 @@
         height: 48px;
         width: 150px;
         line-height: 48px;
-      }
-
-      &.disabled {
-        background: $grey-40;
-
-        &:hover {
-          color: $white;
-          cursor: not-allowed;
-        }
       }
     }
   }

--- a/templates/search.twig
+++ b/templates/search.twig
@@ -54,7 +54,7 @@
                 <div class="col-lg-4">
                     <div class="filter-sidebar">
                         <div class="filter-button d-lg-none">
-                            <button class="btn btn-filter {{ disabled }}" data-bs-toggle="modal" data-bs-target="#filtermodal">
+                            <button class="btn btn-filter btn-primary {{ disabled }}" data-bs-toggle="modal" data-bs-target="#filtermodal">
                                 {{ 'filter'|svgicon }}
                                  {{ __( 'Filters', 'planet4-master-theme' ) }}
                              </button>


### PR DESCRIPTION
### Description

See [PLANET-6985](https://jira.greenpeace.org/browse/PLANET-6985)
These are only applied when the new identity styles are enabled

Related PR: https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/1019 to make sure that these changes are also applied to the Take Action boxout button

### Testing

Make sure that the new identity styles setting is enabled (`Appearance > Customize > Site identity > Enable new Greenpeace visual identity`) and then you should see the new primary buttons colors. Note that on local you will probably need to rebuild the theme to see the changes. You can also test the changes on the [pandora test instance](https://www-dev.greenpeace.org/test-pandora/) where I already toggled the new identity styles (I've added more detailed instructions for UAT in the ticket's comments)