### PR TITLE
PLANET-6988: New layout applied to tag links

### DIFF
--- a/assets/src/scss/base/_typography.scss
+++ b/assets/src/scss/base/_typography.scss
@@ -101,7 +101,7 @@ h6 {
 
 a --link-- {
   &:focus {
-    outline: 2px solid rgba(0, 106, 255, 0.4);
+    outline: 2px solid #99c3ff;
     outline-offset: 2px;
     border-radius: 4px;
   }

--- a/assets/src/scss/components/_buttons.scss
+++ b/assets/src/scss/components/_buttons.scss
@@ -284,6 +284,7 @@ button.load-more-mt {
 
     &:hover {
       background-color: var(--link--color);
+      border-color: var(--link--color);
       color: $white;
     }
 

--- a/assets/src/scss/new-identity/style.scss
+++ b/assets/src/scss/new-identity/style.scss
@@ -15,4 +15,14 @@
   --button-primary--color: var(--grey-900);
   --button-primary--visited--color: var(--grey-900);
   --button-primary--hover--color: var(--grey-900);
+  --post-tag-button--active--color: var(--grey-900);
+  --post-tag-button--active--background-color: var(--gp-green-200);
+  --post-tag-button--background-color: var(--gp-green-100);
+  --post-tag-button--border-color: var(--gp-green-100);
+  --post-tag-button--color: var(--grey-900);
+  --post-tag-button--font-weight: 700;
+  --post-tag-button--hover--background-color: var(--gp-green-200);
+  --post-tag-button--hover--border-color: var(--gp-green-200);
+  --post-tag-button--hover--color: var(--grey-900);
+  --post-tag-button--visited--color: var(--grey-900);
 }


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6988

## Description
New layout applied to Tag links as a part of the new identity project.

## Testing
Navigate any page with tags, for example the [forest category page](https://www-dev.greenpeace.org/test-nix/tag/forests/).

Remember to enable the new layout from the appearance section
