### PR TITLE
PLANET-7300: Move Accordion block into master theme

### DIFF
--- a/assets/src/blocks/Accordion/AccordionEditor.js
+++ b/assets/src/blocks/Accordion/AccordionEditor.js
@@ -1,4 +1,4 @@
-import {Fragment, useState} from '@wordpress/element';
+import {useState} from '@wordpress/element';
 import {InspectorControls, RichText} from '@wordpress/block-editor';
 import {URLInput} from '../../block-editor/URLInput/URLInput';
 import {
@@ -182,10 +182,10 @@ export const AccordionEditor = ({attributes, isSelected, setAttributes, classNam
   };
 
   return (
-    <Fragment>
+    <>
       {isSelected && renderEdit({tabs}, setAttributes, updateTabAttribute)}
       {renderView({tabs, title, description, className}, setAttributes, isSelected, updateTabAttribute)}
-    </Fragment>
+    </>
   );
 };
 

--- a/assets/src/blocks/Accordion/AccordionEditor.js
+++ b/assets/src/blocks/Accordion/AccordionEditor.js
@@ -1,0 +1,191 @@
+import {Fragment, useState} from '@wordpress/element';
+import {InspectorControls, RichText} from '@wordpress/block-editor';
+import {URLInput} from '../../block-editor/URLInput/URLInput';
+import {
+  PanelBody,
+  CheckboxControl,
+  Button,
+} from '@wordpress/components';
+import {debounce} from '@wordpress/compose';
+
+const {__} = wp.i18n;
+
+// Renders the editor view
+const renderView = ({title, description, tabs, className}, setAttributes, isSelected, updateTabAttribute) => {
+  const toAttribute = attributeName => value => setAttributes({
+    [attributeName]: value,
+  });
+
+  const addButton = index => {
+    const newTabs = [...tabs];
+    newTabs[index].button = {};
+    setAttributes({
+      tabs: newTabs,
+    });
+  };
+
+  const removeButton = index => {
+    const newTabs = [...tabs];
+    delete newTabs[index].button;
+    setAttributes({
+      tabs: newTabs,
+    });
+  };
+
+  return (
+    <div className={`block accordion-block ${className ?? ''}`}>
+      <header>
+        <RichText
+          tagName="h2"
+          className="page-section-header"
+          placeholder={__('Enter title', 'planet4-blocks-backend')}
+          value={title}
+          onChange={toAttribute('title')}
+          withoutInteractiveFormatting
+          allowedFormats={[]}
+        />
+      </header>
+      <RichText
+        tagName="p"
+        className="page-section-description"
+        placeholder={__('Enter description', 'planet4-blocks-backend')}
+        value={description}
+        onChange={toAttribute('description')}
+        withoutInteractiveFormatting
+        allowedFormats={['core/bold', 'core/italic']}
+      />
+      {tabs.map((tab, index) => (
+        <div key={`accordion-content-${index}`} className="accordion-content">
+          <RichText
+            tagName="h4"
+            className={`accordion-headline ${isSelected ? 'open' : ''}`}
+            placeholder={__('Enter headline', 'planet4-blocks-backend')}
+            value={tab.headline}
+            onChange={updateTabAttribute('headline', index)}
+            withoutInteractiveFormatting
+            allowedFormats={[]}
+          />
+          <div className={`panel ${isSelected ? '' : 'panel-hidden'}`}>
+            <RichText
+              tagName="p"
+              className="accordion-text"
+              placeholder={__('Enter text', 'planet4-blocks-backend')}
+              value={tab.text}
+              onChange={updateTabAttribute('text', index)}
+              allowedFormats={['core/bold', 'core/italic']}
+            />
+            {tab.button ?
+              <div className="button-container">
+                <RichText
+                  tagName="div"
+                  className="btn btn-secondary accordion-btn"
+                  placeholder={__('Button text', 'planet4-blocks-backend')}
+                  value={tab.button.button_text}
+                  onChange={updateTabAttribute('button_text', index)}
+                  withoutInteractiveFormatting
+                  allowedFormats={[]}
+                />
+                <Button
+                  className="remove-btn"
+                  onClick={() => removeButton(index)}
+                  icon="trash"
+                />
+              </div> :
+              <div onClick={() => addButton(index)} className="add-button" role="presentation">
+                <span className="plus">+</span>
+                {__('Add button', 'planet4-blocks-backend')}
+              </div>
+            }
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+// Renders the sidebar settings
+const renderEdit = ({tabs}, setAttributes, updateTabAttribute) => {
+  const [buttonUrl, setButtonUrl] = useState({});
+
+  const addTab = () => setAttributes({tabs: [...tabs, {}]});
+
+  const removeTab = () => setAttributes({tabs: tabs.slice(0, tabs.length - 1)});
+
+  const debounceButtonUrl = debounce((index, url) => {
+    updateTabAttribute('button_url', index)(url);
+  }, 300);
+
+  return (
+    <InspectorControls>
+      <PanelBody title={__('Settings', 'planet4-blocks-backend')}>
+        {tabs.map((tab, index) => {
+          const {button} = tab;
+          if (!button) {
+            return; // eslint-disable-line array-callback-return
+          }
+
+          return (
+            <div key={`tab-${index}`}>
+              <p>{__('Item', 'planet4-blocks-backend')} {index + 1}</p>
+              <URLInput
+                label={__('Button link', 'planet4-blocks-backend')}
+                value={buttonUrl[index] ? buttonUrl[index].value : button.button_url}
+                onChange={url => {
+                  setButtonUrl({[index]: url, ...buttonUrl});
+                  debounceButtonUrl(index, url);
+                }}
+              />
+              <CheckboxControl
+                label={__('Open in a new tab', 'planet4-blocks-backend')}
+                value={button.button_new_tab}
+                checked={button.button_new_tab}
+                onChange={updateTabAttribute('button_new_tab', index)}
+              />
+            </div>
+          );
+        })}
+        <Button
+          isPrimary
+          onClick={addTab}
+          style={{marginRight: 10}}
+        >
+          {__('Add item', 'planet4-blocks-backend')}
+        </Button>
+        <Button
+          variant="secondary"
+          disabled={tabs.length <= 1}
+          onClick={removeTab}
+        >
+          {__('Remove item', 'planet4-blocks-backend')}
+        </Button>
+      </PanelBody>
+    </InspectorControls>
+  );
+};
+
+export const AccordionEditor = ({attributes, isSelected, setAttributes, className}) => {
+  const {title, description} = attributes;
+
+  // If there are no tabs yet, we add an empty one as placeholder
+  const tabs = attributes.tabs.length > 0 ? attributes.tabs : [{}];
+
+  const updateTabAttribute = (attributeName, index) => value => {
+    const newTabs = [...tabs];
+    if (attributeName.startsWith('button_')) {
+      newTabs[index].button[attributeName] = value;
+    } else {
+      newTabs[index][attributeName] = value;
+    }
+    setAttributes({
+      tabs: newTabs,
+    });
+  };
+
+  return (
+    <Fragment>
+      {isSelected && renderEdit({tabs}, setAttributes, updateTabAttribute)}
+      {renderView({tabs, title, description, className}, setAttributes, isSelected, updateTabAttribute)}
+    </Fragment>
+  );
+};
+

--- a/assets/src/blocks/Accordion/AccordionEditorScript.js
+++ b/assets/src/blocks/Accordion/AccordionEditorScript.js
@@ -1,0 +1,62 @@
+import {AccordionEditor} from './AccordionEditor';
+import {AccordionFrontend} from './AccordionFrontend';
+const {registerBlockType, registerBlockStyle} = wp.blocks;
+
+const BLOCK_NAME = 'planet4-blocks/accordion';
+
+const attributes = {
+  title: {
+    type: 'string',
+    default: '',
+  },
+  description: {
+    type: 'string',
+    default: '',
+  },
+  tabs: {
+    type: 'array',
+    default: [],
+  },
+};
+
+const styles = [
+  {
+    name: 'dark',
+    label: 'Dark',
+    isDefault: true,
+  },
+  {
+    name: 'light',
+    label: 'Light',
+  },
+  {
+    name: 'outline',
+    label: 'Outline',
+  },
+];
+
+registerBlockType(BLOCK_NAME, {
+  title: 'Accordion',
+  icon: 'menu',
+  category: 'planet4-blocks',
+  keywords: [
+    'accordion',
+    'faq',
+    'collapsible',
+  ],
+  supports: {
+    html: false, // Disable "Edit as HTMl" block option.
+  },
+  attributes,
+  edit: AccordionEditor,
+  save: ({attributes: saveAttributes}) => {
+    if (!saveAttributes) {
+      return null;
+    }
+
+    return <AccordionFrontend {...saveAttributes} />;
+  },
+});
+
+// Add our custom styles
+registerBlockStyle(BLOCK_NAME, styles);

--- a/assets/src/blocks/Accordion/AccordionFrontend.js
+++ b/assets/src/blocks/Accordion/AccordionFrontend.js
@@ -1,0 +1,49 @@
+window.dataLayer = window.dataLayer || [];
+
+export const AccordionFrontend = ({title, description, tabs, className}) => (
+  <section className={`block accordion-block ${className ?? ''}`}>
+    {title &&
+      <header>
+        <h2 className="page-section-header">{title}</h2>
+      </header>
+    }
+    {description &&
+      <p className="page-section-description" dangerouslySetInnerHTML={{__html: description}} />
+    }
+    {tabs.map(({headline, text, button}, index) => {
+      const {button_text, button_url, button_new_tab} = button || {};
+      const buttonProps = {};
+      if (button_new_tab) {
+        buttonProps.target = '_blank';
+        buttonProps.rel = 'noopener noreferrer';
+      }
+
+      return (
+        <div key={`accordion-content-${index}`} className="accordion-content">
+          {headline &&
+            <div
+              className="accordion-headline"
+              name={headline}
+            >
+              {headline}
+            </div>
+          }
+          <div className="panel panel-hidden">
+            {text &&
+              <p className="accordion-text" dangerouslySetInnerHTML={{__html: text}} />
+            }
+            {button_text &&
+              <a
+                className="btn btn-secondary accordion-btn"
+                href={button_url}
+                {...buttonProps}
+              >
+                {button_text}
+              </a>
+            }
+          </div>
+        </div>
+      );
+    })}
+  </section>
+);

--- a/assets/src/blocks/Accordion/AccordionScript.js
+++ b/assets/src/blocks/Accordion/AccordionScript.js
@@ -1,0 +1,80 @@
+/* global dataLayer */
+
+document.addEventListener('DOMContentLoaded', () => {
+  function getAnalyticsText(item) {
+    const headline = item.innerText || item.textContent;
+    return headline.length > 50 ? `${headline.substring(0, 50)}...` : headline;
+  }
+
+  function handleReadMoreClick(textToSend) {
+    dataLayer.push({
+      event: 'Read More FAQ',
+      Question: textToSend,
+    });
+  }
+
+  function closeItem(item) {
+    if (item.classList.contains('open')) {
+      // Close the tab (toggle arrow)
+      item.classList.remove('open');
+
+      // Hide the corresponding panel
+      const panel = item.nextElementSibling;
+      panel.classList.add('panel-hidden');
+    }
+  }
+
+  function openItem(item) {
+    if (!item.classList.contains('open')) {
+      // Open the tab (toggle arrow)
+      item.classList.add('open');
+
+      // Show the corresponding panel
+      const panel = item.nextElementSibling;
+      panel.classList.remove('panel-hidden');
+
+      // Add button handler to corresponding panel
+      const button = [...panel.children].find(child => child.classList.contains('accordion-btn'));
+
+      if (button && !button.onclick) {
+        const textToSend = getAnalyticsText(item);
+        button.onclick = () => handleReadMoreClick(textToSend);
+      }
+    }
+  }
+
+  function toggleAccordionItem(item, siblings) {
+    const textToSend = getAnalyticsText(item);
+
+    if (item.classList.contains('open')) {
+      closeItem(item);
+
+      dataLayer.push({
+        event: 'Close FAQ',
+        Question: textToSend,
+      });
+    } else {
+      openItem(item);
+
+      // Close all other items if necessary
+      siblings.forEach(sibling => {
+        if (sibling !== item) {
+          closeItem(sibling);
+        }
+      });
+
+      dataLayer.push({
+        event: 'Expand FAQ',
+        Question: textToSend,
+      });
+    }
+  }
+
+  // Add necessary handlers to accordion blocks
+  const accordionBlocks = [...document.querySelectorAll('.accordion-block')];
+  accordionBlocks.forEach(accordion => {
+    const accordionItems = [...accordion.children].filter(child => child.classList.contains('accordion-content'));
+    const accordionHeadlines = accordionItems.map(item => [...item.children].find(child => child.classList.contains('accordion-headline')));
+    accordionHeadlines.forEach(headline => headline.onclick = () => toggleAccordionItem(headline, accordionHeadlines));
+  });
+});

--- a/assets/src/scss/blocks/Accordion/AccordionEditorStyle.scss
+++ b/assets/src/scss/blocks/Accordion/AccordionEditorStyle.scss
@@ -1,0 +1,57 @@
+.add-button {
+  cursor: pointer;
+  font-weight: 500;
+  color: #0075af;
+  width: fit-content;
+  margin-top: 24px;
+
+  .plus {
+    border: 1px solid #0075af;
+    color: #0075af;
+    padding: 3px 8px;
+    margin-inline-end: 10px;
+    border-radius: 50%;
+  }
+
+  &:hover {
+    text-decoration: underline;
+
+    .plus {
+      color: white;
+      background-color: #0075af;
+      text-decoration: none;
+    }
+  }
+}
+
+.accordion-block .accordion-content .button-container {
+  position: relative;
+  width: 80%;
+
+  .accordion-btn {
+    width: 100%;
+  }
+
+  .remove-btn {
+    background-color: var(--grey-500);
+    border-radius: 50%;
+    position: absolute;
+    top: 10px;
+    right: -15px;
+    color: var(--white);
+
+    &:hover {
+      background-color: var(--grey-600) !important;
+      box-shadow: none !important;
+      color: var(--white) !important;
+    }
+  }
+
+  @include medium-and-up {
+    width: 40%;
+  }
+
+  @include large-and-up {
+    width: 25%;
+  }
+}

--- a/assets/src/scss/blocks/Accordion/AccordionEditorStyle.scss
+++ b/assets/src/scss/blocks/Accordion/AccordionEditorStyle.scss
@@ -1,15 +1,15 @@
 .add-button {
   cursor: pointer;
-  font-weight: 500;
-  color: #0075af;
+  font-weight: var(--font-weight-regular);
+  color: var(--p4-dark-green-800);
   width: fit-content;
-  margin-top: 24px;
+  margin-top: $sp-3;
 
   .plus {
-    border: 1px solid #0075af;
-    color: #0075af;
-    padding: 3px 8px;
-    margin-inline-end: 10px;
+    border: 1px solid var(--p4-dark-green-800);
+    color: var(--p4-dark-green-800);
+    padding: $sp-x $sp-1;
+    margin-inline-end: $sp-1x;
     border-radius: 50%;
   }
 
@@ -17,8 +17,8 @@
     text-decoration: underline;
 
     .plus {
-      color: white;
-      background-color: #0075af;
+      color: var(--white);
+      background-color: var(--p4-dark-green-800);
       text-decoration: none;
     }
   }

--- a/assets/src/scss/blocks/Accordion/AccordionStyle.scss
+++ b/assets/src/scss/blocks/Accordion/AccordionStyle.scss
@@ -1,0 +1,148 @@
+.accordion-block {
+  _-- {
+    font-family: var(--font-family-primary);
+  }
+
+  &.is-style-light .accordion-content .accordion-headline {
+    --accordion-block-light-style-- {
+      border-color: transparent;
+      background: var(--beige-100);
+      color: var(--color-text-body);
+
+      &:hover {
+        background: var(--beige-200);
+      }
+    }
+  }
+
+  &.is-style-outline .accordion-content .accordion-headline {
+    border-color: var(--grey-500);
+    background: var(--white);
+    color: var(--grey-900);
+
+    &:hover {
+      background: var(--grey-100);
+    }
+  }
+
+  .accordion-content {
+    display: flex;
+    flex-direction: column;
+
+    .accordion-headline {
+      --accordion-block-dark-style-- {
+        border-color: transparent;
+        background: var(--p4-dark-green-800);
+        color: var(--white);
+
+        &:hover {
+          background: var(--p4-dark-green-900);
+        }
+      }
+      cursor: pointer;
+      position: relative;
+      display: block;
+      padding-top: 16px;
+      padding-bottom: 16px;
+      padding-inline-start: 16px;
+      padding-inline-end: 44px;
+      font-size: $font-size-sm;
+      border-radius: 4px;
+      font-weight: 500;
+      line-height: 1;
+      margin-top: 0;
+      margin-bottom: 16px;
+      border-width: 1px;
+      border-style: solid;
+
+      &.open:after {
+        transform: rotate(-90deg);
+      }
+
+      &:after {
+        content: "";
+        position: absolute;
+        top: 16px;
+        right: 16px;
+        left: auto;
+        pointer-events: none;
+        height: 1rem;
+        width: 0.5rem;
+        display: inline-block;
+        transition: transform 300ms linear;
+        transform: rotate(90deg);
+        mask-image: url("../../images/chevron.svg");
+        mask-repeat: no-repeat;
+        mask-size: contain;
+        background-repeat: no-repeat;
+        background-color: currentColor;
+
+        html[dir="rtl"] & {
+          right: auto;
+          left: 16px;
+        }
+      }
+    }
+
+    .panel {
+      padding: 0 16px 24px 16px;
+      background-color: white;
+      overflow: hidden;
+      transition: display 1s, opacity 1s, height 1s ease-in-out;
+
+      &.panel-hidden {
+        visibility: hidden;
+        opacity: 0;
+        height: 0;
+        padding: 0;
+      }
+    }
+
+    .accordion-text {
+      margin: 0;
+      font-family: var(--body--font-family);
+      font-weight: 400;
+    }
+
+    .accordion-btn {
+      margin: 24px 10% 0 10%;
+      line-height: 2.5;
+      width: 80%;
+    }
+  }
+
+  @include medium-and-up {
+    .accordion-content {
+      .accordion-headline {
+        padding-inline-start: 24px;
+        font-size: $font-size-md;
+        margin-bottom: 24px;
+
+        &:after {
+          height: 1.25rem;
+          width: 0.6rem;
+          right: 24px;
+
+          html[dir="rtl"] & {
+            left: 24px;
+          }
+        }
+      }
+
+      .panel {
+        padding: 0 24px 40px 24px;
+      }
+
+      .accordion-btn {
+        width: 40%;
+        margin: 24px 0 0 0;
+      }
+    }
+  }
+
+  @include large-and-up {
+    .accordion-content .accordion-btn {
+      width: 25%;
+    }
+  }
+}

--- a/assets/src/scss/blocks/Accordion/AccordionStyle.scss
+++ b/assets/src/scss/blocks/Accordion/AccordionStyle.scss
@@ -42,16 +42,16 @@
       cursor: pointer;
       position: relative;
       display: block;
-      padding-top: 16px;
-      padding-bottom: 16px;
-      padding-inline-start: 16px;
-      padding-inline-end: 44px;
+      padding-top: $sp-2;
+      padding-bottom: $sp-2;
+      padding-inline-start: $sp-2;
+      padding-inline-end: $sp-5x;
       font-size: $font-size-sm;
       border-radius: 4px;
-      font-weight: 500;
+      font-weight: var(--font-weight-regular);
       line-height: 1;
       margin-top: 0;
-      margin-bottom: 16px;
+      margin-bottom: $sp-2;
       border-width: 1px;
       border-style: solid;
 
@@ -85,8 +85,8 @@
     }
 
     .panel {
-      padding: 0 16px 24px 16px;
-      background-color: white;
+      padding: 0 $sp-2 $sp-3 $sp-2;
+      background-color: var(--white);
       overflow: hidden;
       transition: display 1s, opacity 1s, height 1s ease-in-out;
 
@@ -101,11 +101,11 @@
     .accordion-text {
       margin: 0;
       font-family: var(--body--font-family);
-      font-weight: 400;
+      font-weight: var(--font-weight-regular);
     }
 
     .accordion-btn {
-      margin: 24px 10% 0 10%;
+      margin: $sp-3 10% 0 10%;
       line-height: 2.5;
       width: 80%;
     }
@@ -114,9 +114,9 @@
   @include medium-and-up {
     .accordion-content {
       .accordion-headline {
-        padding-inline-start: 24px;
-        font-size: $font-size-md;
-        margin-bottom: 24px;
+        padding-inline-start: $sp-3;
+        font-size: var(--font-size-m--font-family-primary);
+        margin-bottom: $sp-3;
 
         &:after {
           height: 1.25rem;
@@ -130,12 +130,12 @@
       }
 
       .panel {
-        padding: 0 24px 40px 24px;
+        padding: 0 $sp-3 $sp-5 $sp-3;
       }
 
       .accordion-btn {
         width: 40%;
-        margin: 24px 0 0 0;
+        margin: $sp-3 0 0 0;
       }
     }
   }

--- a/assets/src/scss/editorStyle.scss
+++ b/assets/src/scss/editorStyle.scss
@@ -32,3 +32,5 @@
 @import "blocks/PostsList";
 @import "blocks/CarouselHeader/CarouselHeaderStyle";
 @import "blocks/CarouselHeader/CarouselHeaderEditorStyle";
+@import "blocks/Accordion/AccordionStyle";
+@import "blocks/Accordion/AccordionEditorStyle";

--- a/assets/src/scss/style.scss
+++ b/assets/src/scss/style.scss
@@ -84,6 +84,7 @@ Text Domain: planet4-master-theme
 @import "blocks/ActionsList";
 @import "blocks/PostsList";
 @import "blocks/CarouselHeader/CarouselHeaderStyle";
+@import "blocks/Accordion/AccordionStyle";
 
 // Hide WPML footer language switcher.
 .wpml-ls-statics-footer {

--- a/src/Blocks/Accordion.php
+++ b/src/Blocks/Accordion.php
@@ -1,0 +1,105 @@
+<?php
+
+/**
+ * Accordion block class.
+ *
+ * @package P4\MasterTheme
+ * @since 0.1
+ */
+
+ namespace P4\MasterTheme\Blocks;
+
+/**
+ * Class Accordion
+ *
+ * @package P4\MasterTheme\Blocks
+ */
+class Accordion extends BaseBlock
+{
+    /**
+     * Block name.
+     *
+     * @const string BLOCK_NAME.
+     */
+    public const BLOCK_NAME = 'accordion';
+
+    /**
+     * Accordion constructor.
+     */
+    public function __construct()
+    {
+        $this->register_accordion_block();
+    }
+
+    /**
+     * Register Accordion block.
+     */
+    public function register_accordion_block(): void
+    {
+        register_block_type(
+            self::get_full_block_name(),
+            [
+                'attributes' => [
+                    'title' => [
+                        'type' => 'string',
+                        'default' => '',
+                    ],
+                    'description' => [
+                        'type' => 'string',
+                        'default' => '',
+                    ],
+                    'tabs' => [
+                        'type' => 'array',
+                        'default' => [],
+                        'items' => [
+                            'type' => 'object',
+                            // In JSON Schema you can specify object properties in the properties attribute.
+                            'properties' => [
+                                'headline' => [
+                                    'type' => 'string',
+                                    'default' => '',
+                                ],
+                                'text' => [
+                                    'type' => 'string',
+                                    'default' => '',
+                                ],
+                                'button' => [
+                                    'type' => 'object',
+                                    'properties' => [
+                                        'button_text' => [
+                                            'type' => 'string',
+                                            'default' => '',
+                                        ],
+                                        'button_url' => [
+                                            'type' => 'string',
+                                            'default' => '',
+                                        ],
+                                        'button_new_tab' => [
+                                            'type' => 'boolean',
+                                            'default' => false,
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ]
+        );
+
+        add_action('enqueue_block_editor_assets', [ self::class, 'enqueue_editor_assets' ]);
+        add_action('wp_enqueue_scripts', [ self::class, 'enqueue_frontend_assets' ]);
+    }
+
+    /**
+     * Required by the `Base_Block` class.
+     *
+     * @param array $fields Unused, required by the abstract function.
+     * @phpcs:disable SlevomatCodingStandard.Functions.UnusedParameter.UnusedParameter
+     */
+    public function prepare_data(array $fields): array
+    {
+        return [];
+    }
+    // @phpcs:enable SlevomatCodingStandard.Functions.UnusedParameter.UnusedParameter
+}

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -157,6 +157,7 @@ final class Loader
         new MasterBlocks();//NOSONAR
         new Blocks\GuestBook();//NOSONAR
         new Blocks\CarouselHeader();//NOSONAR
+        new Blocks\Accordion();//NOSONAR
 
         if (!BetaBlocks::is_active()) {
             return;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -37,6 +37,8 @@ module.exports = {
     GuestBookEditorScript: './assets/src/blocks/GuestBook/GuestBookEditorScript.js',
     CarouselHeaderScript: './assets/src/blocks/CarouselHeader/CarouselHeaderScript.js',
     CarouselHeaderEditorScript: './assets/src/blocks/CarouselHeader/CarouselHeaderEditorScript.js',
+    AccordionScript: './assets/src/blocks/Accordion/AccordionScript.js',
+    AccordionEditorScript: './assets/src/blocks/Accordion/AccordionEditorScript.js',
   },
   output: {
     filename: '[name].js',


### PR DESCRIPTION
Ref: [PLANET-7300](https://jira.greenpeace.org/browse/PLANET-7300)

[Demo page](https://www-dev.greenpeace.org/test-phobos/accordion-block-demo-page/)

Move the Accordion block to master-theme

Related to [#1172](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/1172)