### PR TITLE
Fix warning on articles list on author page

### DIFF
--- a/src/ListingPage.php
+++ b/src/ListingPage.php
@@ -68,8 +68,11 @@ class ListingPage
      */
     private function set_featured_action(): void
     {
-        $taxonomy = $this->context['taxonomy'];
-        if ($taxonomy->taxonomy !== 'category' && ! is_tag()) {
+        $taxonomy = $this->context['taxonomy'] ?? null;
+        if (
+            !$taxonomy
+            || ($taxonomy->taxonomy !== 'category' && ! is_tag())
+        ) {
             return;
         }
 


### PR DESCRIPTION
Ref: https://sentry.greenpeace.org/organizations/greenpeace-org/issues/868/?query=is%3Aunresolved+release%3Av2.121.0-fix-php8&referrer=issue-stream&statsPeriod=14d&stream_index=1

Fix taxonomy check when page is not relevant

## Test
- consult an author page, display page 2 of their list of articles
- this branch should not generate warnings in logs (`npx wp-env logs`)