### PR TITLE
PLANET-7340: Make Post title mandatory for publishing

### DIFF
--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -134,6 +134,7 @@ class MasterSite extends TimberSite
         add_action('add_meta_boxes', [$this, 'add_meta_box_search'], 10, 2);
         add_action('save_post', [$this, 'save_meta_box_search'], 10, 2);
         add_action('save_post', [$this, 'set_featured_image'], 10, 2);
+        add_filter('wp_insert_post_data', [$this, 'require_post_title'], 10, 1);
         // Save "p4_global_project_tracking_id" on post save.
         add_action('save_post', [$this, 'save_global_project_id'], 10, 1);
         add_action('post_updated', [$this, 'clean_post_cache'], 10, 3);
@@ -397,6 +398,24 @@ class MasterSite extends TimberSite
         }
 
         set_post_thumbnail($post_id, $matches[1][0]);
+    }
+
+    /**
+     * Make post title mandatory on publish.
+     */
+    public static function require_post_title(array $data): ?array
+    {
+        $types = Search\Filters\ContentTypes::get_all();
+        if (
+            empty($data['post_title'])
+            && !empty($data['post_status'])
+            && $data['post_status'] === 'publish'
+            && in_array($data['post_type'], array_keys($types))
+        ) {
+            wp_die(__('Title is a required field.', 'planet4-master-theme-backend'));
+        }
+
+        return $data;
     }
 
     /**


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-7340
Requires: https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/1164

> Do a pre-publish check so that Post title is not empty
> Enforce the rule for publishing or updating a Post
> This should be applied in all post types

## Test

On test instance [Pluto](https://www-dev.greenpeace.org/test-pluto/), try to:
- Publish a post/page with and without a title
- Quick edit a post/page with and without a title
