### PR TITLE
PLANET-7404: Fix page type feed url matching

### DIFF
--- a/src/CustomTaxonomy.php
+++ b/src/CustomTaxonomy.php
@@ -352,6 +352,11 @@ class CustomTaxonomy
         $terms_slugs = $this->get_terms_slugs();
 
         if ($terms_slugs) {
+            // {p4-page-type}/feed urls have to be caught before {p4-page-type}/{cat}
+            $terms = implode('|', $terms_slugs);
+            $rules[sprintf('(%s)/(feed|rdf|rss|rss2|atom)/?$', $terms)] = 'index.php?'
+                    . self::TAXONOMY . '=$matches[1]&feed=$matches[2]';
+
             foreach ($terms_slugs as $slug) {
                 $rules[$slug . '(/page/([0-9]+)?)?/?$'] = 'index.php?'
                     . self::TAXONOMY . '=' . $slug


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-7404

## Test

On local
- `npm run nro:install denmark`
- checkout this branch
- test url `http://www.planet4.test/pressemeddelelse/feed`
  - it's sending back a 404
- flush rewrite rules with `npx wp-env run cli wp rewrite flush`
- test the feed url again
  - it should send back a feed
  - check the rewrite rules with `npx wp-env run cli wp rewrite list`, rules are applied in order, the feed matching rule should be above our individual page type rules

```
| (nyhed|pressemeddelelse|udgivelse)/(feed|rdf|rss | index.php?p4-page-type=$matches[1]&feed=$matches | root         |
| |rss2|atom)/?$                                   | [2]                                              |              |
| nyhed(/page/([0-9]+)?)?/?$                       | index.php?p4-page-type=nyhed&paged=$matches[2]   | root         |
| pressemeddelelse(/page/([0-9]+)?)?/?$            | index.php?p4-page-type=pressemeddelelse&paged=$m | root         |
|                                                  | atches[2]                                        |              |
| udgivelse(/page/([0-9]+)?)?/?$                   | index.php?p4-page-type=udgivelse&paged=$matches[ | root         |
|                                                  | 2]                                               |              |
```