### PR TITLE
Add new fonts

### DIFF
--- a/assets/src/scss/new-identity/_fonts.scss
+++ b/assets/src/scss/new-identity/_fonts.scss
@@ -1,9 +1,9 @@
 $bucket: "https://www.greenpeace.org/static/planet4-assets/";
 
 $fonts: (
+  #{$font-family-greenpeace-sans},
   #{$font-family-source-sans-3},
-  #{$font-family-source-sans-3-bold},
-  #{$font-family-source-sans-3-semibold},
+  #{$font-family-source-serif-pro},
 );
 
 @each $font in $fonts {


### PR DESCRIPTION
# Description
In preparation of [PLANET-7126](https://jira.greenpeace.org/browse/PLANET-7126) and [PLANET-7127](https://jira.greenpeace.org/browse/PLANET-7127)

Currently, all the new font families has included its variants, then, we don't need to have `bold` and `semi bold` font families anymore.

Includes:
- Greenpeace Sans
- Source Sans Pro

<!-- Ref: Please add a url to the ticket this change is addressing.

---

Please provide a brief summary of the change introduced to make review process easier.

Ideally this should also be part of the commit summary.
-->
