### PR TITLE
Modify the children alignment within the donate nav

### DIFF
--- a/assets/src/scss/layout/_navbar.scss
+++ b/assets/src/scss/layout/_navbar.scss
@@ -258,6 +258,7 @@ a.nav-link:hover:before,
 }
 
 .nav-donate {
+  display: flex;
   padding: $sp-2 0;
 
   @include large-and-up {


### PR DESCRIPTION
No ticket needed

# Description
As a part of the maintenance, we should Force the nav donate content to align to middle

Unexpected behavior
![Screenshot 2023-08-29 at 11 25 05](https://github.com/greenpeace/planet4-master-theme/assets/77975803/30fc61d4-ed8b-4cca-8b42-54cad5ff5881)


Expected behavior
![Screenshot 2023-08-29 at 11 25 11](https://github.com/greenpeace/planet4-master-theme/assets/77975803/c815188f-dc0f-40dc-8919-c75faad860ca)
