### PR TITLE
PLANET-7146 Form Builder: Disable IP address retention during submission

### DIFF
--- a/src/GravityFormsExtensions.php
+++ b/src/GravityFormsExtensions.php
@@ -108,6 +108,7 @@ class GravityFormsExtensions
         add_filter('gform_confirmation', [ $this, 'p4_gf_custom_confirmation_redirect' ], 11, 2);
         add_filter('gform_pre_render', [ $this, 'p4_client_side_gravityforms_prefill' ], 10, 1);
         add_action('gform_post_form_duplicated', [ $this, 'p4_gf_duplicated_form' ], 10, 2);
+        add_filter('gform_form_update_meta', [$this, 'p4_gf_enable_default_meta_settings'], 10, 1);
     }
 
     /**
@@ -656,5 +657,17 @@ class GravityFormsExtensions
         foreach ($form_feed as $key => $value) {
             GFAPI::add_feed($new_form_id, $value['meta'], $value['addon_slug']);
         }
+    }
+
+    /**
+     * Enable default meta parameters for Gravity forms.
+     *
+     * @param array $meta Associative array containing all form properties.
+     *
+    */
+    public function p4_gf_enable_default_meta_settings(array $meta): array
+    {
+        $meta['personalData']['preventIP'] = true;
+        return $meta;
     }
 }


### PR DESCRIPTION
**Description: [PLANET-7146](https://jira.greenpeace.org/browse/PLANET-7146)**

**Testing:**

On local, go to Gravity Forms and create a new form, for the current behaviour, the toggle to _Prevent the storage of IP addresses during form submission_  is disabled. 
Having this changes locally or on the associated branch, all newly created forms should have this toggle enabled by default.

<!-- Ref: Please add a url to the ticket this change is addressing.

---

Please provide a brief summary of the change introduced to make review process easier.

Ideally this should also be part of the commit summary.
-->
