### PR TITLE
Revert "Modify the children alignment within the donate nav (#2104)"

### DIFF
--- a/assets/src/scss/layout/_navbar.scss
+++ b/assets/src/scss/layout/_navbar.scss
@@ -258,7 +258,6 @@ a.nav-link:hover:before,
 }
 
 .nav-donate {
-  display: flex;
   padding: $sp-2 0;
 
   @include large-and-up {


### PR DESCRIPTION
This reverts commit b14372485a297d5dd0cc943a68b88f9721d7fecc.

This changes made the Donate submenu appear on top of the Donate button (cf [international](https://www.greenpeace.org/international/))
![Screenshot from 2023-08-31 09-30-14](https://github.com/greenpeace/planet4-master-theme/assets/617346/b3675745-f10c-404e-bdd5-5b607e5e22c5)
