### PR TITLE
PLANET-7431: Author profile page returns all posts by Editor

### DIFF
--- a/author.php
+++ b/author.php
@@ -17,24 +17,16 @@ use Timber\Timber;
 
 $context = Timber::get_context();
 
-$post_args = [
-    'posts_per_page' => 10,
-    'post_type' => 'post',
-    'paged' => 1,
-    'meta_key' => 'p4_author_override',
-    'meta_compare' => 'NOT EXISTS',
-    'has_password' => false, // Skip password protected content.
-];
-
 if (isset($wp_query->query_vars['author'])) {
     $author = new User($wp_query->query_vars['author']);
     $context['author'] = $author;
     $context['title'] = 'Author Archives: ' . $author->name();
-    $post_args['author'] = $wp_query->query_vars['author'];
 
     $context['page_category'] = 'Author Page';
 
-    $context['social_accounts'] = Post::filter_social_accounts($context['footer_social_menu'] ?: []);
+    $context['social_accounts'] = Post::filter_social_accounts(
+        $context['footer_social_menu'] ?: []
+    );
     $context['og_title'] = $author->name;
     $context['og_description'] = get_the_author_meta('description', $author->ID);
     $context['og_image_data'] = [
@@ -49,12 +41,6 @@ if (isset($wp_query->query_vars['author'])) {
     $author_share_buttons->link = $author->link;
     $context['author_share_buttons'] = $author_share_buttons;
 }
-
-// Adjust global query to exclude author override.
-// We can remove this once we convert author overrides to actual users.
-$wp_query->query_vars['meta_key'] = 'p4_author_override';
-$wp_query->query_vars['meta_compare'] = 'NOT EXISTS';
-$wp_query->query_vars['has_password'] = false;
 
 $templates = ['author.twig', 'archive.twig'];
 $page = new ListingPage($templates, $context);

--- a/src/AuthorPage.php
+++ b/src/AuthorPage.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace P4\MasterTheme;
+
+/**
+ * Handle author page main query
+ */
+class AuthorPage
+{
+    public static function hooks(): void
+    {
+        add_action(
+            'pre_get_posts',
+            [self::class, 'filter_author_main_query'],
+            1,
+            10
+        );
+    }
+
+    public static function filter_author_main_query(\WP_Query $query): void
+    {
+        if (!$query->is_main_query() || !$query->is_author()) {
+            return;
+        }
+
+        $query->set('posts_per_page', 10);
+        $query->set('post_type', 'post');
+        $query->set('paged', 1);
+        $query->set('meta_key', 'p4_author_override');
+        $query->set('meta_compare', 'NOT EXISTS');
+        $query->set('has_password', false);
+    }
+}

--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -318,6 +318,8 @@ class MasterSite extends TimberSite
                 return get_template_directory() . '/taxonomy.php';
             }
         );
+
+        AuthorPage::hooks();
     }
 
     /**


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-7431

> The author listing pages show all posts published by the Editor (as per the author dropdown) even though they are not the Author (as per the author override field)

## Issue

The `author.php` page tries to edit the Main query, which has already been processed.  
Moving code to a hook on `pre_get_posts` instead will work the expected way.

## Test

With `international` DB:
- Check the author page `author/angelo-louw/`
- The page should only list articles with this author as author, _not editor_
  - Compare with the current prod page https://www.greenpeace.org/international/author/angelo-louw/