### PR TITLE
PLANET-6990 Apply the new style to body copy links

### DIFF
--- a/assets/src/scss/new-identity/style.scss
+++ b/assets/src/scss/new-identity/style.scss
@@ -121,15 +121,24 @@ table.spreadsheet-table.is-color-gp-green {
   }
 }
 
-a:where(.standalone-link) {
+.standalone-link {
   width: fit-content;
-  border-bottom: 2px solid var(--gp-green-500);
   font-weight: 700 !important;
-  transition: 0.3s cubic-bezier(0.5, 0, 0, 1);
+}
 
-  &:hover {
-    box-shadow: inset 0 calc(-22px) var(--gp-green-100);
-    text-decoration: none !important;
+// Body Copy links selectors
+.post-content,
+.page-content {
+  .standalone-link,
+  p > a,
+  li > a {
+    transition: 0.2s cubic-bezier(0.5, 0, 0, 1);
+    border-bottom: 2px solid var(--gp-green-500);
+
+    &:hover {
+      box-shadow: inset 0 calc(-22px) var(--gp-green-100);
+      text-decoration: none !important;
+    }
   }
 }
 

--- a/tests/e2e/404.spec.js
+++ b/tests/e2e/404.spec.js
@@ -1,6 +1,7 @@
-const { test, expect } = require('@playwright/test');
+const {test, expect} = require('@playwright/test');
 
-test('check the 404 page', async ({ page }) => {
+test('check the 404 page', async ({page}) => {
+  test.setTimeout(240 * 1000);
   const response = await page.goto('./thispagereallywillnotexist');
 
   // Check the page status.
@@ -9,8 +10,9 @@ test('check the 404 page', async ({ page }) => {
   // Check the page text.
   const settingsText = await page.evaluate('window.p4bk_vars.page_text_404');
   await expect(settingsText).toBeDefined();
+  const settingsTextUpdated = settingsText.replace(/\s+/g, ' ').replaceAll('&', '&amp;');
   const pageContent = await page.locator('.speech-bubble').innerHTML();
-  await expect(pageContent.replace(/\s+/g, ' ')).toContain(settingsText.replace(/\s+/g, ' '));
+  await expect(pageContent.replace(/\s+/g, ' ')).toContain(settingsTextUpdated.trim());
 
   // Check the page image background.
   const settingsImage = await page.evaluate('window.p4bk_vars.page_bg_image_404');


### PR DESCRIPTION
### Description: [PLANET-6990](https://jira.greenpeace.org/browse/PLANET-6990)

**Testing**

Check this [post](https://www-dev.greenpeace.org/test-tavros/story/29458/peak-oil-decline-coronavirus-economy/) on the tavros instance. Because the _New Site Identity_ has been enabled, it reflects the new changes for body copy links.

<!-- Ref: Please add a url to the ticket this change is addressing.

---

Please provide a brief summary of the change introduced to make review process easier.

Ideally this should also be part of the commit summary.
-->
