### PR TITLE
POC: Create React Search Page as a replacement of the current one

### DIFF
--- a/assets/src/js/search_react_page.js
+++ b/assets/src/js/search_react_page.js
@@ -1,0 +1,60 @@
+
+import {createRoot, useEffect, useState} from '@wordpress/element';
+
+(function() {
+  const SearchPage = () => {
+    const [searchText, setSearchText] = useState('');
+
+    const onChange = evt => {
+      evt.preventDefault();
+      setSearchText(evt.currentTarget.value);
+    };
+
+    useEffect(() => {
+      const params = new URL(document.location).searchParams;
+      setSearchText(params.get('s'));
+    }, []);
+
+    return (
+      <section style={{padding: '30px'}}>
+        <header style={{display: 'flex', justifyContent: 'space-between'}}>
+          <a className="site-logo" href="http://www.planet4.test/">
+            <img
+              src="http://www.planet4.test/wp-content/themes/planet4-master-theme/images/gp-logo.svg"
+              alt="Greenpeace"
+              data-ga-category="Menu Navigation"
+              data-ga-action="Greenpeace Logo"
+              data-ga-label="Homepage"
+            />
+          </a>
+          <label htmlFor="input-search">
+            <input
+              id="input-search"
+              name="input-search"
+              style={{width: '400px', height: '50px'}}
+              onChange={onChange}
+              placeholder="Search"
+              value={searchText}
+            />
+          </label>
+        </header>
+        <h1 style={{marginTop: '50px', textAlign: 'center'}}>Results for {searchText}</h1>
+        <div style={{width: '70%', display: 'flex', justifyContent: 'space-between'}}>
+          <input
+            style={{width: '100%', height: '50px'}}
+            onChange={onChange}
+            placeholder="Search"
+            value={searchText}
+          />
+          <button type="submit" className="btn btn-primary search-btn btn-block" data-ga-category="Search Page" data-ga-action="Search Button" data-ga-label="n/a">Search</button>
+        </div>
+      </section>
+    );
+  };
+
+  const wrapper = document.createElement('div');
+  wrapper.setAttribute('id', 'root');
+  const root = createRoot(wrapper);
+  document.body.appendChild(wrapper);
+  root.render(<SearchPage />);
+}());

--- a/search.php
+++ b/search.php
@@ -1,46 +1,7 @@
 <?php
 
-/**
- * Search results page
- *
- * Methods for TimberHelper can be found in the /lib sub-directory
- *
- * @package  WordPress
- * @subpackage  Timber
- * @since   Timber 0.1
- */
+use P4\MasterTheme\SearchReactPage;
 
-use P4\MasterTheme\ElasticSearch;
-
-/**
- * Planet4 - Search functionality.
- */
-
-// Limit access to GET method.
-if ('GET' !== filter_input(INPUT_SERVER, 'REQUEST_METHOD')) {
-    return;
+if (is_search()) {
+    new SearchReactPage();
 }
-
-$selected_sort = sanitize_text_field($_GET['orderby']);
-$selected_filters = $_GET['f'] ?? ''; // phpcs:ignore
-$filters = [];
-
-// Handle submitted filter options.
-if ($selected_filters && is_array($selected_filters)) {
-    foreach ($selected_filters as $type_name => $filter_type) {
-        if (! is_array($filter_type)) {
-            continue;
-        }
-        foreach ($filter_type as $name => $filter_id) {
-            $filters[ $type_name ][] = [
-                'id' => $filter_id,
-                'name' => $name,
-            ];
-        }
-    }
-}
-
-$p4_search = new ElasticSearch();
-$p4_search->load(trim(get_search_query()), $selected_sort, $filters);
-$p4_search->add_load_more();
-$p4_search->view();

--- a/src/SearchReactPage.php
+++ b/src/SearchReactPage.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace P4\MasterTheme;
+
+/**
+ * Abstract Class SearchReactPage
+ */
+class SearchReactPage
+{
+    /**
+     * The constructor.
+     */
+    public function __construct()
+    {
+        do_action('wp_head');
+        do_action('wp_footer');
+
+        $this->render_search_page();
+    }
+
+    public function render_search_page(): void
+    {
+        $file = get_template_directory_uri() . '/assets/build/search_react_page.js';
+        echo '
+            <script type="text/javascript">
+                document.addEventListener("DOMContentLoaded", function() {
+                    var script = document.createElement("script");
+                    script.src = "' . $file . '";
+                    document.getElementsByTagName("head")[0].appendChild(script);
+                });
+            </script>
+        ';
+    }
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -33,6 +33,7 @@ module.exports = {
     media_archive: './assets/src/js/media_archive.js',
     "lite-yt-embed": './node_modules/lite-youtube-embed/src/lite-yt-embed.js',
     menu_editor: './assets/src/js/menu_editor.js',
+    search_react_page: './assets/src/js/search_react_page.js',
   },
   output: {
     filename: '[name].js',


### PR DESCRIPTION
## Description
Create a new React Search page as a replacement of the default Template Hierarchy which uses Timber.

<!-- Ref: Please add a url to the ticket this change is addressing.

---

Please provide a brief summary of the change introduced to make review process easier.

Ideally this should also be part of the commit summary.
-->
