### PR TITLE
Update secondary button disabled color for new identity

### DIFF
--- a/assets/src/scss/new-identity/style.scss
+++ b/assets/src/scss/new-identity/style.scss
@@ -38,6 +38,7 @@
   --button-secondary--background: var(--white);
   --button-secondary--border-color: var(--p4-dark-green-800);
   --button-secondary--color: var(--p4-dark-green-800);
+  --button-secondary--disabled--color: var(--p4-dark-green-800);
   --button-secondary--visited--color: var(--p4-dark-green-800);
   --button-secondary--hover--background: var(--p4-dark-green-800);
   --button-secondary--hover--border-color: var(--p4-dark-green-800);

--- a/tests/e2e/404.spec.js
+++ b/tests/e2e/404.spec.js
@@ -18,5 +18,5 @@ test('check the 404 page', async ({ page }) => {
   await expect(page.locator('.page-header-background img')).toHaveAttribute('src', settingsImage);
 
   // Make sure the search input is there.
-  await expect(page.locator('input[aria-label="Search"]')).toBeVisible();
+  await expect(page.locator('form.search-form input')).toBeVisible();
 });


### PR DESCRIPTION
### Description

We forgot this case when working on this 😬 

### Testing

You can either manually add the `disabled` attribute to a secondary button, or you can see this state when loading more articles in the Articles block for example. On this branch if the new identity styles are enabled, the color should be green, whereas on the `main` branch it will still be blue.