### PR TITLE
PLANET-7135: Fix country selector tab index

### DIFF
--- a/assets/src/js/app.js
+++ b/assets/src/js/app.js
@@ -11,6 +11,7 @@ import {setupQueryLoopCarousel} from './query_loop_carousel';
 import {setupClickabelActionsListCards} from './actions_list_clickable_cards';
 import {removeNoPostText} from './query-no-posts';
 import {removeRelatedPostsSection} from './remove_related_section_no_posts';
+import {setupCountrySelector} from './country_selector';
 
 function requireAll(r) {
   r.keys().forEach(r);
@@ -29,3 +30,4 @@ setupQueryLoopCarousel();
 removeNoPostText();
 removeRelatedPostsSection();
 setupClickabelActionsListCards();
+setupCountrySelector();

--- a/assets/src/js/country_selector.js
+++ b/assets/src/js/country_selector.js
@@ -14,7 +14,7 @@ export const setupCountrySelector = () => {
             // This check applies not only to the parent link but also to children
             // In some cases, the country has also different link's languages
             if (countryItem.classList.contains('country-group')) {
-              countryItem.setAttribute('tabIndex', isOpen ? 0 : -1);
+              countryItem.setAttribute('tabIndex', -1);
 
               for (const link of countryItem.querySelectorAll('li')) {
                 link.setAttribute('tabIndex', isOpen ? 0 : -1);

--- a/assets/src/js/country_selector.js
+++ b/assets/src/js/country_selector.js
@@ -1,0 +1,31 @@
+// The script basically add/remove the tabindex attribute within the country selector
+// It helps to improve SEO
+export const setupCountrySelector = () => {
+  const countries = document.querySelectorAll('.countries-list .countries > li');
+
+  // Create a new MutationObserver with a country selector
+  new MutationObserver(
+    mutationList => {
+      for (const mutation of mutationList) {
+        if (mutation.target.className.includes('footer-country-selector') && mutation.attributeName === 'class') {
+          const isOpen = mutation.target.className.includes('open');
+
+          for (const countryItem of countries) {
+            // This check applies not only to the parent link but also to children
+            // In some cases, the country has also different link's languages
+            if (countryItem.classList.contains('country-group')) {
+              countryItem.setAttribute('tabIndex', isOpen ? 0 : -1);
+
+              for (const link of countryItem.querySelectorAll('li')) {
+                link.setAttribute('tabIndex', isOpen ? 0 : -1);
+              }
+            }
+          }
+        }
+      }
+    }
+  ).observe(
+    document.querySelector('.footer-country-selector'),
+    {attributes: true, childList: true, subtree: true}
+  );
+};

--- a/assets/src/js/country_selector.js
+++ b/assets/src/js/country_selector.js
@@ -1,31 +1,50 @@
 // The script basically add/remove the tabindex attribute within the country selector
 // It helps to improve SEO
 export const setupCountrySelector = () => {
-  const countries = document.querySelectorAll('.countries-list .countries > li');
+  const targetNode = document.querySelector('#country-selector');
+  const countriesList = document.querySelector('.countries-list');
+  const footerMenu = document.querySelector('.footer-menu');
+  const footerSocialMedia = document.querySelector('.footer-social-media');
+  const largeAndUpScreens = '(min-width: 992px)';
 
-  // Create a new MutationObserver with a country selector
-  new MutationObserver(
+  const switchOrders = (evt = null) => {
+    const event = evt ? evt : window.matchMedia(largeAndUpScreens);
+    if (event.matches) {
+      footerMenu.parentNode.insertBefore(footerMenu, footerMenu.parentNode.firstChild);
+    } else {
+      footerSocialMedia.parentNode.insertBefore(footerSocialMedia, footerSocialMedia.parentNode.firstChild);
+    }
+  };
+
+  // Create an observer instance linked to the callback function
+  const observer = new MutationObserver(
+    // Callback function to execute when mutations are observed
     mutationList => {
+      // Set default visibility
       for (const mutation of mutationList) {
-        if (mutation.target.className.includes('footer-country-selector') && mutation.attributeName === 'class') {
-          const isOpen = mutation.target.className.includes('open');
-
-          for (const countryItem of countries) {
-            // This check applies not only to the parent link but also to children
-            // In some cases, the country has also different link's languages
-            if (countryItem.classList.contains('country-group')) {
-              countryItem.setAttribute('tabIndex', -1);
-
-              for (const link of countryItem.querySelectorAll('li')) {
-                link.setAttribute('tabIndex', isOpen ? 0 : -1);
-              }
-            }
+        if (mutation.attributeName === 'class') {
+          if (targetNode.classList.contains('open')) {
+            countriesList.style.visibility = 'visible';
+          } else {
+            setTimeout(() => {
+              countriesList.style.visibility = 'hidden';
+            }, 1000); // Follow the .countries-list transition time
           }
         }
       }
     }
-  ).observe(
-    document.querySelector('.footer-country-selector'),
+  );
+
+  // Start observing the target node for configured mutations
+  observer.observe(
+    targetNode,
     {attributes: true, childList: true, subtree: true}
   );
+
+  window.matchMedia(largeAndUpScreens).addEventListener('change', event => {
+    switchOrders(event);
+  });
+
+  // Set default order
+  switchOrders();
 };

--- a/assets/src/js/country_selector.js
+++ b/assets/src/js/country_selector.js
@@ -1,12 +1,27 @@
-// The script basically add/remove the tabindex attribute within the country selector
-// It helps to improve SEO
+/**
+ * The script basically add/remove the tabindex attribute within the country selector
+ * It helps to improve SEO
+ * @return {void}
+ */
 export const setupCountrySelector = () => {
   const targetNode = document.querySelector('#country-selector');
   const countriesList = document.querySelector('.countries-list');
   const footerMenu = document.querySelector('.footer-menu');
   const footerSocialMedia = document.querySelector('.footer-social-media');
-  const largeAndUpScreens = '(min-width: 992px)';
 
+  if (!targetNode || !countriesList || !footerMenu || !footerSocialMedia) {
+    return;
+  }
+
+  const largeAndUpScreens = '(min-width: 992px)';
+  const countriesListTransitionDuration = (
+    parseFloat(getComputedStyle(document.querySelector('.countries-list')).transitionDuration) * 1000
+  ) || 500;
+
+  /**
+   * This funtion re-order the elements from the footer
+   * @param {*} evt
+   */
   const switchOrders = (evt = null) => {
     const event = evt ? evt : window.matchMedia(largeAndUpScreens);
     if (event.matches) {
@@ -28,7 +43,7 @@ export const setupCountrySelector = () => {
           } else {
             setTimeout(() => {
               countriesList.style.visibility = 'hidden';
-            }, 1000); // Follow the .countries-list transition time
+            }, countriesListTransitionDuration);
           }
         }
       }
@@ -36,10 +51,7 @@ export const setupCountrySelector = () => {
   );
 
   // Start observing the target node for configured mutations
-  observer.observe(
-    targetNode,
-    {attributes: true, childList: true, subtree: true}
-  );
+  observer.observe(targetNode, {attributes: true, childList: true, subtree: true});
 
   window.matchMedia(largeAndUpScreens).addEventListener('change', event => {
     switchOrders(event);

--- a/assets/src/js/country_selector.js
+++ b/assets/src/js/country_selector.js
@@ -15,7 +15,7 @@ export const setupCountrySelector = () => {
 
   const largeAndUpScreens = '(min-width: 992px)';
   const countriesListTransitionDuration = (
-    parseFloat(getComputedStyle(document.querySelector('.countries-list')).transitionDuration) * 1000
+    parseFloat(getComputedStyle(countriesList).transitionDuration) * 1000
   ) || 500;
 
   /**
@@ -25,9 +25,9 @@ export const setupCountrySelector = () => {
   const switchOrders = (evt = null) => {
     const event = evt ? evt : window.matchMedia(largeAndUpScreens);
     if (event.matches) {
-      footerMenu.parentNode.insertBefore(footerMenu, footerMenu.parentNode.firstChild);
+      footerMenu.parentNode.prepend(footerMenu);
     } else {
-      footerSocialMedia.parentNode.insertBefore(footerSocialMedia, footerSocialMedia.parentNode.firstChild);
+      footerSocialMedia.parentNode.prepend(footerSocialMedia);
     }
   };
 

--- a/assets/src/scss/layout/_country-selector.scss
+++ b/assets/src/scss/layout/_country-selector.scss
@@ -28,7 +28,6 @@
 
   &.open {
     .country-selector-toggle-container {
-      border-bottom: 1px solid rgba($white, 1);
       transition-delay: 0s;
     }
 

--- a/assets/src/scss/layout/_country-selector.scss
+++ b/assets/src/scss/layout/_country-selector.scss
@@ -93,6 +93,8 @@
   max-height: 0;
   overflow: hidden;
   transition: max-height 0.5s cubic-bezier(0, 1.04, .38, .37) 0s;
+  // Set to hidden because of focus behaviour and a18y
+  visibility: hidden;
 }
 
 .countries-list .container {

--- a/templates/footer.twig
+++ b/templates/footer.twig
@@ -6,7 +6,7 @@
         {% include 'footer_country_selector.twig' %}
     </div>
     {% endif %}
-    <div class="container d-flex flex-column flex-lg-row">
+    <div class="container d-flex flex-column-reverse flex-lg-row">
         {% if nav_type != 'minimal' %}
             <nav class="footer-menu">
                 <ul class="list-unstyled">

--- a/templates/footer.twig
+++ b/templates/footer.twig
@@ -6,12 +6,15 @@
         {% include 'footer_country_selector.twig' %}
     </div>
     {% endif %}
-    <div class="container d-flex flex-column-reverse flex-lg-row">
+    <div class="container d-flex flex-column flex-lg-row">
+        {% if (social_overrides is defined and social_overrides|length) or footer_social_menu|length %}
+            {% include 'footer_social_media.twig' %}
+        {% endif %}
         {% if nav_type != 'minimal' %}
             <nav class="footer-menu">
                 <ul class="list-unstyled">
                     {% for primary in footer_primary_menu %}
-                        <li tabindex="0">
+                        <li>
                             <a
                                 href="{{ primary.url }}"
                                 target="{{ item.target }}"
@@ -29,7 +32,7 @@
                     {% endfor %}
 
                     {% for secondary in footer_secondary_menu %}
-                        <li tabindex="0">
+                        <li>
                             <a
                                 href="{{ secondary.url }}"
                                 target="{{ item.target }}"
@@ -47,9 +50,6 @@
                     {% endfor %}
                 </ul>
             </nav>
-        {% endif %}
-        {% if (social_overrides is defined and social_overrides|length) or footer_social_menu|length %}
-            {% include 'footer_social_media.twig' %}
         {% endif %}
     </div>
 

--- a/templates/footer.twig
+++ b/templates/footer.twig
@@ -6,15 +6,12 @@
         {% include 'footer_country_selector.twig' %}
     </div>
     {% endif %}
-    <div class="container d-flex flex-column flex-lg-row-reverse">
-        {% if (social_overrides is defined and social_overrides|length) or footer_social_menu|length %}
-            {% include 'footer_social_media.twig' %}
-        {% endif %}
+    <div class="container d-flex flex-column flex-lg-row">
         {% if nav_type != 'minimal' %}
             <nav class="footer-menu">
                 <ul class="list-unstyled">
                     {% for primary in footer_primary_menu %}
-                        <li>
+                        <li tabindex="0">
                             <a
                                 href="{{ primary.url }}"
                                 target="{{ item.target }}"
@@ -32,7 +29,7 @@
                     {% endfor %}
 
                     {% for secondary in footer_secondary_menu %}
-                        <li>
+                        <li tabindex="0">
                             <a
                                 href="{{ secondary.url }}"
                                 target="{{ item.target }}"
@@ -50,6 +47,9 @@
                     {% endfor %}
                 </ul>
             </nav>
+        {% endif %}
+        {% if (social_overrides is defined and social_overrides|length) or footer_social_menu|length %}
+            {% include 'footer_social_media.twig' %}
         {% endif %}
     </div>
 

--- a/templates/footer_country_selector.twig
+++ b/templates/footer_country_selector.twig
@@ -29,7 +29,7 @@
             <ul aria-label="{{ __('Sites starting with the letter .' ~ initial ~ '.', 'planet4-master-theme') }}" role="list">
                 {% for country in countries %}
                 {% set main_lang, lang_count = country.lang|first, country.lang|length %}
-                <li>
+                <li role="listitem">
                     <a href="{{ main_lang.url }}"
                         hreflang="{{ main_lang.locale[0] }}"
                         data-ga-category="Country Selector"
@@ -39,7 +39,7 @@
                     {% if lang_count > 1  %}
                     <ul class="lang-list" role="list">
                         {% for k, lang in country.lang %}
-                        <li>
+                        <li role="listitem">
                             <a href="{{ lang.url }}"
                                 hreflang="{{ lang.locale[0] }}"
                                 data-ga-category="Country Selector"

--- a/templates/footer_social_media.twig
+++ b/templates/footer_social_media.twig
@@ -3,7 +3,7 @@
   <ul class="list-unstyled">
     {% if social_overrides is defined and social_overrides|length %}
       {% for social in social_overrides %}
-        <li>
+        <li tabindex="0">
           <a
             href="{{ social.url }}"
             data-ga-category="Footer Navigation"
@@ -29,7 +29,7 @@
             {% set name = class_name %}
           {% endif %}
         {% endfor %}
-        <li>
+        <li tabindex="0">
           <a
             href="{{ social.url }}"
             data-ga-category="Footer Navigation"

--- a/templates/footer_social_media.twig
+++ b/templates/footer_social_media.twig
@@ -3,8 +3,9 @@
   <ul class="list-unstyled">
     {% if social_overrides is defined and social_overrides|length %}
       {% for social in social_overrides %}
-        <li tabindex="0">
+        <li tabindex="-1">
           <a
+            tabindex="0"
             href="{{ social.url }}"
             data-ga-category="Footer Navigation"
             data-ga-action="Social Icons"
@@ -29,12 +30,14 @@
             {% set name = class_name %}
           {% endif %}
         {% endfor %}
-        <li tabindex="0">
+        <li tabindex="-1">
           <a
+            tabindex="0"
             href="{{ social.url }}"
             data-ga-category="Footer Navigation"
             data-ga-action="Social Icons"
             data-ga-label="{{ social.title }}"
+
             {% if ( social.target is same as '_blank' ) %}
               target="_blank"
               rel="me noopener noreferrer"


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-7135

[Demo page](https://www-dev.greenpeace.org/test-jupiter)

# Description
- Fixed the issue but also Improved SEO on the country selector component. 
- Additionally, I've also Implemented a new script which is in charge to add/remove dynamically the `tabindex` attribute depending on the country selector state (`open|close`).

## Testing
1. Scroll down to the footer
2. Click on it footer
3. Then press the `Tab` key.

Within the previous behavior ([see the international dev site](https://www-dev.greenpeace.org/international/)),  the end-user is not able to navigate within page's links NOR social links.
Within the current fix, the user can navigate through ALL the footer's links, including sub-links, even if the list is opened or closed.


https://github.com/greenpeace/planet4-master-theme/assets/77975803/1128f149-22c8-474e-ab60-f4c2731a7804

