### PR TITLE
Update dashdash dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
       },
       "devDependencies": {
         "@commitlint/cli": "^12.1.1",
-        "@greenpeace/dashdash": "^1.1.2",
+        "@greenpeace/dashdash": "^1.2.1",
         "@playwright/test": "^1.30.0",
         "@wordpress/components": "^8.3.2",
         "@wordpress/eslint-plugin": "^2.3.0",
@@ -2158,9 +2158,9 @@
       "dev": true
     },
     "node_modules/@greenpeace/dashdash": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@greenpeace/dashdash/-/dashdash-1.1.3.tgz",
-      "integrity": "sha512-gYpb7ZSpiNx+KHv7YrU8ebOAUx3Saeyc7HPz7qgJ6rTU3HZijrfjQDecJvv99Tn2iuQITTsjF/+oyVfG5/VstA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@greenpeace/dashdash/-/dashdash-1.2.1.tgz",
+      "integrity": "sha512-5Pcza+Qg06sge3ruGsed/jkQyDaf753bb/5LUAO30mhHmAc4OtGKfineotDgNa2ZsAmHzoXwKGpVu4XZ4x0tnw==",
       "dev": true,
       "dependencies": {
         "postcss": "^7.0.32"

--- a/package.json
+++ b/package.json
@@ -11,11 +11,11 @@
   },
   "devDependencies": {
     "@commitlint/cli": "^12.1.1",
-    "@greenpeace/dashdash": "^1.1.2",
+    "@greenpeace/dashdash": "^1.2.1",
     "@playwright/test": "^1.30.0",
     "@wordpress/components": "^8.3.2",
-    "@wordpress/scripts": "3.3.0",
     "@wordpress/eslint-plugin": "^2.3.0",
+    "@wordpress/scripts": "3.3.0",
     "autoprefixer": "^9.6.1",
     "bootstrap": "^5.1.3",
     "css-loader": "^3.6.0",
@@ -38,8 +38,8 @@
   ],
   "dependencies": {
     "classnames": "^2.2.6",
-    "lite-youtube-embed": "^0.1.3",
     "eslint": "^5.16.0",
+    "lite-youtube-embed": "^0.1.3",
     "popper.js": "^1.15.0"
   },
   "engines": {


### PR DESCRIPTION
# Description
The latest `v1.2.1` version includes the possibility to work with prefix and multi-selectors.

The below error was being returned before the new [dash-dash version](https://github.com/greenpeace/planet4-dashdash/releases/tag/v1.2.1)
```
Module build failed (from ./node_modules/mini-css-extract-plugin/dist/loader.js):
ModuleBuildError: Module build failed (from ./node_modules/postcss-loader/src/index.js):
Error: Cannot generate prefix when using multiple selectors. .nav-item _--,.nav-donate _--
    at /home/circleci/project/assets/src/scss/partials/navigation-bar-dark.scss:1:4161
    at /home/circleci/project/node_modules/@greenpeace/dashdash/index.js:59:19
    at /home/circleci/project/node_modules/postcss/lib/container.js:243:18
    at /home/circleci/project/node_modules/postcss/lib/container.js:139:18
```

<!-- Ref: Please add a url to the ticket this change is addressing.

---

Please provide a brief summary of the change introduced to make review process easier.

Ideally this should also be part of the commit summary.
-->
