### PR TITLE
PLANET-7003 Implement client-side dynamic population on form fields

### DIFF
--- a/assets/src/js/gravityforms-client-side.js
+++ b/assets/src/js/gravityforms-client-side.js
@@ -1,0 +1,13 @@
+(() => {
+  if (typeof p4GfClientSideConfig !== 'undefined') {
+    const urlParams = new URLSearchParams(window.location.search);
+    // eslint-disable-next-line no-undef
+    p4GfClientSideConfig.populate.forEach(field => {
+      const value = urlParams.get(field.parameter);
+
+      if(value !== null) {
+        document.getElementById(field.fieldId).value = value;
+      }
+    });
+  }
+})();


### PR DESCRIPTION
### Description: [PLANET-7003](https://jira.greenpeace.org/browse/PLANET-7003)

Hidden fields in GF are now dynamically populated on the frontend with the value passed in the URL params. 

<!-- Ref: Please add a url to the ticket this change is addressing.

---

Please provide a brief summary of the change introduced to make review process easier.

Ideally this should also be part of the commit summary.
-->
