### PR TITLE
PLANET-7413 Rename Greenpeace Media Import button

### DIFF
--- a/src/Exporter.php
+++ b/src/Exporter.php
@@ -116,7 +116,7 @@ class Exporter
         <script>
             jQuery(function(){
                 jQuery(".wrap .page-title-action")
-                    .after('<a href="upload.php?page=media-picker" onclick="window.location.href=&apos;upload.php?page=media-picker&apos;" class="page-title-action"><?php esc_html_e('Import', 'planet4-master-theme-backend'); ?></a>');
+                    .after('<a href="upload.php?page=media-picker" class="add-new-h2"><?php esc_html_e('Import Greenpeace Media', 'planet4-master-theme-backend'); ?></a>');
             });
 
         </script>


### PR DESCRIPTION
- Change button text based on feedback
- Adjust css class to avoid native onclick event

---

Ref: [24.03.19 comment on ticket](https://jira.greenpeace.org/browse/PLANET-7413?focusedId=250491&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-250491)

---

### Testing

We added the `onclick` on 57b0fd3fe0b77923bc9b6fab9ae0ee6e39fab58c because on the Media Library Grid view there is a native event forcing the button to open the "Add New" section. That was creating this short flickering impression mentioned also in the ticket comment. To avoid that I used another class that has the same styles attached but doesn't trigger an `onclick` event.

So to test it:
1. Verify the new name on the button.
2. Test the button in both Media Library views. It should work without any flickering.