### PR TITLE
PLANET-7447 Unescape HTML entities in Carousel header title

### DIFF
--- a/assets/src/blocks/CarouselHeader/StaticCaption.js
+++ b/assets/src/blocks/CarouselHeader/StaticCaption.js
@@ -1,10 +1,15 @@
+const htmlDecode = input => {
+  const doc = new DOMParser().parseFromString(input, 'text/html');
+  return doc.documentElement.textContent;
+};
+
 export const StaticCaption = ({slide}) => (
   <div className="carousel-caption">
     <div className="caption-overlay"></div>
     <div className="container main-header">
       <div className="carousel-captions-wrapper">
         <h2>
-          {slide.header}
+          {htmlDecode(slide.header)}
         </h2>
         <p dangerouslySetInnerHTML={{__html: slide.description}} />
       </div>


### PR DESCRIPTION
Ref. https://jira.greenpeace.org/browse/PLANET-7447

**Issue reproduced here -**
https://www-dev.greenpeace.org/test-titan/test-html-entites-on-carousel-header/

**Issue fixed here-**
https://www-dev.greenpeace.org/test-neptune/test-html-entites-on-carousel-header/