### PR TITLE
Update Node version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,7 +89,7 @@ jobs:
 
   frontend-tests:
     docker:
-      - image: greenpeaceinternational/p4-unit-tests:node16.19.0
+      - image: greenpeaceinternational/p4-unit-tests:node16.20.1
         auth:
           <<: *docker_auth
     steps:
@@ -108,7 +108,7 @@ jobs:
 
   commitlint:
     docker:
-      - image: greenpeaceinternational/p4-unit-tests:node16.19.0
+      - image: greenpeaceinternational/p4-unit-tests:node16.20.1
         auth:
           <<: *docker_auth
     steps:
@@ -119,7 +119,7 @@ jobs:
 
   a11y-tests:
     docker:
-      - image: greenpeaceinternational/p4-unit-tests:node16.19.0
+      - image: greenpeaceinternational/p4-unit-tests:node16.20.1
         auth:
           <<: *docker_auth
     working_directory: /home/circleci/


### PR DESCRIPTION
Update Node version for CI
Related to: https://github.com/greenpeace/planet4-circleci-unit-tests/pull/14
Ref: https://nodejs.org/en/blog/release/v16.20.0
Ref: https://nodejs.org/en/blog/release/v16.20.1