### PR TITLE
PLANET-6793: Sitemap native taxonomies

### DIFF
--- a/assets/src/scss/pages/_sitemap.scss
+++ b/assets/src/scss/pages/_sitemap.scss
@@ -19,4 +19,17 @@
   h5 {
     margin-bottom: 1rem;
   }
+
+  ul {
+    list-style: none;
+    padding-inline-start: 0;
+    @include small-and-less {
+      margin-bottom: 0;
+    }
+
+    li {
+      font-size: inherit;
+      line-height: inherit;
+    }
+  }
 }

--- a/page-templates/sitemap.php
+++ b/page-templates/sitemap.php
@@ -13,23 +13,40 @@ use Timber\Timber;
 
 $context = Timber::get_context();
 $post = new Post(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-$sitemap = new Sitemap();
 $page_meta_data = get_post_meta($post->ID);
 
 $context['post'] = $post;
-$context['header_title'] = is_front_page() ? '' : ( $page_meta_data['p4_title'][0] ?? $post->title );
+$context['header_title'] = is_front_page() ? '' : ($page_meta_data['p4_title'][0] ?? $post->title);
 $context['background_image'] = wp_get_attachment_url(get_post_meta(get_the_ID(), 'background_image_id', 1));
 $context['custom_body_classes'] = 'white-bg';
-
-$context['actions_title'] = __('Act', 'planet4-master-theme');
-$context['issues_title'] = __('Explore', 'planet4-master-theme');
-$context['evergreen_title'] = __('About Greenpeace', 'planet4-master-theme');
-$context['page_types_title'] = __('Articles', 'planet4-master-theme');
-
-$context['actions'] = $sitemap->get_actions();
-$context['issues'] = $sitemap->get_issues();
-$context['evergreen_pages'] = $sitemap->get_evergreen_pages();
-$context['page_types'] = $sitemap->get_page_types();
 $context['page_category'] = 'Sitemap Page';
 
-Timber::render([ 'sitemap.twig' ], $context);
+if (get_theme_mod('new_identity_styles')) {
+    $context['categories'] = get_categories(['orderby' => 'name', 'order' => 'ASC']);
+    $context['posts'] = [];
+    foreach ($context['categories'] as $cat) {
+        if ($cat->slug === 'uncategorized') {
+            continue;
+        }
+        $context['posts'][$cat->term_id] = get_posts([
+            'post_type' => 'page',
+            'category' => $cat->term_id,
+            'orderby' => 'title',
+            'order' => 'ASC',
+        ]);
+    }
+} else {
+    $sitemap = new Sitemap();
+
+    $context['actions_title'] = __('Act', 'planet4-master-theme');
+    $context['issues_title'] = __('Explore', 'planet4-master-theme');
+    $context['evergreen_title'] = __('About Greenpeace', 'planet4-master-theme');
+    $context['page_types_title'] = __('Articles', 'planet4-master-theme');
+
+    $context['actions'] = $sitemap->get_actions();
+    $context['issues'] = $sitemap->get_issues();
+    $context['evergreen_pages'] = $sitemap->get_evergreen_pages();
+    $context['page_types'] = $sitemap->get_page_types();
+}
+
+Timber::render(['sitemap.twig'], $context);

--- a/templates/sitemap.twig
+++ b/templates/sitemap.twig
@@ -47,6 +47,22 @@
                         <br/>
                     </div>
                 {% endif %}
+                {% if categories  %}
+                    {% for cat in categories %}
+                    <div class="col-md-5 order-md-2 order-lg-3 col-lg-3">
+                        {% if posts[cat.term_id] is not empty %}
+                            <h5 class="mb-3 mt-5 mt-lg-0">
+                                <a href="{{ function('get_permalink', cat.term_id) }}">{{ cat.name }}</a>
+                            </h5>
+                            <ul>
+                                {% for post in posts[cat.term_id] %}
+                                <li><a href="{{ post.url }}">{{ post.post_title }}</a></li>
+                                {% endfor %}
+                            </ul>
+                        {% endif %}
+                    </div>
+                    {% endfor %}
+                {% endif %}
             </div>
         </div>
     </div>


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6793

> Follow up from [PLANET-6497](https://jira.greenpeace.org/browse/PLANET-6497), we need to change our Sitemap logic to just display categories and pages.

Display Categories and pages associated to those categories in a list as Sitemap, when new IA is activated.

## Test

- check [mars sitemap](https://www-dev.greenpeace.org/test-mars/sitemap/)
- locally, activate new IA and check that categories are all there (except Uncategorized) and toggle some categories association for pages
