### PR TITLE
Planet 7379 Move remaining sidebar fields to Master theme

### DIFF
--- a/assets/src/block-editor/NavigationType/NavigationType.js
+++ b/assets/src/block-editor/NavigationType/NavigationType.js
@@ -1,0 +1,29 @@
+import {RadioControl} from '@wordpress/components';
+
+const {__} = wp.i18n;
+
+const NAVIGATION_TYPE_PLANET4 = 'planet4';
+const NAVIGATION_TYPE_MINIMAL = 'minimal';
+
+// Navigation type selector
+export const NavigationType = ({value, setValue, defaultValue, options}) => {
+  const defaultOptions = [
+    {
+      label: __('Main website navigation', 'planet4-blocks-backend'),
+      value: NAVIGATION_TYPE_PLANET4,
+    },
+    {
+      label: __('Minimal Navigation', 'planet4-blocks-backend'),
+      value: NAVIGATION_TYPE_MINIMAL,
+    },
+  ];
+
+  return (
+    <RadioControl
+      label={__('Navigation type', 'planet4-blocks-backend')}
+      selected={value || defaultValue || NAVIGATION_TYPE_PLANET4}
+      options={options || defaultOptions}
+      onChange={setValue}
+    />
+  );
+};

--- a/assets/src/block-editor/Sidebar/ActionSidebar.js
+++ b/assets/src/block-editor/Sidebar/ActionSidebar.js
@@ -1,0 +1,48 @@
+import {PluginDocumentSettingPanel} from '@wordpress/edit-post';
+import {NavigationType} from '../NavigationType/NavigationType';
+import {CheckboxSidebarField} from '../SidebarFields/CheckboxSidebarField';
+import {TextSidebarField} from '../SidebarFields/TextSidebarField';
+import {getSidebarFunctions} from './getSidebarFunctions';
+
+const FIELD_NAVTYPE = 'nav_type';
+const HIDE_PAGE_TITLE = 'p4_hide_page_title_checkbox';
+const BUTTON_TEXT = 'action_button_text';
+
+const {__} = wp.i18n;
+
+/**
+ * Add settings to Action pages
+ */
+export const ActionSidebar = {
+  getId: () => 'planet4-action-sidebar',
+  render: () => {
+    const {getParams} = getSidebarFunctions();
+
+    return (
+      <>
+        <PluginDocumentSettingPanel
+          name="page-header-panel"
+          title={__('Page header', 'planet4-blocks-backend')}
+        >
+          <CheckboxSidebarField label={__('Hide page title', 'planet4-blocks-backend')} {...getParams(HIDE_PAGE_TITLE)} />
+        </PluginDocumentSettingPanel>
+        <PluginDocumentSettingPanel
+          name="button-text-panel"
+          title={__('Covers block button text', 'planet4-blocks-backend')}
+        >
+          <TextSidebarField
+            label={__('Edit the button text shown on the Action covers block', 'planet4-blocks-backend')}
+            {...getParams(BUTTON_TEXT)}
+          />
+        </PluginDocumentSettingPanel>
+        <PluginDocumentSettingPanel
+          name="navigation-panel"
+          title={__('Navigation', 'planet4-blocks-backend')}
+          className="navigation-panel"
+        >
+          <NavigationType {...getParams(FIELD_NAVTYPE)} />
+        </PluginDocumentSettingPanel>
+      </>
+    );
+  },
+};

--- a/assets/src/block-editor/Sidebar/AnalyticsTrackingSidebar.js
+++ b/assets/src/block-editor/Sidebar/AnalyticsTrackingSidebar.js
@@ -1,0 +1,59 @@
+import {PluginDocumentSettingPanel} from '@wordpress/edit-post';
+import {dispatch, useSelect} from '@wordpress/data';
+import {SelectSidebarField} from '../SidebarFields/SelectSidebarField';
+import {TextSidebarField} from '../SidebarFields/TextSidebarField';
+import {getSidebarFunctions} from './getSidebarFunctions';
+
+const {__} = wp.i18n;
+
+dispatch('core').addEntities([{
+  baseURL: '/planet4/v1/analytics-values',
+  kind: 'planet4/v1',
+  name: 'analytics-values',
+  label: 'Analytics and tracking values',
+}]);
+
+const GLOBAL_PROJECT = 'p4_campaign_name';
+const LOCAL_PROJECT = 'p4_local_project';
+const BASKET = 'p4_basket_name';
+const DEPARTMENT = 'p4_department';
+
+export const AnalyticsTrackingSidebar = {
+  getId: () => 'planet4-analytics-sidebar',
+  render: () => {
+    const {getParams} = getSidebarFunctions();
+    const postId = wp.data.select('core/editor').getCurrentPostId();
+    const options = useSelect(select => {
+      return select('core').getEntityRecords('planet4/v1', 'analytics-values', {id: postId});
+    });
+
+    const globalOptions = options ? options[0].global_projects : [];
+    const localOptions = options ? options[0].local_projects : [];
+    const basketOptions = options ? options[0].baskets : [];
+
+    return (
+      <>
+        <PluginDocumentSettingPanel
+          name="analytics-panel"
+          title={__('Analytics & Tracking', 'planet4-blocks-backend')}
+        >
+          <SelectSidebarField
+            label={__('Global Project', 'planet4-master-theme-backend')}
+            options={globalOptions}
+            {...getParams(GLOBAL_PROJECT)} />
+          <SelectSidebarField
+            label={__('Local Projects', 'planet4-master-theme-backend')}
+            options={localOptions}
+            {...getParams(LOCAL_PROJECT)} />
+          <SelectSidebarField
+            label={__('Basket Name', 'planet4-master-theme-backend')}
+            options={basketOptions}
+            {...getParams(BASKET)} />
+          <TextSidebarField
+            label={__('Department', 'planet4-master-theme-backend')}
+            {...getParams(DEPARTMENT)} />
+        </PluginDocumentSettingPanel>
+      </>
+    );
+  },
+};

--- a/assets/src/block-editor/Sidebar/CampaignThemeSidebar.js
+++ b/assets/src/block-editor/Sidebar/CampaignThemeSidebar.js
@@ -1,0 +1,173 @@
+import {PluginSidebar, PluginSidebarMoreMenuItem} from '@wordpress/edit-post';
+import {Component} from '@wordpress/element';
+import {resolveField} from '../fromThemeOptions/fromThemeOptions';
+import isShallowEqual from '@wordpress/is-shallow-equal';
+import {savePreviewMeta} from '../saveMetaToPreview';
+import {PostParentLink} from './PostParentLink';
+import {ThemeSettings} from './ThemeSettings';
+import {applyChangesToDom, LocalThemeSettings, themeJsonUrl} from './LocalThemeSettings';
+
+const {__} = wp.i18n;
+
+const isLegacy = theme => [
+  'default',
+  'antarctic',
+  'arctic',
+  'climate',
+  'oceans',
+  'oil',
+  'plastic',
+  'forest',
+].includes(theme) || !theme;
+
+const loadOptions = async value => {
+  if (value === '' || !value) {
+    value = 'default';
+  }
+  const withoutNew = value.replace(/-new$/, '');
+  const name = isLegacy(withoutNew) ? withoutNew : 'default';
+  const baseUrl = window.location.href.split('/wp-admin')[0];
+  const optionsJsonUrl = `${baseUrl}/wp-content/themes/planet4-master-theme/theme_options/${name}.json`;
+
+  const response = await fetch(optionsJsonUrl);
+  return await response.json();
+};
+const makeDefaultOrNull = (result, field) => {
+  // Adding this check to prevent a crash. Probably the previous code can be rewritten to not produce null, but
+  // that would probably cascade into many changes and this is code we'll probably remove soon.
+  if (!field) {
+    return result;
+  }
+  return {
+    ...result,
+    [field.id]: field.default || null,
+  };
+};
+
+// Check if the field has a value in the current post meta that is not allowed anymore by the new options.
+const gotInvalidated = (field, options, meta) => {
+  const resolvedField = resolveField(options, field.id, meta);
+
+  const currentValue = meta[field.id];
+
+  // Either the field does not exist on the new theme, or it has no options.
+  if (!resolvedField || !resolvedField.options) {
+    return !!currentValue;
+  }
+
+  return !(resolvedField.options.some(option => option.value === currentValue));
+};
+
+export class CampaignThemeSidebar extends Component {
+  static getId() {
+    return 'planet4-campaign-theme-sidebar';
+  }
+
+  static getIcon() {
+    return 'admin-appearance';
+  }
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      options: null,
+      meta: null,
+      parent: null,
+    };
+    this.handleThemeSwitch = this.handleThemeSwitch.bind(this);
+  }
+
+  // When theme switches, we need to check if any options were previously chosen that are not allowed in the new theme.
+  // For each of these, we either set them to the default value
+  async handleThemeSwitch(metaKey, newThemeName, meta) {
+    const prevOptions = this.state.options;
+    const options = await loadOptions(newThemeName);
+    this.setState({options});
+
+    // Loop through the new theme's fields, and check whether any of the already chosen options has a value that is not
+    // available anymore.
+    const invalidatedFields = prevOptions?.fields.filter(field => gotInvalidated(field, options, meta)) || [];
+
+    // Set each of the invalidated fields to their default value, or unset them.
+    return invalidatedFields
+      .map(field => resolveField(options, field.id, meta))
+      .reduce(makeDefaultOrNull, {[metaKey]: newThemeName});
+  }
+
+  componentDidMount() {
+    wp.data.subscribe(async () => {
+      const meta = wp.data.select('core/editor').getEditedPostAttribute('meta');
+
+      if (!meta) {
+        return;
+      }
+      let themeName = meta.theme;
+      if (themeName === '') {
+        themeName = 'default';
+      }
+      // This part currently also detects non-related changes to the meta. Not changing that for now, we should put
+      // these values in a single meta key, or even store them in a block in post_content.
+      if (isShallowEqual(this.state.meta, meta)) {
+        return;
+      }
+      this.setState({meta});
+      savePreviewMeta();
+      if (
+        this.state.options === null
+      ) {
+        const options = await loadOptions(themeName);
+        this.setState({options});
+        if (themeName) {
+          try {
+            const response = await fetch(`${themeJsonUrl + themeName.replace('-new', '')}.json`);
+            const theme = await response.json();
+            applyChangesToDom(theme, []);
+          } catch (e) {
+            // eslint-disable-next-line no-console
+            console.error(`Failed loading config for ${themeName}`);
+          }
+        }
+      }
+    });
+    wp.data.subscribe(() => {
+      const parentId = wp.data.select('core/editor').getEditedPostAttribute('parent') || null;
+      if (
+        (!this.state.parent && parentId !== null) ||
+        (this.state.parent && parentId !== this.state.parent.id)
+      ) {
+        const parentPage = parentId ? wp.data.select('core').getEntityRecord('postType', 'campaign', parentId) : null;
+        this.setState({parent: parentPage});
+      }
+    });
+  }
+
+  render() {
+    const {parent, options, meta} = this.state;
+
+    const isLegacyTheme = !options || isLegacy(options.id);
+
+    return (
+      <>
+        <PluginSidebarMoreMenuItem
+          target={CampaignThemeSidebar.getId()}
+          icon={CampaignThemeSidebar.getIcon()}>
+          { __('Theme Options', 'planet4-blocks-backend') }
+        </PluginSidebarMoreMenuItem>
+        <PluginSidebar
+          name={CampaignThemeSidebar.getId()}
+          title={__('Theme Options', 'planet4-blocks-backend')}
+        >
+          { !!parent && <PostParentLink parent={parent} /> }
+          { !parent && meta && <LocalThemeSettings currentTheme={meta.theme} onChange={async value => {
+            this.handleThemeSwitch('theme', value, meta);
+          }} /> }
+          { !parent && <ThemeSettings
+            theme={options}
+            handleThemeSwitch={this.handleThemeSwitch}
+            isLegacyTheme={isLegacyTheme}
+          /> }
+        </PluginSidebar>
+      </>
+    );
+  }
+}

--- a/assets/src/block-editor/Sidebar/LocalThemeSettings.js
+++ b/assets/src/block-editor/Sidebar/LocalThemeSettings.js
@@ -1,0 +1,123 @@
+import {SelectControl} from '@wordpress/components';
+import {useState, useEffect} from '@wordpress/element';
+import {p4ServerThemes} from '../../theme/p4ServerThemes';
+import {useDispatch} from '@wordpress/data';
+
+const {__} = wp.i18n;
+
+const keysAsLabel = obj => Object.keys(obj).map(k => ({label: k, value: k}));
+
+const refactoredThemes = ['climate-new', 'forest-new', 'oceans-new', 'plastic-new'];
+
+// Just a lightweight way to have a separate UI element in the sidebar so that it's clear which themes are legacy and
+// which are new. This is likely just for internal usage to facilitate reviewing the refactored version, eventually
+// editors will work with a single select.
+const useServerThemes = () => {
+  const [serverThemes, setServerThemes] = useState({});
+
+  useEffect(() => {
+    (async () => {
+      const themes = await p4ServerThemes.fetchThemes();
+      setServerThemes(themes);
+    })();
+  }, []);
+
+  return serverThemes;
+};
+
+const getAllDefinedProps = () => Object.values(document.documentElement.style).filter(k => {
+  return 'string' === typeof k && k.match(/^--/);
+});
+const baseUrl = window.location.href.split('/wp-admin')[0];
+export const themeJsonUrl = `${baseUrl}/wp-content/themes/planet4-master-theme/themes/`;
+
+const collectTheme = async (a, t) => {
+  const response = await fetch(`${themeJsonUrl + t.replace('-new', '')}.json`);
+
+  return {
+    ...await a,
+    [t]: await response.json(),
+  };
+};
+
+const useJsonThemes = () => {
+  const [jsonThemes, setJsonThemes] = useState({});
+  useEffect(() => {
+    (async () => {
+      const themes = await refactoredThemes.reduce(collectTheme, {});
+      setJsonThemes(themes);
+    })();
+  }, []);
+
+  return jsonThemes;
+};
+
+export const applyChangesToDom = (theme, initialVars) => {
+  if (!theme) {
+    return;
+  }
+  Object.entries(theme).forEach(([name, value]) => {
+    // This will only work reliably if no other code is adding new custom properties to the root element after this
+    // component is first rendered. This should be the case in the post editor.
+    document.documentElement.style.setProperty(name, value);
+  });
+
+  const customProps = getAllDefinedProps();
+
+  customProps.forEach(k => {
+    if (!Object.keys(theme).includes(k) && !initialVars.includes(k)) {
+      document.documentElement.style.removeProperty(k);
+    }
+  });
+};
+
+const useAppliedCssVariables = (serverThemes, currentTheme) => {
+  const [initialVars] = useState(() => getAllDefinedProps(), []);
+  const jsonThemes = useJsonThemes();
+  const allThemes = {...serverThemes, ...jsonThemes};
+
+  useEffect(() => {
+    applyChangesToDom(allThemes[currentTheme] || {}, initialVars);
+  }, [serverThemes, currentTheme]);
+};
+
+const excludeNewVersions = (themes, [name, theme]) => {
+  return refactoredThemes.includes(name) ? themes : ({...themes, [name]: theme});
+};
+
+const withoutNewVersionsOfThemes = themes => Object.entries(themes).reduce(excludeNewVersions, {});
+
+export const LocalThemeSettings = ({onChange, currentTheme}) => {
+  const [selectedTheme, setSelectedTheme] = useState(currentTheme);
+  const {editPost} = useDispatch('core/editor');
+  const allServerThemes = useServerThemes();
+  const serverThemes = withoutNewVersionsOfThemes(allServerThemes);
+
+  const emitOnChange = () => {
+    if (selectedTheme !== null) {
+      const meta = {theme: selectedTheme};
+      onChange(selectedTheme);
+      editPost({meta});
+    }
+  };
+  useEffect(emitOnChange, [selectedTheme]);
+
+  useAppliedCssVariables(serverThemes, currentTheme);
+
+  if (Object.keys(serverThemes).length === 0) {
+    return null;
+  }
+
+  return <div className="components-panel__body is-opened">
+    <span>
+      { __('Choose from one of the themes created on this site (BETA).', 'planet4-blocks-backend') }
+    </span>
+    <SelectControl
+      label={__('Local theme', 'planet4-blocks-backend')}
+      title={__('Choose from one of the themes created on this site (BETA).', 'planet4-blocks-backend')}
+      options={[{label: 'None', value: ''}, ...keysAsLabel(serverThemes)]}
+      onChange={setSelectedTheme}
+      value={selectedTheme || ''}
+    />
+  </div>;
+};

--- a/assets/src/block-editor/Sidebar/PageHeaderSidebar.js
+++ b/assets/src/block-editor/Sidebar/PageHeaderSidebar.js
@@ -1,0 +1,54 @@
+import {PluginDocumentSettingPanel} from '@wordpress/edit-post';
+import {useSelect} from '@wordpress/data';
+import {CheckboxSidebarField} from '../SidebarFields/CheckboxSidebarField';
+import {TextareaSidebarField} from '../SidebarFields/TextareaSidebarField';
+import {ImageSidebarField} from '../SidebarFields/ImageSidebarField';
+import {TextSidebarField} from '../SidebarFields/TextSidebarField';
+import {getSidebarFunctions} from './getSidebarFunctions';
+
+// The various meta fields
+const HIDE_PAGE_TITLE = 'p4_hide_page_title_checkbox';
+const HEADER_TITLE = 'p4_title';
+const HEADER_SUBTITLE = 'p4_subtitle';
+const HEADER_DESCRIPTION = 'p4_description';
+const BACKGROUND_IMAGE_ID = 'background_image_id';
+const BACKGROUND_IMAGE_URL = 'background_image';
+const HEADER_BUTTON_TITLE = 'p4_button_title';
+const HEADER_BUTTON_LINK = 'p4_button_link';
+const HEADER_BUTTON_NEW_TAB = 'p4_button_link_checkbox';
+
+const {__} = wp.i18n;
+
+/**
+ * Page header settings for the sidebar
+ */
+export const PageHeaderSidebar = {
+  getId: () => 'planet4-page-header-sidebar',
+  render: () => {
+    const postType = useSelect(select => select('core/editor').getCurrentPostType());
+    const isCampaign = postType === 'campaign';
+
+    const {getParams, getImageParams} = getSidebarFunctions();
+
+    return (
+      <PluginDocumentSettingPanel
+        name="page-header-panel"
+        title={__('Page header', 'planet4-blocks-backend')}
+      >
+        <TextSidebarField label={__('Header title', 'planet4-blocks-backend')} {...getParams(HEADER_TITLE)} />
+        <TextSidebarField label={__('Header subtitle', 'planet4-blocks-backend')} {...getParams(HEADER_SUBTITLE)} />
+        <TextareaSidebarField label={__('Header description', 'planet4-blocks-backend')} {...getParams(HEADER_DESCRIPTION)} />
+        {!isCampaign && (
+          <>
+            <TextSidebarField label={__('Header button title', 'planet4-blocks-backend')} {...getParams(HEADER_BUTTON_TITLE)} />
+            <TextSidebarField label={__('Header button link', 'planet4-blocks-backend')} {...getParams(HEADER_BUTTON_LINK)} />
+            <CheckboxSidebarField label={__('Open header button link in new tab', 'planet4-blocks-backend')} {...getParams(HEADER_BUTTON_NEW_TAB)} />
+          </>
+        )}
+        <ImageSidebarField label={__('Background image override', 'planet4-blocks-backend')} {...getImageParams(BACKGROUND_IMAGE_ID, BACKGROUND_IMAGE_URL)} />
+        <CheckboxSidebarField label={__('Hide page title', 'planet4-blocks-backend')} {...getParams(HIDE_PAGE_TITLE)} />
+      </PluginDocumentSettingPanel>
+    );
+  },
+};
+

--- a/assets/src/block-editor/Sidebar/PostParentLink.js
+++ b/assets/src/block-editor/Sidebar/PostParentLink.js
@@ -1,0 +1,12 @@
+const {__} = wp.i18n;
+
+export const PostParentLink = ({parent}) => {
+  return <div className="components-panel__body is-opened">
+    <p>{ __('This is a sub-page of', 'planet4-blocks-backend') }</p>
+    <a
+      href={window.location.href.replace(/\?post=\d+/, `?post=${parent.id}`)}>
+      { parent.title.raw }
+    </a>
+    <p>{ __('Style and analytics settings from the parent page will be used.', 'planet4-blocks-backend') }</p>
+  </div>;
+};

--- a/assets/src/block-editor/Sidebar/SearchEngineOptimizationsSidebar.js
+++ b/assets/src/block-editor/Sidebar/SearchEngineOptimizationsSidebar.js
@@ -1,0 +1,29 @@
+import {PluginDocumentSettingPanel} from '@wordpress/edit-post';
+import {useDispatch, useSelect} from '@wordpress/data';
+import {URLInput} from '../URLInput/URLInput';
+
+const CANONICAL_URL = 'p4_seo_canonical_url';
+
+const {__} = wp.i18n;
+
+export const SearchEngineOptimizationsSidebar = {
+  getId: () => 'planet4-seo-sidebar',
+  render: () => {
+    const meta = useSelect(select => select('core/editor').getEditedPostAttribute('meta'), []);
+    const {editPost} = useDispatch('core/editor', [meta[CANONICAL_URL]]);
+
+    return (
+      <PluginDocumentSettingPanel
+        name="planet4-search-engine-optimizations"
+        title={__('Search Engine Optimizations', 'planet4-blocks-backend')}
+      >
+        <URLInput
+          label={__('Canonical link', 'planet4-blocks-backend')}
+          value={meta[CANONICAL_URL]}
+          onChange={value => editPost({meta: {[CANONICAL_URL]: value}})}
+          help={__('If emtpy a self-reference canonical link will be used', 'planet4-blocks-backend')}
+        />
+      </PluginDocumentSettingPanel>
+    );
+  },
+};

--- a/assets/src/block-editor/Sidebar/ThemeSettings.js
+++ b/assets/src/block-editor/Sidebar/ThemeSettings.js
@@ -1,0 +1,158 @@
+import {useEffect} from '@wordpress/element';
+import {PanelBody, RadioControl, SelectControl} from '@wordpress/components';
+import {getDependencyUpdates, resolveField} from '../fromThemeOptions/fromThemeOptions';
+import ColorPaletteControl from '../ColorPaletteControl/ColorPaletteControl';
+import {NavigationType} from '../NavigationType/NavigationType';
+import {useDispatch, useSelect} from '@wordpress/data';
+
+const {__} = wp.i18n;
+// For existing content each style options is saved in a separate post meta key, and all the names are prefixed with
+// "campaign", because that used to be a thing. Hence the name "legacy fields", because eventually we want to store this
+// differently.
+const LEGACY_FIELDS = {
+  navigationType: 'campaign_nav_type',
+  navigationColor: 'campaign_nav_color',
+  navigationBorder: 'campaign_nav_border',
+  logo: 'campaign_logo',
+  logoColor: 'campaign_logo_color',
+  headingFont: 'campaign_header_primary',
+  bodyFont: 'campaign_body_font',
+  footerTheme: 'campaign_footer_theme',
+  footerLinksColor: 'footer_links_color',
+};
+
+const themeOptions = [
+  {
+    value: '',
+    label: 'Default',
+  },
+  {
+    value: 'climate-new',
+    label: 'Climate Emergency',
+  },
+  {
+    value: 'forest-new',
+    label: 'Forest',
+  },
+  {
+    value: 'oceans-new',
+    label: 'Oceans',
+  },
+  {
+    value: 'plastic-new',
+    label: 'Plastics',
+  },
+
+];
+
+export const ThemeSettings = props => {
+  const {
+    handleThemeSwitch,
+    theme,
+  } = props;
+
+  const meta = useSelect(select => select('core/editor').getEditedPostAttribute('meta'), []);
+  const {editPost} = useDispatch('core/editor');
+
+  useEffect(() => {
+    handleThemeSwitch('theme', meta.theme, meta);
+  }, [meta.theme]);
+
+  // resolveField is a cheap function so it's not a problem to call it twice.
+  const getValue = fieldId => meta[fieldId] || resolveField(theme, fieldId, meta)?.default;
+  const getOptions = fieldId => resolveField(theme, fieldId, meta)?.options || [];
+
+  const updateValueAndDependencies = fieldId => value => {
+    const updatedDeps = getDependencyUpdates(theme, fieldId, value, meta);
+    editPost({meta: {[fieldId]: value, ...updatedDeps}});
+  };
+
+  const navParams = {
+    value: getValue(LEGACY_FIELDS.navigationType),
+    setValue: updateValueAndDependencies(LEGACY_FIELDS.navigationType),
+    options: getOptions(LEGACY_FIELDS.navigationType),
+  };
+
+  return <>
+    <div className="components-panel__body is-opened">
+      <SelectControl
+        options={themeOptions}
+        label={__('Theme', 'planet4-blocks-backend')}
+        value={meta.theme}
+        onChange={value => {
+          editPost({meta: {theme: value}});
+        }}
+      />
+    </div>
+    <PanelBody
+      title={__('Navigation', 'planet4-blocks-backend')}
+      initialOpen={true}
+    >
+      <NavigationType {...navParams} />
+      <ColorPaletteControl
+        value={getValue(LEGACY_FIELDS.navigationColor)}
+        options={getOptions(LEGACY_FIELDS.navigationColor)}
+        onChange={updateValueAndDependencies(LEGACY_FIELDS.navigationColor)}
+        label={__('Navigation Background Color', 'planet4-blocks-backend')}
+        disableCustomColors
+        clearable={false}
+      />
+      {/* This one is actually not used anymore. Might remove later.*/}
+      <RadioControl
+        selected={getValue(LEGACY_FIELDS.navigationBorder)}
+        options={getOptions(LEGACY_FIELDS.navigationBorder)}
+        onChange={updateValueAndDependencies(LEGACY_FIELDS.navigationBorder)}
+        label={__('Navigation bottom border', 'planet4-blocks-backend')}
+      />
+      <SelectControl
+        value={getValue(LEGACY_FIELDS.logo)}
+        options={getOptions(LEGACY_FIELDS.logo)}
+        onChange={updateValueAndDependencies(LEGACY_FIELDS.logo)}
+        label={__('Logo', 'planet4-blocks-backend')}
+      />
+      <RadioControl
+        selected={getValue(LEGACY_FIELDS.logoColor)}
+        options={getOptions(LEGACY_FIELDS.logoColor)}
+        onChange={updateValueAndDependencies(LEGACY_FIELDS.logoColor)}
+        label={__('Logo Color', 'planet4-blocks-backend')}
+        help={__('Change the campaign logo color (if not default)', 'planet4-blocks-backend')}
+      />
+    </PanelBody>
+    <PanelBody
+      title={__('Fonts', 'planet4-blocks-backend')}
+      initialOpen={true}
+    >
+      <SelectControl
+        value={getValue(LEGACY_FIELDS.headingFont)}
+        options={getOptions(LEGACY_FIELDS.headingFont)}
+        onChange={updateValueAndDependencies(LEGACY_FIELDS.headingFont)}
+        label={__('Header Primary Font', 'planet4-blocks-backend')}
+      />
+      <SelectControl
+        value={getValue(LEGACY_FIELDS.bodyFont)}
+        options={getOptions(LEGACY_FIELDS.bodyFont)}
+        onChange={updateValueAndDependencies(LEGACY_FIELDS.bodyFont)}
+        label={__('Body Font', 'planet4-blocks-backend')}
+      />
+    </PanelBody>
+    <PanelBody
+      title={__('Footer', 'planet4-blocks-backend')}
+      initialOpen={true}
+    >
+      <RadioControl
+        selected={getValue(LEGACY_FIELDS.footerTheme)}
+        options={getOptions(LEGACY_FIELDS.footerTheme)}
+        onChange={updateValueAndDependencies(LEGACY_FIELDS.footerTheme)}
+        label={__('Footer background color', 'planet4-blocks-backend')}
+      />
+      <ColorPaletteControl
+        value={getValue(LEGACY_FIELDS.footerLinksColor)}
+        options={getOptions(LEGACY_FIELDS.footerLinksColor)}
+        onChange={updateValueAndDependencies(LEGACY_FIELDS.footerLinksColor)}
+        label={__('Footer links color', 'planet4-blocks-backend')}
+        disableCustomColors
+        clearable={false}
+      />
+    </PanelBody>
+  </>;
+};

--- a/assets/src/block-editor/fromThemeOptions/fromThemeOptions.js
+++ b/assets/src/block-editor/fromThemeOptions/fromThemeOptions.js
@@ -1,0 +1,88 @@
+// Find the variant of a field that should be used, based on the other selected theme options (stored as post "meta").
+// Certain fields can have multiple sets of options, depending on which value is chosen for another field. For example,
+// we have a "default" and a "light" footer theme. Each of these results in a separate set of footer link colors.
+// See https://github.com/greenpeace/planet4-master-theme/blob/1905eee9f94ef1ac64aaed1570ea4150671684c1/campaign_themes/plastic.json#L176-L187
+export const resolveField = (theme, fieldId, meta) => {
+  if (!theme) {
+    return null;
+  }
+
+  const field = theme.fields.find(fieldFound => fieldFound.id === fieldId);
+
+  if (!field) {
+    return null;
+  }
+
+  if (field.dependsOn) {
+    return resolveDependency(theme, field, meta);
+  }
+
+  return field;
+};
+
+const resolveDependency = (theme, field, meta) => {
+  const dependencyField = theme.fields.find(field2 => field2.id === field.dependsOn);
+
+  // Sanity check, the dependent field should be there if the config file is valid.
+  if (!dependencyField) {
+    return null;
+  }
+
+  if (!meta) {
+    return null;
+  }
+
+  const dependencyConfiguration = dependencyField.dependsOn ? resolveDependency(theme, dependencyField, meta) : dependencyField;
+
+  if (!dependencyConfiguration) {
+    return null;
+  }
+
+  let dependencyValue = meta[field.dependsOn];
+
+  const dependencyValueIsAllowed = dependencyConfiguration.options?.find(option => option.value === dependencyValue);
+
+  if (!dependencyValueIsAllowed) {
+    // The field has a dependency and the current value of the post is not in the list of options, so use default value of the dependency.
+    dependencyValue = dependencyConfiguration.default;
+  }
+
+  if (!dependencyValue || !field.configurations[dependencyValue]) {
+    return null;
+  }
+
+  return {
+    id: field.id,
+    ...field.configurations[dependencyValue],
+  };
+};
+
+export const getDependencyUpdates = (theme, fieldName, value, meta) => {
+  const allChildren = theme.fields.filter(field => field.dependsOn === fieldName);
+  const needUpdate = allChildren.filter(
+    field => {
+      const configuration = field.configurations[value];
+
+      if (!configuration) {
+        return typeof meta[field.id] !== 'undefined';
+      }
+
+      if (!configuration.options) {
+        return true;
+      }
+
+      return !(configuration.options.some(option => option.value === meta[field.id]));
+    }
+  );
+
+  // Return object with meta keys to be updated. Unset if there is no configuration for the new value or no default for
+  // that configuration.
+  return needUpdate.reduce((updates, field) => {
+    const configuration = field.configurations[value];
+
+    return {
+      ...updates,
+      [field.id]: configuration?.default || null,
+    };
+  }, {});
+};

--- a/assets/src/block-editor/saveMetaToPreview.js
+++ b/assets/src/block-editor/saveMetaToPreview.js
@@ -1,0 +1,18 @@
+export const savePreviewMeta = () => {
+  const {apiFetch} = wp;
+  const {getEditedPostAttribute, getCurrentPostId} = wp.data.select('core/editor');
+
+  // eslint-disable-next-line no-console
+  console.info('Saving preview meta...');
+
+  if (!['draft', 'auto-draft'].includes(getEditedPostAttribute('status'))) {
+    apiFetch({
+      path: '/planet4/v1/save-preview-meta',
+      method: 'POST',
+      data: {
+        post_id: getCurrentPostId(),
+        meta: getEditedPostAttribute('meta'),
+      },
+    });
+  }
+};

--- a/assets/src/block-editor/setupCustomSidebar.js
+++ b/assets/src/block-editor/setupCustomSidebar.js
@@ -1,23 +1,44 @@
 import {registerPlugin} from '@wordpress/plugins';
 import {OpenGraphSidebar} from './Sidebar/OpenGraphSidebar';
+import {PageHeaderSidebar} from './Sidebar/PageHeaderSidebar';
+import {CampaignThemeSidebar} from './Sidebar/CampaignThemeSidebar';
+import {ActionSidebar} from './Sidebar/ActionSidebar';
+import {SearchEngineOptimizationsSidebar} from './Sidebar/SearchEngineOptimizationsSidebar';
+import {AnalyticsTrackingSidebar} from './Sidebar/AnalyticsTrackingSidebar';
 
 const sidebarsForPostType = postType => {
   switch (postType) {
   case 'campaign':
     return [
+      PageHeaderSidebar,
+      {
+        getId: CampaignThemeSidebar.getId,
+        getIcon: CampaignThemeSidebar.getIcon,
+        render: CampaignThemeSidebar,
+      },
       OpenGraphSidebar,
+      SearchEngineOptimizationsSidebar,
+      AnalyticsTrackingSidebar,
     ];
   case 'p4_action':
     return [
+      ActionSidebar,
       OpenGraphSidebar,
+      SearchEngineOptimizationsSidebar,
+      AnalyticsTrackingSidebar,
     ];
   case 'page':
     return [
+      PageHeaderSidebar,
       OpenGraphSidebar,
+      SearchEngineOptimizationsSidebar,
+      AnalyticsTrackingSidebar,
     ];
   case 'post':
     return [
       OpenGraphSidebar,
+      SearchEngineOptimizationsSidebar,
+      AnalyticsTrackingSidebar,
     ];
   default:
     return null;

--- a/assets/src/theme/p4ServerThemes.js
+++ b/assets/src/theme/p4ServerThemes.js
@@ -1,0 +1,29 @@
+const fetchThemes = async () => {
+  return wp.apiFetch({
+    path: 'planet4/v1/themes/',
+    method: 'GET',
+  });
+};
+
+const uploadTheme = async (name, theme) => {
+  return wp.apiFetch({
+    path: 'planet4/v1/add-theme/',
+    method: 'POST',
+    data: {
+      name,
+      theme,
+    },
+  });
+};
+
+const deleteTheme = async name => {
+  return wp.apiFetch({
+    path: 'planet4/v1/delete-theme/',
+    method: 'POST',
+    data: {
+      name,
+    },
+  });
+};
+
+export const p4ServerThemes = {fetchThemes, uploadTheme, deleteTheme};


### PR DESCRIPTION
Ref. https://jira.greenpeace.org/browse/PLANET-7379 

Move Analytics Tracking, SEO, Action, Campaign Theme, Page Header(atm I moved all fields, afterward we will keep only "hide page title field") sidebar fields to master theme.

