### PR TITLE
PLANET-7425 Add post categories to body dataset

### DIFF
--- a/single.php
+++ b/single.php
@@ -74,7 +74,7 @@ if ('yes' === $post->include_articles) {
     $block_attributes = [
         'exclude_post_id' => $post->ID,
         'tags' => $tag_id_array,
-        'post_categories' => $category_id_array,
+        'categories' => $category_id_array,
         'article_heading' => __('Related Articles', 'planet4-blocks'),
         'read_more_text' => __('Load more', 'planet4-blocks'),
     ];

--- a/templates/base.twig
+++ b/templates/base.twig
@@ -4,7 +4,12 @@
 
 {% endblock %}
 
-<body class="{{ body_class }} {{ custom_body_classes|default("") }}" data-nro="{{ site.link }}" data-post-type="{{ fn( 'get_post_type' ) }}">
+<body
+    class="{{ body_class }} {{ custom_body_classes|default("") }}"
+    data-nro="{{ site.link }}"
+    data-post-type="{{ fn( 'get_post_type' ) }}"
+    data-post-categories="{{ fn( 'get_the_category')|map(cat => cat.term_id)|join(',') }}"
+>
     {% if google_tag_value %}
         <!-- Google Tag Manager (noscript) -->
         <noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ google_tag_value }}"


### PR DESCRIPTION
### Description

See [PLANET-7425](https://jira.greenpeace.org/browse/PLANET-7425)
This is to be used in ArticlesFrontend to retrieve the right content

**Related PR:** https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/1186

### Testing

Both in Pages and Posts, the `ignore_categories` attribute should now work as expected!