### PR TITLE
Fix reading time translation in listing pages

### DIFF
--- a/src/Post.php
+++ b/src/Post.php
@@ -539,7 +539,12 @@ class Post extends TimberPost
         WP_Block $block
     ): string {
         $time = ( new self($block->context['postId'] ?? null) )->reading_time();
-        return $time ? '<span class="article-list-item-readtime">' . $time . ' min read</span>' : '';
+        return $time ?
+            '<span class="article-list-item-readtime">'
+                // translators: reading time in min.
+                . sprintf(__('%d min read', 'planet4-master-theme'), $time) .
+            '</span>'
+            : '';
     }
     // phpcs:enable SlevomatCodingStandard.Functions.UnusedParameter
 


### PR DESCRIPTION
### Description

We forgot to add the possibility to translate this string here, it was reported on Slack! You can find an example page of the issue [here](https://www.greenpeace.org/brasil/blog/)