### PR TITLE
Implement new yellow CSS variables to links

### DIFF
--- a/assets/src/scss/new-identity/style.scss
+++ b/assets/src/scss/new-identity/style.scss
@@ -89,6 +89,10 @@
 
   // TODO: Review these fallback variables after we'll merge the new identity colors
   --comments-block--comment-respond--background: var(--color-background-comments_block);
+  --campaign-covers-block--covers--thumbnail-large--yellow-cta--color: var(--p4-action-yellow-500);
+  --split-two-column-item-tag--color: var(--p4-action-yellow-500);
+  --split-two-column-item-tag--hover--color: var(--p4-action-yellow-500);
+  --split-two-column-item-tag--visited--color: var(--p4-action-yellow-500);
 }
 
 #nav-mobile-menu {


### PR DESCRIPTION
## Description
As a part of [#1044](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/1044) we will need to standardize the yellow color to the Split Two Columns block and to the Campaign Cover block, by using always the `yellow-500` color.

<!-- Ref: Please add a url to the ticket this change is addressing.

---

Please provide a brief summary of the change introduced to make review process easier.

Ideally this should also be part of the commit summary.
-->
