### PR TITLE
PLANET-7247: Fix tag listing page not listing all posts

### DIFF
--- a/tag.php
+++ b/tag.php
@@ -51,6 +51,8 @@ $context['tag_description'] = wpautop($context['tag']->description);
 $context['canonical_link'] = home_url($wp->request);
 
 if (!empty(planet4_get_option('new_ia'))) {
+    // Temporary fix with rewind, cf. https://github.com/WordPress/gutenberg/issues/53593
+    rewind_posts();
     $context['page_category'] = 'Listing Page';
     $view = ListingPageGridView::is_active() ? 'grid' : 'list';
     $query_template = file_get_contents(get_template_directory() . "/parts/query-$view.html");


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-7247
Cf. https://github.com/WordPress/gutenberg/issues/53593
Cf. https://github.com/WordPress/gutenberg/pull/49904

With new IA activated, tag listing pages are missing the first post of the list, for each page, and showing only 9 instead of 10.
This is a known bug in Gutenberg. The fix consists in rewinding the main query  before entering the loop so that we don't miss the first post.

## Test

Locally, use International `npm run nro:install international`
or on [test instance Atlas](https://www-dev.greenpeace.org/test-atlas/tag/renewables/)
- check that default tag listing pages can show 10 posts per page
