### PR TITLE
PLANET-7457 Remove Layout sidebar section in Query Loop block

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -130,6 +130,11 @@
       ]
     },
     "blocks": {
+      "core/query": {
+        "layout": {
+          "allowEditing": false
+        }
+      },
       "core/button": {
         "border": {
           "radius": false


### PR DESCRIPTION
### Description

See [PLANET-7457](https://jira.greenpeace.org/browse/PLANET-7457)
This was confusing for our Actions List and Posts List blocks, I've discussed it with Nikos and it's fine to remove it for all Query Loop blocks since editors don't use them yet. Maybe in the future Gutenberg offers a more granular way of configuring these options per variation.

### Testing

The `Layout` section should no longer be in the sidebar when adding a Posts List or Actions List block.