### PR TITLE
Maintenance: move REST_NAMESPACE const to BaeBlock PHP class

### DIFF
--- a/src/Blocks/BaseBlock.php
+++ b/src/Blocks/BaseBlock.php
@@ -16,6 +16,7 @@ namespace P4\MasterTheme\Blocks;
 abstract class BaseBlock
 {
     public const NAMESPACE = 'planet4-blocks';
+    public const REST_NAMESPACE = 'planet4/v1';
 
     /**
      * Get all the data that will be needed to render the block correctly.

--- a/src/Blocks/Spreadsheet.php
+++ b/src/Blocks/Spreadsheet.php
@@ -30,8 +30,6 @@ class Spreadsheet extends BaseBlock
 
     private const CACHE_LIFETIME = 30;
 
-    private const REST_NAMESPACE = 'planet4/v1';
-
     /**
      * Spreadsheet Table constructor.
      */


### PR DESCRIPTION
[No ticket needed]

# Description
This small change is because to avoid repeated code and easy to maintain. The `REST_NAMESPACE` constant is being used, at least, by two different blocks. These are the Spreadsheet and the Happypoint.

<!-- Ref: Please add a url to the ticket this change is addressing.

---

Please provide a brief summary of the change introduced to make review process easier.

Ideally this should also be part of the commit summary.
-->
