### PR TITLE
Fix limit post revisions query

### DIFF
--- a/src/Migrations/M022UpdatePostRevisions.php
+++ b/src/Migrations/M022UpdatePostRevisions.php
@@ -52,8 +52,11 @@ class M022UpdatePostRevisions extends MigrationScript
                             WHERE post_type = "%2$s"
                             GROUP BY post_parent
                             HAVING count(ID) > %1$s
-                        ) AND post_type = "%2$s"
-                        ORDER BY post_date ASC
+                        )
+                        AND post_type = "%2$s"
+                        ORDER BY
+                            post_parent ASC,
+                            post_date DESC
                     ) AS r
                 ) AS d
                 WHERE d.rwn > %1$s


### PR DESCRIPTION
# Description
After the merge of #1945 we noticed that the query is returning always `0` posts to delete, which seems to be weird since too many posts has more that `20` revisions.
We detected that the problem is because we need to ORDER not only by `post_date` but also by `post_parent`, if not, we have an inconsistency with `@rownumber` counter since the counter is reseted whenever the `post_parent` is looped through a query.

```sql

      @rownumber:=(IF(@postparent=post_parent, @rownumber:=@rownumber+1, 1)) as rwn,
      @postparent:=post_parent
```
and the unexpected result
```
+-------------+------+-------+
| post_parent | rwn  | ID    |
+-------------+------+-------+
|         936 |    1 | 43693 |
|         936 |    2 | 43692 |
|         936 |    3 | 43691 |
|         936 |    4 | 43690 |
|         936 |    5 | 43688 |
|       25566 |    1 | 43601 |
|       25566 |    2 | 43640 |
|         936 |    1 | 43489 |
|          70 |    1 | 43416 |
|          70 |    2 | 29394 |
|         936 |    1 | 43383 |
|         936 |    2 | 43382 |
|         936 |    3 | 43381 |
|         936 |    4 | 43378 |
|         936 |    5 | 43377 |
|         936 |    6 | 43376 |
|         936 |    7 | 43375 |
|         936 |    8 | 43374 |
|         936 |    9 | 43373 |
|         936 |   10 | 43372 |
|         936 |   11 | 43371 |
|          70 |    1 | 30298 |
|          70 |    2 | 30157 |
|         936 |    1 | 29910 |
|          70 |    1 | 29660 |
|          70 |    2 | 29533 |
|          70 |    3 | 29513 |
|          70 |    4 | 29489 |
|          70 |    5 | 29488 |
|          70 |    6 | 29402 |
|          70 |    7 | 29399 |
|          70 |    8 | 29397 |
|          70 |    9 | 29396 |
|          70 |   10 | 29330 |
|          70 |   11 | 29269 |
|       25566 |    1 | 29632 |
|       25566 |    2 | 28583 |
|          70 |    1 | 28573 |
|          70 |    2 | 28572 |
|          70 |    3 | 28453 |
|          70 |    4 | 28452 |
|          70 |    5 | 28443 |
|          70 |    6 | 28441 |
|         936 |    1 | 29908 |
|         936 |    2 | 28294 |
|          70 |    1 | 28228 |
+-------------+------+-------+
```
However, the next query should sort the result correctly
```sql
SET @rownumber:=0;
SET @postparent:=NULL;
SELECT
  @rownumber:=(IF(@postparent=post_parent, @rownumber:=@rownumber+1, 1)) as rownumber,
  @postparent:=post_parent as postparent,
  post_date
FROM (
  SELECT
    ID,
    post_parent,
    post_date
  FROM wp_posts
  WHERE post_parent IN (
    SELECT post_parent
    FROM wp_posts
    WHERE post_type = 'revision'
    GROUP BY post_parent
    HAVING count(ID) > 100
  )
  AND post_type = 'revision'
  ORDER BY post_parent ASC
) r;
```

## Testing
I prefer to set `100` as the limit of post revisions to avoid long query results and use the `SELECT` clause instead of `DELETE`.
```sql
SELECT post_parent, count(ID) as total_revisions
FROM wp_posts
WHERE post_type = 'revision'
GROUP BY post_parent
HAVING count(ID) > 100
+-------------+-----------------+
| post_parent | total_revisions |
+-------------+-----------------+
|          70 |             710 |
|         936 |             158 |
|       25566 |             112 |
+-------------+-----------------+
```

Taking a look into [this post](https://www-dev.greenpeace.org/international/wp-admin/post.php?post=70&action=edit) I see it has `710` revisions, so, if the post revisions is set to `100`, `610` posts might be deleted from the database.

```sql
SET @rownumber:=0;
SET @postparent:=NULL;
SELECT
  count(ID) as total_revisions
FROM (
  SELECT ID, post_parent, post_date, rwn FROM (
    SELECT
      post_parent,
      ID,
      post_date,
      @rownumber:=(IF(@postparent=post_parent, @rownumber:=@rownumber+1, 1)) as rwn,
      @postparent:=post_parent
    FROM (
      SELECT
        ID,
        post_parent,
        post_date
      FROM wp_posts
      WHERE post_parent IN (
        SELECT post_parent
        FROM wp_posts
        WHERE post_type = 'revision'
        GROUP BY post_parent
        HAVING count(ID) > 100
      )
      AND post_type = 'revision'
      AND post_parent = 70
      ORDER BY
        post_parent ASC,
        post_date DESC
    ) AS revisions
  ) AS d
) AS a
WHERE a.rwn > 100;

+-----------------+
| total_revisions |
+-----------------+
|             610 |
+-----------------+
```

Finally, testing the query with the fix and retrieve all the posts that must be deleted
```sql
SET @rownumber:=0;
SET @postparent:=NULL;
SELECT
  count(ID) as total_revisions
FROM (
  SELECT ID, post_parent, post_date, rwn FROM (
    SELECT
      post_parent,
      ID,
      post_date,
      @rownumber:=(IF(@postparent=post_parent, @rownumber:=@rownumber+1, 1)) as rwn,
      @postparent:=post_parent
    FROM (
      SELECT
        ID,
        post_parent,
        post_date
      FROM wp_posts
      WHERE post_parent IN (
        SELECT post_parent
        FROM wp_posts
        WHERE post_type = 'revision'
        GROUP BY post_parent
        HAVING count(ID) > 100
      )
      AND post_type = 'revision'
      ORDER BY
        post_parent ASC,
        post_date DESC
    ) AS revisions
  ) AS d
) AS a
WHERE a.rwn > 100;
+-----------------+
| total_revisions |
+-----------------+
|             680 |
+-----------------+
```
which seems to be fine since according to the below table, `680` `revisions` might to be deleted.
```
+-------------+-----------------+---------------------+
| post_parent | total_revisions | revisions_to_delete |
+-------------+-----------------+---------------------+
|     70      |       710       |         610         |
|     936     |       158       |         58          |
|     25566   |       112       |         12          |
+-------------+-----------------+---------------------+
```
