### PR TITLE
PLANET-7225: Fix font family for headings, links and body text

### DIFF
--- a/assets/src/scss/base/_css-variables.scss
+++ b/assets/src/scss/base/_css-variables.scss
@@ -1,6 +1,6 @@
 :root {
-  --body--font-family: var(--font-family-primary);
-  --headings--font-family: var(--font-family-secondary);
+  --body--font-family: var(--font-family-secondary);
+  --headings--font-family: var(--font-family-primary);
   --headings--font-weight: bold;
   --body--background-color: #{$white};
   --body--color: #{$grey-80};


### PR DESCRIPTION
Ref: [PLANET-7225](https://jira.greenpeace.org/browse/PLANET-7225)

# Description
- Change the `--body--font-family` as the secondary font family.
- Change the `--headings--font-family` as the primary font family.

## Testing
Disable the new identity and then the `Roboto` should be applied to `headings`, `links`, `navigation bar`, among other elements.

[Demo page](https://www-dev.greenpeace.org/test-atlas/)

<!-- Ref: Please add a url to the ticket this change is addressing.

---

Please provide a brief summary of the change introduced to make review process easier.

Ideally this should also be part of the commit summary.
-->
