### PR TITLE
PLANET-7215 Apply the new design to the Submenu block

### DIFF
--- a/assets/src/scss/new-identity/style.scss
+++ b/assets/src/scss/new-identity/style.scss
@@ -239,6 +239,19 @@
   --columns-block--a--not--btn--font-weight: var(--font-weight-regular);
   --single-comment-meta--comment-reply-link--medium-and-up--font-family: var(--font-family-primary);
   --single-comment-meta--comment-reply-link--medium-and-up--font-weight: var(--font-weight-regular);
+  --submenu-block--border-radius: 4px;
+  --submenu-block--background-color: var(--white);
+  --submenu-block--box-shadow: 0 3px 8px 0 rgba(28, 28, 28, 0.2);
+  --submenu-block--padding: 20px 24px 24px 24px;
+  --submenu-block-heading--font-family: var(--font-family-primary);
+  --submenu-block-heading--color: var(--grey-900);
+  --submenu-block-heading--padding-inline-start: 0;
+  --submenu-block-menu--font-family: var(--font-family-tertiary);
+  --submenu-block-menu--margin: 0;
+  --submenu-block-menu--padding: 0;
+  --submenu-block-bullet-item--margin-inline-end: 0;
+  --submenu-block-bullet-item--margin-inline-start: 16px;
+  --submenu-block-number-item--margin-inline-start: 16px;
 }
 
 h1,


### PR DESCRIPTION
### Description

See [PLANET-7215](https://jira.greenpeace.org/browse/PLANET-7215)
Related PR: https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/1096

### Testing

Either on local or on the [oberon test instance](https://www-dev.greenpeace.org/test-oberon/), you can add a Submenu block to a page and make sure it looks as expected both with and without the new identity. Please make sure to test several styles and options of the block (links, etc), also in all different screen sizes!