### PR TITLE
PLANET-7319 Add a Gravity Forms e2e test for Hubspot feeds

### DIFF
--- a/tests/e2e/gravity-forms.spec.js
+++ b/tests/e2e/gravity-forms.spec.js
@@ -22,6 +22,16 @@ test.beforeAll(async ({browser}) => {
   });
 });
 
+test.afterAll(async ({browser}) => {
+  const page = await browser.newPage();
+
+  // Disable Gravity Forms rest API.
+  await toggleRestAPI({page}, false);
+
+  // Delete the form.
+  await page.request.delete(`./wp-json/gf/v2/forms/${createdForm.id}?force=1`);
+});
+
 test('check the Gravity Forms confirmation message, text type', async ({requestUtils, page}) => {
   // Update the form's default confirmation text.
   await page.goto(`./wp-admin/admin.php?page=gf_edit_forms&view=settings&subview=confirmation&id=${createdForm.id}`);
@@ -81,14 +91,4 @@ test('check the Gravity Forms Hubspot feeds', async ({page}) => {
     const hubspotFeed = page.locator('#the-list > tr').first();
     await expect(hubspotFeed.locator('gform-status-indicator-status')).toContainText('Active');
   }
-});
-
-test.afterAll(async ({browser}) => {
-  const page = await browser.newPage();
-
-  // Disable Gravity Forms rest API.
-  await toggleRestAPI({page}, false);
-
-  // Delete the form.
-  await page.request.delete(`./wp-json/gf/v2/forms/${createdForm.id}`);
 });

--- a/tests/e2e/gravity-forms.spec.js
+++ b/tests/e2e/gravity-forms.spec.js
@@ -25,11 +25,11 @@ test.beforeAll(async ({browser}) => {
 test.afterAll(async ({browser}) => {
   const page = await browser.newPage();
 
-  // Disable Gravity Forms rest API.
-  await toggleRestAPI({page}, false);
-
   // Delete the form.
   await page.request.delete(`./wp-json/gf/v2/forms/${createdForm.id}?force=1`);
+
+  // Disable Gravity Forms rest API.
+  await toggleRestAPI({page}, false);
 });
 
 test('check the Gravity Forms confirmation message, text type', async ({requestUtils, page}) => {
@@ -89,6 +89,6 @@ test('check the Gravity Forms Hubspot feeds', async ({page}) => {
     // Check that the feed is active.
     await page.goto(`./wp-admin/admin.php?page=gf_edit_forms&view=settings&subview=gravityformshubspot&id=${createdForm.id}`);
     const hubspotFeed = page.locator('#the-list > tr').first();
-    await expect(hubspotFeed.locator('gform-status-indicator-status')).toContainText('Active');
+    await expect(hubspotFeed.locator('.gform-status-indicator-status')).toContainText('Active');
   }
 });

--- a/tests/e2e/gravity-forms.spec.js
+++ b/tests/e2e/gravity-forms.spec.js
@@ -2,20 +2,27 @@ import {test, expect} from './tools/lib/test-utils.js';
 import {toggleRestAPI, createForm} from './tools/lib/gravity-forms.js';
 
 const CONFIRMATION_MESSAGE = 'This is a dummy confirmation message for testing purposes.';
-const TEST_NAME = 'Jon Snow';
+const TEST_FIRST_NAME = 'Jon';
+const TEST_LAST_NAME = 'Snow';
 const TEST_EMAIL = 'jon.snow@gmail.com';
+
+let createdForm;
 
 test.useAdminLoggedIn();
 
-test('check the Gravity Forms confirmation message, text type', async ({requestUtils, page}) => {
+test.beforeAll(async ({browser}) => {
+  const page = await browser.newPage();
+
   // Enable Gravity Forms rest API.
   await toggleRestAPI({page}, true);
 
   // Create a new form.
-  const createdForm = await createForm({page}, {
-    title: 'A test form for confirmation message, text type',
+  createdForm = await createForm({page}, {
+    title: 'Gravity Forms test form',
   });
+});
 
+test('check the Gravity Forms confirmation message, text type', async ({requestUtils, page}) => {
   // Update the form's default confirmation text.
   await page.goto(`./wp-admin/admin.php?page=gf_edit_forms&view=settings&subview=confirmation&id=${createdForm.id}`);
   await page.locator('#the-list').hover();
@@ -34,7 +41,8 @@ test('check the Gravity Forms confirmation message, text type', async ({requestU
 
   // Fill and submit the form and check the confirmation message text.
   const form = page.locator('form[id^="gform"]');
-  await form.getByLabel('Name').fill(TEST_NAME);
+  await form.getByLabel('First name').fill(TEST_FIRST_NAME);
+  await form.getByLabel('Last name').fill(TEST_LAST_NAME);
   await form.getByLabel('Email').fill(TEST_EMAIL);
   const submitButton = form.getByRole('button', {name: 'Submit'});
   await submitButton.click();
@@ -46,12 +54,41 @@ test('check the Gravity Forms confirmation message, text type', async ({requestU
   await page.goto('./wp-admin/admin.php?page=gf_entries');
   const latestEntry = page.locator('#the-list > tr.entry_row').first();
   await expect(latestEntry).toBeVisible();
-  await expect(latestEntry.locator('td[data-colname="Name"]')).toContainText(TEST_NAME);
+  await expect(latestEntry.locator('td[data-colname="First name"]')).toContainText(TEST_FIRST_NAME);
+  await expect(latestEntry.locator('td[data-colname="Last name"]')).toContainText(TEST_LAST_NAME);
   await expect(latestEntry.locator('td[data-colname="Email"]')).toContainText(TEST_EMAIL);
+});
 
-  // Delete the form.
-  await page.request.delete(`./wp-json/gf/v2/forms/${createdForm.id}`);
+test('check the Gravity Forms Hubspot feeds', async ({page}) => {
+  // Add a Hubspot feed.
+  await page.goto(`./wp-admin/admin.php?page=gf_edit_forms&view=settings&subview=gravityformshubspot&id=${createdForm.id}`);
+  const createFeedLink = page.getByRole('link', {name: 'create one'});
+  // If the Huspot add-on isn't activated, the page will be empty so this link won't be there.
+  if (await createFeedLink.isVisible()) {
+    await createFeedLink.click();
+    // Set lead status to "new".
+    await page.selectOption('#_hs_customer_hs_lead_status', {label: 'New'});
+    // Map contact fields.
+    await page.selectOption('#_hs_customer_firstname', {label: 'First name'});
+    await page.selectOption('#_hs_customer_lastname', {label: 'Last name'});
+    await page.selectOption('#_hs_customer_email', {label: 'Email'});
+    // Save Hubspot feed.
+    await page.getByRole('button', {name: 'Save Settings'}).click();
+    await expect(page.locator('.gforms_note_success')).toBeVisible();
+
+    // Check that the feed is active.
+    await page.goto(`./wp-admin/admin.php?page=gf_edit_forms&view=settings&subview=gravityformshubspot&id=${createdForm.id}`);
+    const hubspotFeed = page.locator('#the-list > tr').first();
+    await expect(hubspotFeed.locator('gform-status-indicator-status')).toContainText('Active');
+  }
+});
+
+test.afterAll(async ({browser}) => {
+  const page = await browser.newPage();
 
   // Disable Gravity Forms rest API.
   await toggleRestAPI({page}, false);
+
+  // Delete the form.
+  await page.request.delete(`./wp-json/gf/v2/forms/${createdForm.id}`);
 });

--- a/tests/e2e/tools/lib/gravity-forms.js
+++ b/tests/e2e/tools/lib/gravity-forms.js
@@ -24,7 +24,12 @@ const createForm = async ({page}, {title}) => {
       fields: [
         {
           type: 'text',
-          label: 'Name',
+          label: 'First name',
+          isRequired: 1,
+        },
+        {
+          type: 'text',
+          label: 'Last name',
           isRequired: 1,
         },
         {


### PR DESCRIPTION
### Description

See [PLANET-7319](https://jira.greenpeace.org/browse/PLANET-7319)

**Steps**

1. Login to the Admin Panel.
2. Create a new Form:
    - First Name (single line text input)
    - Last Name (single line text input)
    - Email (email field)
    - Submit button
3. Go to Form Settings on the Hubspot section.
4. Create a new Feed:
    - Lead Status: New
    - Lifecycle Stage: Lead
    - Map contact fields.
5. Save the Feed.
6. Verify the new Feed has "Active" state.
