### PR TITLE
PLANET-7186 Add setting for Hubspot tracking code

### DIFF
--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -676,6 +676,15 @@ class MasterSite extends TimberSite
         );
         // HubSpot.
         $context['hubspot_active'] = is_plugin_active('gravityformshubspot/hubspot.php');
+        // The Hubspot Tracking Code snippet will add only if the user has accepted "Marketing" cookies.
+        if (
+            $context['hubspot_active']
+            && !isset($_COOKIE['no_track']) && isset($_COOKIE['active_consent_choice'])
+            && $_COOKIE['active_consent_choice'] && isset($_COOKIE['greenpeace'])
+            && in_array($_COOKIE['greenpeace'], [2,4])
+        ) {
+            $context['hubspot_tracking_code'] = $options['hubspot_tracking_code'] ?? '';
+        }
 
         // Dummy thumbnail.
         $context['dummy_thumbnail'] = get_template_directory_uri() . '/images/dummy-thumbnail.png';

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -489,6 +489,26 @@ class Settings
             );
         }
 
+        // This option should be visible only if the GF Hubspot add-on is activated.
+        $is_gf_hubspot_addon = function_exists('is_plugin_active') && is_plugin_active('gravityformshubspot/hubspot.php');
+        if ($is_gf_hubspot_addon) {
+            array_push(
+                $this->subpages['planet4_settings_analytics']['fields'],
+                [
+                    'name' => __('Hubspot tracking code', 'planet4-master-theme-backend'),
+                    'desc' => __(
+                        'Paste here the tracking code from your Hubspot account.',
+                        'planet4-master-theme-backend'
+                    ),
+                    'id' => 'hubspot_tracking_code',
+                    'type' => 'textarea',
+                    'attributes' => [
+                        'type' => 'text',
+                    ],
+                ],
+            );
+        }
+
         $this->hooks();
     }
 

--- a/templates/base.twig
+++ b/templates/base.twig
@@ -48,6 +48,7 @@
         {% endblock %}
 
         {{ function('wp_footer') }}
+        {% include 'hubspot_tracking_code.twig' %}
     {% endblock %}
 </body>
 </html>

--- a/templates/hubspot_tracking_code.twig
+++ b/templates/hubspot_tracking_code.twig
@@ -1,0 +1,3 @@
+{% if hubspot_tracking_code %}
+    {{ hubspot_tracking_code|raw }}
+{% endif %}


### PR DESCRIPTION
Ref. https://jira.greenpeace.org/browse/PLANET-7186

**Task:**
- Added a `Hubspot tracking code` settings option under: Planet 4 > Analytics
- This option should be visible only if the GF Hubspot add-on is activated
- The `Hubspot tracking code` snippet will be added only if,  
   - The user has accepted "Marketing" cookies
- The snippet script will be loaded in the end of the page

eg.
https://www-dev.greenpeace.org/test-leda/wp-admin/admin.php?page=planet4_settings_analytics