### PR TITLE
Capture errors on google client instantiation

### DIFF
--- a/src/AnalyticsValues.php
+++ b/src/AnalyticsValues.php
@@ -173,14 +173,21 @@ final class AnalyticsValues
 
             return self::from_cache_array($cache);
         }
-        $instance = self::using_google();
 
-        wp_cache_add(
-            self::CACHE_KEY,
-            ! $instance ? null : $instance->to_cache_array(),
-            null,
-            300
-        );
+        try {
+            $instance = self::using_google();
+            wp_cache_add(
+                self::CACHE_KEY,
+                ! $instance ? null : $instance->to_cache_array(),
+                null,
+                300
+            );
+        } catch (\Throwable $e) {
+            if (function_exists('\Sentry\captureException')) {
+                \Sentry\captureException($e);
+            }
+            $instance = null;
+        }
 
         return $instance ?? self::from_hardcoded_values();
     }

--- a/src/GoogleDocsClient.php
+++ b/src/GoogleDocsClient.php
@@ -40,9 +40,9 @@ final class GoogleDocsClient
             $instance->client = $client;
 
             return $instance;
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             if (function_exists('\Sentry\captureException')) {
-                \Sentry\captureException($exception);
+                \Sentry\captureException($e);
             }
             return null;
         }


### PR DESCRIPTION
Ref: https://sentry.greenpeace.org/organizations/greenpeace-org/issues/230/

Capture errors on Google libs usage to avoid crashing instance and blocking post editing.

This is currently deployed on Japan instance and handles error properly.
https://sentry.greenpeace.org/organizations/greenpeace-org/discover/results/?field=title&field=event.type&field=timestamp&field=url&field=handled&name=All+Events&query=undefined+method&sort=-timestamp&statsPeriod=24h&yAxis=count%28%29 