### PR TITLE
PLANET-7015 Apply new identity colors to Columns Tasks block

### DIFF
--- a/assets/src/scss/new-identity/style.scss
+++ b/assets/src/scss/new-identity/style.scss
@@ -1,10 +1,12 @@
+@import "../base/tokens";
+
 :root {
-  --body--color: #1c1c1c;
-  --site-footer--background: #1f4912;
-  --countries-list--background: #1a3c10;
-  --site-footer--copyright--background: #1a3c10;
-  --block-columns--step-number--inner--background: #d9f1c5;
-  --block-columns--step-number--background: #d9f1c5;
-  --block-columns--step-number--color: #1c1c1c;
-  --block-columns--card-header--background: #1f4912;
+  --body--color: var(--grey-900);
+  --site-footer--background: var(--p4-dark-green-800);
+  --countries-list--background: var(--p4-dark-green-900);
+  --site-footer--copyright--background: var(--p4-dark-green-900);
+  --block-columns--step-number--inner--background: var(--gp-green-100);
+  --block-columns--step-number--background: var(--gp-green-100);
+  --block-columns--step-number--color: var(--grey-900);
+  --block-columns--card-header--background: var(--p4-dark-green-800);
 }

--- a/assets/src/scss/new-identity/style.scss
+++ b/assets/src/scss/new-identity/style.scss
@@ -3,4 +3,8 @@
   --site-footer--background: #1f4912;
   --countries-list--background: #1a3c10;
   --site-footer--copyright--background: #1a3c10;
+  --block-columns--step-number--inner--background: #d9f1c5;
+  --block-columns--step-number--background: #d9f1c5;
+  --block-columns--step-number--color: #1c1c1c;
+  --block-columns--card-header--background: #1f4912;
 }


### PR DESCRIPTION
### Description

See [PLANET-7015](https://jira.greenpeace.org/browse/PLANET-7015)
These are only applied if the new identity styles are enabled

### Testing

Make sure that the new identity styles setting is enabled (`Appearance > Customize > Site identity > Enable new Greenpeace visual identity`) and then when adding a Planet 4 Columns block to a page, you should see it with the new colors in all screen sizes. You can also use the [neptune test instance](https://www-dev.greenpeace.org/test-neptune/) where the setting has already been enabled, specifically [this page](https://www-dev.greenpeace.org/test-neptune/simple-tasks/) where the block has been added for UAT.