### PR TITLE
PLANET-7175 Fix timeline block editor error

### DIFF
--- a/assets/src/blocks/Timeline/TimelineEditorScript.js
+++ b/assets/src/blocks/Timeline/TimelineEditorScript.js
@@ -14,6 +14,7 @@ import {Timeline} from './Timeline';
 import {languages} from './TimelineLanguages';
 import {URLDescriptionHelp} from './URLDescriptionHelp';
 import {debounce} from '@wordpress/compose';
+import {isLodash} from '../../functions/isLodash';
 
 const {__} = wp.i18n;
 const TIMELINE_JS_VERSION = '3.8.12';
@@ -24,9 +25,17 @@ const positions = [
 ];
 
 const loadAssets = () => {
+  const revertLodash = function() {
+    // Address conflicts between the underscore and lodash libraries.
+    if (isLodash()) {
+      // eslint-disable-next-line no-undef
+      _.noConflict();
+    }
+  };
   // eslint-disable-next-line no-unused-vars
   const [scriptLoaded, scriptError] = useScript(
-    `https://cdn.knightlab.com/libs/timeline3/${TIMELINE_JS_VERSION}/js/timeline-min.js`
+    `https://cdn.knightlab.com/libs/timeline3/${TIMELINE_JS_VERSION}/js/timeline-min.js`,
+    revertLodash
   );
 
   // eslint-disable-next-line no-unused-vars

--- a/assets/src/functions/isLodash.js
+++ b/assets/src/functions/isLodash.js
@@ -1,0 +1,27 @@
+// Determines if _ is lodash or not.
+export const isLodash = () => {
+  let isItLodash = false;
+
+  // If _ is defined and the function _.forEach exists then we know underscore OR lodash are in place
+  // eslint-disable-next-line no-undef
+  if ('undefined' !== typeof (_) && 'function' === typeof (_.forEach)) {
+    // A small sample of some of the functions that exist in lodash but not underscore
+    const funcs = ['get', 'set', 'at', 'cloneDeep'];
+
+    // Simplest if assume exists to start
+    isItLodash = true;
+
+    funcs.forEach(func => {
+      // If just one of the functions do not exist, then not lodash
+      // eslint-disable-next-line no-undef
+      isItLodash = ('function' !== typeof (_[func])) ? false : isItLodash;
+    });
+  }
+
+  if (isItLodash) {
+    // We know that lodash is loaded in the _ variable
+    return true;
+  }
+  // We know that lodash is NOT loaded
+  return false;
+};


### PR DESCRIPTION
Ref. https://jira.greenpeace.org/browse/PLANET-7175

The error was caused by conflicts between the underscore and lodash libraries.

**Testing:**
- The issue can be reproduced on [test-jupiter](https://www-dev.greenpeace.org/test-jupiter/wp-admin/post-new.php) instance as below -

https://github.com/greenpeace/planet4-master-theme/assets/5357471/54ead07b-830b-44dd-9768-97604c0b6116


- The same issue should not reproduce on [test-iocaste](https://www-dev.greenpeace.org/test-iocaste/wp-admin/post-new.php) instance.

**Note:** A similar fix needs to be added in the blocks plugin as well, or it can be tested by disabling the blocks plugin.
