### PR TITLE
Implement CSS variables to font families

### DIFF
--- a/assets/src/scss/base/_css-variables.scss
+++ b/assets/src/scss/base/_css-variables.scss
@@ -1,6 +1,6 @@
 :root {
-  --body--font-family: #{$lora};
-  --headings--font-family: #{$roboto};
+  --body--font-family: var(--font-family-primary);
+  --headings--font-family: var(--font-family-secondary);
   --headings--font-weight: bold;
   --body--background-color: #{$white};
   --body--color: #{$grey-80};

--- a/assets/src/scss/base/_variables.scss
+++ b/assets/src/scss/base/_variables.scss
@@ -2,6 +2,12 @@
 $roboto:     "Roboto", sans-serif;
 $lora:       "Lora", serif;
 
+:root {
+  --font-family-primary: #{$roboto};
+  --font-family-secondary: #{$lora};
+  --font-family-tertiary: #{$lora};
+}
+
 // Media queries
 $extra-small-width:       320px;
 $small-width:             576px;

--- a/assets/src/scss/new-identity/style.scss
+++ b/assets/src/scss/new-identity/style.scss
@@ -1,5 +1,5 @@
-@import "../base/tokens";
 @import "../base/variables";
+@import "../base/tokens";
 @import "../base/mixins";
 @import "./fonts";
 


### PR DESCRIPTION
# Desciption
This allows to NROs to override font families when the new identity is being released.

Related PRs
- https://github.com/greenpeace/planet4-design-tokens/pull/13

<!-- Ref: Please add a url to the ticket this change is addressing.

---

Please provide a brief summary of the change introduced to make review process easier.

Ideally this should also be part of the commit summary.
-->
