### PR TITLE
PLANET-7345: Disable Posts List Query Loop WP variation

### DIFF
--- a/assets/src/blocks/editorIndex.js
+++ b/assets/src/blocks/editorIndex.js
@@ -1,6 +1,11 @@
 import {registerPostsListBlock} from './PostsList';
 import {registerActionsList} from './ActionsList';
 
-// Beta blocks
-registerActionsList();
-registerPostsListBlock();
+wp.domReady(() => {
+  // Make sure to unregister the posts-list native variation before registering planet4-blocks/posts-list-block
+  wp.blocks.unregisterBlockVariation('core/query', 'posts-list');
+
+  // Beta blocks
+  registerActionsList();
+  registerPostsListBlock();
+});


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-7345

# Description
We should avoid naming confusions to editors since we have already a custom Posts List variation with the same name.

FYI, this this is the [merged WordPress's Posts List variation PR](https://github.com/WordPress/gutenberg/pull/26990).

### Before
![Screenshot 2023-12-22 at 12 55 19](https://github.com/greenpeace/planet4-master-theme/assets/77975803/85d4945e-6623-44ce-a406-00c6f4fe89d2)

### After
![Screenshot 2023-12-22 at 12 55 42](https://github.com/greenpeace/planet4-master-theme/assets/77975803/5a297bb2-9089-4bf1-90a7-91b750a3f4d1)


## Testing
Make sure that the WP's Posts List variation is not being appeared through the blocks's list also enable `Planet 4 > Beta blocks`