### PR TITLE
PLANET-7347: PHP warning on allowed block types

### DIFF
--- a/src/Loader.php
+++ b/src/Loader.php
@@ -165,7 +165,14 @@ final class Loader
         add_filter(
             'allowed_block_types_all',
             function ($allowed_block_types) {
-                $allowed_block_types[] = 'core/query';
+                if (!is_array($allowed_block_types)) {
+                    return $allowed_block_types;
+                }
+
+                if (!in_array('core/query', $allowed_block_types)) {
+                    $allowed_block_types[] = 'core/query';
+                }
+
                 return $allowed_block_types;
             },
             10,


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-7347

> Warning: Cannot use a scalar value as an array

[`allowed_block_types_all`](https://developer.wordpress.org/reference/hooks/allowed_block_types_all/) filter can pass a value `$allowed_block_types` as an `array` of allowed blocks, or a `bool` enabling all (`true`) or none (`false`) of the blocks.
This warning is thrown with Planet4 options `Planet 4 Blocks`, `Beta blocks` and `All blocks` activated.

![Screenshot from 2023-11-29 14-33-02](https://github.com/greenpeace/planet4-master-theme/assets/617346/81965eb6-0283-48af-b060-7a87960e1e87)
