### PR TITLE
PLANET-7169 Fix analytics Field tracking ID(i.e projectID) bug

### DIFF
--- a/src/Loader.php
+++ b/src/Loader.php
@@ -92,12 +92,6 @@ final class Loader
             // Load P4 Metaboxes only when adding/editing a new Page/Post/Campaign.
             if ('post-new.php' === $pagenow || 'post.php' === $pagenow) {
                 $this->default_services[] = MetaboxRegister::class;
-                add_action(
-                    'cmb2_save_field_p4_campaign_name',
-                    [ MetaboxRegister::class, 'save_global_project_id' ],
-                    10,
-                    3
-                );
             }
 
             // Load `Campaigns` class only when adding/editing a new tag.

--- a/src/MetaboxRegister.php
+++ b/src/MetaboxRegister.php
@@ -2,8 +2,6 @@
 
 namespace P4\MasterTheme;
 
-use CMB2_Field;
-
 /**
  * Class MetaboxRegister
  */
@@ -93,27 +91,5 @@ class MetaboxRegister
                 'preview_size' => 'large',
             ]
         );
-    }
-
-    /**
-     * Look up the ID of the global campaign and save it on the post.
-     *
-     * @param bool       $updated Whether the field is being updated.
-     * @param string     $action The action being performed on the field.
-     * @param CMB2_Field $field The field being updated.
-     */
-    public static function save_global_project_id(bool $updated, string $action, CMB2_Field $field): void
-    {
-        if (! $updated) {
-            return;
-        }
-        if ('removed' === $action) {
-            update_post_meta($field->object_id(), 'p4_global_project_tracking_id', null);
-
-            return;
-        }
-
-        $project_id = AnalyticsValues::from_cache_or_api_or_hardcoded()->get_id_for_global_project($field->value());
-        update_post_meta($field->object_id, 'p4_global_project_tracking_id', $project_id);
     }
 }


### PR DESCRIPTION
Ref [PLANET-7169](https://jira.greenpeace.org/browse/PLANET-7169)

- Update tracking ID(i.e projectID) value as per Global project standard value changes
- If the global/local project unapproved/removed from spreadsheet, still keep selection with [deprecated] label in P4

**Testing:**
- Add new page/post select analytics fields, save & publish page 
- View page on frontend and check page source
- In page source check datalayer params(gCampaign, gLocalProject, projectID) value
- To test the deprecated label use case - edit the page, change the Global & Local project dropdown value using browser console, save the page and check on frontend datalayer params

eg. 
https://www-dev.greenpeace.org/test-mars/wp-admin/post.php?post=1137&action=edit

