### PR TITLE
PLANET-7448: Exclude password-protected content from Action/Post list block

### DIFF
--- a/assets/src/blocks/ActionsList/index.js
+++ b/assets/src/blocks/ActionsList/index.js
@@ -9,7 +9,8 @@ export const registerActionsListBlock = () => {
   const {registerBlockVariation} = wp.blocks;
   const {__} = wp.i18n;
 
-  const IS_NEW_IA = window.p4_vars.options.new_ia === 'on';
+  const IS_NEW_IA = window.p4_vars.options.new_ia === 'on' ||
+    window.p4_vars.options.new_ia === true;
   const ACT_PAGE = window.p4_vars.options.take_action_page || -1;
 
   const queryPostType = IS_NEW_IA ? 'p4_action' : 'page';
@@ -38,6 +39,7 @@ export const registerActionsListBlock = () => {
         inherit: false,
         postType: queryPostType,
         postIn: [],
+        hasPassword: false,
         ...!IS_NEW_IA && {postParent: ACT_PAGE},
       },
       layout: {

--- a/assets/src/blocks/PostsList/index.js
+++ b/assets/src/blocks/PostsList/index.js
@@ -34,6 +34,7 @@ export const registerPostsListBlock = () => {
         sticky: '',
         inherit: false,
         postIn: [],
+        hasPassword: false,
       },
       layout: {
         type: 'default',

--- a/src/Blocks/QueryLoopExtension.php
+++ b/src/Blocks/QueryLoopExtension.php
@@ -7,6 +7,7 @@ namespace P4\MasterTheme\Blocks;
 /**
  * Handle Posts/Actions List block manual override query with custom `postIn` filter.
  * `include` is not used because it generates some issues with getEntityRecords filters.
+ * Handle filtering password-potected posts.
  */
 class QueryLoopExtension
 {
@@ -23,6 +24,10 @@ class QueryLoopExtension
             if (!empty($postIn)) {
                 $args['post__in'] = array_map('intval', (array) $postIn);
                 $args['orderby'] = 'post__in';
+            }
+            if ($request->has_param('hasPassword')) {
+                $hasPassword = $request->get_param('hasPassword');
+                $args['has_password'] = $hasPassword !== false && $hasPassword !== 'false';
             }
             return $args;
         };
@@ -41,6 +46,9 @@ class QueryLoopExtension
                 if (!empty($blockQuery['postIn'])) {
                     $query['post__in'] = array_map('intval', (array) $blockQuery['postIn']);
                     $query['orderby'] = 'post__in';
+                }
+                if (isset($blockQuery['hasPassword'])) {
+                    $query['has_password'] = (bool) $blockQuery['hasPassword'];
                 }
                 return $query;
             },


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-7448

> We should find a way to exclude password-protected content from the Query Loop block.

## Test

- Insert Actions or Posts list block in a page
- Check which posts are included;
  - edit one of them to add a password ("quick edit" from the list of pages/actions)
  - on this branch, those password-protected posts should not appear in the blocks anymore (after reload), in the editor and on the frontend