### PR TITLE
PLANET-7147 Form Builder: Enable integration with native export tool

### DIFF
--- a/src/GravityFormsExtensions.php
+++ b/src/GravityFormsExtensions.php
@@ -109,6 +109,7 @@ class GravityFormsExtensions
         add_filter('gform_pre_render', [ $this, 'p4_client_side_gravityforms_prefill' ], 10, 1);
         add_action('gform_post_form_duplicated', [ $this, 'p4_gf_duplicated_form' ], 10, 2);
         add_filter('gform_form_update_meta', [$this, 'p4_gf_enable_default_meta_settings'], 10, 1);
+        add_filter('gform_form_post_get_meta', [$this, 'p4_gf_enable_default_meta_settings'], 10, 1);
     }
 
     /**
@@ -670,6 +671,7 @@ class GravityFormsExtensions
         $meta['personalData']['preventIP'] = true;
         $meta['personalData']['retention']['policy'] = 'delete';
         $meta['personalData']['retention']['retain_entries_days'] = 90;
+        $meta['personalData']['exportingAndErasing']['enabled'] = true;
         return $meta;
     }
 }


### PR DESCRIPTION
**Description: [PLANET-7147](https://jira.greenpeace.org/browse/PLANET-7147)**

**Testing:**

On local, go to Gravity Forms and create a new form, for the current behaviour, _Exporting and Erasing Data_ toggle should be off by default.
Having this changes locally or on the associated test instance, all newly created forms should have this toggle switched to on by default.
<!-- Ref: Please add a url to the ticket this change is addressing.

---

Please provide a brief summary of the change introduced to make review process easier.

Ideally this should also be part of the commit summary.
-->
