### PR TITLE
Add template include for custom scripts

### DIFF
--- a/templates/html-header.twig
+++ b/templates/html-header.twig
@@ -50,4 +50,6 @@
             {% for style in custom_styles.css %}{{ style|raw }}{% endfor %}
         </style>
     {% endif %}
+
+    {% include 'custom_scripts.twig' ignore missing %}
 </head>


### PR DESCRIPTION
This will allow adding child theme custom scripts without overriding the whole header template.

We have a use case by MENA to add a fundraising script in the head section. Since we don't offer a way to do that in the Admin Panel, this would help them do that with minimal future maintenance burden.

<!-- Ref: Please add a url to the ticket this change is addressing.

---

Please provide a brief summary of the change introduced to make review process easier.

Ideally this should also be part of the commit summary.
-->
