### PR TITLE
PLANET-7268 Add meta and opengraph html tags on listing pages

### DIFF
--- a/author.php
+++ b/author.php
@@ -43,6 +43,7 @@ if (isset($wp_query->query_vars['author'])) {
         'width' => '300',
         'height' => '300',
     ];
+    $context['og_type'] = 'profile';
 
     $author_share_buttons = new stdClass();
     $author_share_buttons->title = $author->name;

--- a/category.php
+++ b/category.php
@@ -16,9 +16,12 @@ use Timber\Timber;
 $templates = [ 'taxonomy.twig', 'index.twig' ];
 
 $context = Timber::get_context();
-$context['taxonomy'] = get_queried_object();
-$context['wp_title'] = $context['taxonomy']->name;
+$taxonomy = get_queried_object();
+$context['taxonomy'] = $taxonomy;
+$context['wp_title'] = $taxonomy->name;
 $context['canonical_link'] = home_url($wp->request);
+$context['og_type'] = 'website';
+$context['og_description'] = $taxonomy->description;
 
 if (!empty(planet4_get_option('new_ia'))) {
     $view = ListingPageGridView::is_active() ? 'grid' : 'list';
@@ -34,7 +37,7 @@ if (!empty(planet4_get_option('new_ia'))) {
 }
 
 $post_args = [
-    'cat' => $context['taxonomy']->term_id,
+    'cat' => $taxonomy->term_id,
     'posts_per_page' => 10,
     'post_type' => 'post',
     'paged' => 1,

--- a/src/Post.php
+++ b/src/Post.php
@@ -394,6 +394,7 @@ class Post extends TimberPost
     public function get_og_description(): string
     {
         $og_desc = get_post_meta($this->id, 'p4_og_description', true);
+
         if ('' === $og_desc) {
             return $this->post_excerpt;
         }

--- a/tag.php
+++ b/tag.php
@@ -42,13 +42,14 @@ $post = Timber::query_post(false, Post::class); // phpcs:ignore WordPress.WP.Glo
 $context = Timber::get_context();
 if ($post instanceof \WP_Post) {
     $post = new Post($post->ID);
+    Context::set_og_meta_fields($context, $post);
 }
 
-Context::set_og_meta_fields($context, $post);
 $context['tag'] = $tag;
 $context['tag_name'] = single_tag_title('', false);
 $context['tag_description'] = wpautop($context['tag']->description);
 $context['canonical_link'] = home_url($wp->request);
+$context['og_type'] = 'website';
 
 if (!empty(planet4_get_option('new_ia'))) {
     // Temporary fix with rewind, cf. https://github.com/WordPress/gutenberg/issues/53593

--- a/taxonomy.php
+++ b/taxonomy.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * The template for displaying Taxonomy pages.
+ * The template for displaying Taxonomy pages (Post types, Action types).
  *
  * Used to display taxonomy-type pages
  *
@@ -19,9 +19,12 @@ use Timber\Timber;
 $templates = [ 'taxonomy.twig', 'index.twig' ];
 
 $context = Timber::get_context();
-$context['taxonomy'] = get_queried_object();
-$context['wp_title'] = $context['taxonomy']->name;
+$taxonomy = get_queried_object();
+$context['taxonomy'] = $taxonomy;
+$context['wp_title'] = $taxonomy->name;
 $context['canonical_link'] = home_url($wp->request);
+$context['og_type'] = 'website';
+$context['og_description'] = $taxonomy->description;
 
 if (!empty(planet4_get_option('new_ia'))) {
     $context['page_category'] = 'Listing Page';
@@ -51,9 +54,9 @@ $post_args = [
     'has_password' => false, // Skip password protected content.
     'tax_query' => [
         [
-            'taxonomy' => $context['taxonomy']->taxonomy,
+            'taxonomy' => $taxonomy->taxonomy,
             'field' => 'slug',
-            'terms' => $context['taxonomy']->slug,
+            'terms' => $taxonomy->slug,
         ],
     ],
 ];

--- a/templates/base.twig
+++ b/templates/base.twig
@@ -1,6 +1,6 @@
 {% block html_head_container %}
 
-{% include 'html-header.twig' with { 'canonical_link': canonical_link } %}
+{% include 'html-header.twig' %}
 
 {% endblock %}
 

--- a/templates/blocks/meta_fields.twig
+++ b/templates/blocks/meta_fields.twig
@@ -1,8 +1,15 @@
-{% if ((post and (1 != fn('post_password_required', post))) or author is defined) or tag_name is defined %}
+{% set is_listing_page = tag_name is defined or taxonomy is defined or author is defined %}
+{% set is_news_page = page_category == 'News' %}
+
+{% if (post and (1 != fn('post_password_required', post))) or is_listing_page or is_news_page %}
     {% if (author.description is defined and author.description) %}
         {% set meta_description = author.description|striptags %}
     {% elseif (post.post_excerpt is defined and post.post_excerpt) %}
         {% set meta_description = post.post_excerpt|striptags %}
+    {% elseif (tag_description is defined and tag_description) %}
+        {% set meta_description = tag_description|striptags %}
+    {% elseif (taxonomy is defined and taxonomy.description) %}
+        {% set meta_description = taxonomy.description|striptags %}
     {% else %}
         {% set meta_description = site.description %}
     {% endif %}
@@ -25,10 +32,16 @@
 
     <meta name="title" content="{{ title|e('html_attr')|raw }}"/>
     <meta property="og:title" content="{{ title|e('html_attr')|raw }}" />
-    <meta property="og:type" content="article" />
     <meta property="og:url" content="{{ current_url }}" />
+    {% if (og_type) %}
+        <meta property="og:type" content="{{ og_type }}" />
+    {% else %}
+        <meta property="og:type" content="article" />
+    {% endif %}
     {% if (og_description) %}
         <meta property="og:description" content="{{ og_description|striptags }}" />
+    {% elseif (tag_description) %}
+        <meta property="og:description" content="{{ tag_description|striptags }}" />
     {% endif %}
     {% if (og_image_data) %}
         <meta property="og:image" content="{{ og_image_data['url'] }}" />


### PR DESCRIPTION
### Description

See [PLANET-7268](https://jira.greenpeace.org/browse/PLANET-7268)

**Requirements:**
- All listing pages
  - [x] Add `og:site_name` and `og:url`. Use posts as a guide on how to populate those.
  - [x] Use "website" as `og:type`.
- Categories, Tags, Post Types, Action Types
  - [x] Use title and description from their edit page as meta title and description tags, but also as `og:title` and `og:description`.
- Author page
  - [x] Use "profile" as `og:type`.
- News & Stories
  - [x] Use assigned page title as `og:title` and meta title tag.
  - [x] Use assigned page excerpt as `og:description` and meta description tag.
  - [x] Use assigned page featured image as `og:image`.

### Testing

You can inspect pages to make sure the relevant tags are present, you can also use https://opengraph.xyz/ for validation.
- [Tag listing page](https://www-dev.greenpeace.org/test-rhea/tag/renewables/)
- [Post type listing page](https://www-dev.greenpeace.org/test-rhea/press/)
- [Category listing page](https://www-dev.greenpeace.org/test-rhea/category/energy/)
- [Action type listing page](https://www-dev.greenpeace.org/test-rhea/petitions/)
- [Author page](https://www-dev.greenpeace.org/test-rhea/author/tgarcia/)
- [News & stories page](https://www-dev.greenpeace.org/test-rhea/news-stories/)