### PR TITLE
PLANET-7103 Fix comment form logged in text overlap

### DIFF
--- a/assets/src/scss/pages/post/_comments-form.scss
+++ b/assets/src/scss/pages/post/_comments-form.scss
@@ -87,6 +87,8 @@
       position: absolute;
       top: 32px;
       right: 32px;
+      max-width: 70%;
+      line-height: 1.3;
 
       html[dir="rtl"] & {
         left: 32px;


### PR DESCRIPTION
### Description

See [PLANET-7103](https://jira.greenpeace.org/browse/PLANET-7103)
If the user name is too long then before this fix the logged in text would overlap with comment form title

### Testing

Log in and check the comment form on any post. If your username is not long enough, you can manually change the string when inspecting the element.

<img width="716" alt="Screenshot 2023-06-27 at 10 05 09" src="https://github.com/greenpeace/planet4-master-theme/assets/6949075/d64f1084-6378-4f60-88a1-91c1244f660d">