### PR TITLE
PLANET-7102 Add categories DLV on Posts

### DIFF
--- a/page.php
+++ b/page.php
@@ -94,6 +94,7 @@ $context['post'] = $post;
 $context['social_accounts'] = $post->get_social_accounts($context['footer_social_menu'] ?: []);
 $context['page_category'] = $data_layer['page_category'];
 $context['post_tags'] = implode(', ', $post->tags());
+$context['post_categories'] = implode(', ', $post->categories());
 $context['custom_body_classes'] = 'brown-bg ';
 
 if (is_tag()) {

--- a/single-campaign.php
+++ b/single-campaign.php
@@ -85,7 +85,6 @@ Context::set_custom_styles($context, $campaign_meta, 'campaign');
 $context['post'] = $post;
 $context['social_accounts'] = $post->get_social_accounts($context['footer_social_menu'] ?: []);
 $context['page_category'] = $data_layer['page_category'];
-$context['post_tags'] = implode(', ', $post->tags());
 $context['css_vars'] = PostCampaign::css_vars($campaign_meta);
 
 $context['custom_font_families'] = [

--- a/single-p4_action.php
+++ b/single-p4_action.php
@@ -36,6 +36,7 @@ $context['post'] = $post;
 $context['social_accounts'] = $post->get_social_accounts($context['footer_social_menu'] ?: []);
 $context['page_category'] = $data_layer['page_category'];
 $context['post_tags'] = implode(', ', $post->tags());
+$context['post_categories'] = implode(', ', $post->categories());
 $context['custom_body_classes'] = 'brown-bg ';
 
 Context::set_p4_blocks_datalayer($context, $post);

--- a/single.php
+++ b/single.php
@@ -45,6 +45,7 @@ $context['page_type_slug'] = $page_terms_data->slug ?? '';
 $context['social_accounts'] = $post->get_social_accounts($context['footer_social_menu'] ?: []);
 $context['page_category'] = 'Post Page';
 $context['post_tags'] = implode(', ', $post->tags());
+$context['post_categories'] = implode(', ', $post->categories());
 
 Context::set_og_meta_fields($context, $post);
 Context::set_campaign_datalayer($context, $page_meta_data);

--- a/templates/blocks/google_tag_manager.twig
+++ b/templates/blocks/google_tag_manager.twig
@@ -52,6 +52,7 @@
       'post_tags': '{{ post_tags }}',
       'gPlatform': 'Planet 4',
       'p4_blocks': '{{ p4_blocks }}',
+      'post_categories': '{{ post_categories }}',
     });
 
     {% if not post.password_required %}


### PR DESCRIPTION
### Description

See [PLANET-7102](https://jira.greenpeace.org/browse/PLANET-7102)
This is to make it easier to track High Level topics. Since all post types can have categories, I've added this new DLV to all of them (similar to the `post_tags`)

### Testing

On local or on the [atlas test instance](https://www-dev.greenpeace.org/test-atlas/), any post/page/action should now have the `post_categories` DLV which you can check by typing `dataLayer` in the console.