### PR TITLE
PLANET-7035: Add new Page Types to the Data Layer values

### DIFF
--- a/author.php
+++ b/author.php
@@ -66,6 +66,7 @@ if (!empty(planet4_get_option('new_ia'))) {
     $content = do_blocks($query_template);
 
     $context['query_loop'] = $content;
+    $context['page_category'] = 'Listing Page';
     Timber::render([ 'author.twig', 'archive.twig' ], $context);
     exit();
 }

--- a/category.php
+++ b/category.php
@@ -28,6 +28,7 @@ if (!empty(planet4_get_option('new_ia'))) {
     $content = do_blocks($query_template);
 
     $context['query_loop'] = $content;
+    $context['page_category'] = 'Listing Page';
     Timber::render($templates, $context);
     exit();
 }

--- a/index.php
+++ b/index.php
@@ -51,6 +51,7 @@ if (is_home()) {
         $content = do_blocks($query_template);
 
         $context['query_loop'] = $content;
+        $context['page_category'] = 'News';
         Timber::render($templates, $context);
         exit();
     }

--- a/single-p4_action.php
+++ b/single-p4_action.php
@@ -34,7 +34,7 @@ Context::set_custom_styles($context, $page_meta_data);
 
 $context['post'] = $post;
 $context['social_accounts'] = $post->get_social_accounts($context['footer_social_menu'] ?: []);
-$context['page_category'] = $data_layer['page_category'];
+$context['page_category'] = 'Actions';
 $context['post_tags'] = implode(', ', $post->tags());
 $context['post_categories'] = implode(', ', $post->categories());
 $context['custom_body_classes'] = 'brown-bg ';

--- a/src/Post.php
+++ b/src/Post.php
@@ -64,14 +64,15 @@ class Post extends TimberPost
     public function set_data_layer(): void
     {
         $is_new_ia = !empty(planet4_get_option('new_ia'));
+
         if (is_front_page()) {
             $this->data_layer['page_category'] = 'Homepage';
         } elseif (!$is_new_ia && $this->is_act_page()) {
-            $this->data_layer['page_category'] = 'Act';
+            $this->data_layer['page_category'] = 'Actions';
         } elseif (!$is_new_ia && $this->is_explore_page()) {
             $this->data_layer['page_category'] = 'Explore';
         } elseif (!$is_new_ia && $this->is_act_page_child()) {
-            $this->data_layer['page_category'] = 'Take Action';
+            $this->data_layer['page_category'] = 'Actions';
         } elseif (!$is_new_ia && $this->is_issue_page()) {
             $this->data_layer['page_category'] = 'Issue Page';
         } elseif ($this->is_campaign_page()) {
@@ -81,7 +82,7 @@ class Post extends TimberPost
         } elseif ($is_new_ia && $this->is_get_informed_page()) {
             $this->data_layer['page_category'] = 'Get Informed Page';
         } elseif ($is_new_ia && $this->is_take_action_page()) {
-            $this->data_layer['page_category'] = 'Take Action Page';
+            $this->data_layer['page_category'] = 'Actions';
         } elseif ($is_new_ia && $this->is_about_us_page()) {
             $this->data_layer['page_category'] = 'About Us Page';
         } else {

--- a/taxonomy.php
+++ b/taxonomy.php
@@ -24,6 +24,7 @@ $context['wp_title'] = $context['taxonomy']->name;
 $context['canonical_link'] = home_url($wp->request);
 
 if (!empty(planet4_get_option('new_ia'))) {
+    $context['page_category'] = 'Listing Page';
     $view = ListingPageGridView::is_active() ? 'grid' : 'list';
 
     $query_template = file_get_contents(get_template_directory() . "/parts/query-$view.html");


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-7035

# Description
Implement new page types to DLV. It's applied to News, Listing and Action pages.

# Testing
Navigate to any of these pages, open the console and log `window.dataLayer`. In theory the value should be at the index 2, so, `window.dataLayer[2].pageType` should print the right value.

Expected values:
- `News` for the page picked as the "Posts page" in Settings > Reading.
- `Listing Page` for all the auto-generated listing pages (categories, tags, author, post types, etc).
- `Actions` for all the Action pages.
