### PR TITLE
PLANET-7488: Use custom search results configuration

### DIFF
--- a/src/Search.php
+++ b/src/Search.php
@@ -508,10 +508,11 @@ abstract class Search
         }
 
         $args['search_fields'] = [
-            'post_title',
-            'post_content',
-            'post_excerpt',
-            'post_author.display_name',
+            'post_title^1',
+            'post_content^1',
+            'post_excerpt^1',
+            'post_author.display_name^1',
+            'terms.ep_custom_result.name^9999',
         ];
 
         return $args;


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-7488

We currently bypass the default weighing system because of custom fields usage.
Cf. [Weighting::do_weighting](https://github.com/10up/ElasticPress/blob/5acc4ab457d8fdce27488e3425dad1a7b5c7e7fb/includes/classes/Feature/SearchOrdering/SearchOrdering.php#L595-L611) 
Cf. [ep_custom_results](https://github.com/10up/ElasticPress/blob/5acc4ab457d8fdce27488e3425dad1a7b5c7e7fb/includes/classes/Feature/SearchOrdering/SearchOrdering.php#L595-L611)

## Test

With ElasticPress activated
- go to _Custom Search Result_ `/wp-admin/post.php?post=49097&action=edit`
- choose a search term, and reorder the results

## Fix

Insert field `terms.ep_custom_result.name^9999` as used by ElasticPress when weighting function runs.
