### PR TITLE
PLANET-7178 Move Copyright settings to Navigation settings

### DIFF
--- a/src/Settings.php
+++ b/src/Settings.php
@@ -65,36 +65,51 @@ class Settings
                 'title' => 'Navigation',
                 'fields' => [
                     [
-                        'name' => __('NRO Selector Title', 'planet4-master-theme-backend'),
-                        'id' => 'website_navigation_title',
-                        'type' => 'text',
-                    ],
-                    [
                         'name' => __('Select Act Page', 'planet4-master-theme-backend'),
                         'id' => 'act_page',
                         'type' => 'act_page_dropdown',
                         'classes' => $is_new_ia ? 'hidden' : '',
                     ],
-
                     [
                         'name' => __('Select Explore Page', 'planet4-master-theme-backend'),
                         'id' => 'explore_page',
                         'type' => 'explore_page_dropdown',
                         'classes' => $is_new_ia ? 'hidden' : '',
                     ],
-
                     [
                         'name' => __('Select Issues Parent Category', 'planet4-master-theme-backend'),
                         'id' => 'issues_parent_category',
                         'type' => 'category_select_taxonomy',
                         'classes' => $is_new_ia ? 'hidden' : '',
                     ],
-
                     [
                         'name' => __('New Information Architecture', 'planet4-master-theme-backend'),
                         'desc' => __('Enables all features supporting new IA and navigation functionality (<a href="https://planet4.greenpeace.org/manage/information-architecture/" target="_blank">read more</a>)<br>(eg. Actions post type, listing pages pagination, mobile tabs, etc).', 'planet4-master-theme-backend'),
                         'id' => 'new_ia',
                         'type' => 'checkbox',
+                    ],
+                    [
+                        'name' => __('Country Selector text', 'planet4-master-theme-backend'),
+                        'id' => 'website_navigation_title',
+                        'type' => 'text',
+                    ],
+                    [
+                        'name' => __('Copyright Text Line 1', 'planet4-master-theme-backend'),
+                        'id' => 'copyright_line1',
+                        'type' => 'wysiwyg',
+                        'options' => [
+                            'textarea_rows' => 3,
+                            'media_buttons' => false,
+                        ],
+                    ],
+                    [
+                        'name' => __('Copyright Text Line 2', 'planet4-master-theme-backend'),
+                        'id' => 'copyright_line2',
+                        'type' => 'wysiwyg',
+                        'options' => [
+                            'textarea_rows' => 2,
+                            'media_buttons' => false,
+                        ],
                     ],
                 ],
             ],
@@ -294,30 +309,6 @@ class Settings
                         'desc' => __('Add the "Reject all" option in the Cookies box', 'planet4-master-theme-backend'),
                         'id' => 'enable_reject_all_cookies',
                         'type' => 'checkbox',
-                    ],
-                ],
-            ],
-            'planet4_settings_copyright' => [
-                'title' => 'Copyright',
-                'fields' => [
-                    [
-                        'name' => __('Copyright Text Line 1', 'planet4-master-theme-backend'),
-                        'id' => 'copyright_line1',
-                        'type' => 'wysiwyg',
-                        'options' => [
-                            'textarea_rows' => 3,
-                            'media_buttons' => false,
-                        ],
-                    ],
-
-                    [
-                        'name' => __('Copyright Text Line 2', 'planet4-master-theme-backend'),
-                        'id' => 'copyright_line2',
-                        'type' => 'wysiwyg',
-                        'options' => [
-                            'textarea_rows' => 2,
-                            'media_buttons' => false,
-                        ],
                     ],
                 ],
             ],

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -608,18 +608,6 @@ class Settings
     {
         $page_config = $this->subpages[$plugin_page];
 
-        if ('planet4_settings_donate_button' === $plugin_page) {
-            $message = trim($this->show_donate_menu_notice());
-
-            if (empty($message)) {
-                return;
-            }
-
-            echo '<div class="notice notice-info is-dismissible">'
-                . wp_kses_post($message)
-                . '</div>';
-        }
-
         $fields = $page_config['fields'];
         $description = $page_config['description'] ?? null;
         // Allow storing options in a different database record.
@@ -648,20 +636,6 @@ class Settings
             $form // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
         );
     }
-
-    /**
-     * Show notice to inform users that the Donate button settings are now in Appearance > Menus.
-     *
-     * phpcs:disable Generic.Files.LineLength.MaxExceeded
-     */
-    private function show_donate_menu_notice(): string
-    {
-        return '<p>These settings have been moved to <a href="/wp-admin/nav-menus.php?action=locations">a new menu location</a>
-			in Appearance > Menus, specifically the "Donate Button" location.</br>
-			There you can add a custom link with your text and link for the Donate button,
-			and you will also be able to define dropdown menu items if you want to.</p>';
-    }
-    // phpcs:enable Generic.Files.LineLength.MaxExceeded
 
     /**
      * Defines the theme option metabox and field configuration.


### PR DESCRIPTION
### Description

See [PLANET-7178](https://jira.greenpeace.org/browse/PLANET-7178)
This is to simplify our P4 settings. This PR also removes some old code related to the Donate button settings, that we no longer need there since [we moved them](https://github.com/greenpeace/planet4-master-theme/commit/0547c5e7fe88565e6294a1352d0d8748ed32f33d#diff-eb1710f64250974d6d1550d421a31054e6079592ae3a8428cd9530bc086bdd94).

### Testing

The Copyright settings should now be under `Planet 4 > Navigation`. Make sure that the previous Copyright settings values have been preserved.