### PR TITLE
PLANET-7443: Fix Exclude from search EP functionality

### DIFF
--- a/src/ElasticSearch.php
+++ b/src/ElasticSearch.php
@@ -87,8 +87,9 @@ class ElasticSearch extends Search
         add_filter('ep_formatted_args', [ $this, 'ensure_function_score_exists' ], 18, 1);
         add_filter('ep_formatted_args', [ $this, 'set_full_text_search' ], 19, 1);
         add_filter('ep_formatted_args', [ $this, 'set_results_weight' ], 20, 1);
-
         add_filter('ep_formatted_args', [ $this, 'add_mime_type_filter' ], 21, 1);
+
+        add_filter('ep_bypass_exclusion_from_search', fn() => false, 10, 0);
 
         if (wp_doing_ajax()) {
             return;


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-7443

Meta `ep_exclude_from_search` is not used on ajax search query, as our search is considered "in admin".
Fix by forcing meta usage.

## Issue
As for other EP issues, our ajax requests for search are considered "in admin" (passing through admin-ajax.php, setting WP_ADMIN const to true), and so trigger some specific behaviors from EP. Here, it sets the filter `ep_bypass_exclusion_from_search` to `true` (cf [elasticpress source](https://10up.github.io/ElasticPress/includes_classes_Feature_Search_Search.php.html#line733))

## Test

On a local instance using Brasil db, 
- search for `obrigado`
- scroll down to trigger an ajax request for the next 5 results
  - without this fix, you should see Thank you pages for petitions (`Proteja os oceanos - Obrigado` for example), they have the EP box "Exclude from search result" checked in the editor.
  - with this fix, those pages should not appear in the ajax results