### PR TITLE
PLANET-6840: Rename admin panel configuration options from Media Archive

### DIFF
--- a/assets/src/js/media_archive.js
+++ b/assets/src/js/media_archive.js
@@ -1,6 +1,5 @@
 import ArchivePicker from './Components/ArchivePicker';
-import {render} from '@wordpress/element';
-
+import {createRoot} from '@wordpress/element';
 const rootElement = document.getElementById('archive-picker-root');
 
-render(<ArchivePicker />, rootElement);
+createRoot(rootElement).render(<ArchivePicker />);

--- a/src/Features/MediaArchive.php
+++ b/src/Features/MediaArchive.php
@@ -9,6 +9,8 @@ use P4\MasterTheme\Feature;
  */
 class MediaArchive extends Feature
 {
+    public const OPTIONS_KEY = 'p4ml_main_settings';
+
     /**
      * @inheritDoc
      */
@@ -45,5 +47,39 @@ class MediaArchive extends Feature
     public static function show_toggle_production(): bool
     {
         return true;
+    }
+
+     /**
+     * Get the Media Library options settings.
+     *
+     * @return array Settings for the Media Library page.
+     */
+    public static function get_options_page(): array
+    {
+        return [
+            'title' => 'Media Archive',
+            // phpcs:disable Generic.Files.LineLength.MaxExceeded
+            'description' => __('Please enter your Image Archive username and password. Please note that you will need to ask from the Image Archive administrators to enable API access for your account.', 'planet4-master-theme-backend'),
+            // phpcs:enable Generic.Files.LineLength.MaxExceeded
+            'root_option' => self::OPTIONS_KEY,
+            'fields' => [
+                [
+                    'name' => __('Username', 'planet4-master-theme-backend'),
+                    'id' => 'p4ml_api_username',
+                    'type' => 'text',
+                    'attributes' => [
+                        'type' => 'text',
+                    ],
+                ],
+                [
+                    'name' => __('Password', 'planet4-master-theme-backend'),
+                    'id' => 'p4ml_api_password',
+                    'type' => 'text',
+                    'attributes' => [
+                        'type' => 'password',
+                    ],
+                ],
+            ],
+        ];
     }
 }

--- a/src/Features/MediaArchive.php
+++ b/src/Features/MediaArchive.php
@@ -9,8 +9,6 @@ use P4\MasterTheme\Feature;
  */
 class MediaArchive extends Feature
 {
-    public const OPTIONS_KEY = 'p4ml_main_settings';
-
     /**
      * @inheritDoc
      */
@@ -47,39 +45,5 @@ class MediaArchive extends Feature
     public static function show_toggle_production(): bool
     {
         return true;
-    }
-
-     /**
-     * Get the Media Library options settings.
-     *
-     * @return array Settings for the Media Library page.
-     */
-    public static function get_options_page(): array
-    {
-        return [
-            'title' => 'Media Archive',
-            // phpcs:disable Generic.Files.LineLength.MaxExceeded
-            'description' => __('Please enter your Image Archive username and password. Please note that you will need to ask from the Image Archive administrators to enable API access for your account.', 'planet4-master-theme-backend'),
-            // phpcs:enable Generic.Files.LineLength.MaxExceeded
-            'root_option' => self::OPTIONS_KEY,
-            'fields' => [
-                [
-                    'name' => __('Username', 'planet4-master-theme-backend'),
-                    'id' => 'p4ml_api_username',
-                    'type' => 'text',
-                    'attributes' => [
-                        'type' => 'text',
-                    ],
-                ],
-                [
-                    'name' => __('Password', 'planet4-master-theme-backend'),
-                    'id' => 'p4ml_api_password',
-                    'type' => 'text',
-                    'attributes' => [
-                        'type' => 'password',
-                    ],
-                ],
-            ],
-        ];
     }
 }

--- a/src/MediaArchive/UiIntegration.php
+++ b/src/MediaArchive/UiIntegration.php
@@ -28,6 +28,7 @@ class UiIntegration
             return;
         }
         add_action('admin_menu', [ self::class, 'picker_page' ], 10);
+        add_action('admin_menu', [ self::class, 'ml_credentials_page' ], 10);
     }
 
     /**
@@ -58,22 +59,79 @@ class UiIntegration
             return;
         }
 
-        add_menu_page(
-            __('Media Archive', 'planet4-master-theme-backend'),
-            __('Media Archive', 'planet4-master-theme-backend'),
+        add_media_page(
+            __('Archive', 'planet4-master-theme-backend'),
+            __('Archive', 'planet4-master-theme-backend'),
             Capability::USE_MEDIA_ARCHIVE,
             'media-picker',
             [ self::class, 'output_picker' ],
-            'dashicons-format-image',
-            11
         );
+    }
 
-        add_submenu_page(
-            'media-picker',
-            __('Media Archive', 'planet4-master-theme-backend'),
-            __('Library', 'planet4-master-theme-backend'),
+    /**
+     * Add Media Library credential page to media nav.
+     */
+    public static function ml_credentials_page(): void
+    {
+        if (! current_user_can(Capability::USE_MEDIA_ARCHIVE)) {
+            return;
+        }
+
+        add_media_page(
+            __('Media Archive Settings', 'planet4-master-theme-backend'),
+            __('Archive Settings', 'planet4-master-theme-backend'),
             Capability::USE_MEDIA_ARCHIVE,
-            'media-picker'
+            'media-archive-settings',
+            function (): void {
+                $option_key = 'p4ml_main_settings';
+                // phpcs:disable Generic.Files.LineLength.MaxExceeded
+                $description = __('Please enter your Image Archive username and password. Please note that you will need to ask from the Image Archive administrators to enable API access for your account.', 'planet4-master-theme-backend');
+                // phpcs:enable Generic.Files.LineLength.MaxExceeded
+                $form = cmb2_metabox_form(
+                    [
+                        'id' => 'option_metabox',
+                        'show_on' => [
+                            'key' => 'options-page',
+                            'value' => [
+                                $option_key,
+                            ],
+                        ],
+                        'show_names' => true,
+                        'fields' => [
+                            [
+                                'name' => __('Username', 'planet4-master-theme-backend'),
+                                'id' => 'p4ml_api_username',
+                                'type' => 'text',
+                                'attributes' => [
+                                    'type' => 'text',
+                                ],
+                            ],
+                            [
+                                'name' => __('Password', 'planet4-master-theme-backend'),
+                                'id' => 'p4ml_api_password',
+                                'type' => 'text',
+                                'attributes' => [
+                                    'type' => 'password',
+                                ],
+                            ],
+                        ],
+                    ],
+                    $option_key,
+                    [ 'echo' => false ]
+                );
+
+                echo sprintf(
+                    '<div class="wrap %s">
+                        <h2>%s</h2>
+                        %s
+                        %s
+                    </div>',
+                    esc_attr($option_key),
+                    esc_html(get_admin_page_title()),
+                    wp_kses($description ? '<div>' . $description . '</div>' : '', 'post'),
+                    $form // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+                );
+            }
         );
     }
 }

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -3,6 +3,7 @@
 namespace P4\MasterTheme;
 
 use CMB2_Field;
+use P4\MasterTheme\Features\MediaArchive;
 use P4\MasterTheme\Settings\Comments;
 use P4\MasterTheme\Settings\Features;
 
@@ -470,7 +471,6 @@ class Settings
             'planet4_settings_comments' => Comments::get_options_page(),
             'planet4_settings_features' => Features::get_options_page(),
         ];
-        // phpcs:enable Generic.Files.LineLength.MaxExceeded
 
         $is_new_identity = get_theme_mod('new_identity_styles');
         if (!$is_new_identity) {
@@ -488,6 +488,10 @@ class Settings
                     ],
                 ]
             );
+        }
+
+        if (MediaArchive::is_active()) {
+            $this->subpages['planet4_media_archive'] = MediaArchive::get_options_page();
         }
 
         $this->hooks();

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -3,7 +3,6 @@
 namespace P4\MasterTheme;
 
 use CMB2_Field;
-use P4\MasterTheme\Features\MediaArchive;
 use P4\MasterTheme\Settings\Comments;
 use P4\MasterTheme\Settings\Features;
 
@@ -488,10 +487,6 @@ class Settings
                     ],
                 ]
             );
-        }
-
-        if (MediaArchive::is_active()) {
-            $this->subpages['planet4_media_archive'] = MediaArchive::get_options_page();
         }
 
         $this->hooks();


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6840

# Description
- Move "Media Archive" under "Media" right after "Library" and rename it to "-
- Create a new option menu under "Media" named "Archive Settings".
- Show section description text: "Please enter your Image Archive username and password. Please note that you will need to ask from the Image Archive administrators to enable API access for your account."
- Add Fields labels: "Username" and "Password".

# Testing
1. Go to `Media > Archive Settings`
2. Edit any input and try to type a wrong value.
3. These values of `Media > Archive Settings`  might be the same of `Planet 4 > GPI Media Library`
