### PR TITLE
PLANET-6996 Apply new identity colors to the navigation bar

### DIFF
--- a/assets/src/scss/layout/navbar/_burger-menu.scss
+++ b/assets/src/scss/layout/navbar/_burger-menu.scss
@@ -74,7 +74,7 @@ $transition-duration: .2s;
   display: flex;
   flex-direction: column;
   flex-shrink: 0;
-  border-bottom: 1px solid rgba(0, 0, 0, 0.2);
+  border-bottom: var(--top-navigation--separation, 1px solid rgba(0, 0, 0, 0.2));
   padding-block-end: $sp-2;
 
   .site-logo {
@@ -120,7 +120,7 @@ $transition-duration: .2s;
   margin-top: auto;
   width: 100%;
   padding: $sp-3 0 0;
-  border-top: 1px solid rgba(0, 0, 0, 0.2);
+  border-top: var(--top-navigation--separation, 1px solid rgba(0, 0, 0, 0.2));
 
   .btn-donate {
     width: 100%;

--- a/assets/src/scss/layout/navbar/_search.scss
+++ b/assets/src/scss/layout/navbar/_search.scss
@@ -1,7 +1,7 @@
 .nav-search-form {
   background-color: var(--body--background-color);
   border: none;
-  border-top: 1px solid #c4c4c4;
+  border-top: var(--top-navigation--separation, 1px solid #c4c4c4);
   box-shadow: 0 2px 4px transparentize($black, 0.85);
   display: none;
   height: 56px;
@@ -102,6 +102,10 @@
     color: inherit;
     width: calc(100% - 48px);
   }
+
+  &::placeholder {
+    color: $grey-40;
+  }
 }
 
 #search_input:placeholder-shown ~ button.nav-search-clear {
@@ -142,7 +146,9 @@
 }
 
 .nav-search-clear {
-  background-color: $black;
+  _-- {
+    background-color: $black;
+  }
   border: none;
   float: right;
   margin-inline-end: 36px;

--- a/assets/src/scss/layout/navbar/languages.scss
+++ b/assets/src/scss/layout/navbar/languages.scss
@@ -21,7 +21,7 @@
       mask: url("../../images/chevron.svg") 0 0/10px 10px;
       transform: rotate(90deg);
       transition: transform 150ms linear;
-      background-color: $white;
+      background-color: currentColor;
       background-repeat: no-repeat;
     }
 

--- a/assets/src/scss/new-identity/style.scss
+++ b/assets/src/scss/new-identity/style.scss
@@ -67,6 +67,17 @@
   --accordion-block-light-style--background: var(--beige-100);
   --accordion-block-light-style--border-color: transparent;
   --accordion-block-light-style--hover--background: var(--beige-200);
+  --top-navigation--color: var(--grey-900);
+  --nav-link--color: var(--grey-900);
+  --nav-link--hover--color: var(--grey-900);
+  --nav-link--active--color: var(--grey-900);
+  --nav-link--visited--color: var(--grey-900);
+  --nav-search-clear--background-color: var(--grey-900);
+  --top-navigation--separation: 1px solid var(--grey-300);
+}
+
+#nav-mobile-menu {
+  --nav-link--active--color: var(--grey-900);
 }
 
 // Spreadsheet block new color.

--- a/assets/src/scss/partials/navigation-bar-light.scss
+++ b/assets/src/scss/partials/navigation-bar-light.scss
@@ -18,11 +18,3 @@
   --nav-link--active--color: #{$black};
   --nav-link--opacity: 1;
 }
-
-.nav-languages-toggle {
-  @include large-and-up {
-    &::after {
-      background-color: $grey-80;
-    }
-  }
-}


### PR DESCRIPTION
### Description

See [PLANET-6996](https://jira.greenpeace.org/browse/PLANET-6996)
These will only be applied if the new identity styles are enabled. This should only be merged after [this PR](https://github.com/greenpeace/planet4-master-theme/pull/1978), to make sure it's always the light style that is used, because with the dark style it looks weird 😅

### Testing

Make sure that the new identity styles setting is enabled (`Appearance > Customize > Site identity > Enable new Greenpeace visual identity`) and then you should see the new navigation bar colors. You can also test the changes on the [deimos test instance](https://www-dev.greenpeace.org/test-deimos/) where I already toggled the new identity styles.