### PR TITLE
Disable Akismet admin spam button

### DIFF
--- a/admin/js/options.js
+++ b/admin/js/options.js
@@ -1,0 +1,5 @@
+const spamButtons = document.querySelectorAll('.checkforspam');
+
+spamButtons.forEach(box => {
+  box.remove();
+});

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -766,6 +766,15 @@ class Settings
             Loader::theme_file_ver('admin/css/options.css')
         );
         wp_enqueue_style('options-style');
+
+        wp_enqueue_script(
+            'options-script',
+            get_template_directory_uri() . '/admin/js/options.js',
+            [],
+            Loader::theme_file_ver('admin/js/options.js'),
+            true
+        );
+        wp_enqueue_script('options-script');
     }
 
     /**


### PR DESCRIPTION
To reduce the amount of excessive requests to Akismet API, since we are exceeding our current rate limit. Comments are already being scanned through Akismet on submission.

### Testing
1. Add a new comment (without being logged in)
2. Login and go to Comments. This new comment should be pending.

- Before this change a "Check for Spam" button should be visible on top. It's only visible when there is a pending comment.
- After this change the button should be hidden in all cases.