### PR TITLE
Include wide-blocks stylesheet into master theme

### DIFF
--- a/assets/src/scss/layout/_wide-blocks.scss
+++ b/assets/src/scss/layout/_wide-blocks.scss
@@ -1,0 +1,22 @@
+// .block-wide kept for BC of existing content.
+// Can be removed once no content uses it anymore.
+.alignfull, .block-wide {
+  width: 100vw;
+  //     Screen width - block width
+  //  -  --------------------------
+  //                  2
+  margin-left: calc(((100vw - 100%) / 2) * -1);
+
+  html[dir="rtl"] & {
+    margin-right: calc(((100vw - 100%) / 2) * -1);
+  }
+
+  .block-editor & {
+    width: 100%;
+    margin: 0;
+
+    html[dir="rtl"] & {
+      margin: 0;
+    }
+  }
+}

--- a/assets/src/scss/style.scss
+++ b/assets/src/scss/style.scss
@@ -50,6 +50,7 @@ Text Domain: planet4-master-theme
 @import "layout/skewed-overlay";
 @import "layout/tables";
 @import "layout/featured-action";
+@import "layout/wide-blocks";
 
 // Pages
 @import "pages/page";


### PR DESCRIPTION
[No ticket needed]

# Description
Include `.block-wide` and `.alignfull` CSS Classes. It should works when the plugin is disabled.

<!-- Ref: Please add a url to the ticket this change is addressing.

---

Please provide a brief summary of the change introduced to make review process easier.

Ideally this should also be part of the commit summary.
-->
