### PR TITLE
PLANET-7019 Remove navigation bar dark style for new identity

### DIFF
--- a/src/PublicAssets.php
+++ b/src/PublicAssets.php
@@ -89,7 +89,8 @@ final class PublicAssets
      */
     private static function conditionally_load_partials(): void
     {
-        $navbar_version = planet4_get_option('website_navigation_style', 'dark');
+        $is_new_identity = get_theme_mod('new_identity_styles');
+        $navbar_version = $is_new_identity ? 'light' : planet4_get_option('website_navigation_style', 'dark');
         $navbar_file = '/assets/build/navigation-bar-' . $navbar_version . '.min.css';
         Loader::enqueue_versioned_style($navbar_file, 'navigation-bar', [ 'parent-style' ]);
 

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -90,18 +90,6 @@ class Settings
                     ],
 
                     [
-                        'name' => __('Website Navigation Style', 'planet4-master-theme-backend'),
-                        'desc' => __('Select a style', 'planet4-master-theme-backend'),
-                        'id' => 'website_navigation_style',
-                        'type' => 'select',
-                        'default' => 'dark',
-                        'options' => [
-                            'dark' => __('Dark', 'planet4-master-theme-backend'),
-                            'light' => __('Light', 'planet4-master-theme-backend'),
-                        ],
-                    ],
-
-                    [
                         'name' => __('New Information Architecture', 'planet4-master-theme-backend'),
                         'desc' => __('Enables all features supporting new IA and navigation functionality (<a href="https://planet4.greenpeace.org/manage/information-architecture/" target="_blank">read more</a>)<br>(eg. Actions post type, listing pages pagination, mobile tabs, etc).', 'planet4-master-theme-backend'),
                         'id' => 'new_ia',
@@ -499,6 +487,24 @@ class Settings
             ],
         ];
         // phpcs:enable Generic.Files.LineLength.MaxExceeded
+
+        $is_new_identity = get_theme_mod('new_identity_styles');
+        if (!$is_new_identity) {
+            array_push(
+                $this->subpages['planet4_settings_navigation']['fields'],
+                [
+                    'name' => __('Website Navigation Style', 'planet4-master-theme-backend'),
+                    'desc' => __('Select a style', 'planet4-master-theme-backend'),
+                    'id' => 'website_navigation_style',
+                    'type' => 'select',
+                    'default' => 'dark',
+                    'options' => [
+                        'dark' => __('Dark', 'planet4-master-theme-backend'),
+                        'light' => __('Light', 'planet4-master-theme-backend'),
+                    ],
+                ]
+            );
+        }
 
         $this->hooks();
     }


### PR DESCRIPTION
### Description

See [PLANET-7019](https://jira.greenpeace.org/browse/PLANET-7019)
This will only be applied if the new identity styles are enabled. Once we merge the new identity, we'll need to run a migration to properly remove this setting from existing data.

### Testing

Either on local or on the [telesto test instance](https://www-dev.greenpeace.org/test-telesto/), make sure that the Planet 4 `Navigation > Website Navigation Style` setting is now only available in the backend when the new identity styles are disabled. When they are enabled, the light style should always be applied in the frontend.