### PR TITLE
PLANET-7127: Apply the new Greenpeace sans typeface

### DIFF
--- a/assets/src/scss/base/_typography.scss
+++ b/assets/src/scss/base/_typography.scss
@@ -40,12 +40,16 @@ h6 {
 }
 
 h1 {
-  line-height: 1.225;
+  _-- {
+    line-height: 1.225;
+    font-size: $font-size-xxl;
+  }
   margin-bottom: 30px;
-  font-size: $font-size-xxl;
 
   @include medium-and-up {
-    font-size: $font-size-xxxxl;
+    _-- {
+      font-size: $font-size-xxxxl;
+    }
   }
 
   @include large-and-up {
@@ -54,12 +58,16 @@ h1 {
 }
 
 h2 {
-  line-height: 1.38;
+  _-- {
+    line-height: 1.38;
+    font-size: $font-size-xl;
+  }
   margin-bottom: 5px;
-  font-size: $font-size-xl;
 
   @include medium-and-up {
-    font-size: $font-size-xxl;
+    _-- {
+      font-size: $font-size-xxl;
+    }
   }
 
   @include x-large-and-up {
@@ -68,31 +76,45 @@ h2 {
 }
 
 h3 {
-  font-size: $font-size-lg;
+  _-- {
+    font-size: $font-size-lg;
+  }
 
   @include medium-and-up {
-    font-size: $font-size-xl;
+    _-- {
+      font-size: $font-size-xl;
+    }
   }
 }
 
 h4 {
-  font-size: $font-size-md;
+  _-- {
+    font-size: $font-size-md;
+  }
 
   @include medium-and-up {
-    font-size: $font-size-lg;
+    _-- {
+      font-size: $font-size-lg;
+    }
   }
 }
 
 h5 {
-  font-size: $font-size-sm;
+  _-- {
+    font-size: $font-size-sm;
+  }
 
   @include medium-and-up {
-    font-size: $font-size-md;
+    _-- {
+      font-size: $font-size-md;
+    }
   }
 }
 
 h6 {
-  font-size: $font-size-sm;
+  _-- {
+    font-size: $font-size-sm;
+  }
 }
 
 .white-text {

--- a/assets/src/scss/components/_buttons.scss
+++ b/assets/src/scss/components/_buttons.scss
@@ -6,6 +6,8 @@
 [id^="gform_submit_button"] {
   --button-- {
     font-family: var(--headings--font-family);
+    font-size: $font-size-sm;
+    line-height: 3;
     text-align: center;
     font-weight: bold;
     border-radius: 4px;
@@ -32,11 +34,9 @@
 
   display: inline-block;
   position: relative;
-  font-size: $font-size-sm;
   text-decoration: none;
   border: 1px solid transparent;
   cursor: pointer;
-  line-height: 3;
   appearance: none;
 
   &:hover,

--- a/assets/src/scss/layout/_cookies.scss
+++ b/assets/src/scss/layout/_cookies.scss
@@ -61,9 +61,11 @@
 
 .cookies-buttons {
   .btn {
+    _-- {
+      line-height: 2.4;
+      font-size: 14px;
+    }
     width: 100%;
-    line-height: 2.4;
-    font-size: 14px;
   }
 
   .btn-primary {

--- a/assets/src/scss/layout/_navbar.scss
+++ b/assets/src/scss/layout/_navbar.scss
@@ -271,9 +271,11 @@ a.nav-link:hover:before,
 
 .nav-item,
 .nav-donate {
+  _-- {
+    font-size: $font-size-sm;
+    font-weight: 700;
+  }
   color: inherit;
-  font-size: $font-size-sm;
-  font-weight: 700;
 
   @include large-and-up {
     line-height: var(--navbar-menu-height);

--- a/assets/src/scss/new-identity/style.scss
+++ b/assets/src/scss/new-identity/style.scss
@@ -135,6 +135,13 @@
   --cookies-settings--p--font-size: var(--font-size-xs--font-family-tertiary);
   --cookies-settings--p--large-and-up--font-size: var(--font-size-xs--font-family-tertiary);
   --cookies-settings--p--line-height: var(--line-height-xs--font-family-tertiary);
+  --cookies-block--custom-control-description--font-family: var(--font-family-heading);
+  --cookies-block--custom-control-description--font-size: var(--font-size-xl--font-family-primary);
+  --cookies-block--custom-control-description--x-large-and-up--font-size: var(--font-size-2xl--font-family-primary);
+  --cookies-block--custom-control--input--type--checkbox--custom-control-description--font-family: var(--font-family-tertiary);
+  --cookies-block--custom-control--input--type--checkbox--custom-control-description--font-size: var(--font-size-m--font-family-tertiary);
+  --cookies-block--custom-control--input--type--checkbox--custom-control-description--x-large-and-up--font-size: 20px;
+  --cookies-block--always-enabled--font-family: var(--font-family-tertiary);
   --cover-card-excerpt--font-family: var(--font-family-paragraph-secondary);
   --cover-card-excerpt--font-size: var(--font-size-s--font-family-tertiary);
   --cover-card-excerpt--line-height: var(--line-height-s--font-family-tertiary);
@@ -157,7 +164,10 @@
   --site-footer--copyright--span--line-height: var(--line-height-xs--font-family-tertiary);
   --top-page-tags--font-family: var(--font-family-paragraph-secondary);
   --top-page-tags--font-size: var(--font-size-m--font-family-tertiary);
-  --top-navigation--font-family: var(--font-family-paragraph-secondary);
+  --top-page-tags--tag-item--font-weight: var(--font-weight-semibold);
+  --top-navigation--font-family: var(--font-family-primary);
+  --button--font-family: var(--font-family-primary);
+  --button--font-weight: var(--font-weight-regular);
   --ui-datepicker--font-family: var(--font-family-paragraph-secondary);
 }
 
@@ -234,6 +244,10 @@ table.spreadsheet-table.is-color-gp-green {
   font-family: var(--headings--font-family);
 }
 
+.comments-block .comment-respond button {
+  height: 48px;
+}
+
 #gdpr-comments-compliance #gdpr-comments-label {
   line-height: var(--line-height-m--font-family-tertiary);
 }
@@ -247,7 +261,8 @@ table.spreadsheet-table.is-color-gp-green {
   display: inline-block;
   width: fit-content;
   height: var(--link--height);
-  font-weight: 700 !important;
+  font-weight: var(--font-weight-regular);
+  font-family: var(--font-family-primary) !important;
 }
 
 .split-two-column-item-link {
@@ -368,4 +383,9 @@ $palette: (
 .top-page-tags {
   font-weight: var(--font-weight-semibold);
   line-height: var(--line-height-m--font-family-tertiary);
+}
+
+// Articles
+.article-list-item-headline {
+  font-family: var(--font-family-heading);
 }

--- a/assets/src/scss/pages/post/_comments-form.scss
+++ b/assets/src/scss/pages/post/_comments-form.scss
@@ -39,7 +39,9 @@
 }
 
 #gdpr-comments-compliance {
-  font-family: var(--headings--font-family);
+  --comments-compliance-- {
+    font-family: var(--headings--font-family);
+  }
   margin-bottom: 8px;
 
   #gdpr-comments-checkbox {
@@ -61,8 +63,10 @@
 }
 
 .logged-in-as {
-  font-size: 14px;
-  font-family: var(--headings--font-family);
+  _-- {
+    font-size: 14px;
+    font-family: var(--headings--font-family);
+  }
 }
 
 #cancel-comment-reply-link {


### PR DESCRIPTION
Ref: [PLANET-7127](https://jira.greenpeace.org/browse/PLANET-7127)

## Description
Apply the new Greenpeace Sans (primary) typeface to:
- Headings
- Buttons
- Navigation menu items

Related to
 - #2008 
 - #2051
 - #2052
 - https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/1078
