### PR TITLE
PLANET-7344 Make featured image mandatory for publishing

### DIFF
--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -442,17 +442,15 @@ class MasterSite extends TimberSite
      */
     public static function require_post_featured_image(array $data, array $postarr): ?array
     {
-        $thumbnail = (get_the_post_thumbnail() ?: null)
-            ?? $postarr['meta_input']['_thumbnail_id']
-            ?? null;
+        $post_id = $postarr['ID'];
+        $has_thumbnail = has_post_thumbnail($post_id) || isset($postarr['meta_input']['_thumbnail_id']);
         $types = Search\Filters\ContentTypes::get_all();
         if (
-            empty($thumbnail)
-            && !empty($data['post_status'])
+            !empty($data['post_status'])
             && $data['post_status'] === 'publish'
             && in_array($data['post_type'], array_keys($types))
+            && !$has_thumbnail
         ) {
-            debug_print_backtrace(\DEBUG_BACKTRACE_IGNORE_ARGS);
             wp_die(__('Featured image is a required field.', 'planet4-master-theme-backend'));
         }
 

--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -388,20 +388,21 @@ class MasterSite extends TimberSite
      */
     public function set_featured_image(int $post_id, WP_Post $post): void
     {
+        $types = Search\Filters\ContentTypes::get_all();
+        // Ignore autosave, check user's capabilities and post type.
+        if (
+            defined('DOING_AUTOSAVE') && DOING_AUTOSAVE
+            || !current_user_can('edit_post', $post_id)
+            || !in_array($post->post_type, array_keys($types))
+        ) {
+            return;
+        }
 
-        // Ignore autosave.
-        if (defined('DOING_AUTOSAVE') && DOING_AUTOSAVE) {
-            return;
-        }
-        // Check user's capabilities.
-        if (!current_user_can('edit_post', $post_id)) {
-            return;
-        }
-        // Check if user has set the featured image manually or if he has removed it.
+        // Check if user has set the featured image manually.
         $user_set_featured_image = get_post_meta($post_id, '_thumbnail_id', true);
 
-        // Apply this behavior to a Post and only if it does not already a featured image.
-        if ('post' !== $post->post_type || $user_set_featured_image) {
+        // Apply this behavior only if there is not already a featured image.
+        if ($user_set_featured_image) {
             return;
         }
 

--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -135,6 +135,7 @@ class MasterSite extends TimberSite
         add_action('save_post', [$this, 'save_meta_box_search'], 10, 2);
         add_action('save_post', [$this, 'set_featured_image'], 10, 2);
         add_filter('wp_insert_post_data', [$this, 'require_post_title'], 10, 1);
+        add_filter('wp_insert_post_data', [$this, 'require_post_featured_image'], 10, 1);
         // Save "p4_global_project_tracking_id" on post save.
         add_action('save_post', [$this, 'save_global_project_id'], 10, 1);
         add_action('post_updated', [$this, 'clean_post_cache'], 10, 3);
@@ -431,6 +432,24 @@ class MasterSite extends TimberSite
             defined('WP_CLI') && WP_CLI
                 ? throw new \Exception($err_message)
                 : wp_die($err_message);
+        }
+
+        return $data;
+    }
+
+    /**
+     * Make post featured image mandatory on publish.
+     */
+    public static function require_post_featured_image(array $data): ?array
+    {
+        $types = Search\Filters\ContentTypes::get_all();
+        if (
+            empty(get_the_post_thumbnail())
+            && !empty($data['post_status'])
+            && $data['post_status'] === 'publish'
+            && in_array($data['post_type'], array_keys($types))
+        ) {
+            wp_die(__('Featured image is a required field.', 'planet4-master-theme-backend'));
         }
 
         return $data;

--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -135,7 +135,7 @@ class MasterSite extends TimberSite
         add_action('save_post', [$this, 'save_meta_box_search'], 10, 2);
         add_action('save_post', [$this, 'set_featured_image'], 10, 2);
         add_filter('wp_insert_post_data', [$this, 'require_post_title'], 10, 1);
-        add_filter('wp_insert_post_data', [$this, 'require_post_featured_image'], 10, 1);
+        add_filter('wp_insert_post_data', [$this, 'require_post_featured_image'], 10, 2);
         // Save "p4_global_project_tracking_id" on post save.
         add_action('save_post', [$this, 'save_global_project_id'], 10, 1);
         add_action('post_updated', [$this, 'clean_post_cache'], 10, 3);
@@ -440,15 +440,19 @@ class MasterSite extends TimberSite
     /**
      * Make post featured image mandatory on publish.
      */
-    public static function require_post_featured_image(array $data): ?array
+    public static function require_post_featured_image(array $data, array $postarr): ?array
     {
+        $thumbnail = (get_the_post_thumbnail() ?: null)
+            ?? $postarr['meta_input']['_thumbnail_id']
+            ?? null;
         $types = Search\Filters\ContentTypes::get_all();
         if (
-            empty(get_the_post_thumbnail())
+            empty($thumbnail)
             && !empty($data['post_status'])
             && $data['post_status'] === 'publish'
             && in_array($data['post_type'], array_keys($types))
         ) {
+            debug_print_backtrace(\DEBUG_BACKTRACE_IGNORE_ARGS);
             wp_die(__('Featured image is a required field.', 'planet4-master-theme-backend'));
         }
 

--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -135,7 +135,6 @@ class MasterSite extends TimberSite
         add_action('save_post', [$this, 'save_meta_box_search'], 10, 2);
         add_action('save_post', [$this, 'set_featured_image'], 10, 2);
         add_filter('wp_insert_post_data', [$this, 'require_post_title'], 10, 1);
-        add_filter('wp_insert_post_data', [$this, 'require_post_featured_image'], 10, 2);
         // Save "p4_global_project_tracking_id" on post save.
         add_action('save_post', [$this, 'save_global_project_id'], 10, 1);
         add_action('post_updated', [$this, 'clean_post_cache'], 10, 3);
@@ -432,26 +431,6 @@ class MasterSite extends TimberSite
             defined('WP_CLI') && WP_CLI
                 ? throw new \Exception($err_message)
                 : wp_die($err_message);
-        }
-
-        return $data;
-    }
-
-    /**
-     * Make post featured image mandatory on publish.
-     */
-    public static function require_post_featured_image(array $data, array $postarr): ?array
-    {
-        $post_id = $postarr['ID'];
-        $has_thumbnail = has_post_thumbnail($post_id) || isset($postarr['meta_input']['_thumbnail_id']);
-        $types = Search\Filters\ContentTypes::get_all();
-        if (
-            !empty($data['post_status'])
-            && $data['post_status'] === 'publish'
-            && in_array($data['post_type'], array_keys($types))
-            && !$has_thumbnail
-        ) {
-            wp_die(__('Featured image is a required field.', 'planet4-master-theme-backend'));
         }
 
         return $data;

--- a/src/Migrations/M017NewIAToggle.php
+++ b/src/Migrations/M017NewIAToggle.php
@@ -23,10 +23,10 @@ class M017NewIAToggle extends MigrationScript
 
         // If any of the old options was on then enable new IA toggle.
         if (
-            $planet4_ia['action_post_type']
-            || $planet4_ia['list_page_pagination']
-            || $planet4_ia['mobile_tabs_menu']
-            || $planet4_ia['post_page_category_links']
+            $planet4_ia['action_post_type'] ?? null
+            || $planet4_ia['list_page_pagination'] ?? null
+            || $planet4_ia['mobile_tabs_menu'] ?? null
+            || $planet4_ia['post_page_category_links'] ?? null
         ) {
             $options['new_ia'] = true;
         }

--- a/src/Migrations/M025CreateDefaultPostsPage.php
+++ b/src/Migrations/M025CreateDefaultPostsPage.php
@@ -28,6 +28,9 @@ class M025CreateDefaultPostsPage extends MigrationScript
             'post_title' => 'News & Stories',
             'post_excerpt' => 'Read the latest updates.',
             'post_status' => 'publish',
+            'meta_input' => [
+                '_thumbnail_id' => 7581,
+            ],
         );
 
         $new_posts_page_id = wp_insert_post($new_posts_page);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -6,7 +6,9 @@
  * @package P4MT
  */
 
-define('WP_DEBUG', false);
+if (!defined('WP_DEBUG')) {
+    define('WP_DEBUG', false);
+}
 
 $_tests_dir = getenv('WP_TESTS_DIR');
 if (! $_tests_dir) {

--- a/tests/e2e/comments.spec.js
+++ b/tests/e2e/comments.spec.js
@@ -2,19 +2,19 @@ import {test, expect} from './tools/lib/test-utils.js';
 
 test.useAdminLoggedIn();
 
-test('Test adding a Comment to a Post', async ({page, requestUtils, admin}) => {
-  // Post creation using rest api since we already have a test for Post creation
-  const newPost = await requestUtils.createPost({
-    title: 'Test Post',
-    content: `
-      <!-- wp:paragraph -->
-        <p>This is a test post</p>
-      <!-- /wp:paragraph -->
-    `,
-    status: 'publish',
+test('Test adding a Comment to a Post', async ({page, admin, requestUtils}) => {
+  const newPost = await requestUtils.rest({
+    path: '/wp/v2/posts',
+    method: 'POST',
+    data: {
+      title: 'Test post',
+      content: '<!-- wp:paragraph --><p>This is a test post</p><!-- /wp:paragraph -->',
+      status: 'publish',
+      featured_media: 357,
+    },
   });
-
   await page.goto(newPost.link);
+
   await page.getByPlaceholder('Your Comment').fill('Nice Post');
   await page.locator('label#gdpr-comments-label').click();
   if (await page.getByRole('button', {name: 'Post comment'}).isEnabled()) {

--- a/tests/e2e/gallery.spec.js
+++ b/tests/e2e/gallery.spec.js
@@ -1,11 +1,13 @@
 import {test, expect} from './tools/lib/test-utils.js';
-import {publishPostAndVisit} from './tools/lib/post.js';
+import {publishPostAndVisit, createPostWithFeaturedImage} from './tools/lib/post.js';
 
 test.useAdminLoggedIn();
 
 test('Test Gallery basic functionalities', async ({page, admin, editor}) => {
-  await admin.createNewPost({postType: 'page', title: 'Test Page for Gallery', legacyCanvas: true});
-
+  await createPostWithFeaturedImage({admin, editor}, {
+    title: 'Test page for Gallery',
+    postType: 'page',
+  });
   await editor.canvas.getByRole('button', {name: 'Add default block'}).click();
   await page.keyboard.type('This is a test Page for gallery.');
   await page.keyboard.press('Enter');

--- a/tests/e2e/gravity-forms.spec.js
+++ b/tests/e2e/gravity-forms.spec.js
@@ -34,7 +34,7 @@ test.describe('Gravity Forms tests', () => {
     await toggleRestAPI({page}, false);
   });
 
-  test('check the confirmation message, text type', async ({requestUtils, page}) => {
+  test('check the confirmation message, text type', async ({page, requestUtils}) => {
     // Update the form's default confirmation text.
     await page.goto(`./wp-admin/admin.php?page=gf_edit_forms&view=settings&subview=confirmation&id=${createdForm.id}`);
     await page.locator('#the-list > tr:first-child').hover();
@@ -44,15 +44,20 @@ test.describe('Gravity Forms tests', () => {
     await expect(page.locator('.gforms_note_success')).toBeVisible();
 
     // Create a new post with the new form.
-    const newPost = await requestUtils.createPost({
-      title: `Gravity Forms test post - ${testId}`,
-      content: `<!-- wp:gravityforms/form {"formId":"${createdForm.id}"} /-->`,
-      status: 'publish',
+    const newPost = await requestUtils.rest({
+      path: '/wp/v2/posts',
+      method: 'POST',
+      data: {
+        title: `Gravity Forms test post - ${testId}`,
+        content: `<!-- wp:gravityforms/form {"formId":"${createdForm.id}"} /-->`,
+        status: 'publish',
+        featured_media: 357,
+      },
     });
     await page.goto(newPost.link);
 
     // Fill and submit the form and check the confirmation message text.
-    const form = page.locator('form[id^="gform"]');
+    const form = page.locator(`#gform_${createdForm.id}`);
     await form.getByLabel('First name').fill(TEST_FIRST_NAME);
     await form.getByLabel('Last name').fill(TEST_LAST_NAME);
     await form.getByLabel('Email').fill(TEST_EMAIL);

--- a/tests/e2e/navigation-bar.spec.js
+++ b/tests/e2e/navigation-bar.spec.js
@@ -6,15 +6,16 @@ test('Test navigation bar menu', async ({page, admin, requestUtils}) => {
   const testId = Math.floor(Math.random() * 10000); // NOSONAR
   const testPageTitle = `Navbar test ${testId}`;
 
-  // Create a new page
-  await requestUtils.createPage({
-    title: testPageTitle,
-    content: `
-      <!-- wp:paragraph -->
-        <p>The new page for the navigation bar test</p>
-      <!-- /wp:paragraph -->
-    `,
-    status: 'publish',
+  // Create a new page with a dummy paragraph
+  await requestUtils.rest({
+    path: '/wp/v2/pages',
+    method: 'POST',
+    data: {
+      title: testPageTitle,
+      content: '<!-- wp:paragraph --><p>The new page for the navigation bar test</p><!-- /wp:paragraph -->',
+      status: 'publish',
+      featured_media: 357,
+    },
   });
 
   // Go to Appearance > Menus

--- a/tests/e2e/search.spec.js
+++ b/tests/e2e/search.spec.js
@@ -8,14 +8,15 @@ test('check search works', async ({page, requestUtils}) => {
   const tagPageTitle = `#Tag ${testId}`;
   const postTitle = `Test Post ${testId}`;
 
-  const tagPage = await requestUtils.createPage({
-    title: tagPageTitle,
-    content: `
-      <!-- wp:paragraph -->
-        <p>The redirect page for the tag</p>
-      <!-- /wp:paragraph -->
-    `,
-    status: 'publish',
+  const tagPage = await requestUtils.rest({
+    path: '/wp/v2/pages',
+    method: 'POST',
+    data: {
+      title: tagPageTitle,
+      content: '<!-- wp:paragraph --><p>The redirect page for the new tag</p><!-- /wp:paragraph -->',
+      status: 'publish',
+      featured_media: 357,
+    },
   });
 
   const tag = await requestUtils.rest({
@@ -31,22 +32,23 @@ test('check search works', async ({page, requestUtils}) => {
     },
   });
 
-  await requestUtils.createPost({
-    title: postTitle,
-    content: `
-      <!-- wp:paragraph -->
-        <p>This is a search test post</p>
-      <!-- /wp:paragraph -->
-    `,
-    status: 'publish',
-    tags: [tag.id],
+  await requestUtils.rest({
+    path: '/wp/v2/posts',
+    method: 'POST',
+    data: {
+      title: postTitle,
+      content: '<!-- wp:paragraph --><p>This is a search test post</p><!-- /wp:paragraph -->',
+      status: 'publish',
+      featured_media: 357,
+      tags: [tag.id],
+    },
   });
 
   await page.goto('./');
 
   const searchBox = page.getByPlaceholder('Search');
   await searchBox.click();
-  await searchBox.type(testId);
+  await searchBox.fill(testId);
   await page.keyboard.press('Enter');
 
   const searchResult = await page.innerHTML('.result-statement');

--- a/tests/e2e/special-pages.spec.js
+++ b/tests/e2e/special-pages.spec.js
@@ -2,7 +2,7 @@ import {test, expect} from './tools/lib/test-utils.js';
 
 test.useAdminLoggedIn();
 
-test('Test special pages (Act and Explore)', async ({page, requestUtils, admin}) => {
+test('Test special pages (Act and Explore)', async ({page, admin, requestUtils}) => {
   // Check if new IA is enabled, in which case the Act and Explore pages have been removed.
   await admin.visitAdminPage('admin.php', 'page=planet4_settings_navigation');
   await page.waitForSelector('#new_ia');
@@ -12,19 +12,30 @@ test('Test special pages (Act and Explore)', async ({page, requestUtils, admin})
     await expect(page.locator('#explore_page')).toBeHidden();
   } else {
     // Create 2 new pages.
-    const actPage = await requestUtils.createPage({
-      title: 'Act page test',
-      content: '<!-- wp:paragraph --><p>Random content</p><!-- /wp:paragraph -->',
-      status: 'publish',
-    });
-    const explorePage = await requestUtils.createPage({
-      title: 'Explore page test',
-      content: '<!-- wp:paragraph --><p>Random content</p><!-- /wp:paragraph -->',
-      status: 'publish',
+    const actPage = await requestUtils.rest({
+      path: '/wp/v2/pages',
+      method: 'POST',
+      data: {
+        title: 'Act page test',
+        content: '<!-- wp:paragraph --><p>Random content</p><!-- /wp:paragraph -->',
+        status: 'publish',
+        featured_media: 357,
+      },
     });
 
-    // Reload the page to make sure that the new pages are available.
-    await page.reload();
+    const explorePage = await requestUtils.rest({
+      path: '/wp/v2/pages',
+      method: 'POST',
+      data: {
+        title: 'Explore page test',
+        content: '<!-- wp:paragraph --><p>Random content</p><!-- /wp:paragraph -->',
+        status: 'publish',
+        featured_media: 357,
+      },
+    });
+
+    // Go back to the Navigation settings.
+    await admin.visitAdminPage('admin.php', 'page=planet4_settings_navigation');
 
     // Save previous values to restore them after the test.
     const previousActPage = await page.locator('#act_page').inputValue();

--- a/tests/e2e/tools/lib/editor.js
+++ b/tests/e2e/tools/lib/editor.js
@@ -1,0 +1,34 @@
+/**
+ * @typedef {Object} Editor
+ * @property {Object}   canvas     - Canvas
+ * @typedef {Object} Locator
+ * @property {Function} getByRole  - Get by role
+ * @property {Function} getByLabel - Get by label
+ */
+
+/**
+ * Open side panel settings for edited post/page/etc.
+ *
+ * @param {{Editor, Page}} editor
+ * @return {Locator} Playwright Locator
+ */
+
+/**
+ * @param {{Editor}} editor
+ * @param {string}   panelTitle - Panel title
+ * @return {Locator} Playwright Locator
+ */
+async function openComponentPanel({editor}, panelTitle) {
+  await editor.openDocumentSettingsSidebar();
+  const editorSettings = await editor.canvas.getByRole('region', {name: 'Editor settings'});
+  await editorSettings.locator('.edit-post-sidebar__panel-tab').first().click();
+  const panelButton = await editorSettings.getByRole('button', {name: panelTitle, exact: true});
+  const panelExpanded = await panelButton.getAttribute('aria-expanded');
+  if (panelExpanded === 'false') {
+    await panelButton.click();
+  }
+
+  return editorSettings;
+}
+
+export {openComponentPanel};

--- a/tests/e2e/tools/lib/post.js
+++ b/tests/e2e/tools/lib/post.js
@@ -1,3 +1,5 @@
+import {openComponentPanel} from './editor.js';
+
 async function publishPost({page, editor}) {
   await editor.publishPost();
 
@@ -15,4 +17,20 @@ async function publishPostAndVisit({page, editor}) {
   await page.goto(urlString);
 }
 
-export {publishPost, publishPostAndVisit};
+async function createPostWithFeaturedImage({admin, editor}, params) {
+  const newPost = await admin.createNewPost({...params, legacyCanvas: true});
+  const editorSettings = await openComponentPanel({editor}, 'Featured image');
+  await editorSettings.getByRole('button', {name: 'Set featured image'}).click();
+  const imageModal = await editor.canvas.getByRole('dialog', {name: 'Featured image'});
+  const mediaLibraryTab = await imageModal.locator('#menu-item-browse');
+  const mediaLibraryTabOpen = await mediaLibraryTab.getAttribute('aria-selected');
+  if (mediaLibraryTabOpen === 'false') {
+    await mediaLibraryTab.click();
+  }
+  await imageModal.getByRole('checkbox', {name: 'OCEANS-GP0STOM6C'}).click();
+  await imageModal.getByRole('button', {name: 'Set featured image'}).click();
+
+  return newPost;
+}
+
+export {publishPost, publishPostAndVisit, createPostWithFeaturedImage};

--- a/tests/p4-testcase.php
+++ b/tests/p4-testcase.php
@@ -12,6 +12,8 @@
 // phpcs:ignore PSR1.Classes.ClassDeclaration.MissingNamespace
 class P4TestCase extends WP_UnitTestCase
 {
+    public int $attachment_id;
+
     /**
      * Setup test
      */
@@ -27,6 +29,10 @@ class P4TestCase extends WP_UnitTestCase
      */
     private function initialize_planet4_data(): void
     {
+        $this->attachment_id = (int) $this->factory->attachment->create_upload_object(
+            dirname(__DIR__) . '/tests/data/images/pressmedia.jpg',
+            0
+        );
 
         // Create a user with editor role.
         $this->factory->user->create(
@@ -55,6 +61,9 @@ class P4TestCase extends WP_UnitTestCase
                 'post_type' => 'page',
                 'post_title' => 'ACT',
                 'post_name' => 'act',
+                'meta_input' => [
+                    '_thumbnail_id' => $this->attachment_id,
+                ],
             ]
         );
 
@@ -63,6 +72,9 @@ class P4TestCase extends WP_UnitTestCase
                 'post_type' => 'page',
                 'post_title' => 'EXPLORE',
                 'post_name' => 'explore',
+                'meta_input' => [
+                    '_thumbnail_id' => $this->attachment_id,
+                ],
             ]
         );
 
@@ -72,6 +84,9 @@ class P4TestCase extends WP_UnitTestCase
                 'post_title' => 'Take action page',
                 'post_name' => 'take-action-page',
                 'post_parent' => $act_page_id,
+                'meta_input' => [
+                    '_thumbnail_id' => $this->attachment_id,
+                ],
             ]
         );
 

--- a/tests/test-action-type-custom-taxonomy.php
+++ b/tests/test-action-type-custom-taxonomy.php
@@ -32,6 +32,9 @@ class ActionTypeCustomTaxonomyTest extends P4TestCase
                 'post_title' => 'The name of the place is Babylon',
                 'post_name' => 'test-taxonomy-url',
                 'post_content' => 'test content',
+                'meta_input' => [
+                    '_thumbnail_id' => $this->attachment_id,
+                ],
             ]
         );
 
@@ -63,6 +66,9 @@ class ActionTypeCustomTaxonomyTest extends P4TestCase
                 'post_content' => 'test content',
                 'tax_input' => [
                     'action-type' => [ 'contest', 'event', 'petition' ],
+                ],
+                'meta_input' => [
+                    '_thumbnail_id' => $this->attachment_id,
                 ],
             ]
         );

--- a/tests/test-category-page.php
+++ b/tests/test-category-page.php
@@ -29,11 +29,6 @@ class CategoryPageTest extends P4TestCase
 
         $post_data = $this->get_posts()['post_with_category_tag_custom_term'];
         $post = $this->factory->post->create_and_get($post_data);
-        $attachment_id = $this->factory->attachment->create_upload_object(
-            dirname(__DIR__) . '/tests/data/images/pressmedia.jpg',
-            0
-        );
-        set_post_thumbnail($post, $attachment_id);
 
         // Wrap WP_Post around Post.
         $post = new Post($post->ID);
@@ -142,6 +137,10 @@ class CategoryPageTest extends P4TestCase
      */
     public function get_posts(): array
     {
+        $attachment_id = $this->factory->attachment->create_upload_object(
+            dirname(__DIR__) . '/tests/data/images/pressmedia.jpg',
+            0
+        );
 
         return [
 
@@ -159,6 +158,9 @@ class CategoryPageTest extends P4TestCase
                 'tax_input' => [
                     'p4-page-type' => [ 'story' ],
                 ],
+                'meta_input' => [
+                    '_thumbnail_id' => $attachment_id,
+                ]
             ],
             'post_with_category_tag' => [
                 'post_type' => 'post',
@@ -171,6 +173,9 @@ class CategoryPageTest extends P4TestCase
                 'tags_input' => [
                     'arcticsunrise',
                 ],
+                'meta_input' => [
+                    '_thumbnail_id' => $attachment_id,
+                ]
             ],
             'post_with_category' => [
                 'post_type' => 'post',
@@ -180,6 +185,9 @@ class CategoryPageTest extends P4TestCase
                 'post_category' => [
                     get_category_by_slug('nature')->term_id,
                 ],
+                'meta_input' => [
+                    '_thumbnail_id' => $attachment_id,
+                ]
             ],
         ];
     }

--- a/tests/test-category-page.php
+++ b/tests/test-category-page.php
@@ -137,11 +137,6 @@ class CategoryPageTest extends P4TestCase
      */
     public function get_posts(): array
     {
-        $attachment_id = $this->factory->attachment->create_upload_object(
-            dirname(__DIR__) . '/tests/data/images/pressmedia.jpg',
-            0
-        );
-
         return [
 
             'post_with_category_tag_custom_term' => [
@@ -159,8 +154,8 @@ class CategoryPageTest extends P4TestCase
                     'p4-page-type' => [ 'story' ],
                 ],
                 'meta_input' => [
-                    '_thumbnail_id' => $attachment_id,
-                ]
+                    '_thumbnail_id' => $this->attachment_id,
+                ],
             ],
             'post_with_category_tag' => [
                 'post_type' => 'post',
@@ -174,8 +169,8 @@ class CategoryPageTest extends P4TestCase
                     'arcticsunrise',
                 ],
                 'meta_input' => [
-                    '_thumbnail_id' => $attachment_id,
-                ]
+                    '_thumbnail_id' => $this->attachment_id,
+                ],
             ],
             'post_with_category' => [
                 'post_type' => 'post',
@@ -186,8 +181,8 @@ class CategoryPageTest extends P4TestCase
                     get_category_by_slug('nature')->term_id,
                 ],
                 'meta_input' => [
-                    '_thumbnail_id' => $attachment_id,
-                ]
+                    '_thumbnail_id' => $this->attachment_id,
+                ],
             ],
         ];
     }

--- a/tests/test-custom-permalinks.php
+++ b/tests/test-custom-permalinks.php
@@ -45,6 +45,9 @@ class CustomPermalinksTest extends P4TestCase
                 'post_name' => 'nature-page',
                 'post_content' => 'test content',
                 'post_parent' => $page->ID,
+                'meta_input' => [
+                    '_thumbnail_id' => $this->attachment_id,
+                ],
             ]
         );
 
@@ -55,6 +58,9 @@ class CustomPermalinksTest extends P4TestCase
                 'post_title' => 'The name of the place is Babylon 10.',
                 'post_name' => 'test-taxonomy-url',
                 'post_content' => 'test content',
+                'meta_input' => [
+                    '_thumbnail_id' => $this->attachment_id,
+                ],
             ]
         );
         wp_set_object_terms($post_id, 'story', 'p4-page-type');
@@ -114,6 +120,9 @@ class CustomPermalinksTest extends P4TestCase
                 'post_title' => 'Test p4 page type taxonomy terms in permalinks',
                 'post_name' => 'test-taxonomy-url',
                 'post_content' => 'test content',
+                'meta_input' => [
+                    '_thumbnail_id' => $this->attachment_id,
+                ],
             ]
         );
         wp_set_object_terms($post->ID, 'story', 'p4-page-type');
@@ -149,6 +158,9 @@ class CustomPermalinksTest extends P4TestCase
                 'post_title' => 'Test /%p4_page_type%/%postname%/ permastruct',
                 'post_name' => 'test-taxonomy-url',
                 'post_content' => 'test content',
+                'meta_input' => [
+                    '_thumbnail_id' => $this->attachment_id,
+                ],
             ]
         );
         wp_set_object_terms($post_id, 'story', 'p4-page-type');

--- a/tests/test-custom-taxonomy.php
+++ b/tests/test-custom-taxonomy.php
@@ -20,7 +20,6 @@ class CustomTaxonomyTest extends P4TestCase
      */
     public function test_post_has_a_taxonomy_term_assigned(): void
     {
-
         // Get editor user.
         $user = get_user_by('login', 'p4_editor');
         wp_set_current_user($user->ID);
@@ -32,6 +31,9 @@ class CustomTaxonomyTest extends P4TestCase
                 'post_title' => 'The name of the place is Babylon',
                 'post_name' => 'test-taxonomy-url',
                 'post_content' => 'test content',
+                'meta_input' => [
+                    '_thumbnail_id' => $this->attachment_id,
+                ],
             ]
         );
 
@@ -49,7 +51,6 @@ class CustomTaxonomyTest extends P4TestCase
      */
     public function test_post_has_a_single_taxonomy_term_assigned(): void
     {
-
         // Get editor user.
         $user = get_user_by('login', 'p4_editor');
         wp_set_current_user($user->ID);
@@ -63,6 +64,9 @@ class CustomTaxonomyTest extends P4TestCase
                 'post_content' => 'test content',
                 'tax_input' => [
                     'p4-page-type' => [ 'story', 'publication' ],
+                ],
+                'meta_input' => [
+                    '_thumbnail_id' => $this->attachment_id,
                 ],
             ]
         );

--- a/tests/test-open-graph.php
+++ b/tests/test-open-graph.php
@@ -24,7 +24,6 @@ class OpenGraphTest extends P4TestCase
      */
     public function test_post_custom_open_graph_data(array $post_data, string $template): void
     {
-
         // Get author user.
         $user = get_user_by('login', 'p4_author');
         wp_set_current_user($user->ID);
@@ -34,6 +33,7 @@ class OpenGraphTest extends P4TestCase
             0
         );
         $post_data['meta_input']['p4_og_image_id'] = $attachment_id;
+        $post_data['meta_input']['_thumbnail_id'] = $attachment_id;
         $post_id = $this->factory->post->create($post_data);
 
         $permalink = get_permalink($post_id);
@@ -94,12 +94,16 @@ class OpenGraphTest extends P4TestCase
      */
     public function test_post_open_graph_data(array $post_data, string $template): void
     {
-
         // Get author user.
         $user = get_user_by('login', 'p4_author');
         wp_set_current_user($user->ID);
 
         // Create a sample post.
+        $attachment_id = $this->factory->attachment->create_upload_object(
+            dirname(__DIR__) . '/tests/data/images/pressmedia.jpg',
+            0
+        );
+        $post_data['meta_input']['_thumbnail_id'] = $attachment_id;
         $post_id = $this->factory->post->create($post_data);
 
         $permalink = get_permalink($post_id);
@@ -142,7 +146,6 @@ class OpenGraphTest extends P4TestCase
      */
     public function posts_with_custom_og_provider(): array
     {
-
         return [
             [
                 [


### PR DESCRIPTION
### Description

See [PLANET-7344](https://jira.greenpeace.org/browse/PLANET-7344)

I didn't add a WP alert similar to what we do [here](https://github.com/greenpeace/planet4-master-theme/blob/main/src/MasterSite.php#L430) for the title, because I couldn't find a way to properly check whether or not a featured image was set at this point, so the alert was always shown no matter what. From what I've tested the check from the plugin is enough to disable the update/publish button when no image is set, only issue then is that there is no explanation when it's an update but that's also the case for the title 🤷‍♀️ 

**Related PR:** https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/1190

### Testing

You should no longer be able to publish or update a Page/Post/Action without setting a featured image or adding an image in the content.