### PR TITLE
Fix regex to get YouTube video id for shorts

### DIFF
--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -1386,7 +1386,7 @@ class MasterSite extends TimberSite
     {
         // @see https://stackoverflow.com/questions/3392993/php-regex-to-get-youtube-video-id
         // phpcs:ignore Generic.Files.LineLength.MaxExceeded
-        $re = '/(?im)\b(?:https?:\/\/)?(?:w{3}\.)?youtu(?:be)?\.(?:com|be)\/(?:(?:\??v=?i?=?\/?)|watch\?vi?=|watch\?.*?&v=|embed\/|)([A-Z0-9_-]{11})\S*(?=\s|$)/';
+        $re = "/^(?:http(?:s)?:\/\/)?(?:www\.)?(?:m\.)?(?:youtu\.be\/|youtube\.com\/(?:(?:watch)?\?(?:.*&)?v(?:i)?=|(?:embed|v|vi|user|shorts)\/))([^\?&\"'>]+)/";
         preg_match_all($re, $url, $matches, PREG_SET_ORDER);
         $youtube_id = $matches[0][1] ?? null;
 


### PR DESCRIPTION
### Description

The previous regex didn't work with shorts. I found this new regex on the same [StackOverflow thread](https://stackoverflow.com/questions/3392993/php-regex-to-get-youtube-video-id) that is linked in our comment.

### Testing

On local, add 2 Embed blocks to a page, one with a YouTube short and one with a regular YouTube video. On `main` branch the embed with a short will be broken in the frontend, whereas on this branch both should work as expected.