### PR TITLE
PLANET-7045 Create settings options for new IA pages

### DIFF
--- a/admin/css/options.css
+++ b/admin/css/options.css
@@ -1,4 +1,4 @@
-.planet4_options .cmb-row {
+.planet4_options .cmb-row:not(.hidden) {
   display: grid;
   grid-template-columns: 1fr 1fr;
 }
@@ -16,8 +16,12 @@
   float: none;
 }
 
+.hidden {
+  display: none;
+}
+
 @media (min-width: 768px) {
-  .planet4_options .cmb-row {
+  .planet4_options .cmb-row:not(.hidden) {
     display: grid;
     grid-template-columns: 1fr 4fr;
   }

--- a/admin/js/options.js
+++ b/admin/js/options.js
@@ -3,3 +3,22 @@ const spamButtons = document.querySelectorAll('.checkforspam');
 spamButtons.forEach(box => {
   box.remove();
 });
+
+document.addEventListener('DOMContentLoaded', () => {
+  const newIASetting = document.querySelector('#new_ia');
+
+  if (!newIASetting) {
+    return;
+  }
+
+  const actPageDropdown = document.querySelector('[data-fieldtype="act_page_dropdown"]');
+  const explorePageDropdown = document.querySelector('[data-fieldtype="explore_page_dropdown"]');
+  const issuesParentCategoryDropdown = document.querySelector('[data-fieldtype="category_select_taxonomy"]');
+
+  newIASetting.addEventListener('change', event => {
+    const {checked} = event.currentTarget;
+    actPageDropdown.classList.toggle('hidden', checked);
+    explorePageDropdown.classList.toggle('hidden', checked);
+    issuesParentCategoryDropdown.classList.toggle('hidden', checked);
+  });
+});

--- a/admin/js/options.js
+++ b/admin/js/options.js
@@ -4,6 +4,7 @@ spamButtons.forEach(box => {
   box.remove();
 });
 
+// Show/hide old special pages when enabling or disabling the new IA.
 document.addEventListener('DOMContentLoaded', () => {
   const newIASetting = document.querySelector('#new_ia');
 
@@ -14,6 +15,11 @@ document.addEventListener('DOMContentLoaded', () => {
   const actPageDropdown = document.querySelector('[data-fieldtype="act_page_dropdown"]');
   const explorePageDropdown = document.querySelector('[data-fieldtype="explore_page_dropdown"]');
   const issuesParentCategoryDropdown = document.querySelector('[data-fieldtype="category_select_taxonomy"]');
+
+  // Needed for page reload when saving settings.
+  actPageDropdown.classList.toggle('hidden', newIASetting.checked);
+  explorePageDropdown.classList.toggle('hidden', newIASetting.checked);
+  issuesParentCategoryDropdown.classList.toggle('hidden', newIASetting.checked);
 
   newIASetting.addEventListener('change', event => {
     const {checked} = event.currentTarget;

--- a/src/Post.php
+++ b/src/Post.php
@@ -63,20 +63,27 @@ class Post extends TimberPost
      */
     public function set_data_layer(): void
     {
+        $is_new_ia = !empty(planet4_get_option('new_ia'));
         if (is_front_page()) {
             $this->data_layer['page_category'] = 'Homepage';
-        } elseif ($this->is_act_page()) {
+        } elseif (!$is_new_ia && $this->is_act_page()) {
             $this->data_layer['page_category'] = 'Act';
-        } elseif ($this->is_explore_page()) {
+        } elseif (!$is_new_ia && $this->is_explore_page()) {
             $this->data_layer['page_category'] = 'Explore';
-        } elseif ($this->is_take_action_page()) {
+        } elseif (!$is_new_ia && $this->is_act_page_child()) {
             $this->data_layer['page_category'] = 'Take Action';
-        } elseif ($this->is_issue_page()) {
+        } elseif (!$is_new_ia && $this->is_issue_page()) {
             $this->data_layer['page_category'] = 'Issue Page';
         } elseif ($this->is_campaign_page()) {
             $this->data_layer['page_category'] = 'Campaign Page';
         } elseif (is_tag()) {
             $this->data_layer['page_category'] = 'Tag Page';
+        } elseif ($is_new_ia && $this->is_get_informed_page()) {
+            $this->data_layer['page_category'] = 'Get Informed Page';
+        } elseif ($is_new_ia && $this->is_take_action_page()) {
+            $this->data_layer['page_category'] = 'Take Action Page';
+        } elseif ($is_new_ia && $this->is_about_us_page()) {
+            $this->data_layer['page_category'] = 'About Us Page';
         } else {
             $this->data_layer['page_category'] = 'Default Page';
         }
@@ -116,7 +123,7 @@ class Post extends TimberPost
      * Checks if post is a Take Action page (child of act page).
      *
      */
-    public function is_take_action_page(): bool
+    public function is_act_page_child(): bool
     {
         $act_page_id = planet4_get_option('act_page');
         $pages = [];
@@ -167,6 +174,39 @@ class Post extends TimberPost
     public function is_campaign_page(): bool
     {
         return PostCampaign::POST_TYPE === $this->post_type;
+    }
+
+    /**
+     * Checks if post is the Get Informed page.
+     *
+     */
+    public function is_get_informed_page(): bool
+    {
+        $act_page_id = planet4_get_option('get_informed_page');
+
+        return absint($act_page_id) === $this->id;
+    }
+
+    /**
+     * Checks if post is the Take Action page.
+     *
+     */
+    public function is_take_action_page(): bool
+    {
+        $act_page_id = planet4_get_option('take_action_page');
+
+        return absint($act_page_id) === $this->id;
+    }
+
+    /**
+     * Checks if post is the About Us page.
+     *
+     */
+    public function is_about_us_page(): bool
+    {
+        $act_page_id = planet4_get_option('about_us_page');
+
+        return absint($act_page_id) === $this->id;
     }
 
     /**

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -60,6 +60,7 @@ class Settings
         // Set our subpages.
         // Each subpage has a title and a path and the fields.
         // phpcs:disable Generic.Files.LineLength.MaxExceeded
+        $is_new_ia = !empty(planet4_get_option('new_ia'));
         $this->subpages = [
             'planet4_settings_navigation' => [
                 'title' => 'Navigation',
@@ -73,18 +74,21 @@ class Settings
                         'name' => __('Select Act Page', 'planet4-master-theme-backend'),
                         'id' => 'act_page',
                         'type' => 'act_page_dropdown',
+                        'classes' => $is_new_ia ? 'hidden' : '',
                     ],
 
                     [
                         'name' => __('Select Explore Page', 'planet4-master-theme-backend'),
                         'id' => 'explore_page',
                         'type' => 'explore_page_dropdown',
+                        'classes' => $is_new_ia ? 'hidden' : '',
                     ],
 
                     [
                         'name' => __('Select Issues Parent Category', 'planet4-master-theme-backend'),
                         'id' => 'issues_parent_category',
                         'type' => 'category_select_taxonomy',
+                        'classes' => $is_new_ia ? 'hidden' : '',
                     ],
 
                     [

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -469,6 +469,22 @@ class Settings
                         'id' => 'enable_google_consent_mode',
                         'type' => 'checkbox',
                     ],
+                    // New IA special pages.
+                    [
+                        'name' => __('Select "Get Informed" page', 'planet4-master-theme-backend'),
+                        'id' => 'get_informed_page',
+                        'type' => $is_new_ia ? 'get_informed_page_dropdown' : 'hidden',
+                    ],
+                    [
+                        'name' => __('Select "Take Action" page', 'planet4-master-theme-backend'),
+                        'id' => 'take_action_page',
+                        'type' => $is_new_ia ? 'take_action_page_dropdown' : 'hidden',
+                    ],
+                    [
+                        'name' => __('Select "About Us" page', 'planet4-master-theme-backend'),
+                        'id' => 'about_us_page',
+                        'type' => $is_new_ia ? 'about_us_page_dropdown' : 'hidden',
+                    ],
                 ],
             ],
             'planet4_settings_comments' => Comments::get_options_page(),
@@ -524,9 +540,12 @@ class Settings
         add_action('admin_init', [ $this, 'init' ]);
         add_action('admin_menu', [ $this, 'add_options_pages' ]);
         add_action('cmb2_save_options-page_fields_' . self::METABOX_ID, [ $this, 'add_notifications' ]);
-        add_filter('cmb2_render_act_page_dropdown', [ $this, 'p4_render_act_page_dropdown' ], 10, 2);
-        add_filter('cmb2_render_explore_page_dropdown', [ $this, 'p4_render_explore_page_dropdown' ], 10, 2);
+        add_filter('cmb2_render_act_page_dropdown', [ $this, 'p4_render_page_dropdown' ], 10, 2);
+        add_filter('cmb2_render_explore_page_dropdown', [ $this, 'p4_render_page_dropdown' ], 10, 2);
         add_filter('cmb2_render_category_select_taxonomy', [ $this, 'p4_render_category_dropdown' ], 10, 2);
+        add_filter('cmb2_render_get_informed_page_dropdown', [ $this, 'p4_render_page_dropdown' ], 10, 2);
+        add_filter('cmb2_render_take_action_page_dropdown', [ $this, 'p4_render_page_dropdown' ], 10, 2);
+        add_filter('cmb2_render_about_us_page_dropdown', [ $this, 'p4_render_page_dropdown' ], 10, 2);
         add_filter('cmb2_render_pagetype_select_taxonomy', [ $this, 'p4_render_pagetype_dropdown' ], 10, 2);
         add_action('admin_enqueue_scripts', [ $this, 'enqueue_admin_assets' ]);
         add_action('admin_init', [$this, 'add_new_identity_styles_toggle_value']);
@@ -597,9 +616,8 @@ class Settings
      *
      * @param CMB2_Field $field_args Field arguments.
      * @param mixed $value Value.
-     * phpcs:disable SlevomatCodingStandard.Functions.UnusedParameter -- add_filter callback
      */
-    public function p4_render_act_page_dropdown(CMB2_Field $field_args, $value): void
+    public function p4_render_page_dropdown(CMB2_Field $field_args, $value): void
     {
         wp_dropdown_pages(
             [
@@ -607,32 +625,10 @@ class Settings
                 'hide_empty' => 0,
                 'hierarchical' => true,
                 'selected' => esc_attr($value),
-                'name' => 'act_page',
+                'name' => $field_args->id(),
             ]
         );
     }
-    // phpcs:enable SlevomatCodingStandard.Functions.UnusedParameter
-
-    /**
-     * Render explore page dropdown.
-     *
-     * @param CMB2_Field $field_args Field arguments.
-     * @param mixed $value Value.
-     * phpcs:disable SlevomatCodingStandard.Functions.UnusedParameter -- add_filter callback
-     */
-    public function p4_render_explore_page_dropdown(CMB2_Field $field_args, $value): void
-    {
-        wp_dropdown_pages(
-            [
-                'show_option_none' => esc_html__('Select Page', 'planet4-master-theme-backend'),
-                'hide_empty' => 0,
-                'hierarchical' => true,
-                'selected' => esc_attr($value),
-                'name' => 'explore_page',
-            ]
-        );
-    }
-    // phpcs:enable SlevomatCodingStandard.Functions.UnusedParameter
 
     /**
      * Render category dropdown.

--- a/tests/e2e/special-pages.spec.js
+++ b/tests/e2e/special-pages.spec.js
@@ -3,51 +3,61 @@ import {test, expect} from './tools/lib/test-utils.js';
 test.useAdminLoggedIn();
 
 test('Test special pages (Act and Explore)', async ({page, requestUtils, admin}) => {
-  // Create 2 new pages.
-  const actPage = await requestUtils.createPage({
-    title: 'Act page test',
-    content: '<!-- wp:paragraph --><p>Random content</p><!-- /wp:paragraph -->',
-    status: 'publish',
-  });
-
-  const explorePage = await requestUtils.createPage({
-    title: 'Explore page test',
-    content: '<!-- wp:paragraph --><p>Random content</p><!-- /wp:paragraph -->',
-    status: 'publish',
-  });
+  // Check if new IA is enabled, in which case the Act and Explore pages have been removed.
   await admin.visitAdminPage('admin.php', 'page=planet4_settings_navigation');
-  await page.waitForSelector('#act_page');
-  await page.waitForSelector('#explore_page');
-  const previousActPage = await page.locator('#act_page').inputValue();
-  const previousExplorePage = await page.locator('#explore_page').inputValue();
+  await page.waitForSelector('#new_ia');
+  const isNewIAEnabled = await page.locator('#new_ia').isChecked();
+  if (isNewIAEnabled) {
+    await expect(page.locator('#act_page')).toBeHidden();
+    await expect(page.locator('#explore_page')).toBeHidden();
+  } else {
+    // Create 2 new pages.
+    const actPage = await requestUtils.createPage({
+      title: 'Act page test',
+      content: '<!-- wp:paragraph --><p>Random content</p><!-- /wp:paragraph -->',
+      status: 'publish',
+    });
+    const explorePage = await requestUtils.createPage({
+      title: 'Explore page test',
+      content: '<!-- wp:paragraph --><p>Random content</p><!-- /wp:paragraph -->',
+      status: 'publish',
+    });
 
-  // Set the 2 new pages instead.
-  await page.selectOption('#act_page', actPage.id.toString());
-  await page.selectOption('#explore_page', explorePage.id.toString());
-  await page.locator('input[type="submit"]').click();
-  await page.locator('.notice-success').isVisible();
+    // Reload the page to make sure that the new pages are available.
+    await page.reload();
 
-  // Go to each page and make sure they have the right datalayer "pageType" value.
-  await page.goto(`./${actPage.slug}`);
-  let dataLayer = await page.evaluate(() => window.dataLayer || []);
-  if (dataLayer.length > 0) {
-    const {pageType} = dataLayer.find(data => data.pageType !== undefined);
-    expect(pageType).toBe('Act');
+    // Save previous values to restore them after the test.
+    const previousActPage = await page.locator('#act_page').inputValue();
+    const previousExplorePage = await page.locator('#explore_page').inputValue();
+
+    // Set the 2 new pages instead.
+    await page.selectOption('#act_page', actPage.id.toString());
+    await page.selectOption('#explore_page', explorePage.id.toString());
+    await page.locator('input[type="submit"]').click();
+    await page.locator('.notice-success').isVisible();
+
+    // Go to each page and make sure they have the right datalayer "pageType" value.
+    await page.goto(`./${actPage.slug}`);
+    let dataLayer = await page.evaluate(() => window.dataLayer || []);
+    if (dataLayer.length > 0) {
+      const {pageType} = dataLayer.find(data => data.pageType !== undefined);
+      expect(pageType).toBe('Act');
+    }
+
+    await page.goto(`./${explorePage.slug}`);
+    dataLayer = await page.evaluate(() => window.dataLayer || []);
+    if (dataLayer.length > 0) {
+      const {pageType} = dataLayer.find(data => data.pageType !== undefined);
+      expect(pageType).toBe('Explore');
+    }
+
+    // Reset the Act and Explore pages.
+    await admin.visitAdminPage('admin.php', 'page=planet4_settings_navigation');
+    await page.waitForSelector('#act_page');
+    await page.waitForSelector('#explore_page');
+    await page.selectOption('#act_page', previousActPage);
+    await page.selectOption('#explore_page', previousExplorePage);
+    await page.locator('input[type="submit"]').click();
+    await page.locator('.notice-success').isVisible();
   }
-
-  await page.goto(`./${explorePage.slug}`);
-  dataLayer = await page.evaluate(() => window.dataLayer || []);
-  if (dataLayer.length > 0) {
-    const {pageType} = dataLayer.find(data => data.pageType !== undefined);
-    expect(pageType).toBe('Explore');
-  }
-
-  // Reset the Act and Explore pages.
-  await admin.visitAdminPage('admin.php', 'page=planet4_settings_navigation');
-  await page.waitForSelector('#act_page');
-  await page.waitForSelector('#explore_page');
-  await page.selectOption('#act_page', previousActPage);
-  await page.selectOption('#explore_page', previousExplorePage);
-  await page.locator('input[type="submit"]').click();
-  await page.locator('.notice-success').isVisible();
 });


### PR DESCRIPTION
### Description

See [PLANET-7045](https://jira.greenpeace.org/browse/PLANET-7045)
With the new IA we no longer need the old special pages (`Act`, `Explore` and `Issues Parent Category`) but we want to add new ones to the Analytics section (`Get Informed`, `About Us`, and `Take Action`)

### Testing

Either on local or on the jupiter test instance,
- go to `Planet 4 > Navigation`
- disable the new IA and save, making sure that the `Act`, `Explore` and `Issues Parent Category` dropdowns are shown
- go to `Planet 4 > Analytics` and make sure the new `Get Informed`, `About Us`, and `Take Action` dropdowns are hidden
- go back to `Planet 4 > Navigation` and enable the new IA, making sure that the `Act`, `Explore` and `Issues Parent Category` dropdowns are now hidden
- go back to `Planet 4 > Analytics` and select pages for the new `Get Informed`, `About Us`, and `Take Action` dropdowns
- check these pages to make sure they have the correct dataLayer page type values