### PR TITLE
Idea: Create block-editor directory for components

### DIFF
--- a/assets/src/block-editor/ImagePlaceholderIcon/ImagePlaceholderIcon.js
+++ b/assets/src/block-editor/ImagePlaceholderIcon/ImagePlaceholderIcon.js
@@ -1,0 +1,7 @@
+export const ImagePlaceholderIcon = ({width, height, fill}) =>
+  <svg {...{width, height, fill}} xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 512 376">
+    <path d="M0,0v376h512V0H0z M480,344H32V32h448V344z" />
+    <circle cx="409.1" cy="102.9" r="40.9" />
+    <polygon
+      points="480,344 32,344 118.3,179.8 140,191.1 189,113.8 289,226.9 297.9,217.6 315,239.9 341,193.5 393.9,264.7 409,248.8" />
+  </svg>;

--- a/assets/src/block-editor/URLInput/URLInput.js
+++ b/assets/src/block-editor/URLInput/URLInput.js
@@ -1,0 +1,24 @@
+import {TextControl} from '@wordpress/components';
+import {URLValidationMessage} from '../URLValidationMessage/URLValidationMessage';
+
+export const URLInput = props => {
+  const {label, placeholder, value, onChange, disabled, help} = props;
+
+  return (
+    <div>
+      <TextControl
+        label={label}
+        placeholder={placeholder}
+        value={value}
+        onChange={onChange}
+        disabled={disabled}
+        help={help}
+      />
+      {!disabled &&
+            <URLValidationMessage
+              url={value}
+            />
+      }
+    </div>
+  );
+};

--- a/assets/src/block-editor/URLValidationMessage/URLValidationMessage.js
+++ b/assets/src/block-editor/URLValidationMessage/URLValidationMessage.js
@@ -1,0 +1,28 @@
+import {Component} from '@wordpress/element';
+
+export class URLValidationMessage extends Component {
+  isValid(url) {
+    if (!url) {
+      return true;
+    }
+
+    if (!url.toLowerCase().startsWith('https://')) {
+      return false;
+    }
+
+    return true;
+  }
+
+  render() {
+    const {__} = wp.i18n;
+    const {url} = this.props;
+
+    if (this.isValid(url)) {
+      return null;
+    }
+
+    return (
+      <span className="input_error">{ __('The URL must start with "https://"', 'planet4-blocks-backend') }</span>
+    );
+  }
+}


### PR DESCRIPTION
No ticket needed.

# Desctription
Create block-editor directory which will be included all components (from [here](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/tree/main/assets/src/components)) used by the editor. 

This PR replicates a similar structure of what [WordPress has already](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-editor).

This is a (partial) preparation before moving all blocks from the plugin to the theme.

<!-- Ref: Please add a url to the ticket this change is addressing.

---

Please provide a brief summary of the change introduced to make review process easier.

Ideally this should also be part of the commit summary.
-->
