### PR TITLE
Fix author avatar resolution

### DIFF
--- a/templates/blocks/author_profile.twig
+++ b/templates/blocks/author_profile.twig
@@ -5,7 +5,7 @@
                 <figure class="author-block-image d-none d-sm-none d-md-block">
                     <img
                         itemprop="image"
-                        src="{{ fn('get_avatar_url', post.author.id, {'size' : 294 }) }}"
+                        src="{{ fn('get_avatar_url', post.author.id, {'size' : 294 }) | trim('=s96-c') }}"
                         alt="{{ post.author.name }}"
                     />
                 </figure>


### PR DESCRIPTION
Fix author avatar resolution in Author block in posts

Avatar URL was already fixed for the block used for small viewport, but not for the large one.