### PR TITLE
Make pre-publish error message more prominent

### DIFF
--- a/assets/src/scss/editorOverrides.scss
+++ b/assets/src/scss/editorOverrides.scss
@@ -235,7 +235,10 @@ input.describe[type=text][data-setting=caption] {
 }
 
 .p4-plugin-pre-publish-panel-error {
-  background-color: var(--beige-100) !important;
+  ul {
+    background: var(--red-500);
+    color: var(--white);
+  }
 }
 
 .cmb2_required_field_error {


### PR DESCRIPTION
Used the same color options as [forms validation messages](https://github.com/greenpeace/planet4-master-theme/blob/v1.281.0/assets/src/scss/layout/_gravity-forms.scss#L106-L107).

### Testing
To view the message try two use cases:
1. Create a new page, add a Carousel Header and try to publish
2. Create a new post, leave the title empty and try to publish