### PR TITLE
PLANET-7022 Apply new identity colors to transparent buttons

### DIFF
--- a/assets/src/scss/base/_palette.scss
+++ b/assets/src/scss/base/_palette.scss
@@ -19,6 +19,10 @@ $palette: (
 @each $name, $color in $palette {
   .has-#{$name}-color {
     color: $color;
+
+    --transparent-button--border-color: #{$color};
+    --transparent-button--color: #{$color};
+    --transparent-button--hover--background: #{$color};
   }
 
   .has-#{$name}-background-color {

--- a/assets/src/scss/new-identity/style.scss
+++ b/assets/src/scss/new-identity/style.scss
@@ -92,6 +92,12 @@ $palette: (
 );
 
 @each $name, $color in $palette {
+  .has-#{$name}-color {
+    --transparent-button--border-color: #{$color};
+    --transparent-button--color: #{$color};
+    --transparent-button--hover--background: #{$color};
+  }
+
   .has-#{$name}-background-color {
     --transparent-button--hover--color: #{$color};
     --transparent-button--active--color: #{$color};

--- a/assets/src/scss/new-identity/style.scss
+++ b/assets/src/scss/new-identity/style.scss
@@ -72,3 +72,28 @@ table.spreadsheet-table.is-color-dark-green {
     }
   }
 }
+
+// Colors for transparent buttons.
+$palette: (
+  "green-400": var(--gp-green-400),
+  "green-500": var(--gp-green-500),
+  "green-800": var(--gp-green-800),
+  "action-yellow": var(--p4-action-yellow-500),
+  "dark-green-800": var(--p4-dark-green-800),
+  "beige-100": var(--beige-100),
+  "blue-green-800": #167f82,
+  "red-500": var(--red-500),
+  "white": var(--white),
+  "grey-100": var(--grey-100),
+  "grey-200": var(--grey-200),
+  "grey-600": var(--grey-600),
+  "grey-800": var(--grey-800),
+  "grey-900": var(--grey-900),
+);
+
+@each $name, $color in $palette {
+  .has-#{$name}-background-color {
+    --transparent-button--hover--color: #{$color};
+    --transparent-button--active--color: #{$color};
+  }
+}


### PR DESCRIPTION
### Description

This is needed for the Highlighted CTA pattern (see [PLANET-7022](https://jira.greenpeace.org/browse/PLANET-7022))

**Related PR:** https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/1030

### Testing

Either on local (make sure the new identity styles are enabled!) or on the janus test instance, you can check the new available colors for the pattern. You can also use [this page](https://www-dev.greenpeace.org/test-janus/highlighted-ctas/) that I made for UAT.