### PR TITLE
PLANET-7267 Make sure editor links are styled with the new identity

### DIFF
--- a/assets/src/scss/new-identity/style.scss
+++ b/assets/src/scss/new-identity/style.scss
@@ -349,6 +349,11 @@ table.spreadsheet-table.is-color-gp-green {
   @include shared-link-styles;
 }
 
+// Editor links
+.editor-styles-wrapper p > a {
+  @include shared-link-styles;
+}
+
 .cookies-settings-header h4 {
   font-family: var(--font-family-paragraph-secondary);
 }


### PR DESCRIPTION
### Description

See [PLANET-7267](https://jira.greenpeace.org/browse/PLANET-7267)
Before this change they were not visible

Related PR: https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/1122

### Testing

You can test the fix either on local or on [this page](https://www-dev.greenpeace.org/test-atlas/wp-admin/post.php?post=1168&action=edit) I created on the atlas test instance.