### PR TITLE
PLANET-7426: Add reading_time datalayer variable

### DIFF
--- a/single.php
+++ b/single.php
@@ -50,6 +50,7 @@ $context['post_categories'] = implode(', ', $post->categories());
 Context::set_og_meta_fields($context, $post);
 Context::set_campaign_datalayer($context, $page_meta_data);
 Context::set_utm_params($context, $post);
+Context::set_reading_time_datalayer($context, $post);
 
 $context['filter_url'] = add_query_arg(
     [

--- a/src/Context.php
+++ b/src/Context.php
@@ -131,6 +131,20 @@ class Context
     }
 
     /**
+     * Set reading_time datalayer value
+     * Requires milliseconds
+     */
+    public static function set_reading_time_datalayer(array &$context, object $post): void
+    {
+        $rt = $post->reading_time();
+        if ($rt === null) {
+            return;
+        }
+
+        $context['reading_time'] = $rt * 1000;
+    }
+
+    /**
      * Get campaign scope from value selected in the Global Projects dropdown.
      * Conditions:
      * - If Global Project equals "Local Campaign" then Scope is Local.

--- a/templates/blocks/google_tag_manager.twig
+++ b/templates/blocks/google_tag_manager.twig
@@ -53,6 +53,7 @@
       'gPlatform': 'Planet 4',
       'p4_blocks': '{{ p4_blocks }}',
       'post_categories': '{{ post_categories }}',
+      {{ reading_time ? "'reading_time': #{reading_time},"|raw : '' }}
     });
 
     {% if not post.password_required %}

--- a/templates/single.twig
+++ b/templates/single.twig
@@ -62,7 +62,7 @@
                             </address>
                         {% endif %}
                         <time class="single-post-time" pubdate>{{ post.post_date|date }}</time>
-                        {% set reading_time = post.reading_time %}
+                        {% set reading_time = post.reading_time_for_display %}
                         {% if reading_time %}
                             <span class="single-post-meta-bullet" aria-hidden="true">&#8226;</span>
                             <span class="single-post-meta-readtime">

--- a/templates/tease-author.twig
+++ b/templates/tease-author.twig
@@ -47,7 +47,7 @@
 
         <div class="search-result-item-info">
             <span class="search-result-item-date">{{ post.post_date|date }}</span>
-            {% set reading_time = post.reading_time %}
+            {% set reading_time = post.reading_time_for_display %}
             {% if reading_time %}
                 <span class="single-post-meta-bullet" aria-hidden="true">&#8226;</span>
                 <span class="single-post-meta-readtime">

--- a/templates/tease-taxonomy-action.twig
+++ b/templates/tease-taxonomy-action.twig
@@ -46,7 +46,7 @@
             {% endif %}
 
             <span class="search-result-item-date">{{ post.post_date|date }}</span>
-            {% set reading_time = post.reading_time %}
+            {% set reading_time = post.reading_time_for_display %}
             {% if reading_time %}
                 <span class="single-post-meta-bullet" aria-hidden="true">&#8226;</span>
                 <span class="single-post-meta-readtime">

--- a/templates/tease-taxonomy-post.twig
+++ b/templates/tease-taxonomy-post.twig
@@ -56,7 +56,7 @@
                 </span>
             {% endif %}
             <span class="search-result-item-date">{{ post.post_date|date }}</span>
-            {% set reading_time = post.reading_time %}
+            {% set reading_time = post.reading_time_for_display %}
             {% if reading_time %}
                 <span class="single-post-meta-bullet" aria-hidden="true">&#8226;</span>
                 <span class="single-post-meta-readtime">


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-7426
Requires: https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/1189

> dataLayer variable for reading_time for all Posts, in milliseconds
> Add the dataLayer variable regardless on whether it's being displayed in the frontend

A variable `reading_time` is added to `dataLayer` as reading time of the displayed post, in milliseconds. This appears even if the post type is not configured for Reading time display. 

![Screenshot from 2024-03-04 14-15-57](https://github.com/greenpeace/planet4-master-theme/assets/617346/98e67072-b037-4cf0-9e3b-dd2dba4b8ee3)

## Changes
- `Post::reading_time()` now returns time in seconds
- `Post::reading_time_for_display()` returns rounded time in minute or null, taking taxonomy configuration into account