### PR TITLE
PLANET-7014 Apply new identity colors to Accordion block

### DIFF
--- a/assets/src/scss/new-identity/style.scss
+++ b/assets/src/scss/new-identity/style.scss
@@ -140,3 +140,16 @@ $palette: (
     --transparent-button--active--color: #{$color};
   }
 }
+
+// Accordion block new color.
+.accordion-block.is-style-outline .accordion-content .accordion-headline {
+  --accordion-block-outline-style-- {
+    border-color: var(--grey-500);
+    background: var(--white);
+    color: var(--grey-900);
+
+    &:hover {
+      background: var(--grey-100);
+    }
+  }
+}

--- a/assets/src/scss/new-identity/style.scss
+++ b/assets/src/scss/new-identity/style.scss
@@ -62,6 +62,11 @@
   --link--color: var(--grey-900);
   --link--visited--color: var(--grey-900);
   --link--hover--color: var(--grey-900);
+  --accordion-block-dark-style--background: var(--p4-dark-green-800);
+  --accordion-block-dark-style--hover--background: var(--p4-dark-green-900);
+  --accordion-block-light-style--background: var(--beige-100);
+  --accordion-block-light-style--border-color: transparent;
+  --accordion-block-light-style--hover--background: var(--beige-200);
 }
 
 // Spreadsheet block new color.


### PR DESCRIPTION
### Description

See [PLANET-7014](https://jira.greenpeace.org/browse/PLANET-7014)
These will only be applied if the new identity styles are enabled

**Related PR:** https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/1031

### Testing

You can add an Accordion block on local or on the janus test instance, making sure you enabled the new identity styles, and test out the various styles. You can also check [this page](https://www-dev.greenpeace.org/test-janus/all-the-accordions/) that I made for UAT. Make sure the block also still looks fine with the "old" styles, if the new identity is not enabled.