### PR TITLE
Fix Donate button dropdown arrow color

### DIFF
--- a/assets/src/scss/layout/_navbar.scss
+++ b/assets/src/scss/layout/_navbar.scss
@@ -72,7 +72,7 @@
           mask: url("../../images/chevron.svg") 0 0/10px 10px;
           transform: rotate(90deg);
           transition: transform 150ms linear;
-          background-color: $white;
+          background-color: currentColor;
           background-repeat: no-repeat;
         }
       }


### PR DESCRIPTION
### Description

You can see the issue on the [nix instance](https://www-dev.greenpeace.org/test-nix/).
With the new identity, the color is now no longer white but grey. To simplify the code we can just always set it to `currentColor`.