### PR TITLE
PLANET-7333: Fix author avatar URL trimmed

### DIFF
--- a/templates/author.twig
+++ b/templates/author.twig
@@ -5,7 +5,7 @@
         {% if ( author.avatar ) %}
             <figure class="author-image" aria-label="{{ __( 'Picture of ' ~ author.name , 'planet4-master-theme' ) }}">
                 <img itemprop="image" class="author-pic"
-                     src="{{ fn('get_avatar_url', author.id, {'size' : 300}) | trim('=s96-c') }}"
+                     src="{{ fn('get_avatar_url', author.id, {'size' : 300}) | replace({'=s96-c':""}) }}"
                      alt="{{ author.name }}">
             </figure>
         {% endif %}

--- a/templates/blocks/author_profile.twig
+++ b/templates/blocks/author_profile.twig
@@ -5,7 +5,7 @@
                 <figure class="author-block-image d-none d-sm-none d-md-block">
                     <img
                         itemprop="image"
-                        src="{{ fn('get_avatar_url', post.author.id, {'size' : 294 }) | trim('=s96-c') }}"
+                        src="{{ fn('get_avatar_url', post.author.id, {'size' : 294 }) | replace({'=s96-c':""}) }}"
                         alt="{{ post.author.name }}"
                     />
                 </figure>
@@ -16,7 +16,7 @@
                     <figure class="author-block-image d-block d-sm-block d-md-none">
                         <img
                             itemprop="image"
-                            src="{{ fn('get_avatar_url', post.author.id, {'size' : 294 }) | trim('=s96-c') }}"
+                            src="{{ fn('get_avatar_url', post.author.id, {'size' : 294 }) | replace({'=s96-c':""}) }}"
                             alt="{{ post.author.name }}"
                         />
                     </figure>


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-7333

Replace `trim()` function with `replace()` to avoid removing legitimate characters in avatar URL.

## Test

To test locally, you can edit `author.twig` and change the avatar url function with a static link to check if the URL ends up truncated:
```diff
-                     src="{{ fn('get_avatar_url', author.id, {'size' : 300}) | trim('=s96-c') }}"
+                     src="{{ "https://lh3.googleusercontent.com/a/ACg8ocJQbijyyfXduAZ9es8nsKGgelZZUctDai9y7RoDSqfkcoc"  | trim('=s96-c') }}"
````