### PR TITLE
Fix warnings on PHP8

### DIFF
--- a/index.php
+++ b/index.php
@@ -27,7 +27,7 @@ if (is_home()) {
     $data_layer = $post->get_data_layer();
 
     $page_meta_data = get_post_meta($post->ID);
-    $page_meta_data = array_map('reset', $page_meta_data);
+    $page_meta_data = array_map(fn ($v) => reset($v), $page_meta_data);
 
     $context['title'] = ( $page_meta_data['p4_title'] ?? '' )
         ? ( $page_meta_data['p4_title'] ?? '' )

--- a/page-templates/evergreen.php
+++ b/page-templates/evergreen.php
@@ -25,7 +25,7 @@ use Timber\Timber;
 $context = Timber::get_context();
 $post = new Post(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 $page_meta_data = get_post_meta($post->ID);
-$page_meta_data = array_map('reset', $page_meta_data);
+$page_meta_data = array_map(fn ($v) => reset($v), $page_meta_data);
 
 // Set Navigation Issues links.
 $post->set_issues_links();

--- a/search.php
+++ b/search.php
@@ -21,7 +21,8 @@ if ('GET' !== filter_input(INPUT_SERVER, 'REQUEST_METHOD')) {
     return;
 }
 
-$selected_sort = sanitize_text_field($_GET['orderby']);
+$selected_sort = empty($_GET['orderby'])
+                ? null : sanitize_text_field($_GET['orderby']);
 $selected_filters = $_GET['f'] ?? ''; // phpcs:ignore
 $filters = [];
 

--- a/single-campaign.php
+++ b/single-campaign.php
@@ -30,7 +30,7 @@ if (isset($_GET['preview'])) { // phpcs:ignore WordPress.Security.NonceVerificat
         $meta = array_merge($meta, get_post_meta($post_preview->ID));
     }
 }
-$meta = array_map('reset', $meta);
+$meta = array_map(fn ($v) => reset($v), $meta);
 
 $current_level_campaign_id = $post->ID;
 
@@ -43,7 +43,7 @@ if ($top_level_campaign_id === $post->ID) {
     $campaign_meta = $meta;
 } else {
     $campaign_meta = get_post_meta($top_level_campaign_id);
-    $campaign_meta = array_map('reset', $campaign_meta);
+    $campaign_meta = array_map(fn ($v) => reset($v), $campaign_meta);
 }
 
 // This is just an example of how to get children pages, this will probably be done in some kind of menu block.

--- a/single-p4_action.php
+++ b/single-p4_action.php
@@ -19,7 +19,7 @@ use Timber\Timber;
 $context = Timber::get_context();
 $post = new Post(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 $page_meta_data = get_post_meta($post->ID);
-$page_meta_data = array_map('reset', $page_meta_data);
+$page_meta_data = array_map(fn ($v) => reset($v), $page_meta_data);
 
 // Set GTM Data Layer values.
 $post->set_data_layer();

--- a/src/MediaArchive/ApiClient.php
+++ b/src/MediaArchive/ApiClient.php
@@ -265,6 +265,9 @@ WHERE m.meta_key = "' . Image::ARCHIVE_ID_META_KEY . '"
         $prepared = $wpdb->prepare($sql, array_merge([ $wpdb->posts, $wpdb->postmeta ], $ids));
         // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
         $results = $wpdb->get_results($prepared, ARRAY_A);
+        if (!is_array($results)) {
+            return [];
+        }
 
         // Return as indexed array to make lookups easier.
         $indexed = [];

--- a/src/Post.php
+++ b/src/Post.php
@@ -530,7 +530,7 @@ class Post extends TimberPost
         $is_valid = true;
 
         // Check if page url has a unique id(custom hash), appended with it, if not add one.
-        $custom_hash = sanitize_text_field($_GET['ch']);
+        $custom_hash = empty($_GET['ch']) ? null : sanitize_text_field($_GET['ch']);
         if (!$custom_hash) {
             wp_safe_redirect(add_query_arg('ch', password_hash(uniqid('', true), PASSWORD_DEFAULT), get_permalink()));
             exit();

--- a/src/Search.php
+++ b/src/Search.php
@@ -540,7 +540,8 @@ abstract class Search
             parse_str($query_string, $filters_array);
             $selected_sort = $filters_array['orderby'] ?? self::DEFAULT_SORT;
         } else {
-            $selected_sort = sanitize_text_field($_GET['orderby']);
+            $selected_sort = empty($_GET['orderby'])
+                ? null : sanitize_text_field($_GET['orderby']);
         }
         $selected_sort = sanitize_sql_orderby($selected_sort);
 


### PR DESCRIPTION
Ref: [reset() - Array must be passed by reference](https://sentry.greenpeace.org/organizations/greenpeace-org/issues/305/?query=is%3Aunresolved++url%3A%22https%3A%2F%2Fwww-dev.greenpeace.org%3A80%2Ftest-pandora%2F%2A%22&referrer=issue-stream&statsPeriod=14d&stream_index=0)
Ref: [Undefined array key `ch`](https://sentry.greenpeace.org/organizations/greenpeace-org/issues/292/?query=is%3Aunresolved++url%3A%22https%3A%2F%2Fwww-dev.greenpeace.org%3A80%2Ftest-pandora%2F%2A%22&referrer=issue-stream&statsPeriod=14d&stream_index=1)
Ref: [Undefined array key `orderby`](https://sentry.greenpeace.org/organizations/greenpeace-org/issues/368/?query=is%3Aunresolved&referrer=issue-stream&stream_index=2)
Ref: [foreach argument must be of type array|object](https://sentry.greenpeace.org/organizations/greenpeace-org/issues/63/?query=is%3Aunresolved+runtime%3A%22php+8.1.2%22&referrer=issue-stream&statsPeriod=14d&stream_index=2)

