### PR TITLE
Lower Sentry sampling rate to 25%

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -497,3 +497,11 @@ add_filter(
     10,
     2
 );
+
+if (class_exists('\\Sentry\\Options')) {
+    add_filter('wp_sentry_options', function (\Sentry\Options $options) {
+        // Only sample 25% of the events
+        $options->setSampleRate(0.25);
+        return $options;
+    });
+}


### PR DESCRIPTION
Following CPU spike incident.
From https://github.com/stayallive/wp-sentry/#wp_sentry_options

Report only 25% of errors for the time being.
We can probably later refine to modify the rate to specific error types only (cf https://docs.sentry.io/platforms/php/configuration/sampling/ ).
