### PR TITLE
PLANET-7016 Apply the new colors to the Table block

### DIFF
--- a/assets/src/scss/base/_colors.scss
+++ b/assets/src/scss/base/_colors.scss
@@ -53,9 +53,6 @@ $light-blue-bg:         #d6e6f2;
 // Colors to be fixed/addressed:
 $cookie-bkg:            #c0dbe2;
 
-// Table/spreadsheet colors
-$table-font-color: #020202;
-
 // Background colors
 // Grey variant (default)
 $table-header-grey: #45494c;

--- a/assets/src/scss/layout/_tables.scss
+++ b/assets/src/scss/layout/_tables.scss
@@ -42,7 +42,7 @@
       font-size: $font-size-xs;
       padding: $sp-2x;
       vertical-align: top;
-      color: $table-font-color;
+      color: var(--body--color);
 
       @include mobile-only {
         min-width: 300px;

--- a/assets/src/scss/new-identity/style.scss
+++ b/assets/src/scss/new-identity/style.scss
@@ -42,36 +42,65 @@
   --button-secondary--hover--background: var(--p4-dark-green-800);
   --button-secondary--hover--border-color: var(--p4-dark-green-800);
   --button-secondary--hover--color: var(--white);
-  --block-spreadsheet--color: var(--grey-900);
-  --block-spreadsheet-grey-header--background: var(--grey-800);
-  --block-spreadsheet-grey-odd-row--background: #eaedee;
-  --block-spreadsheet-grey-even-row--background: var(--grey-100);
-  --block-spreadsheet-green-header--background: var(--gp-green-800);
-  --block-spreadsheet-green-odd-row--background: var(--beige-200);
-  --block-spreadsheet-green-even-row--background: var(--beige-100);
-  --block-spreadsheet-blue-header--background: #167f82;
-  --block-spreadsheet-blue-odd-row--background: var(--beige-200);
-  --block-spreadsheet-blue-even-row--background: var(--beige-100);
+  --table-footer-new--background: #dad8d1;
+  --table-header-grey--background: var(--grey-800);
+  --table-odd-row-grey--background: var(--grey-200);
+  --table-even-row-grey--background: var(--grey-100);
+  --table-footer-grey--background: var(--grey-300);
+  --table-header-green--background: var(--p4-dark-green-800);
+  --table-odd-row-green--background: var(--beige-200);
+  --table-even-row-green--background: var(--beige-100);
+  --table-footer-green--background: var(--table-footer-new--background);
+  --table-header-blue--background: #167f82;
+  --table-odd-row-blue--background: var(--beige-200);
+  --table-even-row-blue--background: var(--beige-100);
+  --table-footer-blue--background: var(--table-footer-new--background);
+  --table-header-gp-green--background: var(--gp-green-800);
+  --table-odd-row-gp-green--background: var(--beige-200);
+  --table-even-row-gp-green--background: var(--beige-100);
+  --table-footer-gp-green--background: var(--table-footer-new--background);
   --link--color: var(--grey-900);
   --link--visited--color: var(--grey-900);
   --link--hover--color: var(--grey-900);
 }
 
 // Spreadsheet block new color.
-table.spreadsheet-table.is-color-dark-green {
-  th --block-spreadsheet-dark-green-header-- {
-    background: var(--p4-dark-green-800);
+table.spreadsheet-table.is-color-gp-green {
+  th {
+    background-color: var(--table-header-gp-green--background);
   }
 
   tr {
-    td --block-spreadsheet-dark-green-even-row-- {
-      background: var(--beige-200);
-    }
+    background-color: var(--table-even-row-gp-green--background);
+  }
 
-    &:nth-child(odd) {
-      td --block-spreadsheet-dark-green-odd-row-- {
-        background: var(--beige-100);
+  tr:nth-child(odd) {
+    background: var(--table-odd-row-gp-green--background);
+  }
+}
+
+// Table background colors (header, footer, odd/even rows)
+.wp-block-table {
+  table {
+    // GP-Green background
+    &.has-gp-green-background-color {
+      th {
+        background-color: var(--table-header-gp-green--background);
       }
+
+      tr {
+        background-color: var(--table-even-row-gp-green--background);
+      }
+
+      tfoot td {
+        background-color: var(--table-footer-gp-green--background);
+      }
+    }
+  }
+
+  &.is-style-stripes table {
+    &.has-gp-green-background-color tr:nth-child(odd) {
+      background-color: var(--table-odd-row-gp-green--background);
     }
   }
 }

--- a/functions.php
+++ b/functions.php
@@ -589,6 +589,35 @@ add_filter(
                           ],
                     ],
                 ],
+                'blocks' => [
+                    'core/table' => [
+                        'color' => [
+                            'palette' => [
+                                [
+                                    'name' => 'Grey 800',
+                                    'slug' => 'grey',
+                                    'color' => '#45494c',
+                                ],
+
+                                [
+                                    'name' => 'Dark Green 800',
+                                    'slug' => 'green',
+                                    'color' => '#1f4912',
+                                ],
+                                [
+                                    'name' => 'Blue 800',
+                                    'slug' => 'blue',
+                                    'color' => '#167f82',
+                                ],
+                                [
+                                    'name' => 'GP Green 800',
+                                    'slug' => 'gp-green',
+                                    'color' => '#198700',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
             ],
         ];
 


### PR DESCRIPTION
### Description: [PLANET-7016](https://jira.greenpeace.org/browse/PLANET-7016)

**Testing**

You can use this [page](https://www-dev.greenpeace.org/test-umbriel/test-new-identity-colors/) on the Umbriel instance to test the new changes for the Table block. Switching between the new identity styles and old ones should be reflected on the table.


Ref PR: https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/1029

<!-- Ref: Please add a url to the ticket this change is addressing.

---

Please provide a brief summary of the change introduced to make review process easier.

Ideally this should also be part of the commit summary.
-->
