### PR TITLE
Add background color back to texts

### DIFF
--- a/assets/src/scss/base/_palette.scss
+++ b/assets/src/scss/base/_palette.scss
@@ -18,12 +18,16 @@ $palette: (
 
 @each $name, $color in $palette {
   .has-#{$name}-color {
+    color: #{$color};
+
     --transparent-button--border-color: #{$color};
     --transparent-button--color: #{$color};
     --transparent-button--hover--background: #{$color};
   }
 
   .has-#{$name}-background-color {
+    background-color: #{$color};
+
     --transparent-button--hover--color: #{$color};
     --transparent-button--active--color: #{$color};
   }


### PR DESCRIPTION
# Description
The background color has been wrongly removed after #2124 

The issue has been reported by [Quentin on Slack](https://greenpeace-gpi.slack.com/archives/C0160MX64AG/p1698411622511229)

<!-- Ref: Please add a url to the ticket this change is addressing.

---

Please provide a brief summary of the change introduced to make review process easier.

Ideally this should also be part of the commit summary.
-->
