### PR TITLE
Add missing is_rest_request function to BaseBlock class

### DIFF
--- a/src/Blocks/BaseBlock.php
+++ b/src/Blocks/BaseBlock.php
@@ -44,8 +44,7 @@ abstract class BaseBlock
 
         // Return empty string if rendered output contains only whitespace or new lines.
         // If it is a rest request from editor/admin area, return a message that block has no content.
-        $empty_content = (defined('REST_REQUEST') && REST_REQUEST) ?
-            '<div class="EmptyMessage">' . $empty_message . '</div>' : '';
+        $empty_content = $this->is_rest_request() ? '<div class="EmptyMessage">' . $empty_message . '</div>' : '';
 
         return ctype_space($block_output) ? $empty_content : $block_output;
     }
@@ -69,6 +68,14 @@ abstract class BaseBlock
                 'message' => $message,
             ]
         );
+    }
+
+    /**
+     * Returns if current request is a rest api request.
+     */
+    public static function is_rest_request(): bool
+    {
+        return defined('REST_REQUEST') && REST_REQUEST;
     }
 
     /**


### PR DESCRIPTION
### Description

This is needed for the [Social Media block](https://github.com/greenpeace/planet4-master-theme/blob/eef1d17d1dad3693c6d4b609e78921896cf58730/src/Blocks/SocialMedia.php#L131) but we forgot to add it. I found this issue while checking [Sentry](https://sentry.greenpeace.org/organizations/greenpeace-org/issues/1621/?environment=development&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=7d&stream_index=0).