### PR TITLE
PLANET-7415: Add manual override to Actions list block

### DIFF
--- a/assets/src/block-editor/PostSelector/PostSelector.js
+++ b/assets/src/block-editor/PostSelector/PostSelector.js
@@ -23,6 +23,7 @@ export const PostSelector = attributes => {
     selected,
     placeholder,
     postType,
+    postParent,
     onChange,
     maxLength,
     maxSuggestions,
@@ -34,10 +35,14 @@ export const PostSelector = attributes => {
   const act_parent = window?.p4ge_vars?.planet4_options.act_page || null;
   const args = {per_page: -1, orderby: 'title', post_status: 'publish'};
   const posts = useSelect(select => {
-    if ('post' === postType || 'p4_action' === postType) {
+    if ('post' === postType || 'p4_action' === postType || 'page' === postType) {
       return [
         ...select('core').getEntityRecords('postType', postType, {include: selected}) || [],
-        ...select('core').getEntityRecords('planet4/v1', 'published', {post_type: postType, ...args}) || [],
+        ...select('core').getEntityRecords('planet4/v1', 'published', {
+          post_type: postType,
+          ...postParent && {post_parent: postParent},
+          ...args,
+        }) || [],
       ];
     }
 

--- a/assets/src/block-editor/PostSelector/PostSelector.js
+++ b/assets/src/block-editor/PostSelector/PostSelector.js
@@ -34,9 +34,9 @@ export const PostSelector = attributes => {
   const act_parent = window?.p4ge_vars?.planet4_options.act_page || null;
   const args = {per_page: -1, orderby: 'title', post_status: 'publish'};
   const posts = useSelect(select => {
-    if ('post' === postType) {
+    if ('post' === postType || 'p4_action' === postType) {
       return [
-        ...select('core').getEntityRecords('postType', 'post', {include: selected}) || [],
+        ...select('core').getEntityRecords('postType', postType, {include: selected}) || [],
         ...select('core').getEntityRecords('planet4/v1', 'published', {post_type: postType, ...args}) || [],
       ];
     }

--- a/assets/src/block-editor/QueryLoopBlockExtension/index.js
+++ b/assets/src/block-editor/QueryLoopBlockExtension/index.js
@@ -114,7 +114,7 @@ export const setupQueryLoopBlockExtension = () => {
                   />
                 </PanelBody>
               )}
-              {isPostsList &&
+              {(isPostsList || isActionsList) &&
                 <PanelBody title={__('Manual override', 'planet4-blocks-backend')} initialOpen={query.postIn.length > 0}>
                   <PostSelector
                     label={__('CAUTION: Adding articles individually will override the automatic functionality of this block. For good user experience, please include at least three articles so that spacing and alignment of the design remains intact.', 'planet4-blocks-backend')}

--- a/assets/src/block-editor/QueryLoopBlockExtension/index.js
+++ b/assets/src/block-editor/QueryLoopBlockExtension/index.js
@@ -114,13 +114,14 @@ export const setupQueryLoopBlockExtension = () => {
                   />
                 </PanelBody>
               )}
-              {(isPostsList || isActionsList) &&
+              {
                 <PanelBody title={__('Manual override', 'planet4-blocks-backend')} initialOpen={query.postIn.length > 0}>
                   <PostSelector
                     label={__('CAUTION: Adding articles individually will override the automatic functionality of this block. For good user experience, please include at least three articles so that spacing and alignment of the design remains intact.', 'planet4-blocks-backend')}
                     selected={query.postIn || []}
                     onChange={updateQuery}
                     postType={query.postType || 'post'}
+                    postParent={query?.postParent || null}
                     placeholder={__('Select articles', 'planet4-blocks-backend')}
                     maxLength={10}
                     maxSuggestions={20}

--- a/assets/src/blocks/ActionsList/index.js
+++ b/assets/src/blocks/ActionsList/index.js
@@ -37,6 +37,7 @@ export const registerActionsListBlock = () => {
         sticky: '',
         inherit: false,
         postType: queryPostType,
+        postIn: [],
         ...!IS_NEW_IA && {postParent: ACT_PAGE},
       },
       layout: {

--- a/assets/src/blocks/PostsList/index.js
+++ b/assets/src/blocks/PostsList/index.js
@@ -87,4 +87,3 @@ export const registerPostsListBlock = () => {
     ],
   });
 };
-

--- a/assets/src/editorIndex.js
+++ b/assets/src/editorIndex.js
@@ -1,5 +1,5 @@
-import {registerPostsListBlock} from './blocks/PostsList';
 import {registerActionsListBlock} from './blocks/ActionsList';
+import {registerPostsListBlock} from './blocks/PostsList';
 import {registerSubmenuBlock} from './blocks/Submenu/SubmenuBlock';
 import {registerTakeActionBoxoutBlock} from './blocks/TakeActionBoxout/TakeActionBoxoutBlock';
 import {registerHappypointBlock} from './blocks/Happypoint/HappypointBlock';

--- a/src/Blocks/QueryLoopExtension.php
+++ b/src/Blocks/QueryLoopExtension.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace P4\MasterTheme\Blocks;
 
 /**
- * Handle Posts List block manual override query with custom `postIn` filter.
+ * Handle Posts/Actions List block manual override query with custom `postIn` filter.
  * `include` is not used because it generates some issues with getEntityRecords filters.
  */
-class PostsList
+class QueryLoopExtension
 {
     public static function registerHooks(): void
     {
@@ -18,19 +18,17 @@ class PostsList
 
     public static function registerEditorQuery(): void
     {
-        add_filter(
-            'rest_post_query',
-            function ($args, $request) {
-                $postIn = $request->get_param('postIn');
-                if (!empty($postIn)) {
-                    $args['post__in'] = array_map('intval', (array) $postIn);
-                    $args['orderby'] = 'post__in';
-                }
-                return $args;
-            },
-            10,
-            2
-        );
+        $postInFilter = function ($args, $request) {
+            $postIn = $request->get_param('postIn');
+            if (!empty($postIn)) {
+                $args['post__in'] = array_map('intval', (array) $postIn);
+                $args['orderby'] = 'post__in';
+            }
+            return $args;
+        };
+
+        add_filter('rest_post_query', $postInFilter, 10, 2);
+        add_filter('rest_p4_action_query', $postInFilter, 10, 2);
     }
 
     public static function registerFrontendQuery(): void

--- a/src/Blocks/QueryLoopExtension.php
+++ b/src/Blocks/QueryLoopExtension.php
@@ -28,6 +28,7 @@ class QueryLoopExtension
         };
 
         add_filter('rest_post_query', $postInFilter, 10, 2);
+        add_filter('rest_page_query', $postInFilter, 10, 2);
         add_filter('rest_p4_action_query', $postInFilter, 10, 2);
     }
 

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -170,7 +170,7 @@ final class Loader
             return;
         }
 
-        Blocks\PostsList::registerHooks();
+        Blocks\QueryLoopExtension::registerHooks();
         add_filter(
             'allowed_block_types_all',
             function ($allowed_block_types) {


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-7415
Requires: https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/1192

> Follow the work of [PLANET-7367](https://jira.greenpeace.org/browse/PLANET-7367) and replicate the "Manual Override".

![Screenshot from 2024-03-07 14-42-42](https://github.com/greenpeace/planet4-master-theme/assets/617346/8d0ec5ea-e449-431e-9fbc-f3ddf18acb0d)

## Test

- Add an Actions List block to a page
- Override the post list with specific Actions pages
- Check backend and frontend display