### PR TITLE
Small fix to get bigger avatars on certain pages

### DIFF
--- a/templates/author.twig
+++ b/templates/author.twig
@@ -5,7 +5,7 @@
         {% if ( author.avatar ) %}
             <figure class="author-image" aria-label="{{ __( 'Picture of ' ~ author.name , 'planet4-master-theme' ) }}">
                 <img itemprop="image" class="author-pic"
-                     src="{{ fn('get_avatar_url', author.id, {'size' : 300}) }}"
+                     src="{{ fn('get_avatar_url', author.id, {'size' : 300}) | trim('=s96-c') }}"
                      alt="{{ author.name }}">
             </figure>
         {% endif %}

--- a/templates/blocks/author_profile.twig
+++ b/templates/blocks/author_profile.twig
@@ -16,7 +16,7 @@
                     <figure class="author-block-image d-block d-sm-block d-md-none">
                         <img
                             itemprop="image"
-                            src="{{ fn('get_avatar_url', post.author.id, {'size' : 294 }) }}"
+                            src="{{ fn('get_avatar_url', post.author.id, {'size' : 294 }) | trim('=s96-c') }}"
                             alt="{{ post.author.name }}"
                         />
                     </figure>


### PR DESCRIPTION
Google profile avatars plugins seems to add a suffix string that fetches smaller images than what we want in certain cases.

This is a hotfix till we have a response from them for a better way to handle this.

### Testing 

Unfortunately we can't test this easily locally, since we don't have Google login.

But here is how it looks currently in production: https://www.greenpeace.org/international/author/nikos-roussos/
vs
How it looks fixed in the test instance: https://www-dev.greenpeace.org/test-mars/author/nroussos/

_(inspect the img src)_