### PR TITLE
Add new identity colors to our color palette

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -501,3 +501,97 @@ add_filter(
     10,
     2
 );
+
+// Replace color palette with the new one when new identity styles are enabled.
+add_filter(
+    'wp_theme_json_data_theme',
+    function ($theme_json) {
+        $new_identity_styles = get_theme_mod('new_identity_styles');
+
+        if (!$new_identity_styles) {
+            return $theme_json;
+        }
+
+        $new_color_palette = [
+            'version' => 2,
+            'settings' => [
+                'color' => [
+                    'palette' => [
+                          [
+                            'name' => 'Green 400',
+                            'slug' => 'green-400',
+                            'color' => '#80d643',
+                          ],
+                          [
+                            'name' => 'Green 500',
+                            'slug' => 'green-500',
+                            'color' => '#66cc00',
+                          ],
+                          [
+                            'name' => 'Green 800',
+                            'slug' => 'green-800',
+                            'color' => '#198700',
+                          ],
+                          [
+                            'name' => 'Action Yellow',
+                            'slug' => 'action-yellow',
+                            'color' => '#ffe100',
+                          ],
+                          [
+                            'name' => 'Dark Green 800',
+                            'slug' => 'dark-green-800',
+                            'color' => '#1f4912',
+                          ],
+                          [
+                            'name' => 'Beige 100',
+                            'slug' => 'beige-100',
+                            'color' => '#f6f4ef',
+                          ],
+                          [
+                            'name' => 'Blue Green 800',
+                            'slug' => 'blue-green-800',
+                            'color' => '#167f82',
+                          ],
+                          [
+                            'name' => 'Red 500',
+                            'slug' => 'red-500',
+                            'color' => '#d43b57',
+                          ],
+                          [
+                            'name' => 'White',
+                            'slug' => 'white',
+                            'color' => '#ffffff',
+                          ],
+                          [
+                            'name' => 'Grey 100',
+                            'slug' => 'grey-100',
+                            'color' => '#f5f7f8',
+                          ],
+                          [
+                            'name' => 'Grey 200',
+                            'slug' => 'grey-200',
+                            'color' => '#ececec',
+                          ],
+                          [
+                            'name' => 'Grey 600',
+                            'slug' => 'grey-600',
+                            'color' => '#6f7376',
+                          ],
+                          [
+                            'name' => 'Grey 800',
+                            'slug' => 'grey-800',
+                            'color' => '#45494c',
+                          ],
+                          [
+                            'name' => 'Grey 900',
+                            'slug' => 'grey-900',
+                            'color' => '#1c1c1c',
+                          ],
+                    ],
+                ],
+            ],
+        ];
+
+        return $theme_json->update_with($new_color_palette);
+    }
+);


### PR DESCRIPTION
### Description

These new colors were suggested by Houssam for the new palette, of course we can always add/remove some in the future if needed.

### Testing

You can check the new color palette with any block that offers color customisations, such as the Paragraph. Make sure they are applied as expected, both in the backend and frontend. You can use [this page](https://www-dev.greenpeace.org/test-pandora/new-color-palette/) I made for UAT. Please also make sure that the rest of the theme settings are not impacted, and that the "old" palette still shows as expected if the new identity styles are not enabled 🙂 