### PR TITLE
Remove buttons box-shadow

### DIFF
--- a/admin/css/login.css
+++ b/admin/css/login.css
@@ -51,7 +51,6 @@ body.login #login_error, body.login .message, body.login .success {
 
 body.login div#login form#loginform p.submit input#wp-submit {
   background: #f36b35;
-  box-shadow: 0 2px 5px rgba(0, 0, 0, .25);
   text-shadow: none;
   height: auto;
   border: none;

--- a/assets/src/scss/components/_buttons.scss
+++ b/assets/src/scss/components/_buttons.scss
@@ -78,8 +78,6 @@
   line-height: 3.1;
 }
 
-$primary-button-box-shadow: 0 2px 5px rgba(0, 0, 0, .25);
-
 .btn-primary,
 .wp-block-button.is-style-cta a,
 .gform_footer input[type="submit"] {
@@ -89,7 +87,6 @@ $primary-button-box-shadow: 0 2px 5px rgba(0, 0, 0, .25);
     // Adding this here so that the variable exists, though technically not needed.
     // This allows for the hover variable to be previewed.
     border-color: transparent;
-    box-shadow: $primary-button-box-shadow;
 
     &:visited {
       color: $white;
@@ -100,7 +97,6 @@ $primary-button-box-shadow: 0 2px 5px rgba(0, 0, 0, .25);
       background: $orange-hover;
       color: $white;
       border: 1px solid transparent;
-      box-shadow: $primary-button-box-shadow;
     }
 
     &:disabled,
@@ -121,7 +117,6 @@ $primary-button-box-shadow: 0 2px 5px rgba(0, 0, 0, .25);
     background: transparentize($white, .7);
     border-color: $dark-blue;
     color: $dark-blue;
-    box-shadow: none;
 
     &:visited {
       color: $dark-blue;
@@ -158,7 +153,6 @@ $primary-button-box-shadow: 0 2px 5px rgba(0, 0, 0, .25);
 .btn-action {
   background-color: transparentize($white, .8);
   border-color: $white;
-  box-shadow: 0 2px 5px rgba(0, 0, 0, .25);
 
   &:hover {
     background-color: $orange;
@@ -171,22 +165,18 @@ $primary-button-box-shadow: 0 2px 5px rgba(0, 0, 0, .25);
   }
 }
 
-$donate-button-box-shadow: 0 2px 5px rgba(0, 0, 0, .25);
-
 .btn-donate {
   --button-donate-- {
     background: $orange;
     color: $white;
     min-width: 180px;
     padding: 2px 30px;
-    box-shadow: $donate-button-box-shadow;
     border-width: 1px;
     border-color: transparent;
 
     &:hover {
       background: $orange-hover;
       color: $white;
-      box-shadow: $donate-button-box-shadow;
       border: 1px solid transparent;
     }
 

--- a/assets/src/scss/editorOverrides.scss
+++ b/assets/src/scss/editorOverrides.scss
@@ -90,8 +90,6 @@
     color: $dark-blue;
     padding: 2px $sp-4;
   }
-
-  box-shadow: none;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -110,7 +108,6 @@
     background: $orange;
     border-color: transparent;
     color: $white;
-    box-shadow: 0 2px 5px rgba(0, 0, 0, .25);
   }
 
   &.has-background {

--- a/assets/src/scss/layout/_navbar.scss
+++ b/assets/src/scss/layout/_navbar.scss
@@ -55,14 +55,12 @@ $navbar-default-height: 60px;
   .btn-donate {
     _-- {
       border: none;
-      box-shadow: none;
       font-size: inherit;
       min-width: 116px;
       padding: 2px 17px;
 
       &:hover {
         border: none;
-        box-shadow: none;
       }
     }
 


### PR DESCRIPTION
### Description

I've checked with the design team and we can already make this change regardless of the new identity.

### Testing

All buttons should no longer have a `box-shadow`. 