### PR TITLE
PLANET-7198 Add self-reference canonical urls to listing pages

### DIFF
--- a/author.php
+++ b/author.php
@@ -49,6 +49,7 @@ if (isset($wp_query->query_vars['author'])) {
     $author_share_buttons->description = get_the_author_meta('description', $author->ID);
     $author_share_buttons->link = $author->link;
     $context['author_share_buttons'] = $author_share_buttons;
+    $context['canonical_link'] = home_url($wp->request);
 }
 
 if (!empty(planet4_get_option('new_ia'))) {

--- a/category.php
+++ b/category.php
@@ -18,6 +18,7 @@ $templates = [ 'taxonomy.twig', 'index.twig' ];
 $context = Timber::get_context();
 $context['taxonomy'] = get_queried_object();
 $context['wp_title'] = $context['taxonomy']->name;
+$context['canonical_link'] = home_url($wp->request);
 
 if (!empty(planet4_get_option('new_ia'))) {
     $view = ListingPageGridView::is_active() ? 'grid' : 'list';

--- a/page.php
+++ b/page.php
@@ -96,6 +96,10 @@ $context['page_category'] = $data_layer['page_category'];
 $context['post_tags'] = implode(', ', $post->tags());
 $context['custom_body_classes'] = 'brown-bg ';
 
+if (is_tag()) {
+    $context['canonical_link'] = home_url($wp->request);
+}
+
 if (post_password_required($post->ID)) {
     // Password protected form validation.
     $context['is_password_valid'] = $post->is_password_valid();

--- a/tag.php
+++ b/tag.php
@@ -36,6 +36,7 @@ if (is_tag()) {
         $templates = [ 'tag.twig', 'archive.twig', 'index.twig' ];
 
         $context['tag_name'] = single_tag_title('', false);
+        $context['canonical_link'] = home_url($wp->request);
         $context['tag_description'] = wpautop($context['tag']->description);
         $tag_image_id = get_term_meta($context['tag']->term_id, 'tag_attachment_id', true);
 

--- a/taxonomy.php
+++ b/taxonomy.php
@@ -21,6 +21,7 @@ $templates = [ 'taxonomy.twig', 'index.twig' ];
 $context = Timber::get_context();
 $context['taxonomy'] = get_queried_object();
 $context['wp_title'] = $context['taxonomy']->name;
+$context['canonical_link'] = home_url($wp->request);
 
 if (!empty(planet4_get_option('new_ia'))) {
     $view = ListingPageGridView::is_active() ? 'grid' : 'list';

--- a/templates/base.twig
+++ b/templates/base.twig
@@ -1,6 +1,6 @@
 {% block html_head_container %}
 
-{% include 'html-header.twig' %}
+{% include 'html-header.twig' with { 'canonical_link': canonical_link } %}
 
 {% endblock %}
 

--- a/templates/html-header.twig
+++ b/templates/html-header.twig
@@ -29,6 +29,9 @@
         {% endfor %}
     {% endif %}
 
+    {% if canonical_link %}
+        <link rel="canonical" href="{{ canonical_link }}">
+    {% endif %}
 
     {{ wp_head }}
 

--- a/tests/test-category-page.php
+++ b/tests/test-category-page.php
@@ -126,7 +126,8 @@ class CategoryPageTest extends P4TestCase
         wp_styles();
         $output = TimberHelper::ob_function(
             function (): void {
-                    include get_template_directory() . '/category.php';
+                global $wp;
+                include get_template_directory() . '/category.php';
             }
         );
 


### PR DESCRIPTION
### Description

See [PLANET-7198](https://jira.greenpeace.org/browse/PLANET-7198)

### Testing

You can check that the canonical links are now present on the neptune test instance:
- [author page](https://www-dev.greenpeace.org/test-neptune/author/ltiralon/)
- tag page [with redirect](https://www-dev.greenpeace.org/test-neptune/tag/climate/) and [without](https://www-dev.greenpeace.org/test-neptune/tag/renewables/) (on this one you can also make sure that the pagination is added to the canonical link as expected)
- [post type](https://www-dev.greenpeace.org/test-neptune/press/)
- [category](https://www-dev.greenpeace.org/test-neptune/category/issues/energy/)

Please test the changes with both the list and grid styles (`Listing page grid view` setting in [Planet 4 > Features](https://www-dev.greenpeace.org/test-neptune/wp-admin/admin.php?page=planet4_settings_features))