### PR TITLE
PLANET-6235: Fix ElasticSearch class usage

### DIFF
--- a/src/Search.php
+++ b/src/Search.php
@@ -235,11 +235,15 @@ abstract class Search
                 1
             );
         }
-        remove_filter(
-            'pre_get_posts',
-            [ Features::factory()->get_registered_feature('documents'), 'setup_document_search' ],
-            10
-        );
+
+        if (class_exists(Features::class)) {
+            remove_filter(
+                'pre_get_posts',
+                [ Features::factory()->get_registered_feature('documents'), 'setup_document_search' ],
+                10
+            );
+        }
+
         add_filter(
             'ep_post_query_db_args',
             [ self::class, 'exclude_unwanted_attachments' ],


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6235

Conditional class usage so that ElasticPress plugin can be safely disabled locally, without triggering a Fatal error

## Test

- Locally, disable the ElasticPress plugin
  - your instance should give an error on Search page
  - with this branch, it runs without error
