### PR TITLE
Fix link style rule

### DIFF
--- a/assets/src/scss/new-identity/style.scss
+++ b/assets/src/scss/new-identity/style.scss
@@ -286,8 +286,9 @@ table.spreadsheet-table.is-color-gp-green {
 
 // Body links
 .post-content,
+.post-content > article,
 .page-content {
-  p > a,
+  p:not(.article-list-item-meta) a,
   > ul li a,
   > ol li a {
     @include shared-link-styles;


### PR DESCRIPTION
Links styles don't apply if a link is included in an inline tag like `<em>` or `<strong>`.
This is due to a child combinator `p > a` that doesn't allow for `p > em > a`. The declaration also misses `.post-content > article` selector for lists.

Example: https://planet4.greenpeace.org/story/16394/v2-105-106/