### PR TITLE
PLANET-7397 Move Issues block pattern into master theme

### DIFF
--- a/assets/src/block-templates/issues/block.json
+++ b/assets/src/block-templates/issues/block.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://schemas.wp.org/trunk/block.json",
+  "apiVersion": 2,
+  "name": "planet4-block-templates/issues",
+  "title": "Issues",
+  "category": "planet4-block-templates",
+  "icon": "editor-table",
+  "textdomain": "planet4-blocks-backend",
+  "attributes": {
+    "backgroundColor": { "type": "string" },
+    "title": { "type": "string" }
+  }
+}

--- a/assets/src/block-templates/issues/index.js
+++ b/assets/src/block-templates/issues/index.js
@@ -1,0 +1,4 @@
+import metadata from './block.json';
+import template from './template';
+
+export {metadata, template};

--- a/assets/src/block-templates/issues/template.js
+++ b/assets/src/block-templates/issues/template.js
@@ -1,0 +1,116 @@
+import mainThemeUrl from '../main-theme-url';
+
+const {__} = wp.i18n;
+
+const item = ['core/group', {
+  backgroundColor: 'white',
+  style: {
+    border: {radius: '4px'},
+    spacing: {
+      padding: {
+        top: '32px',
+        right: '16px',
+        bottom: '32px',
+        left: '16px',
+      },
+    },
+  },
+  layout: {
+    type: 'flex',
+    flexWrap: 'nowrap',
+    justifyContent: 'left',
+    orientation: 'horizontal',
+  },
+}, [
+  ['core/image', {
+    className: 'force-no-lightbox force-no-caption my-0 square-40',
+    url: `${mainThemeUrl}/images/placeholders/placeholder-40x40.jpg`,
+    alt: __('Enter text', 'planet4-blocks-backend'),
+  }],
+  ['core/heading', {
+    level: 5,
+    className: 'w-auto',
+    style: {
+      typography: {fontSize: '1rem'},
+      spacing: {
+        margin: {top: '0px', bottom: '0px', left: '16px'},
+      },
+    },
+    textAlign: 'left',
+    placeholder: __('Enter text', 'planet4-blocks-backend'),
+  }],
+]];
+
+const template = ({
+  backgroundColor = 'beige-100',
+  title = '',
+}) => ([
+  ['core/group', {
+    align: 'full',
+    backgroundColor,
+    className: 'block',
+    style: {
+      spacing: {
+        padding: {
+          top: '80px',
+          bottom: '80px',
+        },
+      },
+    },
+  },
+  [
+    ['core/group', {
+      className: 'container',
+    }, [
+      ['core/heading', {
+        level: 2,
+        content: title,
+        placeholder: __('Enter title', 'planet4-blocks-backend'),
+        style: {
+          spacing: {
+            margin: {
+              bottom: '24px',
+            },
+          },
+        },
+        textAlign: 'center',
+      },
+      ],
+      ['core/paragraph', {
+        className: 'my-0',
+        placeholder: __('Enter description', 'planet4-blocks-backend'),
+        align: 'center',
+      },
+      ],
+      ['core/group', {
+        className: 'is-style-space-evenly',
+        layout: {
+          type: 'flex',
+          allowOrientation: false,
+        },
+        style: {
+          spacing: {
+            padding: {
+              top: '40px',
+              bottom: '56px',
+            },
+          },
+        },
+      },
+      [...Array(4).keys()].map(() => item),
+      ],
+      ['core/buttons', {
+        layout: {
+          type: 'flex',
+          justifyContent: 'center',
+        },
+      }, [
+        ['core/button', {placeholder: __('Enter text', 'planet4-blocks-backend')}]]],
+    ],
+    ],
+  ],
+  ],
+]
+);
+
+export default template;

--- a/assets/src/block-templates/register.js
+++ b/assets/src/block-templates/register.js
@@ -2,7 +2,7 @@ import edit from './edit';
 import save from './save';
 import templateList from './template-list';
 
-const {registerBlockType} = wp.blocks;
+const {registerBlockType, getBlockTypes} = wp.blocks;
 const {getCurrentPostType} = wp.data.select('core/editor');
 
 const setSupport = metadata => {
@@ -25,6 +25,12 @@ export const registerBlockTemplates = blockTemplates => {
   templates.forEach(blockTemplate => {
     // eslint-disable-next-line prefer-const
     let {metadata, template, templateLock = false} = blockTemplate;
+
+    // To be removed when we finally migrate all patterns to master theme
+    const blockAlreadyExists = getBlockTypes().find(block => block.name === metadata.name);
+    if (blockAlreadyExists) {
+      return;
+    }
 
     if (metadata.postTypes && !metadata.postTypes.includes(postType)) {
       return null;

--- a/assets/src/block-templates/template-list.js
+++ b/assets/src/block-templates/template-list.js
@@ -1,3 +1,7 @@
 import * as sideImgTextCta from './side-image-with-text-and-cta';
+import * as issues from './issues';
 
-export default [sideImgTextCta];
+export default [
+  sideImgTextCta,
+  issues,
+];

--- a/src/Patterns/BlockPattern.php
+++ b/src/Patterns/BlockPattern.php
@@ -3,7 +3,7 @@
 /**
  * Base pattern class.
  *
- * @package P4\MasterTheme
+ * @package P4\MasterTheme\Patterns
  */
 
 namespace P4\MasterTheme\Patterns;
@@ -42,6 +42,7 @@ abstract class BlockPattern
     {
         return [
             SideImageWithTextAndCta::class,
+            Issues::class,
         ];
     }
 

--- a/src/Patterns/Issues.php
+++ b/src/Patterns/Issues.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * Issues class.
+ *
+ * @package P4\MasterTheme\Patterns
+ * @since 0.1
+ */
+
+namespace P4\MasterTheme\Patterns;
+
+/**
+ * Class Issues.
+ *
+ * @package P4\MasterTheme\Patterns
+ */
+class Issues extends BlockPattern
+{
+    /**
+     * Returns the pattern name.
+     */
+    public static function get_name(): string
+    {
+        return 'p4/issues';
+    }
+
+    /**
+     * Returns the pattern config.
+     *
+     * @param array $params Optional array of parameters for the config.
+     */
+    public static function get_config(array $params = []): array
+    {
+        return [
+            'title' => 'Issues',
+            'categories' => [ 'planet4' ],
+            'content' => '
+				<!-- wp:planet4-block-templates/issues ' . wp_json_encode($params, \JSON_FORCE_OBJECT) . ' /-->
+			',
+        ];
+    }
+}


### PR DESCRIPTION
Description: [PLANET-7397](https://jira.greenpeace.org/browse/PLANET-7397)

Testing:

If you comment out this [code](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/blob/main/classes/class-loader.php#L184) and [this](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/blob/main/assets/src/editorIndex.js#L52) in the blocks repo locally, you should still see the Issues Pattern in the editor

<!-- Ref: Please add a url to the ticket this change is addressing.

---

Please provide a brief summary of the change introduced to make review process easier.

Ideally this should also be part of the commit summary.
-->
