### PR TITLE
Fix clear search button in large screens

### DIFF
--- a/assets/src/scss/layout/navbar/_search.scss
+++ b/assets/src/scss/layout/navbar/_search.scss
@@ -146,7 +146,7 @@
 }
 
 .nav-search-clear {
-  background-color: var(--grey-900);
+  background-color: var(--top-navigation--color, var(--grey-900));
   border: none;
   float: right;
   margin-inline-end: 36px;
@@ -162,7 +162,6 @@
   }
 
   @include x-large-and-up {
-    background-color: var(--top-navigation--color, var(--white));
     display: inline-block;
     margin-inline-end: 0;
   }


### PR DESCRIPTION
### Description

It shouldn't be white but stay grey in all screen sizes, otherwise we don't see it

### Testing

You can compare the 2 versions on test instances, by typing in the navbar search input in large screens:
- [broken](https://www-dev.greenpeace.org/test-rhea/)
- [fixed](https://www-dev.greenpeace.org/test-pandora/)