### PR TITLE
PLANET-7367: Add manual override to Posts List block

### DIFF
--- a/assets/src/block-editor/PostSelector/PostSelector.js
+++ b/assets/src/block-editor/PostSelector/PostSelector.js
@@ -1,0 +1,115 @@
+import {FormTokenField} from '@wordpress/components';
+import {dispatch, useSelect} from '@wordpress/data';
+const {__} = wp.i18n;
+
+// Allows to query a custom endpoint with select('core') tools
+dispatch('core').addEntities([{
+  baseURL: '/planet4/v1/published',
+  kind: 'planet4/v1',
+  name: 'published',
+  label: 'All published of post_type',
+}]);
+
+/**
+ * Post selector with autosuggestion
+ * Based on post type
+ *
+ * @param {Object} attributes
+ * @return {Object} Selector Interface
+ */
+export const PostSelector = attributes => {
+  const {
+    label,
+    selected,
+    placeholder,
+    postType,
+    onChange,
+    maxLength,
+    maxSuggestions,
+  } = attributes;
+
+  /**
+   * Fetch relevant posts for autosuggestions
+   */
+  const act_parent = window?.p4ge_vars?.planet4_options.act_page || null;
+  const args = {per_page: -1, orderby: 'title', post_status: 'publish'};
+  const posts = useSelect(select => {
+    if ('post' === postType) {
+      return [
+        ...select('core').getEntityRecords('postType', 'post', {include: selected}) || [],
+        ...select('core').getEntityRecords('planet4/v1', 'published', {post_type: postType, ...args}) || [],
+      ];
+    }
+
+    if ('post,page' === postType) {
+      return [
+        ...select('core').getEntityRecords('postType', 'post', {include: selected}) || [],
+        ...select('core').getEntityRecords('postType', 'page', {include: selected}) || [],
+        ...select('core').getEntityRecords('planet4/v1', 'published', {post_type: postType, ...args}) || [],
+      ];
+    }
+
+    if ('act_page' === postType) {
+      const selectedPosts = [
+        ...select('core').getEntityRecords('postType', 'page', {include: selected}) || [],
+        ...select('core').getEntityRecords('postType', 'p4_action', {include: selected}) || [],
+      ];
+      const actions = select('core').getEntityRecords('postType', 'p4_action', args) || [];
+      const pages = act_parent ?
+        (select('core').getEntityRecords('postType', 'page', {post_parent: act_parent, ...args}) || []) :
+        [];
+      return [].concat(selectedPosts, actions, pages);
+    }
+
+    return [];
+  }, [postType]);
+
+  /**
+   * Convert posts to {id, title}
+   */
+  const options = posts.map(post => ({
+    id: parseInt(post.id),
+    title: post.title?.raw || post.post_title,
+  }));
+
+  /**
+   * Resolve Titles to IDs for saving values
+   *
+   * @param {Array} titles
+   */
+  const setPostsIdsFromTitles = titles => {
+    const postIds = titles?.length ?
+      titles.map(token => options.find(option => option.title === token)?.id) :
+      [];
+    onChange(postIds);
+  };
+
+  /**
+   * Resolve IDs to Titles
+   *
+   * @param {Array} ids
+   * @return {Array} new array of ids
+   */
+  const getPostsTitlesFromIds = ids => {
+    return options?.length && ids?.length ?
+      ids.map(postId => options.find(option => option.id === parseInt(postId))?.title).filter(t => t) :
+      [];
+  };
+
+  // Get field initial value
+  const getValue = () => getPostsTitlesFromIds(selected);
+
+  return (
+    <FormTokenField
+      label={label || __('Select posts', 'planet4-blocks-backend')}
+      value={getValue() || null}
+      suggestions={options.map(post => post.title || '<empty title>')}
+      onChange={value => {
+        setPostsIdsFromTitles(value);
+      }}
+      placeholder={placeholder || __('Select posts', 'planet4-blocks-backend')}
+      maxLength={maxLength}
+      maxSuggestions={maxSuggestions || 50}
+    />
+  );
+};

--- a/assets/src/blocks/PostsList/index.js
+++ b/assets/src/blocks/PostsList/index.js
@@ -1,5 +1,9 @@
 const POSTS_LIST_BLOCK = 'planet4-blocks/posts-list-block';
 
+import {InspectorControls} from '@wordpress/block-editor';
+import {PanelBody} from '@wordpress/components';
+import {PostSelector} from '../../block-editor/PostSelector/PostSelector';
+
 export const registerPostsListBlock = () => {
   const {registerBlockVariation} = wp.blocks;
   const {__} = wp.i18n;
@@ -31,6 +35,7 @@ export const registerPostsListBlock = () => {
         exclude: [],
         sticky: '',
         inherit: false,
+        postIn: [],
       },
     },
     scope: ['inserter'],
@@ -69,3 +74,41 @@ export const registerPostsListBlock = () => {
   }
   );
 };
+
+export const withManualPostSelection = BlockEdit => props => {
+  const {__} = wp.i18n;
+  const {name, attributes, setAttributes} = props;
+  const updateQuery = (value, query) => {
+    setAttributes({query: {
+      ...query,
+      postIn: value && value.length > 0 ? value : [],
+    }});
+  };
+
+  if (name === 'core/query' && attributes.namespace === POSTS_LIST_BLOCK) {
+    const {query} = attributes;
+    return (
+      <>
+        <BlockEdit {...props} />
+        <InspectorControls>
+          <PanelBody title={__('Manual override', 'planet4-blocks-backend')} initialOpen={query.postIn.length > 0}>
+            <PostSelector
+              label={__('CAUTION: Adding articles individually will override the automatic functionality of this block. For good user experience, please include at least three articles so that spacing and alignment of the design remains intact.', 'planet4-blocks-backend')}
+              selected={query.postIn || []}
+              onChange={value => updateQuery(value, query)}
+              postType={query.postType || 'post'}
+              placeholder={__('Select articles', 'planet4-blocks-backend')}
+              maxLength={10}
+              maxSuggestions={20}
+            />
+          </PanelBody>
+        </InspectorControls>
+      </>
+    );
+  }
+
+  return <BlockEdit {...props} />;
+};
+
+wp.hooks.addFilter('editor.BlockEdit', 'core/query', withManualPostSelection);
+

--- a/src/Blocks/PostsList.php
+++ b/src/Blocks/PostsList.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace P4\MasterTheme\Blocks;
+
+/**
+ * Handle Posts List block manual override query with custom `postIn` filter.
+ * `include` is not used because it generates some issues with getEntityRecords filters.
+ */
+class PostsList
+{
+    public static function registerHooks(): void
+    {
+        self::registerEditorQuery();
+        self::registerFrontendQuery();
+    }
+
+    public static function registerEditorQuery(): void
+    {
+        add_filter(
+            'rest_post_query',
+            function ($args, $request) {
+                $postIn = $request->get_param('postIn');
+                if (!empty($postIn)) {
+                    $args['post__in'] = array_map('intval', (array) $postIn);
+                    $args['orderby'] = 'post__in';
+                }
+                return $args;
+            },
+            10,
+            2
+        );
+    }
+
+    public static function registerFrontendQuery(): void
+    {
+        add_filter(
+            'query_loop_block_query_vars',
+            function ($query, $block) {
+                $blockQuery = $block->context['query'] ?? [];
+                if (!empty($blockQuery['postIn'])) {
+                    $query['post__in'] = array_map('intval', (array) $blockQuery['postIn']);
+                    $query['orderby'] = 'post__in';
+                }
+                return $query;
+            },
+            10,
+            2
+        );
+    }
+}

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -165,6 +165,7 @@ final class Loader
             return;
         }
 
+        Blocks\PostsList::registerHooks();
         add_filter(
             'allowed_block_types_all',
             function ($allowed_block_types) {


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-7367

> Follow up from [PLANET-7214](https://jira.greenpeace.org/browse/PLANET-7214) to meet feature parity with the Articles block. We need an option for editors to able to select which specific posts they want to be displayed.

- import of component PostSelector from plugin
- use of a custom filter `postIn` and handle of value in hooks
  - I tried to use the `include` filter available on rest API, but it generates some issues with various requests (maybe mixing up some cache), coming probably from [this piece of code](https://github.com/WordPress/gutenberg/blob/e2bda4036db44339aa56d0c85fa3d75edd79cd81/packages/core-data/src/queried-data/get-query-parts.js#L82-L91)

![Screenshot from 2024-01-05 16-58-36](https://github.com/greenpeace/planet4-master-theme/assets/617346/22516e18-bb20-4359-81b8-b085c1aec58b)

## Test

- Activate Core blocks and All blocks in _planet4 > Features_
- Add a _Posts List_ block to a new page
- Use the _Manual Override_ option to display specific posts in the block
  - Check in the editor and on the frontend that those articles are present and in order