### PR TITLE
PLANET-6997 Apply new identity colors to cookies box

### DIFF
--- a/assets/src/scss/new-identity/style.scss
+++ b/assets/src/scss/new-identity/style.scss
@@ -136,7 +136,7 @@ table.spreadsheet-table.is-color-gp-green {
   }
 }
 
-// Body Copy links selectors
+// Body links
 .post-content,
 .page-content {
   p > a,
@@ -145,6 +145,16 @@ table.spreadsheet-table.is-color-gp-green {
   }
 }
 
+// Cookies box links
+.cookies-text,
+.cookies-settings-details {
+  a {
+    @include shared-link-styles;
+    transition-timing-function: cubic-bezier(0.5, 0, 0, 0.5);
+  }
+}
+
+// Standalone links
 .standalone-link,
 .comment-reply-link {
   @include shared-link-styles;

--- a/assets/src/scss/new-identity/style.scss
+++ b/assets/src/scss/new-identity/style.scss
@@ -63,7 +63,7 @@
   --table-odd-row-green--background: var(--beige-200);
   --table-even-row-green--background: var(--beige-100);
   --table-footer-green--background: var(--table-footer-new--background);
-  --table-header-blue--background: #167f82;
+  --table-header-blue--background: var(--blue-green-800);
   --table-odd-row-blue--background: var(--beige-200);
   --table-even-row-blue--background: var(--beige-100);
   --table-footer-blue--background: var(--table-footer-new--background);
@@ -171,7 +171,7 @@ $palette: (
   "action-yellow": var(--p4-action-yellow-500),
   "dark-green-800": var(--p4-dark-green-800),
   "beige-100": var(--beige-100),
-  "blue-green-800": #167f82,
+  "blue-green-800": var(--blue-green-800),
   "red-500": var(--red-500),
   "white": var(--white),
   "grey-100": var(--grey-100),


### PR DESCRIPTION
### Description

See [PLANET-6997](https://jira.greenpeace.org/browse/PLANET-6997)
We only need to make sure that links follow the body links styles

### Testing

When the new identity styles are enabled, the cookies box should have the new identity colors. Make sure to test it with links within the texts. Also, make sure that the "old" cookies box still looks fine!