### PR TITLE
PLANET-7191: Fix search action and content toggles

### DIFF
--- a/templates/search.twig
+++ b/templates/search.twig
@@ -259,10 +259,10 @@
                             {% endif %}
                             {% if ( action_types|length > 0 ) %}
                                 <div class="filteritem">
-                                    <a data-bs-toggle="collapse" href="#item-content" class="{{ collapsed }}" aria-expanded="{{ expanded }}">
+                                    <a data-bs-toggle="collapse" href="#item-action" class="{{ collapsed }}" aria-expanded="{{ expanded }}">
                                         {{ __( 'Action Type', 'planet4-master-theme' ) }} <span></span>
                                     </a>
-                                    <div id="item-content" class="collapse {{ show }}" role="tabpanel">
+                                    <div id="item-action" class="collapse {{ show }}" role="tabpanel">
                                         <ul class="list-unstyled">
                                             {% for id, action_type in action_types %}
                                                 {% if ( action_type.results > 0 ) %}

--- a/tests/e2e/tickets/PLANET-7191/PLANET-7191.test.js
+++ b/tests/e2e/tickets/PLANET-7191/PLANET-7191.test.js
@@ -1,0 +1,29 @@
+import {test, expect} from '../../tools/lib/test-utils.js';
+
+test('check search filters toggles', async ({page}) => {
+  await page.goto('./?s=');
+
+  const actionLink = await page.getByRole('link', {name: 'Action Type'});
+  const contentLink = await page.getByRole('link', {name: 'Content Type'});
+  const actionList = await page.locator('.filteritem').filter({has: actionLink}).getByRole('tabpanel');
+  const contentList = await page.locator('.filteritem').filter({has: contentLink}).getByRole('tabpanel');
+
+  await expect(actionList).toBeVisible();
+  await expect(contentList).toBeVisible();
+
+  await actionLink.click();
+  await expect(actionList).toBeHidden();
+  await expect(contentList).toBeVisible();
+
+  await contentLink.click();
+  await expect(actionList).toBeHidden();
+  await expect(contentList).toBeHidden();
+
+  await contentLink.click();
+  await expect(actionList).toBeHidden();
+  await expect(contentList).toBeVisible();
+
+  await actionLink.click();
+  await expect(actionList).toBeVisible();
+  await expect(contentList).toBeVisible();
+});


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-7191

> Search "Action type" or "Content type" filters toggle the same section

## Test

Locally, run (with elastic activated)
```
> TICKET=PLANET-7191 npx playwright test --ui tests/e2e/tickets/PLANET-7191/PLANET-7191.test.js
```

On test instance, click on Content Type and Action Type toggles, they should act independently.