### PR TITLE
PLANET-7409: Implement new parameters on Google Consent Mode

### DIFF
--- a/assets/src/js/cookies.js
+++ b/assets/src/js/cookies.js
@@ -92,6 +92,8 @@ export const setupCookies = () => {
     if (ENABLE_GOOGLE_CONSENT_MODE) {
       updateGoogleConsent({
         ad_storage: 'granted',
+        ad_user_data: 'granted',
+        ad_personalization: 'granted',
         ...ENABLE_ANALYTICAL_COOKIES && {analytics_storage: 'granted'},
       });
     }
@@ -155,6 +157,8 @@ export const setupCookies = () => {
       if (ENABLE_GOOGLE_CONSENT_MODE) {
         updateGoogleConsent({
           ad_storage: marketingCookiesChecked ? 'granted' : 'denied',
+          ad_user_data: marketingCookiesChecked ? 'granted' : 'denied',
+          ad_personalization: marketingCookiesChecked ? 'granted' : 'denied',
           ...ENABLE_ANALYTICAL_COOKIES && {analytics_storage: analyticalCookiesChecked ? 'granted' : 'denied'},
         });
       }
@@ -176,6 +180,8 @@ export const setupCookies = () => {
     if (ENABLE_GOOGLE_CONSENT_MODE) {
       updateGoogleConsent({
         ad_storage: 'denied',
+        ad_user_data: 'denied',
+        ad_personalization: 'denied',
         ...ENABLE_ANALYTICAL_COOKIES && {analytics_storage: 'denied'},
       });
     }

--- a/templates/blocks/google_tag_manager.twig
+++ b/templates/blocks/google_tag_manager.twig
@@ -26,6 +26,8 @@
     if ( cookie_consent ) {
       var capabilities = {
         ad_storage: marketing_consent ? 'granted' : 'denied',
+        ad_user_data: marketing_consent ? 'granted' : 'denied',
+        ad_personalization: marketing_consent ? 'granted' : 'denied',
         {% if cookies.enable_analytical_cookies %}
         ...{'analytics_storage': analytical_consent ? 'granted' : 'denied'}
         {% endif %}
@@ -35,11 +37,15 @@
     } else {
       var capabilities = {
         ad_storage: 'denied',
+        ad_user_data: 'denied',
+        ad_personalization: 'denied',
         {% if cookies.enable_analytical_cookies %}
         ...{'analytics_storage': 'denied'}
         {% endif %}
       };
       gtag('consent', 'default', capabilities);
+      gtag('set', 'url_passthrough', true);
+      gtag('set', 'ads_data_redaction', capabilities.ad_storage === 'denied');
       dataLayer.push({event: 'defaultConsent', ...capabilities});
     }
     {% endif %}


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-7409

> Two new parameters need to be implemented on the Consent Mode script: 
> 
>     ad_user_data 
>     ad_personalization 
>  The new parameters should be set using the **same value as the ad_storage parameter**. 
> 
>  In the scripts that execute the consent default, the following instruction should be added: 
> 
>  gtag('set', 'url_passthrough', true); 
>  gtag('set', 'ads_data_redaction', true); 
> 
>  The url_passthrough parameter should always be set to true and is only set when the script that executes the consent default is run. 
>     The ads_data_redaction parameter should be set according to the following logic: 
>       - true when ad_storage is set to denied. 
>       - false when ad_storage is set to granted. 

