### PR TITLE
Add php platform to composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,6 +57,9 @@
     "allow-plugins": {
       "composer/installers": true,
       "dealerdirect/phpcodesniffer-composer-installer": true
+    },
+    "platform": {
+      "php": "7.4"
     }
   }
 }


### PR DESCRIPTION
# Description
It has been added automatically after I installed the new develop environment

**No ticket needed**
