### PR TITLE
PLANET-7417 Add grid layout to Posts List block

### DIFF
--- a/assets/src/blocks/PostsList/index.js
+++ b/assets/src/blocks/PostsList/index.js
@@ -1,6 +1,7 @@
 export const POSTS_LIST_BLOCK_NAME = 'planet4-blocks/posts-list';
 export const POSTS_LISTS_LAYOUT_TYPES = [
   {label: 'List', value: 'default', columnCount: 3},
+  {label: 'Grid', value: 'grid', columnCount: 4},
   {label: 'Carousel', value: 'flex', columnCount: 8},
 ];
 

--- a/assets/src/scss/blocks/ActionsList.scss
+++ b/assets/src/scss/blocks/ActionsList.scss
@@ -1,6 +1,20 @@
 .actions-list {
   margin-bottom: $sp-4;
 
+  &.is-custom-layout-carousel {
+    @include medium-and-less {
+      .wp-block-post {
+        width: 354px;
+      }
+    }
+
+    @include large-and-up {
+      .carousel-item-wrapper {
+        grid-template-columns: repeat(3, 1fr);
+      }
+    }
+  }
+
   .carousel-controls,
   .carousel-indicators {
     display: none;
@@ -67,6 +81,10 @@
     -webkit-line-clamp: 3;
     -webkit-box-orient: vertical;
     overflow: hidden;
+
+    @include large-and-up {
+      line-height: 1.5;
+    }
   }
 
   .wp-block-post-featured-image img {

--- a/assets/src/scss/blocks/PostsList.scss
+++ b/assets/src/scss/blocks/PostsList.scss
@@ -24,10 +24,6 @@
     width: 100%;
   }
 
-  &:not(.is-custom-layout-carousel).wp-block-post-template.is-layout-flow li {
-    width: 100% !important;
-  }
-
   .wp-block-columns.is-layout-flex {
     gap: $sp-2x;
   }
@@ -49,27 +45,65 @@
     }
   }
 
+  .wp-block-post-title {
+    font-size: 18px;
+
+    a {
+      -webkit-line-clamp: 2;
+    }
+
+    @include medium-and-less {
+      margin-top: $sp-x;
+    }
+
+    @include large-and-up {
+      font-size: 20px;
+    }
+  }
+
   .wp-block-group.is-layout-flow {
     flex-basis: 70%;
   }
 
   &.is-custom-layout-carousel {
-    .wp-block-post-title {
-      font-size: 18px;
+    .wp-block-columns {
+      flex-direction: column;
+      gap: $sp-2;
+      margin-bottom: 0;
+    }
 
-      @include large-and-up {
-        font-size: 20px;
+    .wp-block-post-terms:not(:first-child) {
+      display: none;
+    }
+
+    @include medium-and-less {
+      .wp-block-post {
+        width: 250px;
+      }
+
+      .wp-block-post-featured-image img {
+        height: 192px;
       }
     }
-  }
 
-  .wp-block-post-title {
-    color: var(--grey-900);
-    font-family: var(--font-family-tertiary);
-    margin-top: 5px;
+    @include medium-and-up {
+      .wp-block-post {
+        width: 276px;
+      }
+    }
 
-    a {
-      -webkit-line-clamp: 2;
+    @include large-and-up {
+      .wp-block-post-terms:not(:first-child) {
+        display: block;
+      }
+
+      .carousel-item-wrapper {
+        grid-template-columns: repeat(4, 1fr);
+      }
+
+      .wp-block-post {
+        width: 100%;
+      }
     }
   }
 
@@ -83,19 +117,14 @@
   .wp-block-post-excerpt {
     margin-top: -15px;
 
-    &__excerpt {
+    p {
       width: 100%;
       margin-bottom: $sp-1;
       font-size: var(--font-size-m--font-family-secondary);
       -webkit-line-clamp: 3;
 
-      @include medium-and-up {
-        -webkit-line-clamp: 2;
-        width: 100%;
-      }
-
       @include large-and-up {
-        -webkit-line-clamp: 3;
+        line-height: 1.5;
       }
     }
   }
@@ -168,6 +197,29 @@
     .wp-block-post-excerpt,
     .wp-block-post-terms {
       margin-top: 0;
+    }
+  }
+
+  &.is-custom-layout-grid {
+    display: block !important;
+
+    .wp-block-columns {
+      flex-direction: column;
+      gap: $sp-2;
+      margin-bottom: 0;
+    }
+
+    .wp-block-post-template {
+      display: grid;
+      gap: $sp-3;
+
+      @include medium-and-up {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+
+      @include large-and-up {
+        grid-template-columns: repeat(4, minmax(0, 1fr));
+      }
     }
   }
 }

--- a/assets/src/scss/editorOverrides.scss
+++ b/assets/src/scss/editorOverrides.scss
@@ -421,8 +421,8 @@ input.describe[type=text][data-setting=caption] {
   }
 }
 
-// Posts List Block Override
-.posts-list:not(.is-custom-layout-carousel) {
+// Posts List Block Override for the List layout
+.posts-list.is-custom-layout-list {
   .wp-block-post-template.is-layout-flow li {
     height: 240px;
     margin-bottom: 12px;

--- a/assets/src/scss/layout/_query-loop-overrides.scss
+++ b/assets/src/scss/layout/_query-loop-overrides.scss
@@ -24,19 +24,6 @@
       margin-bottom: 0;
     }
 
-    // Apply only to Posts List.
-    &.posts-list {
-      .wp-block-columns {
-        flex-direction: column;
-        gap: $sp-1;
-        margin-bottom: 0;
-      }
-
-      .wp-block-post-terms:not(:first-child) {
-        display: none;
-      }
-    }
-
     @include medium-and-less {
       .carousel {
         overflow: hidden;
@@ -64,31 +51,6 @@
           }
         }
       }
-
-      // Apply only to Actions List.
-      &.actions-list .wp-block-post {
-        width: 354px;
-      }
-
-      // Apply only to Posts List.
-      &.posts-list {
-        .wp-block-post {
-          width: 250px;
-        }
-
-        .wp-block-post-featured-image img {
-          height: 192px;
-        }
-      }
-    }
-
-    @include medium-and-up {
-      // Apply only to Posts List.
-      &.posts-list {
-        .wp-block-post {
-          width: 276px;
-        }
-      }
     }
 
     @include large-and-up {
@@ -100,26 +62,6 @@
         display: grid;
         column-gap: $sp-3;
         padding: $sp-1x $sp-1;
-      }
-
-      // Apply only to Posts List.
-      &.posts-list {
-        .wp-block-post-terms:not(:first-child) {
-          display: block;
-        }
-
-        .carousel-item-wrapper {
-          grid-template-columns: repeat(4, 1fr);
-        }
-
-        .wp-block-post {
-          width: 100%;
-        }
-      }
-
-      // Apply only to Actions List.
-      &.actions-list .carousel-item-wrapper {
-        grid-template-columns: repeat(3, 1fr);
       }
 
       .carousel-controls {


### PR DESCRIPTION
### Description

See [PLANET-7417](https://jira.greenpeace.org/browse/PLANET-7417)

Following a conversation with Houssam, instead of a carousel in smaller screens we will keep a grid there too, with 2 items per row on tablets and 1 item per row on mobiles.

In this PR I also moved some CSS around, to make sure that everything specific to the Actions List or Posts List blocks are in their respective files.

### Testing

You can make sure all the layouts look and behave as expected for both list blocks:
- [Posts List](https://www-dev.greenpeace.org/test-sinope/posts-lists/)
- [Actions List](https://www-dev.greenpeace.org/test-sinope/actions-lists/)

Make sure to test in all screen sizes 🙂 