### PR TITLE
PLANET-7216: Fix error on tag page

### DIFF
--- a/tag.php
+++ b/tag.php
@@ -40,6 +40,9 @@ if ($redirect_id) {
 
 $post = Timber::query_post(false, Post::class); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 $context = Timber::get_context();
+if ($post instanceof \WP_Post) {
+    $post = new Post($post->ID);
+}
 
 Context::set_og_meta_fields($context, $post);
 $context['tag'] = $tag;


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-7216

Fix instance of Post on tag page being WP_Post in some cases.

## Test

On local, load a Mena instance
- `npm run nro:install mena`
- check a tag page like `/en/tag/aboutus/`
  - on _main_ it crashes
  - on this branch the page displays properly