### PR TITLE
PLANET-6081 Remove external link icon when no href

### DIFF
--- a/assets/src/js/external_links.js
+++ b/assets/src/js/external_links.js
@@ -7,7 +7,7 @@ export const setupExternalLinks = () => {
   const links = [...document.querySelectorAll(linkSelector)];
 
   links.forEach(link => {
-    if (link.matches('.boxout *')) {
+    if (link.matches('.boxout *') || !link.href) {
       return;
     }
     // We don't want to show the icon in headings/titles,


### PR DESCRIPTION
### Description

This should solve the issue seen in the Handbook ideas for the comments link ([PLANET-6081](https://jira.greenpeace.org/browse/PLANET-6081))

On [this page](https://planet4.greenpeace.org/idea/have-pages-visible-only-to-people-with-the-link-restricted-access/#comments) for example you can see that the comments link has the external link icon, and I'm guessing it's because it doesn't have a `href`:

<img width="66" alt="Screenshot 2024-02-02 at 11 24 50" src="https://github.com/greenpeace/planet4-master-theme/assets/6949075/9c952a82-09af-48f6-8c88-63c28c45fff6">

<img width="290" alt="Screenshot 2024-02-02 at 11 33 25" src="https://github.com/greenpeace/planet4-master-theme/assets/6949075/b7e51dc8-357d-4497-9a6e-ae8db4b22a0d">

