### PR TITLE
PLANET-7143 Fix spacing in RTL paginated listing pages

### DIFF
--- a/assets/src/scss/pages/_listing-page.scss
+++ b/assets/src/scss/pages/_listing-page.scss
@@ -27,12 +27,6 @@
       height: 190px;
       object-fit: cover;
       object-position: 50% 50%;
-      margin-right: $sp-2;
-
-      html[dir="rtl"] & {
-        margin-right: 0;
-        margin-left: $sp-2;
-      }
 
       @include medium-and-up {
         height: 200px;
@@ -191,7 +185,7 @@
   &.wp-block-query--list {
     .query-list-item-body {
       @include medium-and-up {
-        padding: 0 0 0 $sp-2x;
+        padding-inline-start: $sp-2x;
       }
     }
   }


### PR DESCRIPTION
### Description

See [PLANET-7143](https://jira.greenpeace.org/browse/PLANET-7143)
On bigger screens some padding was missing between the image and text

### Testing

On local, make sure you have the paginated lists enabled (`Planet 4 > Navigation > New Information Architecture` setting) and go to any listing page (such as `/press`). You can then manually change the direction to `rtl` on the `html` element and see that the padding is now correct. Please test all screen sizes and also the `ltr` version!
Alternatively, you can check out [this listing page](https://www-dev.greenpeace.org/test-neptune/story/) from the neptune test instance.