### PR TITLE
Adjust GF redirection message

### DIFF
--- a/src/GravityFormsExtensions.php
+++ b/src/GravityFormsExtensions.php
@@ -577,11 +577,12 @@ class GravityFormsExtensions
             GFCommon::log_debug(__METHOD__ . '(): Redirect to URL: ' . $url);
 
             $html = sprintf(
-                '<p><b>%s</b></p><p>%s <a href="' . $url . '">%s</a> %s</p>',
-                __('Thank you!', 'planet4-master-theme'),
-                __('Please', 'planet4-master-theme'),
-                __('click here', 'planet4-master-theme'),
-                __('if you aren\'t redirected within a few seconds.', 'planet4-master-theme')
+                // translators: %s = Redirection url variable.
+                __(
+                    'Thank you! Please <a href="%s">click here</a> if you are not redirected within a few seconds.',
+                    'planet4-master-theme'
+                ),
+                $url,
             );
 
             // Get the tag manager data layer ID from master theme settings
@@ -615,7 +616,7 @@ class GravityFormsExtensions
                 }
                 </script>';
 
-            $confirmation = $html . $script;
+            $confirmation = '<p>' . $html . '</p>' . $script;
         }
 
         return $confirmation;


### PR DESCRIPTION
That would make it easier for editors to translate since it would appear as one line in Loco. This also gives them the option to completely blank the text if they don't wish to appear at all. 

I had to remove formatting too from the translatable part (except from `href`) to make it easier for editors.

![image](https://user-images.githubusercontent.com/939357/231392381-702d7ddf-5c97-4ba7-89fa-a60adce5a655.png)
