### PR TITLE
PLANET-7148 Form Builder: Enforce data retention policy

### DIFF
--- a/src/GravityFormsExtensions.php
+++ b/src/GravityFormsExtensions.php
@@ -668,6 +668,8 @@ class GravityFormsExtensions
     public function p4_gf_enable_default_meta_settings(array $meta): array
     {
         $meta['personalData']['preventIP'] = true;
+        $meta['personalData']['retention']['policy'] = 'delete';
+        $meta['personalData']['retention']['retain_entries_days'] = 90;
         return $meta;
     }
 }


### PR DESCRIPTION
Description: [PLANET-7146](https://jira.greenpeace.org/browse/PLANET-7146)

Testing:

On local, go to Gravity Forms and create a new form, for the current behaviour, the _Retention Policy_ should have _`Retain entries indefinitely`_ as the default.
Having this changes locally or on the associated branch, all newly created forms should have _`Delete entries permanently automatically`_ as the default with a `90days` period.

<!-- Ref: Please add a url to the ticket this change is addressing.

---

Please provide a brief summary of the change introduced to make review process easier.

Ideally this should also be part of the commit summary.
-->
