### PR TITLE
PLANET-7444 Remove unnecessary code for image alignment

### DIFF
--- a/assets/src/scss/pages/post/_article-content.scss
+++ b/assets/src/scss/pages/post/_article-content.scss
@@ -120,29 +120,6 @@
     }
   }
 
-  .alignleft {
-    @include small-and-up {
-      float: left;
-      margin: 0 $sp-1 $sp-1 0;
-      padding-top: 6px;
-      max-width: 100%;
-    }
-  }
-
-  .alignright {
-    @include small-and-up {
-      float: right;
-      margin: 0 0 $sp-1 $sp-1;
-      padding-top: 6px;
-      max-width: 100%;
-    }
-  }
-
-  .aligncenter {
-    margin-left: auto;
-    margin-right: auto;
-  }
-
   cite {
     display: block;
     margin-top: 15px;


### PR DESCRIPTION
### Description

See [PLANET-7444](https://jira.greenpeace.org/browse/PLANET-7444)
This code has been moved to `Image.scss` in the plugin so that it works for all post types

**Related PR:** https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/1194

### Testing

I've added the various Image alignments on the following:
- [Page](https://www-dev.greenpeace.org/test-pandora/page-with-images/)
- [Post](https://www-dev.greenpeace.org/test-pandora/story/1273/post-with-images/)
- [Action](https://www-dev.greenpeace.org/test-pandora/petitions/action-with-images/)