### PR TITLE
Fix migration to avoid failing on post update errors

### DIFF
--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -427,7 +427,10 @@ class MasterSite extends TimberSite
             && $data['post_status'] === 'publish'
             && in_array($data['post_type'], array_keys($types))
         ) {
-            wp_die(__('Title is a required field.', 'planet4-master-theme-backend'));
+            $err_message = __('Title is a required field.', 'planet4-master-theme-backend');
+            defined('WP_CLI') && WP_CLI
+                ? throw new \Exception($err_message)
+                : wp_die($err_message);
         }
 
         return $data;

--- a/src/Migrations/M028MovePageHeaderSideBarOptions.php
+++ b/src/Migrations/M028MovePageHeaderSideBarOptions.php
@@ -52,7 +52,12 @@ class M028MovePageHeaderSideBarOptions extends MigrationScript
 
                 self::update_meta_options($page_meta_data, $page_header_title, $page);
 
-                wp_update_post($updated_args);
+                try {
+                    wp_update_post($updated_args);
+                } catch (\Throwable $e) {
+                    echo 'Error on page ', $page->ID, "\n";
+                    echo $e->getMessage(), "\n";
+                }
 
                 continue;
             }
@@ -129,7 +134,12 @@ class M028MovePageHeaderSideBarOptions extends MigrationScript
                     'ID' => $page->ID,
                 );
 
-                wp_update_post($post_args);
+                try {
+                    wp_update_post($post_args);
+                } catch (\Throwable $e) {
+                    echo 'Error on page ', $page->ID, "\n";
+                    echo $e->getMessage(), "\n";
+                }
 
                 continue;
             }
@@ -185,7 +195,12 @@ class M028MovePageHeaderSideBarOptions extends MigrationScript
                     'ID' => $page->ID,
                 );
 
-                wp_update_post($post_args);
+                try {
+                    wp_update_post($post_args);
+                } catch (\Throwable $e) {
+                    echo 'Error on page ', $page->ID, "\n";
+                    echo $e->getMessage(), "\n";
+                }
 
                 continue;
             }


### PR DESCRIPTION
Catch "Title is required" errors
Catch WPML missing translations errors

## Test

Using `switzerland` DB
- run `npx wp-env run cli wp p4-run-activator`
- patch M028 should run without failing (some warnings may appear)
  - some warnings should appear
  - some messages 'Error on page xxx' should appear
