### PR TITLE
PLANET-7277 Listing pages: add a featured Action section

### DIFF
--- a/assets/src/scss/layout/_featured-action.scss
+++ b/assets/src/scss/layout/_featured-action.scss
@@ -1,0 +1,103 @@
+.featured-action-section {
+  position: relative;
+  margin-top: $sp-6x;
+  margin-bottom: $sp-6x;
+  display: flex;
+  border-radius: $sp-x;
+  gap: $sp-3;
+  box-shadow: 0 1px 8px rgba(0, 0, 0, .16);
+  transition: box-shadow 0.2s;
+
+  &:hover {
+    box-shadow: 0 1px 14px rgba(0, 0, 0, 0.3);
+
+    .btn {
+      background-color: var(--button-primary--hover--background);
+    }
+
+    .featured-action-section__content h5 {
+      text-decoration: underline;
+    }
+  }
+}
+
+.featured-action-section__link {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+}
+
+.featured-action-section__image img {
+  width: 356px;
+  height: 210px;
+  object-fit: fill;
+  border-top-left-radius: $sp-x;
+  border-bottom-left-radius: $sp-x;
+}
+
+.featured-action-section__content {
+  width: 100%;
+  padding: $sp-3 $sp-2 $sp-2 0;
+  position: relative;
+}
+
+.featured-action-section__content h5,
+.featured-action-section__content p {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  -webkit-line-clamp: 2;
+}
+
+.featured-action-section__content p {
+  font-size: var(--font-size-s--font-family-tertiary);
+  font-family: var(--font-family-paragraph-secondary);
+}
+
+.featured-action-section__content-btn {
+  position: absolute;
+  right: $sp-2;
+  bottom: $sp-2;
+}
+
+.featured-action-section__content-btn a {
+  height: 38px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+@media (max-width: 1200px) {
+  .featured-action-section__image img {
+    width: 296px;
+  }
+}
+
+@media (max-width: 991px) {
+  .featured-action-section__image {
+    padding: $sp-2 0 $sp-2 $sp-2;
+  }
+
+  .featured-action-section__image img {
+    width: 96px;
+    height: 96px;
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+  }
+
+  .featured-action-section__content {
+    padding: $sp-2 $sp-2 $sp-2 0;
+  }
+
+  .featured-action-section__content p {
+    display: none;
+  }
+}
+
+@media (max-width: 500px) {
+  .featured-action-section {
+    gap: $sp-1;
+  }
+}

--- a/assets/src/scss/style.scss
+++ b/assets/src/scss/style.scss
@@ -49,6 +49,7 @@ Text Domain: planet4-master-theme
 @import "layout/page-section";
 @import "layout/skewed-overlay";
 @import "layout/tables";
+@import "layout/featured-action";
 
 // Pages
 @import "pages/page";

--- a/category.php
+++ b/category.php
@@ -17,11 +17,24 @@ $templates = [ 'taxonomy.twig', 'index.twig' ];
 
 $context = Timber::get_context();
 $taxonomy = get_queried_object();
+$featured_action = get_posts([
+    'post_type' => 'p4_action',
+    'category' => $taxonomy->term_id,
+    'orderby' => 'date',
+    'order' => 'DESC',
+    'numberposts' => 1,
+])[0] ?? null;
+$featured_action_id = $featured_action->ID ?? null;
+
 $context['taxonomy'] = $taxonomy;
 $context['wp_title'] = $taxonomy->name;
 $context['canonical_link'] = home_url($wp->request);
 $context['og_type'] = 'website';
 $context['og_description'] = $taxonomy->description;
+$context['featured_action'] = $featured_action;
+$context['featured_action_image'] = has_post_thumbnail($featured_action_id) ?
+    get_the_post_thumbnail($featured_action_id, 'medium') : null;
+$context['featured_action_url'] = get_permalink($featured_action_id);
 
 if (!empty(planet4_get_option('new_ia'))) {
     $view = ListingPageGridView::is_active() ? 'grid' : 'list';

--- a/tag.php
+++ b/tag.php
@@ -22,6 +22,14 @@ if (!is_tag()) {
 
 $tag = get_queried_object();
 $redirect_id = get_term_meta($tag->term_id, 'redirect_page', true);
+$featured_action = get_posts([
+    'post_type' => 'p4_action',
+    'tag_id' => $tag->term_id,
+    'orderby' => 'date',
+    'order' => 'DESC',
+    'numberposts' => 1,
+])[0] ?? null;
+$featured_action_id = $featured_action->ID ?? null;
 
 if ($redirect_id) {
     global $wp_query;
@@ -48,6 +56,10 @@ $context['tag_name'] = single_tag_title('', false);
 $context['tag_description'] = wpautop($context['tag']->description);
 $context['canonical_link'] = home_url($wp->request);
 $context['og_type'] = 'website';
+$context['featured_action'] = $featured_action;
+$context['featured_action_image'] = has_post_thumbnail($featured_action_id) ?
+    get_the_post_thumbnail($featured_action_id, 'medium') : null;
+$context['featured_action_url'] = get_permalink($featured_action_id);
 
 // Temporary fix with rewind, cf. https://github.com/WordPress/gutenberg/issues/53593
 rewind_posts();

--- a/templates/featured-action.twig
+++ b/templates/featured-action.twig
@@ -1,0 +1,18 @@
+<div class="featured-action-section">
+    <div class="featured-action-section__image">
+        {{ image|raw }}
+    </div>
+    <div class="featured-action-section__content">
+        <h5>{{ post_title }}</h5>
+        <p>{{ post_excerpt }}</p>
+        <div class="featured-action-section__content-btn">
+            <a href="{{ url }}"
+                class="btn btn-primary search-btn btn-block"
+            >
+                {{ __('Take Action', 'planet4-master-theme' ) }}
+            </a>
+        </div>
+    </div>
+    <a class="featured-action-section__link" href="{{ url }}"></a>
+</div>
+

--- a/templates/tag.twig
+++ b/templates/tag.twig
@@ -13,6 +13,16 @@
                     <span aria-label="hashtag">#</span>{{ tag_name|e('wp_kses_post')|raw }}
                 </h1>
                 <div class="page-header-content">{{ tag_description|e('wp_kses_post')|raw }}</div>
+                {% if ( featured_action ) %}
+                    {% include 'featured-action.twig'
+                        with {
+                            'image': featured_action_image,
+                            'post_title': featured_action.post_title,
+                            'post_excerpt': featured_action.post_excerpt,
+                            'url': featured_action_url
+                        }
+                    %}
+                {% endif %}
             </div>
             <div class="pull-right d-none d-md-block">
                 <div class="sharethis-inline-share-buttons"></div>

--- a/templates/taxonomy.twig
+++ b/templates/taxonomy.twig
@@ -11,6 +11,16 @@
             <div class="page-header-content">
                 <p>{{ taxonomy.description|e('wp_kses_post')|raw }}</p>
             </div>
+            {% if ( featured_action ) %}
+                {% include 'featured-action.twig'
+                    with {
+                        'image': featured_action_image,
+                        'post_title': featured_action.post_title,
+                        'post_excerpt': featured_action.post_excerpt,
+                        'url': featured_action_url
+                    }
+                %}
+            {% endif %}
         </div>
     </header>
 


### PR DESCRIPTION
**Ref: [PLANET-7277](https://jira.greenpeace.org/browse/PLANET-7277)**

**Testing:**
On test instance or locally, if you have Actions and visit a Category or Tag Listing Page and the taxonomy matches the Action, you should see a featured action section.

[Example Page](https://www-dev.greenpeace.org/test-venus/tag/forests/)
<!-- Ref: Please add a url to the ticket this change is addressing.

---

Please provide a brief summary of the change introduced to make review process easier.

Ideally this should also be part of the commit summary.
-->
