### PR TITLE
PLANET-6994: Implement new identity colors to standalone links

### DIFF
--- a/assets/src/scss/new-identity/style.scss
+++ b/assets/src/scss/new-identity/style.scss
@@ -84,6 +84,7 @@ a:where(.standalone-link) {
 
   &:hover {
     box-shadow: inset 0 calc(-22px) var(--gp-green-100);
+    text-decoration: none !important;
   }
 }
 

--- a/assets/src/scss/new-identity/style.scss
+++ b/assets/src/scss/new-identity/style.scss
@@ -80,7 +80,7 @@ a:where(.standalone-link) {
   width: fit-content;
   border-bottom: 2px solid var(--gp-green-500);
   font-weight: 700 !important;
-  transition: 0.2s cubic-bezier(0.5, 0, 0, 1);
+  transition: 0.3s cubic-bezier(0.5, 0, 0, 1);
 
   &:hover {
     box-shadow: inset 0 calc(-22px) var(--gp-green-100);

--- a/assets/src/scss/new-identity/style.scss
+++ b/assets/src/scss/new-identity/style.scss
@@ -76,6 +76,17 @@ table.spreadsheet-table.is-color-dark-green {
   }
 }
 
+a:where(.standalone-link) {
+  width: fit-content;
+  border-bottom: 2px solid var(--gp-green-500);
+  font-weight: 700 !important;
+  transition: 0.2s cubic-bezier(0.5, 0, 0, 1);
+
+  &:hover {
+    box-shadow: inset 0 calc(-22px) var(--gp-green-100);
+  }
+}
+
 // Colors for transparent buttons.
 $palette: (
   "green-400": var(--gp-green-400),


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6994

As a part of the new identity, It's Including the new `hover` effect to some links (not all).

**IMPORTANT NOTE**
I was trying to find the best CSS pure way to define the `offset-y` (as `-22px`) through the `drop-shadow` property, without using Javascript, but I haven't find it yet. 
The problem there is that `22px`  is applied to ALL links with `font-sizes` higher than `22px` and lower. Thus, doesn't matter which is the `font-size`, the `inset` drop shadow will be always `22px` and I disagree with that 🙃. 
Of course we can do it directly with Vainilla JS, but the performance will be impacted.
