### PR TITLE
PLANET-5789 Make sure posts report is only visible to some users

### DIFF
--- a/src/PostReportController.php
+++ b/src/PostReportController.php
@@ -63,6 +63,10 @@ class PostReportController
      */
     public function add_posts_report_admin_menu_item(): void
     {
+        if (! current_user_can('edit_posts')) {
+            return;
+        }
+
         add_posts_page(
             __('Posts Report', 'planet4-master-theme-backend'),
             __('Posts Report', 'planet4-master-theme-backend'),


### PR DESCRIPTION
### Description

See [PLANET-5789](https://jira.greenpeace.org/browse/PLANET-5789)
I couldn't find a way to specifically target subscribers, but I think it makes sense that users who can't edit posts shouldn't see the posts report?

Actually, it turns out only subscribers cannot edit posts so that's a good solution 😄 