### PR TITLE
PLANET-7238: Fix core/query layout for WP6.4

### DIFF
--- a/assets/src/blocks/ActionsList/index.js
+++ b/assets/src/blocks/ActionsList/index.js
@@ -44,10 +44,6 @@ export const registerActionsList = () => {
           postType: queryPostType,
           ...!IS_NEW_IA && {postParent: ACT_PAGE},
         },
-        displayLayout: {
-          type: 'flex',
-          columns: 3,
-        },
       },
       innerBlocks: [
         ['core/heading', {placeholder: __('Enter title', 'planet4-blocks-backend')}],
@@ -62,7 +58,7 @@ export const registerActionsList = () => {
             },
           },
         }],
-        ['core/post-template', {}, [
+        ['core/post-template', {layout: {type: 'grid', columnCount: 3}}, [
           ['core/post-featured-image', {isLink: true}],
           ['core/group', {}, [
             ['core/post-terms', {term: 'post_tag', separator: ' '}],


### PR DESCRIPTION
Move layout declaration to post-template

- `displayLayout` was [removed from core/query attributes](https://github.com/WordPress/gutenberg/pull/49050/files#diff-47c277e0638989855123b829b2f5044edb47fe394770f2fea4f0775c0b944936)
- grid layout is handled by core/post-template