### PR TITLE
PLANET-7394: Fix missing up/down arrow icon in CarouselHeader

### DIFF
--- a/assets/src/scss/blocks/CarouselHeader/SidebarSlidesEditor.scss
+++ b/assets/src/scss/blocks/CarouselHeader/SidebarSlidesEditor.scss
@@ -95,7 +95,7 @@
     width: 100%;
     height: 100%;
     background-size: 9px 9px;
-    background-image: url("../../public/images/icons/chevron.svg");
+    background-image: url("../../images/chevron.svg");
     background-repeat: no-repeat;
     background-position: center;
     transform-origin: center;


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-7394

# Description
Fix image arrow's path

## Testing
Navigate through [this page](https://www-dev.greenpeace.org/test-atlas/wp-admin/post.php?post=1353&action=edit) and select the CarouselHeader. Arrows should be visible in right panel.

![Screenshot 2024-01-12 at 13 59 13](https://github.com/greenpeace/planet4-master-theme/assets/77975803/0b083830-f8ad-4b48-9046-a04c38699e8c)


<!-- Ref: Please add a url to the ticket this change is addressing.

---

Please provide a brief summary of the change introduced to make review process easier.

Ideally this should also be part of the commit summary.
-->
