### PR TITLE
PLANET-7411 Change name of Media Archive to Greenpeace Media

### DIFF
--- a/assets/src/js/Components/ArchivePicker/ArchivePickerToolbar.js
+++ b/assets/src/js/Components/ArchivePicker/ArchivePickerToolbar.js
@@ -20,7 +20,7 @@ export default function ArchivePickerToolbar() {
 
   return useMemo(() => (
     <div className="archive-picker-toolbar">
-      {!bulkSelect && <h3 className="archive-picker-title">{__('Media Archive', 'planet4-master-theme-backend')}</h3>}
+      {!bulkSelect && <h3 className="archive-picker-title">{__('Greenpeace Media', 'planet4-master-theme-backend')}</h3>}
       <nav className={classNames('nav-bulk-select', {'bulk-enabled': bulkSelect})}>
         {(bulkSelect && processingIds.length) ? (
           <span className="info">{sprintf(__('Processing %d images', 'planet4-master-theme-backend'), processingIds.length)}</span>

--- a/assets/src/js/media_archive_editor_view.js
+++ b/assets/src/js/media_archive_editor_view.js
@@ -19,7 +19,7 @@ const frame = wp.media.view.MediaFrame.Select;
         new State({
           id: 'mediaArchive',
           search: false,
-          title: 'Media Archive',
+          title: __('Greenpeace Media', 'planet4-master-theme-backend'),
         }),
       ]);
 
@@ -33,7 +33,7 @@ const frame = wp.media.view.MediaFrame.Select;
           priority: 20,
         },
         mediaArchive: {
-          text: __('Media Archive', 'planet4-master-theme-backend'),
+          text: __('Greenpeace Media', 'planet4-master-theme-backend'),
           priority: 30,
         },
         browse: {

--- a/src/MediaArchive/UiIntegration.php
+++ b/src/MediaArchive/UiIntegration.php
@@ -56,8 +56,8 @@ class UiIntegration
         }
 
         add_media_page(
-            __('Archive', 'planet4-master-theme-backend'),
-            __('Archive', 'planet4-master-theme-backend'),
+            __('Greenpeace Media', 'planet4-master-theme-backend'),
+            __('Greenpeace Media', 'planet4-master-theme-backend'),
             Capability::USE_MEDIA_ARCHIVE,
             'media-picker',
             [ self::class, 'output_picker' ],
@@ -74,8 +74,8 @@ class UiIntegration
         }
 
         add_media_page(
-            __('Media Archive Settings', 'planet4-master-theme-backend'),
-            __('Archive Settings', 'planet4-master-theme-backend'),
+            __('Greenpeace Media Settings', 'planet4-master-theme-backend'),
+            __('Greenpeace Media Settings', 'planet4-master-theme-backend'),
             Capability::USE_MEDIA_ARCHIVE,
             'media-archive-settings',
             function (): void {


### PR DESCRIPTION
**Ref: [PLANET-7411](https://jira.greenpeace.org/browse/PLANET-7411)**

**Testing:**

_Media Archive_ should now be named _Greenpeace Media_ in both the Dashboard and Editor view

<!-- Ref: Please add a url to the ticket this change is addressing.

---

Please provide a brief summary of the change introduced to make review process easier.

Ideally this should also be part of the commit summary.
-->
