### PR TITLE
PLANET-7149 Fix Gravity Forms submit button styles

### DIFF
--- a/assets/src/scss/components/_buttons.scss
+++ b/assets/src/scss/components/_buttons.scss
@@ -3,7 +3,7 @@
 .wp-block-file a.wp-block-file__button,
 .gfield button:not(.add_list_item):not(.delete_list_item):not([id^="mceu"]),
 .gform_button_select_files,
-.gform_footer input[type="submit"] {
+[id^="gform_submit_button"] {
   --button-- {
     font-family: var(--headings--font-family);
     text-align: center;
@@ -80,7 +80,7 @@
 
 .btn-primary,
 .wp-block-button.is-style-cta a,
-.gform_footer input[type="submit"] {
+[id^="gform_submit_button"] {
   --button-primary-- {
     background: $orange;
     color: $white;


### PR DESCRIPTION
### Description

See [PLANET-7149](https://jira.greenpeace.org/browse/PLANET-7149)
GP Luxembourg for some reason [replaced](https://github.com/greenpeace/planet4-child-theme-luxembourg/blob/bc79f742169b60d619ccfcbbd961264235fb2389/plugins/gravityforms-gpf/src/Plugin.php#L113-L114) the `input` tag by a `button` so our previous selector doesn't work for them. By using the `id` instead the problem should be solved, and it should still work for other sites too.

### Testing

Either on local or on the telesto test instance, if you add a Gravity Forms the submit button should be styled as expected (with our primary buttons styles).