### PR TITLE
PLANET-7192 Enable elasticpress search query on admin ajax request

### DIFF
--- a/src/Search.php
+++ b/src/Search.php
@@ -107,6 +107,15 @@ abstract class Search
      */
     public static function add_general_filters(): void
     {
+        // Allow ajax search.
+        add_filter(
+            'ep_ajax_wp_query_integration',
+            function () {
+                return true;
+            },
+            10
+        );
+
         // Call apply filters to catch issue in WPML's ElasticPress integration, which uses the wrong filter name.
         add_filter(
             'ep_formatted_args',


### PR DESCRIPTION
Ref. https://jira.greenpeace.org/browse/PLANET-7192

**Issue:**
- The new version of elasticpress plugin, list the images, password protected posts in search result, the searched post also has wrong links.
- This PR fixes issues listeding in [PLANET-7183](https://jira.greenpeace.org/browse/PLANET-7183) 

The elasticpress(v4.7.2) plugin by default won't filter data with admin ajax queries. with the help of `ep_ajax_wp_query_integration` filter add support for admin ajax search request.

**Testing:**
The fix is available for testing on [GP Sweden development instance](https://www-dev.greenpeace.org/sweden/?s=&orderby=_score). You can check the search result on click of "Show more 5 results" button.
