### PR TITLE
PLANET-6991 Apply the new dark green color to contextual links

### DIFF
--- a/assets/src/scss/new-identity/style.scss
+++ b/assets/src/scss/new-identity/style.scss
@@ -33,4 +33,6 @@
   --author-block--background: var(--beige-100);
   --author-block-description-button--color: var(--gp-green-800);
   --author-block-description-button--hover--color: var(--gp-green-800);
+  --top-page-tags--tag-item--visited--color: var(--gp-green-800);
+  --top-page-tags--tag-item--color: var(--gp-green-800);
 }

--- a/assets/src/scss/pages/_listing-page.scss
+++ b/assets/src/scss/pages/_listing-page.scss
@@ -74,10 +74,22 @@
   font-size: $font-size-sm;
   font-family: var(--headings--font-family);
   line-height: 25px;
+  color: var(--top-page-tags--tag-item--color, var(--link--color));
+
+  a {
+    color: inherit;
+
+    &:visited {
+      color: var(--top-page-tags--tag-item--visited--color, var(--link--visited--color));
+    }
+
+    &:hover,
+    &:active {
+      color: var(--top-page-tags--tag-item--color, var(--link--hover--color));
+    }
+  }
 
   .wrapper-post-tag {
-    color: var(--link--color);
-
     a {
       display: inline-block;
 


### PR DESCRIPTION
### Description

See [PLANET-6991](https://jira.greenpeace.org/browse/PLANET-6991)
This change is only visible if the new identity styles are enabled

### Testing

Make sure that the new identity styles setting is enabled (`Appearance > Customize > Site identity > Enable new Greenpeace visual identity`) and then you should see the new contextual link colors. Note that on local you will probably need to rebuild the theme to see the changes. You can also test the changes on the [leda test instance](https://www-dev.greenpeace.org/test-leda/) where I already toggled the new identity styles (I've added more detailed instructions for UAT in the ticket's comments).  Please make sure that the old links still look as expected (when the new identity styles are not enabled).