### PR TITLE
PLANET-7183 Fix search unwanted attachments

### DIFF
--- a/src/Search.php
+++ b/src/Search.php
@@ -226,15 +226,6 @@ abstract class Search
                 2
             );
         }
-        // Only invoked if the page for posts is set.
-        if (null !== get_option('page_for_posts')) {
-            add_filter(
-                'pre_get_posts',
-                [ self::class, 'exclude_page_for_posts' ],
-                10,
-                1
-            );
-        }
 
         if (class_exists(Features::class)) {
             remove_filter(
@@ -245,8 +236,8 @@ abstract class Search
         }
 
         add_filter(
-            'ep_post_query_db_args',
-            [ self::class, 'exclude_unwanted_attachments' ],
+            'pre_get_posts',
+            [ self::class, 'exclude_unwanted_ids' ],
             10,
             1
         );
@@ -1043,15 +1034,15 @@ abstract class Search
     }
 
     /**
-     * Fetch all attachments that we don't want to include in search,
+     * Fetch all ids that we don't want to include in search,
      * so that we can exclude them from ElasticPress sync.
      *
-     * @param mixed[] $args The args ElasticPress will use to fetch the ids of posts that will be synced.
+     * @param WP_Query $query The Query ElasticPress will use to fetch the ids of posts.
      *
-     * @return mixed The args with exclusion of unwanted ids.
+     * @return WP_Query The query with exclusion of unwanted ids.
      * @throws Exception\SqlInIsEmpty Well it really won't unless we make self::DOCUMENT_TYPES into an empty array.
      */
-    public static function exclude_unwanted_attachments(array $args)
+    public static function exclude_unwanted_ids(WP_Query $query): WP_QUERY
     {
         global $wpdb;
 
@@ -1061,29 +1052,19 @@ abstract class Search
             . ' WHERE post_type = "attachment"'
             . ' AND post_mime_type NOT IN ' . $params->string_list(self::DOCUMENT_TYPES);
 
-        $unwanted_attachment_ids = $wpdb->get_col(
+        // Exclude the unwanted attachments (such as images).
+        $unwanted_ids = $wpdb->get_col(
             $wpdb->prepare($sql, $params->get_values()) // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
         );
 
-        $args['post__not_in'] = $unwanted_attachment_ids;
-
-        return $args;
-    }
-
-    /**
-     * Exclude the page for posts set through the Settings > Reading page.
-     *
-     * @param WP_Query $query The Query ElasticPress will use to fetch the ids of posts.
-     *
-     * @return WP_Query The Query with exclusion of the page for posts.
-     */
-    public static function exclude_page_for_posts(WP_Query $query): WP_Query
-    {
+        // Exclude the page for posts set through the Settings > Reading page.
         $page_for_posts = get_option('page_for_posts');
 
         if ($page_for_posts) {
-            $query->set('post__not_in', [ $page_for_posts ]);
+            $unwanted_ids = array_merge($unwanted_ids, [ $page_for_posts ]);
         }
+
+        $query->set('post__not_in', $unwanted_ids);
 
         return $query;
     }


### PR DESCRIPTION
### Description

See [PLANET-7183](https://jira.greenpeace.org/browse/PLANET-7183) (in the comments)
We should only show PDF files but before this fix images showed too. It seems to be due to the use of `ep_post_query_db_args` filter that no longer works as expected.

### Testing

Before this fix you'll see images in search results, after they should no longer be there (but PDF files should still show as expected)