### PR TITLE
Add missing first-child selector to remove margin top

### DIFF
--- a/assets/src/scss/pages/_page.scss
+++ b/assets/src/scss/pages/_page.scss
@@ -42,12 +42,11 @@
       }
     }
 
-    & > .wp-block-group {
-      margin-top: 0;
-    }
-
-    & > .wp-block-image:first-child {
-      margin-top: 0;
+    > .wp-block-group,
+    > .wp-block-image {
+      &:first-child {
+        margin-top: 0;
+      }
     }
 
     .navigation-bar_min ~ & {


### PR DESCRIPTION
### Description

This is for pages without a title. Only the first `.wp-block-group` child of the page should have the margin top removed, not every direct child.