### PR TITLE
PLANET-7276 Add a 'back to News & stories' link to listing pages

### DIFF
--- a/assets/src/scss/layout/_breadcrumbs.scss
+++ b/assets/src/scss/layout/_breadcrumbs.scss
@@ -36,6 +36,26 @@
     &:not(:only-child):not(:last-child):not(.page-type) {
       margin-inline-end: $sp-1;
     }
+
+    &.back-to-news::before {
+      content: "";
+      pointer-events: none;
+      margin-inline-end: $sp-1;
+      height: 12px;
+      width: 7px;
+      mask-image: url("../../images/chevron.svg");
+      mask-repeat: no-repeat;
+      mask-size: contain;
+      mask-position: center;
+      background-repeat: no-repeat;
+      background-color: var(--gp-green-800);
+      display: inline-block;
+      rotate: 180deg;
+
+      html[dir="rtl"] & {
+        rotate: 0deg;
+      }
+    }
   }
 
   .main-tag-chevron {

--- a/category.php
+++ b/category.php
@@ -40,6 +40,11 @@ if (!empty(planet4_get_option('new_ia'))) {
     $content = do_blocks($template);
     $context['listing_page_content'] = $content;
     $context['page_category'] = 'Listing Page';
+    $news_page = (int) get_option('page_for_posts');
+    if ($news_page) {
+        $news_page_link = get_permalink($news_page);
+        $context['news_page_link'] = $news_page_link;
+    }
     Timber::render($templates, $context);
     exit();
 }

--- a/category.php
+++ b/category.php
@@ -10,6 +10,7 @@
  */
 
 use P4\MasterTheme\Post;
+use P4\MasterTheme\Context;
 use Timber\Timber;
 
 $templates = [ 'taxonomy.twig', 'index.twig' ];
@@ -40,11 +41,8 @@ if (!empty(planet4_get_option('new_ia'))) {
     $content = do_blocks($template);
     $context['listing_page_content'] = $content;
     $context['page_category'] = 'Listing Page';
-    $news_page = (int) get_option('page_for_posts');
-    if ($news_page) {
-        $news_page_link = get_permalink($news_page);
-        $context['news_page_link'] = $news_page_link;
-    }
+    Context::set_news_page_link($context);
+
     Timber::render($templates, $context);
     exit();
 }

--- a/src/Context.php
+++ b/src/Context.php
@@ -184,4 +184,20 @@ class Context
             'nav_type' => $meta['nav_type'] ?? 'planet4',
         ];
     }
+
+    /**
+     * Set the 'News & stories' page in the context, needed for some listing pages.
+     *
+     * @param array       $context   Context to be set.
+     */
+    public static function set_news_page_link(array &$context): void
+    {
+        $news_page = (int) get_option('page_for_posts');
+        if (!$news_page) {
+            return;
+        }
+
+        $news_page_link = get_permalink($news_page);
+        $context['news_page_link'] = $news_page_link;
+    }
 }

--- a/tag.php
+++ b/tag.php
@@ -67,6 +67,12 @@ $template = file_get_contents(get_template_directory() . "/parts/query-listing-p
 $content = do_blocks($template);
 $context['listing_page_content'] = $content;
 
+$news_page = (int) get_option('page_for_posts');
+if ($news_page) {
+    $news_page_link = get_permalink($news_page);
+    $context['news_page_link'] = $news_page_link;
+}
+
 $templates = ['tag.twig', 'archive.twig', 'index.twig'];
 $campaign = new TaxonomyCampaign($templates, $context);
 $campaign->view();

--- a/tag.php
+++ b/tag.php
@@ -66,12 +66,7 @@ $context['page_category'] = 'Listing Page';
 $template = file_get_contents(get_template_directory() . "/parts/query-listing-page.html");
 $content = do_blocks($template);
 $context['listing_page_content'] = $content;
-
-$news_page = (int) get_option('page_for_posts');
-if ($news_page) {
-    $news_page_link = get_permalink($news_page);
-    $context['news_page_link'] = $news_page_link;
-}
+Context::set_news_page_link($context);
 
 $templates = ['tag.twig', 'archive.twig', 'index.twig'];
 $campaign = new TaxonomyCampaign($templates, $context);

--- a/taxonomy.php
+++ b/taxonomy.php
@@ -30,6 +30,11 @@ if (!empty(planet4_get_option('new_ia'))) {
     $template = file_get_contents(get_template_directory() . "/parts/query-listing-page.html");
     $content = do_blocks($template);
     $context['listing_page_content'] = $content;
+    $news_page = (int) get_option('page_for_posts');
+    if ($news_page) {
+        $news_page_link = get_permalink($news_page);
+        $context['news_page_link'] = $news_page_link;
+    }
     Timber::render($templates, $context);
     exit();
 }

--- a/taxonomy.php
+++ b/taxonomy.php
@@ -13,6 +13,7 @@
 
 use P4\MasterTheme\Post;
 use P4\MasterTheme\ActionPage;
+use P4\MasterTheme\Context;
 use Timber\Timber;
 
 $templates = [ 'taxonomy.twig', 'index.twig' ];
@@ -30,11 +31,8 @@ if (!empty(planet4_get_option('new_ia'))) {
     $template = file_get_contents(get_template_directory() . "/parts/query-listing-page.html");
     $content = do_blocks($template);
     $context['listing_page_content'] = $content;
-    $news_page = (int) get_option('page_for_posts');
-    if ($news_page) {
-        $news_page_link = get_permalink($news_page);
-        $context['news_page_link'] = $news_page_link;
-    }
+    Context::set_news_page_link($context);
+
     Timber::render($templates, $context);
     exit();
 }

--- a/templates/tag.twig
+++ b/templates/tag.twig
@@ -8,6 +8,11 @@
                     {% if ( category_name ) %}
                         <a class="tag-item tag-item--main" href="{{ category_link|default('#') }}">{{ category_name|e('wp_kses_post')|raw }}</a>
                     {% endif %}
+                    {% if ( news_page_link ) %}
+                        <a class="back-to-news tag-item" href="{{ news_page_link }}">
+                            {{__( 'News & stories', 'planet4-master-theme' )}}
+                        </a>
+                    {% endif %}
                 </div>
                 <h1 class="page-header-title">
                     <span aria-label="hashtag">#</span>{{ tag_name|e('wp_kses_post')|raw }}

--- a/templates/taxonomy.twig
+++ b/templates/taxonomy.twig
@@ -1,12 +1,20 @@
 {% extends "base.twig" %}
 
 {% block content %}
+    {% set is_action = taxonomy.taxonomy == 'action-type' %}
 
     <div class="clearfix"></div>
     <div class="skewed-overlay"></div>
 
     <header class="page-header">
         <div class="container">
+            <div class="top-page-tags">
+                {% if ( news_page_link and not is_action ) %}
+                    <a class="back-to-news tag-item" href="{{ news_page_link }}">
+                        {{__( 'News & stories', 'planet4-master-theme' )}}
+                    </a>
+                {% endif %}
+            </div>
             <h1 class="page-header-title">{{ taxonomy.name }}</h1>
             <div class="page-header-content">
                 <p>{{ taxonomy.description|e('wp_kses_post')|raw }}</p>
@@ -23,8 +31,6 @@
             {% endif %}
         </div>
     </header>
-
-    {% set is_action = taxonomy.taxonomy == 'action-type' %}
 
     <div class="page-content container">
         {% if listing_page_content %}


### PR DESCRIPTION
### Description

See [PLANET-7276](https://jira.greenpeace.org/browse/PLANET-7276)

**Requirements**

- Add a link to the "News & Stories" page as defined in `Settings > Reading > Posts page`.
- This should be applied in Category, Tag and Post Type listing pages.
- Add link following the [design mockups](https://www.figma.com/file/9NtbY8n3at8uOEJTsLrETb/P4-Design-System?type=design&node-id=4276-5015&mode=design&t=7AuHHMgJ8pgw8EKX-0)

### Testing

You can test the new link on the following listing pages:
- [Post Type](https://www-dev.greenpeace.org/test-oberon/press/)
- [Tag](https://www-dev.greenpeace.org/test-oberon/tag/renewables/)
- [Category](https://www-dev.greenpeace.org/test-oberon/category/energy/)