### PR TITLE
PLANET-7159 Add help tooltip to Media Archive

### DIFF
--- a/admin/css/picker.css
+++ b/admin/css/picker.css
@@ -117,6 +117,7 @@
   background: white;
   width: 80%;
   font-size: 12px;
+  line-height: 1.5;
   border-radius: 4px;
   padding: 16px;
   margin-bottom: 8px;
@@ -359,6 +360,21 @@
 @media (min-width: 1200px) {
   .picker-sidebar {
     width: var(--sidebar-width-large);
+  }
+
+  .image-picker .help span {
+    line-height: 32px;
+    width: 32px;
+    height: 32px;
+    font-size: 18px;
+  }
+
+  .image-picker .help:hover .tooltip {
+    font-size: 14px;
+  }
+
+  .image-picker .help:hover .tooltip:after {
+    right: 8px;
   }
 }
 

--- a/admin/css/picker.css
+++ b/admin/css/picker.css
@@ -22,6 +22,11 @@
   display: grid;
   grid-template-columns: repeat(1, 1fr);
   gap: 0 16px;
+  position: relative;
+}
+
+.image-picker {
+  position: relative;
 }
 
 .image-picker li img {
@@ -80,6 +85,62 @@
 .image-picker.open-sidebar li img.picker-selected {
   border-color: #1772a5;
   opacity: 100%;
+}
+
+.image-picker.open-sidebar .help {
+  display: none;
+}
+
+.image-picker .help {
+  position: absolute;
+  bottom: 8px;
+  right: 8px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  z-index: 1;
+}
+
+.image-picker .help span {
+  background: white;
+  border-radius: 50%;
+  text-align: center;
+  line-height: 24px;
+  font-weight: 500;
+  cursor: pointer;
+  width: 24px;
+  height: 24px;
+}
+
+.image-picker .help .tooltip {
+  display: none;
+}
+
+.image-picker .help:hover .tooltip {
+  display: block;
+  position: relative;
+  background: white;
+  width: 80%;
+  font-size: 12px;
+  border-radius: 4px;
+  padding: 16px;
+  margin-bottom: 8px;
+  color: black;
+}
+
+.image-picker .help:hover .tooltip:after {
+  content: "";
+  position: absolute;
+  bottom: -14px;
+  right: 4px;
+  border-top: 8px solid white;
+  border-bottom: 8px solid transparent;
+  border-left: 8px solid transparent;
+  border-right: 8px solid transparent;
+}
+
+.image-picker .help:hover .tooltip a {
+  color: black;
 }
 
 .picker-sidebar-fields {
@@ -170,6 +231,7 @@
   display: flex;
   margin-top: 8px;
   margin-bottom: 8px;
+  height: auto;
 }
 
 .multiple-search-item {
@@ -226,10 +288,6 @@
   justify-content: center;
 }
 
-.multiple-search-form {
-  height: auto;
-}
-
 .multiple-search-list {
   box-sizing: border-box;
   display: grid;
@@ -260,8 +318,11 @@
     grid-template-columns: repeat(3, 1fr);
   }
 
-  .image-picker.open-sidebar .picker-list {
+  .image-picker.open-sidebar {
     width: calc(100% - var(--sidebar-width-tablet) - 52px);
+  }
+
+  .image-picker.open-sidebar .picker-list {
     grid-template-columns: repeat(1, 1fr);
   }
 
@@ -269,8 +330,12 @@
     height: 160px;
   }
 
-  .image-picker li img {
-    height: 160px;
+  .image-picker .help:hover .tooltip {
+    max-width: 330px;
+  }
+
+  .image-picker.open-sidebar .help {
+    display: flex;
   }
 
   .multiple-search {
@@ -314,14 +379,16 @@
   }
 }
 
-
 @media (min-width: 1440px) {
   .picker-list {
     grid-template-columns: repeat(5, 1fr);
   }
 
-  .image-picker.open-sidebar .picker-list {
+  .image-picker.open-sidebar {
     width: calc(100% - var(--sidebar-width-large) - 60px);
+  }
+
+  .image-picker.open-sidebar .picker-list {
     grid-template-columns: repeat(3, 1fr);
   }
 

--- a/admin/css/picker.css
+++ b/admin/css/picker.css
@@ -87,10 +87,6 @@
   opacity: 100%;
 }
 
-.image-picker.open-sidebar .help {
-  display: none;
-}
-
 .image-picker .help {
   position: absolute;
   bottom: 8px;
@@ -98,7 +94,6 @@
   display: flex;
   flex-direction: column;
   align-items: flex-end;
-  z-index: 1;
 }
 
 .image-picker .help span {
@@ -133,10 +128,8 @@
   position: absolute;
   bottom: -14px;
   right: 4px;
-  border-top: 8px solid white;
-  border-bottom: 8px solid transparent;
-  border-left: 8px solid transparent;
-  border-right: 8px solid transparent;
+  border: 8px solid transparent;
+  border-top-color: white;
 }
 
 .image-picker .help:hover .tooltip a {
@@ -332,10 +325,6 @@
 
   .image-picker .help:hover .tooltip {
     max-width: 330px;
-  }
-
-  .image-picker.open-sidebar .help {
-    display: flex;
   }
 
   .multiple-search {

--- a/assets/src/js/Components/ArchivePicker.js
+++ b/assets/src/js/Components/ArchivePicker.js
@@ -128,7 +128,19 @@ const reducer = (state, action) => {
 };
 
 export default function ArchivePicker() {
-  const [{loading, loaded, showAddedMessage, processingImages, processingError, images, pageNumber, searchText, selectedImages, selectedImagesAmount, error}, dispatch] = useReducer(reducer, initialState);
+  const [{
+    loading,
+    loaded,
+    showAddedMessage,
+    processingImages,
+    processingError,
+    images,
+    pageNumber,
+    searchText,
+    selectedImages,
+    selectedImagesAmount,
+    error,
+  }, dispatch] = useReducer(reducer, initialState);
   const [abortController, setAbortController] = useState(null);
 
   const fetch = useCallback(async () => {
@@ -245,6 +257,20 @@ export default function ArchivePicker() {
 
       <div className={classNames('image-picker', {'open-sidebar': selectedImagesAmount > 0})}>
         <ArchivePickerList />
+
+        {images.length > 0 && (
+          <div className="help">
+            <div
+              className="tooltip"
+              dangerouslySetInnerHTML={{
+                __html: __(
+                  'The <strong>Media Archive</strong> pulls images from <a target="_blank" href="https://media.greenpeace.org/">media.greenpeace.org</a>. You can import these images into your Wordpress Media Library and Post/Page. If you have further questions, you can visit the <a target="_blank" href="https://planet4.greenpeace.org/manage/administer/media-archive/">Media Archive Page</a> in the Handbook.', 'planet4-master-theme-backend'
+                ),
+              }}
+            />
+            <span>?</span>
+          </div>
+        )}
 
         {loading && (
           <div className="archive-picker-loading">{__('Loading...', 'planet4-master-theme-backend')}</div>

--- a/assets/src/js/Components/ArchivePicker.js
+++ b/assets/src/js/Components/ArchivePicker.js
@@ -258,7 +258,7 @@ export default function ArchivePicker() {
       <div className={classNames('image-picker', {'open-sidebar': selectedImagesAmount > 0})}>
         <ArchivePickerList />
 
-        {images.length > 0 && (
+        {!!images.length && (
           <div className="help">
             <div
               className="tooltip"


### PR DESCRIPTION
### Description

See [PLANET-7159](https://jira.greenpeace.org/browse/PLANET-7159)

### Testing

You can test the changes by going to the Media Archive either on local or on the [telesto test instance](https://www-dev.greenpeace.org/test-telesto/wp-admin/upload.php?page=media-picker), and make sure the help tooltip looks and behaves as expected in all screen sizes.