### PR TITLE
PLANET-6986 Update secondary buttons colors for new identity

### DIFF
--- a/assets/src/scss/new-identity/style.scss
+++ b/assets/src/scss/new-identity/style.scss
@@ -35,4 +35,11 @@
   --author-block-description-button--hover--color: var(--gp-green-800);
   --top-page-tags--tag-item--visited--color: var(--gp-green-800);
   --top-page-tags--tag-item--color: var(--gp-green-800);
+  --button-secondary--background: var(--white);
+  --button-secondary--border-color: var(--p4-dark-green-800);
+  --button-secondary--color: var(--p4-dark-green-800);
+  --button-secondary--visited--color: var(--p4-dark-green-800);
+  --button-secondary--hover--background: var(--p4-dark-green-800);
+  --button-secondary--hover--border-color: var(--p4-dark-green-800);
+  --button-secondary--hover--color: var(--white);
 }


### PR DESCRIPTION
### Description

See [PLANET-6986](https://jira.greenpeace.org/browse/PLANET-6986)
These are only applied when the new identity styles are enabled

### Testing

Make sure that the new identity styles setting is enabled (`Appearance > Customize > Site identity > Enable new Greenpeace visual identity`) and then you should see the new primary buttons colors. Note that on local you will probably need to rebuild the theme to see the changes. You can also test the changes on the [nix test instance](https://www-dev.greenpeace.org/test-nix/) where I already toggled the new identity styles (I've added more detailed instructions for UAT in the ticket's comments)