### PR TITLE
PLANET-7302 Move Cookies block into master theme

### DIFF
--- a/assets/src/blocks/Cookies/CookiesBlock.js
+++ b/assets/src/blocks/Cookies/CookiesBlock.js
@@ -1,0 +1,48 @@
+import {CookiesEditor} from './CookiesEditor.js';
+
+export const BLOCK_NAME = 'planet4-blocks/cookies';
+
+export const registerCookiesBlock = () => {
+  const {registerBlockType} = wp.blocks;
+
+  registerBlockType(BLOCK_NAME, {
+    title: 'Cookies',
+    icon: 'welcome-view-site',
+    category: 'planet4-blocks',
+    supports: {
+      multiple: false, // Use the block just once per post.
+    },
+    attributes: {
+      title: {
+        type: 'string',
+        default: '',
+      },
+      description: {
+        type: 'string',
+        default: '',
+      },
+      necessary_cookies_name: {
+        type: 'string',
+      },
+      necessary_cookies_description: {
+        type: 'string',
+      },
+      all_cookies_name: {
+        type: 'string',
+      },
+      all_cookies_description: {
+        type: 'string',
+      },
+      analytical_cookies_name: {
+        type: 'string',
+      },
+      analytical_cookies_description: {
+        type: 'string',
+      },
+    },
+    edit: CookiesEditor,
+    save() {
+      return null;
+    },
+  });
+};

--- a/assets/src/blocks/Cookies/CookiesEditor.js
+++ b/assets/src/blocks/Cookies/CookiesEditor.js
@@ -1,0 +1,18 @@
+import {CookiesFrontend} from './CookiesFrontend';
+
+export const CookiesEditor = ({attributes, isSelected, setAttributes}) => {
+  const toAttribute = attributeName => value => {
+    if (isSelected) {
+      setAttributes({[attributeName]: value});
+    }
+  };
+
+  return (
+    <CookiesFrontend
+      {...attributes}
+      isEditing
+      toAttribute={toAttribute}
+      isSelected={isSelected}
+    />
+  );
+};

--- a/assets/src/blocks/Cookies/CookiesEditorScript.js
+++ b/assets/src/blocks/Cookies/CookiesEditorScript.js
@@ -1,0 +1,3 @@
+import {registerCookiesBlock} from './CookiesBlock';
+
+registerCookiesBlock();

--- a/assets/src/blocks/Cookies/CookiesFieldResetButton.js
+++ b/assets/src/blocks/Cookies/CookiesFieldResetButton.js
@@ -1,0 +1,28 @@
+const {__} = wp.i18n;
+
+import {Tooltip} from '@wordpress/components';
+
+const COOKIES_DEFAULT_COPY = window.p4_vars.cookies_default_copy || {};
+
+export const CookiesFieldResetButton = ({fieldName, toAttribute, currentValue}) => {
+  const defaultValue = COOKIES_DEFAULT_COPY[fieldName] || '';
+
+  if (!currentValue || !defaultValue || currentValue === defaultValue) {
+    return null;
+  }
+
+  return (
+    <div className="field-reset-button">
+      <Tooltip text={__('This value is defined in the settings, in Planet 4 > Cookies', 'planet4-blocks-backend')}>
+        <span className="info">i</span>
+      </Tooltip>
+      <span
+        className="cta"
+        onClick={() => toAttribute(fieldName)(undefined)}
+        role="presentation"
+      >
+        {__('Use default value', 'planet4-blocks-backend')}
+      </span>
+    </div>
+  );
+};

--- a/assets/src/blocks/Cookies/CookiesFrontend.js
+++ b/assets/src/blocks/Cookies/CookiesFrontend.js
@@ -1,0 +1,323 @@
+import {FrontendRichText} from '../components/FrontendRichText/FrontendRichText';
+import {removeCookie, useCookie, writeCookie} from './useCookie';
+import {useState, useEffect} from '@wordpress/element';
+import {CookiesFieldResetButton} from './CookiesFieldResetButton';
+
+const {__} = wp.i18n;
+
+const dataLayer = window.dataLayer || [];
+
+const COOKIES_DEFAULT_COPY = window.p4_vars.cookies_default_copy || {};
+
+function gtag() {
+  dataLayer.push(arguments);
+}
+
+// Planet4 settings(Planet 4 > Cookies > Enable Analytical Cookies).
+const ENABLE_ANALYTICAL_COOKIES = window.p4_vars.enable_analytical_cookies;
+
+// Planet4 settings (Planet 4 > Analytics > Enable Google Consent Mode).
+const ENABLE_GOOGLE_CONSENT_MODE = window.p4_vars.enable_google_consent_mode;
+
+const CONSENT_COOKIE = 'greenpeace';
+const NO_TRACK_COOKIE = 'no_track';
+const ACTIVE_CONSENT_COOKIE = 'active_consent_choice';
+const ONLY_NECESSARY = '1';
+const NECESSARY_MARKETING = '2';
+const NECESSARY_ANALYTICAL = '3';
+const NECESSARY_ANALYTICAL_MARKETING = '4';
+
+const hideCookiesBox = () => {
+  // the .cookie-notice element belongs to the P4 Master Theme
+  const cookiesBox = document.querySelector('#set-cookie');
+  if (cookiesBox) {
+    cookiesBox.classList.remove('shown');
+  }
+};
+
+export const CookiesFrontend = props => {
+  const {
+    isSelected,
+    title,
+    description,
+    necessary_cookies_name,
+    necessary_cookies_description,
+    analytical_cookies_name,
+    analytical_cookies_description,
+    all_cookies_name,
+    all_cookies_description,
+    isEditing,
+    className,
+    toAttribute = () => {},
+  } = props;
+
+  // Whether consent was revoked by the user since current page load.
+  const [userRevokedMarketingCookies, setUserRevokedMarketingCookies] = useState(false);
+  const [userRevokedAnalyticalCookies, setUserRevokedAnalyticalCookies] = useState(false);
+  const [consentCookie, setConsentCookie] = useCookie(CONSENT_COOKIE);
+  const analyticalCookiesChecked = [NECESSARY_ANALYTICAL, NECESSARY_ANALYTICAL_MARKETING].includes(consentCookie);
+  const marketingCookiesChecked = [NECESSARY_MARKETING, NECESSARY_ANALYTICAL_MARKETING].includes(consentCookie);
+  const hasConsent = marketingCookiesChecked || analyticalCookiesChecked;
+
+  const updateNoTrackCookie = () => {
+    if (hasConsent) {
+      removeCookie(NO_TRACK_COOKIE);
+    } else {
+      writeCookie(NO_TRACK_COOKIE, '1');
+    }
+  };
+  useEffect(updateNoTrackCookie, [userRevokedAnalyticalCookies, userRevokedMarketingCookies]);
+
+  const updateConsent = (key, granted) => {
+    dataLayer.push({
+      event: 'updateConsent',
+    });
+
+    if (!ENABLE_GOOGLE_CONSENT_MODE) {
+      return;
+    }
+
+    gtag('consent', 'update', {
+      [key]: granted ? 'granted' : 'denied',
+    });
+    dataLayer.push({
+      event: 'updateConsent',
+      [key]: granted ? 'granted' : 'denied',
+    });
+  };
+
+  const toggleHubSpotConsent = () => {
+    if (!marketingCookiesChecked && userRevokedMarketingCookies) {
+      const _hsp = window._hsp = window._hsp || [];
+      _hsp.push(['revokeCookieConsent']);
+    }
+  };
+  useEffect(toggleHubSpotConsent, [marketingCookiesChecked, userRevokedMarketingCookies]);
+
+  const updateActiveConsentChoice = () => {
+    if (hasConsent) {
+      writeCookie(ACTIVE_CONSENT_COOKIE, '1');
+      hideCookiesBox();
+    }
+  };
+  useEffect(updateActiveConsentChoice, [marketingCookiesChecked, analyticalCookiesChecked]);
+
+  const getFieldValue = fieldName => {
+    if (props[fieldName] === undefined) {
+      return COOKIES_DEFAULT_COPY[fieldName] || '';
+    }
+    return props[fieldName] || '';
+  };
+
+  const isFieldValid = fieldName => getFieldValue(fieldName).trim().length > 0;
+
+  return (
+    <>
+      <section className={`block cookies-block ${className ?? ''}`}>
+        {(isEditing || title) &&
+        <header>
+          <FrontendRichText
+            tagName="h2"
+            className="page-section-header cookies-title"
+            placeholder={__('Enter title', 'planet4-blocks-backend')}
+            value={title}
+            onChange={toAttribute('title')}
+            withoutInteractiveFormatting
+            editable={isEditing}
+            allowedFormats={[]}
+          />
+        </header>
+        }
+        {(isEditing || description) &&
+        <FrontendRichText
+          tagName="p"
+          className="page-section-description cookies-description"
+          placeholder={__('Enter description', 'planet4-blocks-backend')}
+          value={description}
+          onChange={toAttribute('description')}
+          withoutInteractiveFormatting
+          editable={isEditing}
+          allowedFormats={['core/bold', 'core/italic']}
+        />
+        }
+        {(isEditing || (isFieldValid('necessary_cookies_name') && isFieldValid('necessary_cookies_description'))) &&
+          <>
+            <div className="d-flex align-items-center">
+              <FrontendRichText
+                tagName="span"
+                className="custom-control-description cookies-header-text"
+                placeholder={__('Enter necessary cookies name', 'planet4-blocks-backend')}
+                value={getFieldValue('necessary_cookies_name')}
+                onChange={toAttribute('necessary_cookies_name')}
+                withoutInteractiveFormatting
+                editable={isEditing}
+                allowedFormats={[]}
+              />
+              <span className="always-enabled">{__('Always enabled', 'planet4-blocks')}</span>
+              {isEditing &&
+                <CookiesFieldResetButton
+                  fieldName="necessary_cookies_name"
+                  currentValue={necessary_cookies_name}
+                  toAttribute={toAttribute}
+                />
+              }
+            </div>
+            <div className="d-flex align-items-center">
+              <FrontendRichText
+                tagName="p"
+                className="cookies-checkbox-description"
+                placeholder={__('Enter necessary cookies description', 'planet4-blocks-backend')}
+                value={getFieldValue('necessary_cookies_description')}
+                onChange={toAttribute('necessary_cookies_description')}
+                withoutInteractiveFormatting
+                editable={isEditing}
+                allowedFormats={['core/bold', 'core/italic']}
+              />
+              {isEditing &&
+                <CookiesFieldResetButton
+                  fieldName="necessary_cookies_description"
+                  currentValue={necessary_cookies_description}
+                  toAttribute={toAttribute}
+                />
+              }
+            </div>
+          </>
+        }
+        {(ENABLE_ANALYTICAL_COOKIES && (isEditing || (isFieldValid('analytical_cookies_name') && isFieldValid('analytical_cookies_description')))) &&
+          <>
+            <div className="d-flex align-items-center">
+              <label className="custom-control" style={isSelected ? {pointerEvents: 'none'} : null} htmlFor="analytical-cookies__control">
+                <input
+                  id="analytical-cookies__control"
+                  type="checkbox"
+                  tabIndex={isSelected ? '-1' : null}
+                  name="analytical_cookies"
+                  onChange={() => {
+                    updateConsent('analytics_storage', !analyticalCookiesChecked);
+                    if (analyticalCookiesChecked) {
+                      setUserRevokedAnalyticalCookies(true);
+                      if (marketingCookiesChecked) {
+                        setConsentCookie(NECESSARY_MARKETING);
+                      } else {
+                        setConsentCookie(ONLY_NECESSARY);
+                      }
+                    } else if (marketingCookiesChecked) {
+                      setConsentCookie(NECESSARY_ANALYTICAL_MARKETING);
+                    } else {
+                      setConsentCookie(NECESSARY_ANALYTICAL);
+                    }
+                  }}
+                  checked={analyticalCookiesChecked}
+                  className="p4-custom-control-input"
+                />
+                <FrontendRichText
+                  tagName="span"
+                  className="custom-control-description cookies-header-text"
+                  placeholder={__('Enter analytical cookies name', 'planet4-blocks-backend')}
+                  value={getFieldValue('analytical_cookies_name')}
+                  onChange={toAttribute('analytical_cookies_name')}
+                  withoutInteractiveFormatting
+                  editable={isEditing}
+                  allowedFormats={[]}
+                />
+              </label>
+              {isEditing &&
+                <CookiesFieldResetButton
+                  fieldName="analytical_cookies_name"
+                  currentValue={analytical_cookies_name}
+                  toAttribute={toAttribute}
+                />
+              }
+            </div>
+            <div className="d-flex align-items-center">
+              <FrontendRichText
+                tagName="p"
+                className="cookies-checkbox-description"
+                placeholder={__('Enter analytical cookies description', 'planet4-blocks-backend')}
+                value={getFieldValue('analytical_cookies_description')}
+                onChange={toAttribute('analytical_cookies_description')}
+                withoutInteractiveFormatting
+                editable={isEditing}
+                allowedFormats={['core/bold', 'core/italic']}
+              />
+              {isEditing &&
+                <CookiesFieldResetButton
+                  fieldName="analytical_cookies_description"
+                  currentValue={analytical_cookies_description}
+                  toAttribute={toAttribute}
+                />
+              }
+            </div>
+          </>
+        }
+        {(isEditing || (isFieldValid('all_cookies_name') && isFieldValid('all_cookies_description'))) &&
+          <>
+            <div className="d-flex align-items-center">
+              <label className="custom-control" style={isSelected ? {pointerEvents: 'none'} : null} htmlFor="all-cookies__control">
+                <input
+                  id="all-cookies__control"
+                  type="checkbox"
+                  tabIndex={isSelected ? '-1' : null}
+                  onChange={() => {
+                    updateConsent('ad_storage', !marketingCookiesChecked);
+                    if (marketingCookiesChecked) {
+                      setUserRevokedMarketingCookies(true);
+                      if (ENABLE_ANALYTICAL_COOKIES && analyticalCookiesChecked) {
+                        setConsentCookie(NECESSARY_ANALYTICAL);
+                      } else {
+                        setConsentCookie(ONLY_NECESSARY);
+                      }
+                    } else if (ENABLE_ANALYTICAL_COOKIES && analyticalCookiesChecked) {
+                      setConsentCookie(NECESSARY_ANALYTICAL_MARKETING);
+                    } else {
+                      setConsentCookie(NECESSARY_MARKETING);
+                    }
+                  }}
+                  name="all_cookies"
+                  checked={marketingCookiesChecked}
+                  className="p4-custom-control-input"
+                />
+                <FrontendRichText
+                  tagName="span"
+                  className="custom-control-description cookies-header-text"
+                  placeholder={__('Enter all cookies name', 'planet4-blocks-backend')}
+                  value={getFieldValue('all_cookies_name')}
+                  onChange={toAttribute('all_cookies_name')}
+                  withoutInteractiveFormatting
+                  editable={isEditing}
+                  allowedFormats={[]}
+                />
+              </label>
+              {isEditing &&
+                <CookiesFieldResetButton
+                  fieldName="all_cookies_name"
+                  currentValue={all_cookies_name}
+                  toAttribute={toAttribute}
+                />
+              }
+            </div>
+            <div className="d-flex align-items-center">
+              <FrontendRichText
+                tagName="p"
+                className="cookies-checkbox-description"
+                placeholder={__('Enter all cookies description', 'planet4-blocks-backend')}
+                value={getFieldValue('all_cookies_description')}
+                onChange={toAttribute('all_cookies_description')}
+                withoutInteractiveFormatting
+                editable={isEditing}
+                allowedFormats={['core/bold', 'core/italic']}
+              />
+              {isEditing &&
+                <CookiesFieldResetButton
+                  fieldName="all_cookies_description"
+                  currentValue={all_cookies_description}
+                  toAttribute={toAttribute}
+                />
+              }
+            </div>
+          </>
+        }
+      </section>
+    </>
+  );
+};

--- a/assets/src/blocks/Cookies/CookiesScript.js
+++ b/assets/src/blocks/Cookies/CookiesScript.js
@@ -1,0 +1,12 @@
+import {createRoot} from 'react-dom/client';
+import {BLOCK_NAME} from './CookiesBlock';
+import {CookiesFrontend} from './CookiesFrontend';
+
+// Fallback for non migrated content. Remove after migration.
+document.querySelectorAll(`[data-render="${BLOCK_NAME}"]`).forEach(
+  blockNode => {
+    const attributes = JSON.parse(blockNode.dataset.attributes);
+    const rootElement = createRoot(blockNode);
+    rootElement.render(<CookiesFrontend {...attributes.attributes} />);
+  }
+);

--- a/assets/src/blocks/Cookies/useCookie.js
+++ b/assets/src/blocks/Cookies/useCookie.js
@@ -1,0 +1,44 @@
+import {useState, useEffect} from '@wordpress/element';
+
+export const readCookie = name => {
+  const declarations = document.cookie.split(';');
+  let match = null;
+  declarations.forEach(part => {
+    const [key, value] = part.split('=');
+    if (key.trim() === name) {
+      match = value;
+    }
+  });
+  return match;
+};
+
+export const writeCookie = (name, value, days = 365) => {
+  const date = new Date();
+  date.setTime(date.getTime() + (days * 24 * 60 * 60 * 1000));
+  const secureMode = document.location.protocol === 'http:' ?
+    ';SameSite=Lax' :
+    ';SameSite=None;Secure';
+  document.cookie = encodeURI(name) + '=' + encodeURI(value) + ';domain=.' + document.domain + ';path=/;' + '; expires=' + date.toGMTString() + secureMode;
+};
+
+// Value should not matter as cookie is expired.
+export const removeCookie = name => writeCookie(name, '0', -1);
+
+export const useCookie = name => {
+  const [value, setValue] = useState(() => readCookie(name));
+
+  const saveCookie = () => {
+    if (value === null) {
+      removeCookie(name);
+      return;
+    }
+    writeCookie(name, value);
+  };
+  useEffect(saveCookie, [value]);
+
+  return [
+    value,
+    setValue,
+  ];
+};
+

--- a/assets/src/blocks/components/FrontendRichText/FrontendRichText.js
+++ b/assets/src/blocks/components/FrontendRichText/FrontendRichText.js
@@ -1,0 +1,13 @@
+const RichText = wp.blockEditor ? wp.blockEditor.RichText : null;
+
+export const FrontendRichText = ({editable, ...richTextProps}) => {
+  const renderAsRichText = RichText && editable;
+  const TagName = richTextProps.tagName;
+
+  return renderAsRichText ?
+    <RichText {...richTextProps} /> :
+    <TagName
+      className={richTextProps.className}
+      dangerouslySetInnerHTML={{__html: richTextProps.value}}
+    />;
+};

--- a/assets/src/scss/blocks.scss
+++ b/assets/src/scss/blocks.scss
@@ -1,0 +1,5 @@
+@import "blocks/ActionsList";
+@import "blocks/PostsList";
+@import "blocks/CarouselHeader/CarouselHeaderStyle";
+@import "blocks/Accordion/AccordionStyle";
+@import "blocks/Cookies/CookiesStyle";

--- a/assets/src/scss/blocks/Cookies/CookiesEditorStyle.scss
+++ b/assets/src/scss/blocks/Cookies/CookiesEditorStyle.scss
@@ -1,0 +1,33 @@
+.cookies-block {
+  .cookies-checkbox-description.rich-text {
+    display: inline-block;
+  }
+
+  .field-reset-button {
+    display: inline-block;
+    color: var(--grey-600);
+    margin-inline-start: 16px;
+    font-family: var(--font-family-tertiary);
+    font-size: 13px;
+    vertical-align: middle;
+    white-space: nowrap;
+
+    .cta {
+      cursor: pointer;
+
+      &:hover {
+        text-decoration: underline;
+      }
+    }
+
+    .info {
+      margin-inline-end: 8px;
+      border-radius: 50%;
+      width: 18px;
+      height: 18px;
+      display: inline-block;
+      text-align: center;
+      border: solid 1px var(--grey-600);
+    }
+  }
+}

--- a/assets/src/scss/blocks/Cookies/CookiesStyle.scss
+++ b/assets/src/scss/blocks/Cookies/CookiesStyle.scss
@@ -1,0 +1,58 @@
+.cookies-block {
+  .custom-control-description,
+  .custom-control input[type="checkbox"] ~ .custom-control-description {
+    _-- {
+      font-size: var(--font-size-xl--font-family-primary);
+      font-family: var(--font-family-primary);
+    }
+
+    @include x-large-and-up {
+      _-- {
+        font-size: var(--font-size-2xl--font-family-primary);
+      }
+    }
+  }
+
+  .always-enabled {
+    _-- {
+      font-size: var(--font-size-xxs--font-family-tertiary);
+      font-weight: var(--font-weight-bold);
+    }
+
+    font-family: var(--font-family-tertiary);
+    background: var(--grey-900);
+    color: white;
+    border-radius: $sp-x;
+    padding: $sp-x;
+    margin-inline-start: $sp-1;
+  }
+
+  .cookies-title,
+  .cookies-header-text,
+  .cookies-checkbox-description {
+    font-family: var(--font-family-tertiary) !important;
+  }
+
+  .cookies-title,
+  .cookies-header-text {
+    font-weight: var(--font-weight-bold) !important;
+  }
+
+  .cookies-title {
+    font-size: var(--font-size-xs--font-family-primary);
+  }
+
+  .cookies-description {
+    font-family: var(--font-family-tertiary);
+    font-size: var(--font-size-xxxs--font-family-primary);
+  }
+
+  .cookies-header-text {
+    font-size: var(--font-size-xxxs--font-family-primary)  !important;
+    line-height: var(--line-height-xs--font-family-primary) !important;
+  }
+
+  .cookies-checkbox-description {
+    font-size: var(--font-size-xxs--font-family-tertiary);
+  }
+}

--- a/assets/src/scss/editorStyle.scss
+++ b/assets/src/scss/editorStyle.scss
@@ -28,9 +28,9 @@
 @import "base/css-variables";
 
 // Blocks
-@import "blocks/ActionsList";
-@import "blocks/PostsList";
-@import "blocks/CarouselHeader/CarouselHeaderStyle";
+@import "blocks";
+
+// Blocks editor styles
 @import "blocks/CarouselHeader/CarouselHeaderEditorStyle";
-@import "blocks/Accordion/AccordionStyle";
 @import "blocks/Accordion/AccordionEditorStyle";
+@import "blocks/Cookies/CookiesEditorStyle";

--- a/assets/src/scss/style.scss
+++ b/assets/src/scss/style.scss
@@ -81,10 +81,7 @@ Text Domain: planet4-master-theme
 @import "base/css-variables";
 
 // Blocks
-@import "blocks/ActionsList";
-@import "blocks/PostsList";
-@import "blocks/CarouselHeader/CarouselHeaderStyle";
-@import "blocks/Accordion/AccordionStyle";
+@import "blocks";
 
 // Hide WPML footer language switcher.
 .wpml-ls-statics-footer {

--- a/src/Blocks/Cookies.php
+++ b/src/Blocks/Cookies.php
@@ -1,0 +1,79 @@
+<?php
+
+/**
+ * Cookies block class.
+ *
+ * @package P4GBKS
+ * @since 0.1
+ */
+
+ namespace P4\MasterTheme\Blocks;
+
+ /**
+  * Class Cookies
+  *
+  * @package P4\MasterTheme\Blocks
+  */
+class Cookies extends BaseBlock
+{
+    /** @const string BLOCK_NAME */
+    public const BLOCK_NAME = 'cookies';
+
+    /**
+     * Cookies constructor.
+     */
+    public function __construct()
+    {
+        register_block_type(
+            self::get_full_block_name(),
+            [
+                // todo: Remove when all content is migrated.
+                'render_callback' => [ self::class, 'render_frontend' ],
+                'attributes' => [
+                    'title' => [
+                        'type' => 'string',
+                        'default' => '',
+                    ],
+                    'description' => [
+                        'type' => 'string',
+                        'default' => '',
+                    ],
+                    'necessary_cookies_name' => [
+                        'type' => 'string',
+                    ],
+                    'necessary_cookies_description' => [
+                        'type' => 'string',
+                    ],
+                    'all_cookies_name' => [
+                        'type' => 'string',
+                    ],
+                    'all_cookies_description' => [
+                        'type' => 'string',
+                    ],
+                    'analytical_cookies_name' => [
+                        'type' => 'string',
+                    ],
+                    'analytical_cookies_description' => [
+                        'type' => 'string',
+                    ],
+                ],
+            ]
+        );
+
+        add_action('enqueue_block_editor_assets', [ self::class, 'enqueue_editor_assets' ]);
+        add_action('wp_enqueue_scripts', [ self::class, 'enqueue_frontend_assets' ]);
+    }
+
+    /**
+     * Required by the `BaseBlock` class.
+     *
+     * @param array $fields Unused, required by the abstract function.
+     *
+     * @return array Array.
+     * @phpcs:disable SlevomatCodingStandard.Functions.UnusedParameter.UnusedParameter
+     */
+    public function prepare_data(array $fields): array
+    {
+        return [];
+    }
+}

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -158,6 +158,7 @@ final class Loader
         new Blocks\GuestBook();//NOSONAR
         new Blocks\CarouselHeader();//NOSONAR
         new Blocks\Accordion();//NOSONAR
+        new Blocks\Cookies();//NOSONAR
 
         if (!BetaBlocks::is_active()) {
             return;

--- a/src/MasterBlocks.php
+++ b/src/MasterBlocks.php
@@ -59,6 +59,9 @@ class MasterBlocks
                 'wp-edit-post',
             ]
         );
+
+        $reflection_vars = self::get_js_variables();
+        wp_localize_script('planet4-blocks-theme-editor-script', 'p4_vars', $reflection_vars);
     }
 
     /**
@@ -82,6 +85,34 @@ class MasterBlocks
             $js_creation,
             true
         );
-        wp_enqueue_script('planet4-blocks-script');
+        wp_enqueue_script('planet4-blocks-theme-script');
+
+        $reflection_vars = self::get_js_variables();
+        wp_localize_script('planet4-blocks-theme-script', 'p4_vars', $reflection_vars);
+    }
+
+    /**
+     * Add variables reflected from PHP to JS.
+     */
+    public function get_js_variables(): array
+    {
+        $option_values = get_option('planet4_options');
+
+        $cookies_default_copy = [
+            'necessary_cookies_name' => $option_values['necessary_cookies_name'] ?? '',
+            'necessary_cookies_description' => $option_values['necessary_cookies_description'] ?? '',
+            'analytical_cookies_name' => $option_values['analytical_cookies_name'] ?? '',
+            'analytical_cookies_description' => $option_values['analytical_cookies_description'] ?? '',
+            'all_cookies_name' => $option_values['all_cookies_name'] ?? '',
+            'all_cookies_description' => $option_values['all_cookies_description'] ?? '',
+        ];
+
+        $reflection_vars = [
+            'enable_analytical_cookies' => $option_values['enable_analytical_cookies'] ?? '',
+            'enable_google_consent_mode' => $option_values['enable_google_consent_mode'] ?? '',
+            'cookies_default_copy' => $cookies_default_copy,
+        ];
+
+        return $reflection_vars;
     }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -39,6 +39,8 @@ module.exports = {
     CarouselHeaderEditorScript: './assets/src/blocks/CarouselHeader/CarouselHeaderEditorScript.js',
     AccordionScript: './assets/src/blocks/Accordion/AccordionScript.js',
     AccordionEditorScript: './assets/src/blocks/Accordion/AccordionEditorScript.js',
+    CookiesScript: './assets/src/blocks/Cookies/CookiesScript.js',
+    CookiesEditorScript: './assets/src/blocks/Cookies/CookiesEditorScript.js',
   },
   output: {
     filename: '[name].js',


### PR DESCRIPTION
### Description

See [PLANET-7302](https://jira.greenpeace.org/browse/PLANET-7302)

**Requirements**

- Move Cookies block code to master theme.
- Migrate any additional dependencies it may need.
- Use the Guestbook block as a guide for the code/folder structure.
- The block should be tied to the Planet 4 Blocks feature flag.

This PR also includes style fixes for the `CookiesFieldResetButton` component, following this [mockup](https://www.figma.com/file/9NtbY8n3at8uOEJTsLrETb/P4-Design-System?type=design&node-id=4843%3A11035&mode=design&t=9qnx7PZ7YsEeosgJ-1). This was forgotten when working on the new identity.

**Related PR:** https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/1169

### Testing 

Both new and existing Cookies blocks should still behave as expected in the editor and in the frontend. On the test instance there is already one on the [Privacy page](https://www-dev.greenpeace.org/test-janus/privacy-and-cookies/) for example.