### PR TITLE
Convert navbar variables to CSS variables

### DIFF
--- a/assets/src/scss/base/_css-variables.scss
+++ b/assets/src/scss/base/_css-variables.scss
@@ -9,4 +9,9 @@
   --link--text-decoration: none;
   --link--hover--text-decoration: underline;
   --link--visited--color: #{$link-color-visited};
+  --navbar-height: 60px;
+  --navbar-menu-height: 68px;
+  --navbar-menu-min-height: 40px;
+  --navbar-menu-height--small: 60px;
+  --navbar-menu-height--large: 68px;
 }

--- a/assets/src/scss/layout/_navbar.scss
+++ b/assets/src/scss/layout/_navbar.scss
@@ -1,9 +1,3 @@
-$menu-height: 68px;
-$menu-height-large: 68px;
-$menu-height-small: 60px;
-$min-height: 40px;
-$navbar-default-height: 60px;
-
 .top-navigation {
   _-- {
     background: $dark-blue;
@@ -282,7 +276,7 @@ a.nav-link:hover:before,
   font-weight: 700;
 
   @include large-and-up {
-    line-height: $menu-height;
+    line-height: var(--navbar-menu-height);
 
     &:hover {
       .nav-submenu {
@@ -306,7 +300,7 @@ a.nav-link:hover:before,
 
 .navigation-bar_min {
   --top-navigation-min-- {
-    height: $min-height;
+    height: var(--navbar-menu-min-height);
   }
 
   justify-content: center;

--- a/assets/src/scss/layout/navbar/_search.scss
+++ b/assets/src/scss/layout/navbar/_search.scss
@@ -7,19 +7,19 @@
   height: 56px;
   inset-inline-start: 0;
   position: fixed;
-  top: $menu-height-small;
+  top: var(--navbar-menu-height--small);
   z-index: 3;
   width: 100%;
 
   .admin-bar & {
-    top: $menu-height-small + 46px;
+    top: calc(var(--navbar-menu-height--small) + 46px);
 
     @media (min-width: 783px) {
-      top: $menu-height-small + 32px;
+      top: calc(var(--navbar-menu-height--small) + 32px);
     }
 
     @include large-and-up {
-      top: $menu-height + 32px;
+      top: calc(var(--navbar-menu-height) + 32px);
     }
   }
 
@@ -55,7 +55,7 @@
   }
 
   @include large-and-up {
-    top: $menu-height;
+    top: var(--navbar-menu-height);
   }
 
   @include x-large-and-up {
@@ -82,7 +82,7 @@
   display: inline-block;
   flex-grow: 1;
   font-size: $font-size-sm;
-  line-height: $menu-height;
+  line-height: var(--navbar-menu-height);
   padding-inline: 12px 8px;
   width: auto;
 
@@ -137,7 +137,7 @@
 
   @include x-large-and-up {
     display: inline-block;
-    line-height: $menu-height;
+    line-height: var(--navbar-menu-height);
   }
 }
 

--- a/assets/src/scss/layout/navbar/_site-logo.scss
+++ b/assets/src/scss/layout/navbar/_site-logo.scss
@@ -1,8 +1,8 @@
 .site-logo {
-  line-height: $menu-height-small;
+  line-height: var(--navbar-menu-height--small);
 
   @include large-and-up {
-    line-height: $menu-height-large;
+    line-height: var(--navbar-menu-height--large);
   }
 
   img {
@@ -22,7 +22,7 @@
   }
 
   .navigation-bar_min & {
-    line-height: $min-height;
+    line-height: var(--navbar-menu-min-height);
 
     img {
       height: 18px;

--- a/assets/src/scss/layout/navbar/languages.scss
+++ b/assets/src/scss/layout/navbar/languages.scss
@@ -10,7 +10,7 @@
   @include large-and-up {
     border-inline-start: var(--top-navigation--separation, 1px solid transparentize($white, 0.5));
     display: inline-block;
-    line-height: $menu-height;
+    line-height: var(--navbar-menu-height);
 
     &::after {
       content: "";

--- a/assets/src/scss/pages/_page.scss
+++ b/assets/src/scss/pages/_page.scss
@@ -1,7 +1,3 @@
-$menu-height-small: 3.375rem;
-$menu-height-large: 3.75rem;
-$min-height: 40px;
-
 .page-content {
   > * {
     position: relative;
@@ -14,10 +10,10 @@ $min-height: 40px;
   }
 
   &.no-page-title {
-    padding-top: $menu-height-small;
+    padding-top: var(--navbar-menu-height--small);
 
-    @include medium-and-up {
-      padding-top: $menu-height-large;
+    @include large-and-up {
+      padding-top: var(--navbar-menu-height--large);
     }
 
     & > p:first-child {
@@ -40,19 +36,23 @@ $min-height: 40px;
       }
     }
 
+    & > .wp-block-group {
+      margin-top: 0;
+    }
+
     & > .wp-block-image:first-child {
       margin-top: 0;
     }
 
     .navigation-bar_min ~ & {
-      padding-top: $min-height;
+      padding-top: var(--navbar-menu-min-height);
     }
   }
 }
 
 .with-mobile-tabs ~ :not(.page-header) + .page-content {
   @include medium-and-less {
-    padding-top: calc(#{$menu-height-small} + 50px);
+    padding-top: calc(var(--navbar-menu-height--small) + 50px);
   }
 }
 


### PR DESCRIPTION
## Description
As a part of https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/969 I'd suggest also to re implement the Navigation variables. 

By doing this will be more easier to maintain afterwards and to migrate to design tokens since we're are start using `CSS Variables`.

Here is the [demo page](https://www-dev.greenpeace.org/test-pluto/page-header-demo-page)