### PR TITLE
PLANET-7219 Apply new identity link styles to the author block/page and 404 page

### DIFF
--- a/assets/src/js/external_links.js
+++ b/assets/src/js/external_links.js
@@ -3,7 +3,7 @@ const {__} = wp.i18n;
 export const setupExternalLinks = () => {
   const siteURL = window.location.host;
 
-  const linkSelector = ['.page-content', 'article'].map(sel => `${sel} a:not(.btn):not(.cover-card-heading):not(.wp-block-button__link):not(.share-btn):not([href*="${siteURL}"]):not([href*=".pdf"]):not([href^="/"]):not([href^="#"]):not([href^="javascript:"])`).join(', ');
+  const linkSelector = ['.page-content', 'article', '.author-details'].map(sel => `${sel} a:not(.btn):not(.cover-card-heading):not(.wp-block-button__link):not(.share-btn):not([href*="${siteURL}"]):not([href*=".pdf"]):not([href^="/"]):not([href^="#"]):not([href^="javascript:"])`).join(', ');
   const links = [...document.querySelectorAll(linkSelector)];
 
   links.forEach(link => {

--- a/assets/src/scss/new-identity/style.scss
+++ b/assets/src/scss/new-identity/style.scss
@@ -330,6 +330,11 @@ table.spreadsheet-table.is-color-gp-green {
   }
 }
 
+// 404 page links
+.page-404-page .speech-bubble a {
+  @include shared-link-styles;
+}
+
 .cookies-settings-header h4 {
   font-family: var(--font-family-paragraph-secondary);
 }

--- a/assets/src/scss/new-identity/style.scss
+++ b/assets/src/scss/new-identity/style.scss
@@ -315,6 +315,12 @@ table.spreadsheet-table.is-color-gp-green {
   }
 }
 
+// Author block/page links
+.author-block-info > div a,
+.author-details a {
+  @include shared-link-styles;
+}
+
 // Cookies box links
 .cookies-text,
 .cookies-settings-details {


### PR DESCRIPTION
### Description

See [PLANET-7219](https://jira.greenpeace.org/browse/PLANET-7219)

This PR includes several fixes:
- apply the new identity link styles to the Author block/page
- add the external link icon to the author page, to be consistent with the author block
- apply the new identity link styles to the 404 page content

### Testing

You can test the new identity link styles in this [Author page](https://www-dev.greenpeace.org/test-atlas/author/ltiralon/), and for the Author block you can see it on [this post](https://www-dev.greenpeace.org/test-atlas/press/1113/duis-posuere-6/). You can test the 404 page [here](https://www-dev.greenpeace.org/test-atlas/404/) for example.