### PR TITLE
PLANET-7047: Migrate Donate button setting to a menu

### DIFF
--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -587,27 +587,16 @@ class MasterSite extends TimberSite
             }
         );
 
-        $donate_menu_default[] = [
-            'link' => planet4_get_option('donate_button', '#'),
-            'title' => planet4_get_option('donate_text', __('Donate', 'planet4-master-theme')),
-        ];
-
-        // Donate button menu dropdown.
-        // If no Donate menu is defined, we use the old settings from Planet 4 > Donate.
-        $donate_menu_items = $donate_menu_default;
-
         // Check if the menu has been created.
         if (has_nav_menu('donate-menu')) {
             $donate_menu = new TimberMenu('donate-menu');
 
             // Check if it has at least 1 item added into the menu.
             if (! empty($donate_menu->get_items())) {
-                $donate_menu_items = $donate_menu->get_items();
+                $context['donate_menu_items'] = $donate_menu->get_items();
             }
         }
 
-        $context['donate_menu_default'] = $donate_menu_default;
-        $context['donate_menu_items'] = $donate_menu_items;
 
         $languages = function_exists('icl_get_languages') ? icl_get_languages() : [];
         $context['site_languages'] = $languages;
@@ -651,8 +640,6 @@ class MasterSite extends TimberSite
             $context['p4_visitor_type'] = 'guest';
         }
 
-        $context['donatelink'] = $options['donate_button'] ?? '#';
-        $context['donatetext'] = $options['donate_text'] ?? __('Donate', 'planet4-master-theme');
         $context['website_navbar_title'] = $options['website_navigation_title']
             ?? __('International (English)', 'planet4-master-theme');
 

--- a/src/Migrations/M018MigrateDonateButtonSetting.php
+++ b/src/Migrations/M018MigrateDonateButtonSetting.php
@@ -21,6 +21,7 @@ class M018MigrateDonateButtonSetting extends MigrationScript
         global $wpdb;
 
         $donate_menu_slug = 'donate-menu';
+        $option_key = 'planet4_options';
 
         $sql = 'SELECT t.term_id FROM wp_terms AS t WHERE t.slug="%s"';
         $prepared_sql = $wpdb->prepare($sql, array($donate_menu_slug));
@@ -42,8 +43,27 @@ class M018MigrateDonateButtonSetting extends MigrationScript
             return;
         }
 
-        $locations = get_theme_mod('nav_menu_locations');
-        $locations[$donate_menu_slug] = (int) $term['term_id'];
-        set_theme_mod('nav_menu_locations', $locations);
+        $term_id = $term['term_id'];
+
+        $options = get_option($option_key);
+
+        wp_update_nav_menu_item(
+            $term_id,
+            0,
+            [
+                'menu-item-title' => $options['donate_text'],
+                'menu-item-url' => $options['donate_button'],
+                'menu-item-status' => 'publish',
+                'menu-item-type' => 'custom',
+            ],
+        );
+
+        $nav_menu_locations = get_theme_mod('nav_menu_locations');
+        $nav_menu_locations[$donate_menu_slug] = (int) $term['term_id'];
+        set_theme_mod('nav_menu_locations', $nav_menu_locations);
+
+        unset($options['donate_text']);
+        unset($options['donate_button']);
+        update_option($option_key, $options);
     }
 }

--- a/src/Migrations/M018MigrateDonateButtonSetting.php
+++ b/src/Migrations/M018MigrateDonateButtonSetting.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace P4\MasterTheme\Migrations;
+
+use P4\MasterTheme\MigrationRecord;
+use P4\MasterTheme\MigrationScript;
+
+/**
+ *  Migrate Donate button setting to a menu.
+ */
+class M018MigrateDonateButtonSetting extends MigrationScript
+{
+    /**
+     * Perform the actual migration.
+     *
+     * @param MigrationRecord $record Information on the execution, can be used to add logs.
+     * phpcs:disable SlevomatCodingStandard.Functions.UnusedParameter -- interface implementation
+     */
+    protected static function execute(MigrationRecord $record): void
+    {
+        global $wpdb;
+
+        $donate_menu_slug = 'donate-menu';
+
+        $sql = 'SELECT t.term_id FROM wp_terms AS t WHERE t.slug="%s"';
+        $prepared_sql = $wpdb->prepare($sql, array($donate_menu_slug));
+        $results = $wpdb->get_results($prepared_sql);
+
+        if (count($results)) {
+            return;
+        }
+
+        $term = wp_insert_term(
+            'Donate Menu',
+            'nav_menu',
+            [
+                'slug' => $donate_menu_slug,
+            ],
+        );
+
+        if (is_wp_error($term) || !isset($term['term_id'])) {
+            return;
+        }
+
+        $locations = get_theme_mod('nav_menu_locations');
+        $locations[$donate_menu_slug] = (int) $term['term_id'];
+        set_theme_mod('nav_menu_locations', $locations);
+    }
+}

--- a/src/Migrator.php
+++ b/src/Migrator.php
@@ -19,6 +19,7 @@ use P4\MasterTheme\Migrations\M014RemoveDropdownNavigationMenusOption;
 use P4\MasterTheme\Migrations\M015RemoveListingPagesBackgroundImage;
 use P4\MasterTheme\Migrations\M016CreateDefaultActionType;
 use P4\MasterTheme\Migrations\M017NewIAToggle;
+use P4\MasterTheme\Migrations\M018MigrateDonateButtonSetting;
 
 /**
  * Run any new migration scripts and record results in the log.
@@ -55,6 +56,7 @@ class Migrator
             M015RemoveListingPagesBackgroundImage::class,
             M016CreateDefaultActionType::class,
             M017NewIAToggle::class,
+            M018MigrateDonateButtonSetting::class,
         ];
 
         // Loop migrations and run those that haven't run yet.

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -95,28 +95,6 @@ class Settings
                     ],
                 ],
             ],
-            'planet4_settings_donate_button' => [
-                'title' => 'Donate button',
-                'fields' => [
-                    [
-                        'name' => __('Donate button link', 'planet4-master-theme-backend'),
-                        'id' => 'donate_button',
-                        'type' => 'text',
-                        'attributes' => [
-                            'type' => 'text',
-                        ],
-                    ],
-
-                    [
-                        'name' => __('Donate button text', 'planet4-master-theme-backend'),
-                        'id' => 'donate_text',
-                        'type' => 'text',
-                        'attributes' => [
-                            'type' => 'text',
-                        ],
-                    ],
-                ],
-            ],
             'planet4_settings_defaults_content' => [
                 'title' => 'Defaults content',
                 'fields' => [

--- a/templates/burger-menu.twig
+++ b/templates/burger-menu.twig
@@ -49,11 +49,11 @@
     <div class="burger-menu-footer">
         <a
             class="btn btn-donate"
-            href="{{ donate_menu_default[0].link }}"
+            href="{{ donate_menu_items[0].link }}"
             data-ga-category="Menu Navigation"
             data-ga-action="Donate"
             data-ga-label="{{ page_category }}">
-            {{ donate_menu_default[0].title }}
+            {{ donate_menu_items[0].title }}
         </a>
     </div>
 </div>


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-7047

## Description
Create a new `nav_menu` (AKA `wp_term`) as `donate-menu` in cases where this `term` is not already created. 
Also remove the Donate Button settings page.

In addition to that:
- Unset from `planet4_options` all the `donate settings`
- Remove default values from `$context` 

## Testing
By default we provide the `donate-menu` as `Theme location` with unassigned term.

![Screenshot 2023-07-31 at 09 09 45](https://github.com/greenpeace/planet4-master-theme/assets/77975803/71a817c2-ba30-4460-b74a-a7b4857a752c)

After running `wp-env run cli wp p4-run-activator` you'll get

![Screenshot 2023-07-31 at 09 16 23](https://github.com/greenpeace/planet4-master-theme/assets/77975803/036d7349-5f4c-402b-93d4-59e8478b49f5)

![Screenshot 2023-07-31 at 09 17 52](https://github.com/greenpeace/planet4-master-theme/assets/77975803/09e74c23-b74f-4007-a755-a8f0abd8945d)
