### PR TITLE
PLANET-7177 Move Default P4 Post Type setting under Settings > Writing

### DIFF
--- a/src/CustomTaxonomy.php
+++ b/src/CustomTaxonomy.php
@@ -4,6 +4,7 @@ namespace P4\MasterTheme;
 
 use WP_Post;
 use WP_Term;
+use P4\MasterTheme\Settings\DefaultPostType;
 
 /**
  * Class CustomTaxonomy
@@ -89,8 +90,8 @@ class CustomTaxonomy
         $all_types = $this->get_terms();
         if (-1 === $current_type) {
             // Assign default p4-pagetype for new POST.
-            $default_p4_pagetype = $this->get_default_p4_pagetype();
-            $current_type = $default_p4_pagetype->slug;
+            $planet4_default_post_type = $this->get_planet4_default_post_type();
+            $current_type = $planet4_default_post_type->slug;
         }
 
         wp_nonce_field('p4-save-page-type', 'p4-page-type-nonce');
@@ -208,20 +209,19 @@ class CustomTaxonomy
      *
      * @return WP_term|int|WP_Error
      */
-    public function get_default_p4_pagetype()
+    public function get_planet4_default_post_type()
     {
-        $options = get_option('planet4_options');
-        $default_p4_pagetype = $options['default_p4_pagetype'] ?? 0;
+        $planet4_default_post_type = DefaultPostType::get_option() ?? 0;
 
-        if (0 === $default_p4_pagetype) {
+        if (0 === $planet4_default_post_type) {
             // If default p4-pagetype setting not found, use taxonomy's first term.
             $all_terms = $this->get_terms();
-            $default_p4_pagetype = $all_terms[0] ?? 0;
+            $planet4_default_post_type = $all_terms[0] ?? 0;
         } else {
-            $default_p4_pagetype = get_term($default_p4_pagetype, self::TAXONOMY);
+            $planet4_default_post_type = get_term($planet4_default_post_type, self::TAXONOMY);
         }
 
-        return $default_p4_pagetype;
+        return $planet4_default_post_type;
     }
 
     /**
@@ -428,12 +428,12 @@ class CustomTaxonomy
             return;
         }
 
-        $default_p4_pagetype = $this->get_default_p4_pagetype();
+        $planet4_default_post_type = $this->get_planet4_default_post_type();
 
         // Assign default p4-pagetype, if no term is assigned to post.
         if (empty($terms)) {
-            if ($default_p4_pagetype instanceof \WP_Term) {
-                wp_set_post_terms($post_id, [$default_p4_pagetype->term_id], self::TAXONOMY);
+            if ($planet4_default_post_type instanceof \WP_Term) {
+                wp_set_post_terms($post_id, [$planet4_default_post_type->term_id], self::TAXONOMY);
             }
             // Assign the first term, if more than one terms are assigned.
         } elseif (count($terms) > 1 && $terms[0] instanceof \WP_Term) {

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -90,6 +90,7 @@ final class Loader
             $this->default_services[] = MediaArchive\Rest::class;
             $this->default_services[] = Settings\ReadingTime::class;
             $this->default_services[] = Settings\CommentsGdpr::class;
+            $this->default_services[] = Settings\DefaultPostType::class;
 
             // Load P4 Metaboxes only when adding/editing a new Page/Post/Campaign.
             if ('post-new.php' === $pagenow || 'post.php' === $pagenow) {

--- a/src/Migrations/M021MigrateDefaultPostType.php
+++ b/src/Migrations/M021MigrateDefaultPostType.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace P4\MasterTheme\Migrations;
+
+use P4\MasterTheme\MigrationRecord;
+use P4\MasterTheme\MigrationScript;
+use P4\MasterTheme\Settings\DefaultPostType;
+
+class M021MigrateDefaultPostType extends MigrationScript
+{
+    /**
+     * Perform the actual migration.
+     *
+     * @param MigrationRecord $record Information on the execution, can be used to add logs.
+     * phpcs:disable SlevomatCodingStandard.Functions.UnusedParameter -- interface implementation
+     */
+    public static function execute(MigrationRecord $record): void
+    {
+        $value = planet4_get_option('default_p4_pagetype');
+
+        $options = get_option('planet4_options');
+        unset($options['default_p4_pagetype']);
+        update_option('planet4_options', $options);
+
+        if (!$value) {
+            return;
+        }
+
+        update_option(DefaultPostType::KEY, $value);
+    }
+    // phpcs:enable SlevomatCodingStandard.Functions.UnusedParameter
+}

--- a/src/Migrator.php
+++ b/src/Migrator.php
@@ -22,6 +22,7 @@ use P4\MasterTheme\Migrations\M017NewIAToggle;
 use P4\MasterTheme\Migrations\M018MigrateDonateButtonSetting;
 use P4\MasterTheme\Migrations\M019MigrateReadingTime;
 use P4\MasterTheme\Migrations\M020MigrateCommentsSettings;
+use P4\MasterTheme\Migrations\M021MigrateDefaultPostType;
 
 /**
  * Run any new migration scripts and record results in the log.
@@ -61,6 +62,7 @@ class Migrator
             M018MigrateDonateButtonSetting::class,
             M019MigrateReadingTime::class,
             M020MigrateCommentsSettings::class,
+            M021MigrateDefaultPostType::class,
         ];
 
         // Loop migrations and run those that haven't run yet.

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -102,12 +102,6 @@ class Settings
                 'title' => 'Defaults content',
                 'fields' => [
                     [
-                        'name' => __('Default P4 Post Type', 'planet4-master-theme-backend'),
-                        'id' => 'default_p4_pagetype',
-                        'type' => 'pagetype_select_taxonomy',
-                    ],
-
-                    [
                         'name' => __('Take Action Covers default button text', 'planet4-master-theme-backend'),
                         'id' => 'take_action_covers_button_text',
                         'type' => 'text',
@@ -508,7 +502,6 @@ class Settings
         add_filter('cmb2_render_get_informed_page_dropdown', [$this, 'p4_render_page_dropdown'], 10, 2);
         add_filter('cmb2_render_take_action_page_dropdown', [$this, 'p4_render_page_dropdown'], 10, 2);
         add_filter('cmb2_render_about_us_page_dropdown', [$this, 'p4_render_page_dropdown'], 10, 2);
-        add_filter('cmb2_render_pagetype_select_taxonomy', [$this, 'p4_render_pagetype_dropdown'], 10, 2);
         add_action('admin_enqueue_scripts', [$this, 'enqueue_admin_assets']);
         add_action('admin_init', [$this, 'add_new_identity_styles_toggle_value']);
 
@@ -610,29 +603,6 @@ class Settings
                 'orderby' => 'name',
                 'selected' => $value,
                 'name' => 'issues_parent_category',
-            ]
-        );
-    }
-    // phpcs:enable SlevomatCodingStandard.Functions.UnusedParameter
-
-    /**
-     * Render p4-pagetype dropdown.
-     *
-     * @param CMB2_Field $field_args CMB2 field Object.
-     * @param mixed $value Pagetype taxonomy ID.
-     * phpcs:disable SlevomatCodingStandard.Functions.UnusedParameter -- add_filter callback
-     */
-    public function p4_render_pagetype_dropdown(CMB2_Field $field_args, $value): void
-    {
-
-        wp_dropdown_categories(
-            [
-                'show_option_none' => __('Select Posttype', 'planet4-master-theme-backend'),
-                'hide_empty' => 0,
-                'orderby' => 'name',
-                'selected' => $value,
-                'name' => 'default_p4_pagetype',
-                'taxonomy' => 'p4-page-type',
             ]
         );
     }

--- a/src/Settings/DefaultPostType.php
+++ b/src/Settings/DefaultPostType.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace P4\MasterTheme\Settings;
+
+class DefaultPostType
+{
+    public const KEY = 'planet4_default_post_type';
+
+    public function __construct()
+    {
+        $this->hooks();
+    }
+
+    public function hooks(): void
+    {
+        add_action('admin_init', [self::class, 'register_settings']);
+    }
+
+    public static function register_settings(): void
+    {
+        register_setting(
+            'writing',
+            self::KEY,
+            ['type' => 'integer'],
+        );
+
+        add_settings_field(
+            self::KEY,
+            __('Default P4 Post Type', 'planet4-master-theme-backend'),
+            [self::class, 'settings_field'],
+            'writing',
+        );
+    }
+
+    public static function settings_field(): void
+    {
+        wp_dropdown_categories(
+            [
+                'show_option_none' => __('Select Post Type', 'planet4-master-theme-backend'),
+                'hide_empty' => 0,
+                'orderby' => 'name',
+                'selected' => self::get_option(),
+                'name' => self::KEY,
+                'taxonomy' => 'p4-page-type',
+            ]
+        );
+    }
+
+    public static function get_option(): int
+    {
+        return get_option(self::KEY);
+    }
+}


### PR DESCRIPTION
### Description

See [PLANET-7177](https://jira.greenpeace.org/browse/PLANET-7177)

### Testing

The `Default P4 Post Type` setting should now be in `Settings > Writing`, you can make sure it still works as expected by creating a new post without any post type.