### PR TITLE
PLANET-7400 Move Side image with text and CTA block pattern into master theme

### DIFF
--- a/assets/src/block-templates/edit.js
+++ b/assets/src/block-templates/edit.js
@@ -1,0 +1,16 @@
+import {useBlockProps, InnerBlocks} from '@wordpress/block-editor';
+
+export default function(template, templateLock = false) {
+  return props => {
+    return (
+      <div {...useBlockProps()}>
+        {
+          wp.element.createElement(InnerBlocks, {
+            template: template(props.attributes ?? {}),
+            templateLock,
+          })
+        }
+      </div>
+    );
+  };
+}

--- a/assets/src/block-templates/main-theme-url.js
+++ b/assets/src/block-templates/main-theme-url.js
@@ -1,0 +1,1 @@
+export default window.p4bk_vars.themeUrl || '';

--- a/assets/src/block-templates/register.js
+++ b/assets/src/block-templates/register.js
@@ -1,0 +1,40 @@
+import edit from './edit';
+import save from './save';
+import templateList from './template-list';
+
+const {registerBlockType} = wp.blocks;
+const {getCurrentPostType} = wp.data.select('core/editor');
+
+const setSupport = metadata => {
+  if (!metadata.supports) {
+    metadata.supports = {};
+  }
+
+  // block templates don't appear in html, they're just an editing structure
+  metadata.supports.customClassName = false;
+  // block templates don't appear in blocks list/block inserter
+  metadata.supports.inserter = false;
+
+  return metadata;
+};
+
+export const registerBlockTemplates = blockTemplates => {
+  const templates = blockTemplates || templateList;
+  const postType = getCurrentPostType();
+
+  templates.forEach(blockTemplate => {
+    // eslint-disable-next-line prefer-const
+    let {metadata, template, templateLock = false} = blockTemplate;
+
+    if (metadata.postTypes && !metadata.postTypes.includes(postType)) {
+      return null;
+    }
+
+    metadata = setSupport(metadata);
+
+    registerBlockType(metadata, {
+      edit: edit(template, templateLock),
+      save,
+    });
+  });
+};

--- a/assets/src/block-templates/save.js
+++ b/assets/src/block-templates/save.js
@@ -1,0 +1,3 @@
+export default function() {
+  return wp.element.createElement(wp.blockEditor.InnerBlocks.Content, {});
+}

--- a/assets/src/block-templates/side-image-with-text-and-cta/block.json
+++ b/assets/src/block-templates/side-image-with-text-and-cta/block.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://schemas.wp.org/trunk/block.json",
+  "apiVersion": 2,
+  "name": "planet4-block-templates/side-image-with-text-and-cta",
+  "title": "Side image with text and CTA",
+  "category": "planet4-block-templates",
+  "textdomain": "planet4-blocks-backend",
+  "attributes": {
+    "title": { "type": "string" },
+    "backgroundColor": { "type": "string" },
+    "alignFull": { "type": "boolean" },
+    "mediaPosition": { "type": "string", "enum": [ "left", "right" ] }
+  }
+}

--- a/assets/src/block-templates/side-image-with-text-and-cta/index.js
+++ b/assets/src/block-templates/side-image-with-text-and-cta/index.js
@@ -1,0 +1,4 @@
+import metadata from './block.json';
+import template from './template';
+
+export {metadata, template};

--- a/assets/src/block-templates/side-image-with-text-and-cta/template.js
+++ b/assets/src/block-templates/side-image-with-text-and-cta/template.js
@@ -1,0 +1,27 @@
+import mainThemeUrl from '../main-theme-url';
+
+const {__} = wp.i18n;
+
+const template = ({
+  title = '',
+  backgroundColor = '',
+  alignFull = false,
+  mediaPosition = 'left',
+}) => ([
+  ['core/media-text', {
+    mediaType: 'image',
+    mediaPosition,
+    mediaUrl: `${mainThemeUrl}/images/placeholders/placeholder-546x415.jpg`,
+    isStackedOnMobile: true,
+    backgroundColor,
+    alignFull,
+  }, [
+    ['core/heading', {level: 2, placeholder: __('Enter title', 'planet4-blocks-backend'), content: title}],
+    ['core/paragraph', {placeholder: __('Enter description', 'planet4-blocks-backend')}],
+    ['core/buttons', {}, [
+      ['core/button'],
+    ]],
+  ]],
+]);
+
+export default template;

--- a/assets/src/block-templates/template-list.js
+++ b/assets/src/block-templates/template-list.js
@@ -1,0 +1,3 @@
+import * as sideImgTextCta from './side-image-with-text-and-cta';
+
+export default [sideImgTextCta];

--- a/assets/src/editorIndex.js
+++ b/assets/src/editorIndex.js
@@ -7,6 +7,7 @@ import {setupCustomSidebar} from './block-editor/setupCustomSidebar';
 import {setupQueryLoopBlockExtension} from './block-editor/QueryLoopBlockExtension';
 import {registerSocialMediaBlock} from './blocks/SocialMedia/SocialMediaBlock';
 import {registerMediaBlock} from './blocks/Media/MediaBlock';
+import {registerBlockTemplates} from './block-templates/register';
 
 wp.domReady(() => {
   // Make sure to unregister the posts-list native variation before registering planet4-blocks/posts-list
@@ -18,6 +19,9 @@ wp.domReady(() => {
   registerHappypointBlock();
   registerSocialMediaBlock();
   registerMediaBlock();
+
+  // Block Templates
+  registerBlockTemplates();
 
   // Beta blocks
   registerActionsListBlock();

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -5,6 +5,7 @@ namespace P4\MasterTheme;
 use P4\MasterTheme\Settings\Features;
 use P4\MasterTheme\Features\Planet4Blocks;
 use P4\MasterTheme\Features\Dev\BetaBlocks;
+use P4\MasterTheme\Patterns\BlockPattern;
 use RuntimeException;
 
 /**
@@ -167,6 +168,9 @@ final class Loader
         new Blocks\Happypoint();//NOSONAR
         new Blocks\SocialMedia();//NOSONAR
         new Blocks\Media();//NOSONAR
+
+        // Load block patterns.
+        BlockPattern::register_all();
 
         if (!BetaBlocks::is_active()) {
             return;

--- a/src/Patterns/BlockPattern.php
+++ b/src/Patterns/BlockPattern.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * Base pattern class.
+ *
+ * @package P4\MasterTheme
+ */
+
+namespace P4\MasterTheme\Patterns;
+
+/**
+ * Class Base_Pattern
+ *
+ * @package P4\MasterTheme\Patterns
+ */
+abstract class BlockPattern
+{
+    /**
+     * Returns the pattern name.
+     */
+    abstract public static function get_name(): string;
+
+    /**
+     * Returns the pattern config.
+     *
+     * @param array $params Optional array of parameters for the config.
+     */
+    abstract public static function get_config(array $params = []): array;
+
+    /**
+     * Returns the pattern classname used for tracking patterns.
+     */
+    public static function get_classname(): string
+    {
+        return self::make_classname(static::get_name());
+    }
+
+    /**
+     * Patterns list.
+     */
+    public static function get_list(): array
+    {
+        return [
+            SideImageWithTextAndCta::class,
+        ];
+    }
+
+    /**
+     * Pattern constructor.
+     */
+    public static function register_all(): void
+    {
+        if (! function_exists('register_block_pattern')) {
+            return;
+        }
+
+        $patterns = self::get_list();
+
+        /**
+         * @var $pattern self
+         */
+        foreach ($patterns as $pattern) {
+            register_block_pattern($pattern::get_name(), $pattern::get_config());
+        }
+    }
+
+    /**
+     * @param string $name Pattern name.
+     */
+    private static function make_classname(string $name): string
+    {
+        return 'is-pattern-' . preg_replace('#[^_a-zA-Z0-9-]#', '-', $name);
+    }
+}

--- a/src/Patterns/SideImageWithTextAndCta.php
+++ b/src/Patterns/SideImageWithTextAndCta.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * Side image with text and CTA pattern class.
+ *
+ * @package P4\MasterTheme\Patterns
+ * @since 0.1
+ */
+
+namespace P4\MasterTheme\Patterns;
+
+/**
+ * Class Side image with text and CTA.
+ *
+ * @package P4\MasterTheme\Patterns
+ */
+class SideImageWithTextAndCta extends BlockPattern
+{
+    /**
+     * Returns the pattern name.
+     */
+    public static function get_name(): string
+    {
+        return 'p4/side-image-with-text-and-cta';
+    }
+
+    /**
+     * Returns the pattern config.
+     *
+     * @param array $params Optional array of parameters for the config.
+     */
+    public static function get_config(array $params = []): array
+    {
+        return [
+            'title' => 'Side image with text and CTA',
+            'categories' => [ 'planet4' ],
+            'content' => '<!-- wp:planet4-block-templates/side-image-with-text-and-cta '
+                . wp_json_encode($params, \JSON_FORCE_OBJECT)
+                . ' /-->',
+        ];
+    }
+}


### PR DESCRIPTION
**Description: [PLANET-7400](https://jira.greenpeace.org/browse/PLANET-7400)**

Testing: 

If you comment out this [code](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/blob/main/classes/class-loader.php#L184) and [this](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/blob/main/assets/src/editorIndex.js#L52) in the blocks repo locally, you should still see the _Side Image with Text_ Pattern in the editor

<!-- Ref: Please add a url to the ticket this change is addressing.

---

Please provide a brief summary of the change introduced to make review process easier.

Ideally this should also be part of the commit summary.
-->
