### PR TITLE
PLANET-6997 Apply the new colors to cookies box

### DIFF
--- a/assets/src/scss/layout/_cookies-settings.scss
+++ b/assets/src/scss/layout/_cookies-settings.scss
@@ -106,7 +106,7 @@
   &.with-reject-all {
     flex-wrap: wrap;
 
-    .btn-primary {
+    .btn-donate {
       width: 100%;
       margin-top: $sp-2;
     }
@@ -119,7 +119,7 @@
         margin-inline-end: $sp-2;
       }
 
-      .btn-primary {
+      .btn-donate {
         flex-grow: 1;
         width: auto;
         margin-top: 0;

--- a/assets/src/scss/layout/_cookies.scss
+++ b/assets/src/scss/layout/_cookies.scss
@@ -64,7 +64,7 @@
     font-size: 14px;
   }
 
-  .btn-primary {
+  .btn-donate {
     margin-top: $sp-2;
   }
 
@@ -72,11 +72,11 @@
     display: flex;
     justify-content: space-between;
 
-    .btn-primary:only-child {
+    .btn-donate:only-child {
       width: 100%;
     }
 
-    .btn-primary,
+    .btn-donate,
     .btn-secondary {
       width: auto;
       flex-grow: 1;

--- a/templates/cookies.twig
+++ b/templates/cookies.twig
@@ -19,7 +19,7 @@
                     </button>
                 {% endif %}
                 <button
-                    class="btn btn-primary p-0 allow-all-cookies"
+                    class="btn btn-donate p-0 allow-all-cookies"
                     data-ga-category="Cookies box"
                     data-ga-action="Accept all cookies"
                 >

--- a/templates/cookies/cookies_settings.twig
+++ b/templates/cookies/cookies_settings.twig
@@ -55,7 +55,7 @@
             {{ __( 'Allow all', 'planet4-master-theme' ) }}
         </button>
         <button
-            class="btn btn-primary"
+            class="btn btn-donate"
             id="save-cookies-settings"
             data-ga-category="Cookies box"
             data-ga-action="Save preferences"


### PR DESCRIPTION
### Description

See [PLANET-6997](https://jira.greenpeace.org/browse/PLANET-6997)
These are part of the new identity styles. We need to merge a few other PRs before this one is completely ready:
- https://github.com/greenpeace/planet4-master-theme/pull/1961
- https://github.com/greenpeace/planet4-master-theme/pull/1951
- https://github.com/greenpeace/planet4-master-theme/pull/1966
- https://github.com/greenpeace/planet4-master-theme/pull/1955

### Testing

Make sure that the new identity styles setting is enabled (`Appearance > Customize > Site identity > Enable new Greenpeace visual identity`) and then you should see the new cookies box colors. Note that the links are not fully styled yet, but that's handled in a separate PR/ticket for the body links. You can also test the changes on the [rhea test instance](https://www-dev.greenpeace.org/test-rhea/) where I already toggled the new identity styles. Please also make sure that the old box still looks as expected (without the new identity styles enabled). 