### PR TITLE
Add trailing slash on Opengraph url

### DIFF
--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -612,7 +612,7 @@ class MasterSite extends TimberSite
         $context['languages'] = count($languages); // Keep this variable name as long as NRO themes use it.
 
         $context['site'] = $this;
-        $context['current_url'] = home_url($wp->request);
+        $context['current_url'] = trailingslashit(home_url($wp->request));
         $context['sort_options'] = $this->sort_options;
         $context['default_sort'] = Search::DEFAULT_SORT;
 


### PR DESCRIPTION
This is needed to make sure the `og:url` is identical to canonical url which ends with a forward slash. Flagged from Google Search Console as an issue.

### Testing
- Before this fix, view source of any post and check `og:url`. It shouldn't have forward slash. But `link rel="canonical"` does.
- After this fix, both tags should end with a forward slash.