### PR TITLE
PLANET-7492 Make sure blocks are not registered twice

### DIFF
--- a/assets/src/blocks/Media/MediaBlock.js
+++ b/assets/src/blocks/Media/MediaBlock.js
@@ -17,7 +17,13 @@ export const lacksAttributes = attributes => {
 };
 
 export const registerMediaBlock = () => {
-  const {registerBlockType} = wp.blocks;
+  const {registerBlockType, getBlockTypes} = wp.blocks;
+
+  const blockAlreadyExists = getBlockTypes().find(block => block.name === BLOCK_NAME);
+
+  if (blockAlreadyExists) {
+    return;
+  }
 
   registerBlockType(BLOCK_NAME, {
     title: __('Media block', 'planet4-blocks-backend'),

--- a/assets/src/blocks/SocialMedia/SocialMediaBlock.js
+++ b/assets/src/blocks/SocialMedia/SocialMediaBlock.js
@@ -3,47 +3,55 @@ import {socialMediaV1} from './deprecated/socialMediaV1';
 import {OEMBED_EMBED_TYPE, FACEBOOK_PAGE_TAB_TIMELINE} from './SocialMediaConstants.js';
 import {SocialMediaFrontend} from './SocialMediaFrontend.js';
 
-const {registerBlockType} = wp.blocks;
+const {registerBlockType, getBlockTypes} = wp.blocks;
 
 const BLOCK_NAME = 'planet4-blocks/social-media';
 
-export const registerSocialMediaBlock = () => registerBlockType(BLOCK_NAME, {
-  title: 'Social Media',
-  icon: 'share',
-  category: 'planet4-blocks',
-  attributes: {
-    title: {
-      type: 'string',
-      default: '',
+export const registerSocialMediaBlock = () => {
+  const blockAlreadyExists = getBlockTypes().find(block => block.name === BLOCK_NAME);
+
+  if (blockAlreadyExists) {
+    return;
+  }
+
+  registerBlockType(BLOCK_NAME, {
+    title: 'Social Media',
+    icon: 'share',
+    category: 'planet4-blocks',
+    attributes: {
+      title: {
+        type: 'string',
+        default: '',
+      },
+      description: {
+        type: 'string',
+        default: '',
+      },
+      embed_type: {
+        type: 'string',
+        default: OEMBED_EMBED_TYPE,
+      },
+      facebook_page_tab: {
+        type: 'string',
+        default: FACEBOOK_PAGE_TAB_TIMELINE,
+      },
+      social_media_url: {
+        type: 'string',
+        default: '',
+      },
+      alignment_class: {
+        type: 'string',
+        default: '',
+      },
+      embed_code: {
+        type: 'string',
+        default: '',
+      },
     },
-    description: {
-      type: 'string',
-      default: '',
-    },
-    embed_type: {
-      type: 'string',
-      default: OEMBED_EMBED_TYPE,
-    },
-    facebook_page_tab: {
-      type: 'string',
-      default: FACEBOOK_PAGE_TAB_TIMELINE,
-    },
-    social_media_url: {
-      type: 'string',
-      default: '',
-    },
-    alignment_class: {
-      type: 'string',
-      default: '',
-    },
-    embed_code: {
-      type: 'string',
-      default: '',
-    },
-  },
-  edit: SocialMediaEditor,
-  save: ({attributes}) => <SocialMediaFrontend {...attributes} />,
-  deprecated: [
-    socialMediaV1,
-  ],
-});
+    edit: SocialMediaEditor,
+    save: ({attributes}) => <SocialMediaFrontend {...attributes} />,
+    deprecated: [
+      socialMediaV1,
+    ],
+  });
+};

--- a/assets/src/blocks/Submenu/SubmenuBlock.js
+++ b/assets/src/blocks/Submenu/SubmenuBlock.js
@@ -7,7 +7,13 @@ const {__} = wp.i18n;
 const BLOCK_NAME = 'planet4-blocks/submenu';
 
 export const registerSubmenuBlock = () => {
-  const {registerBlockType} = wp.blocks;
+  const {registerBlockType, getBlockTypes} = wp.blocks;
+
+  const blockAlreadyExists = getBlockTypes().find(block => block.name === BLOCK_NAME);
+
+  if (blockAlreadyExists) {
+    return;
+  }
 
   registerBlockType(BLOCK_NAME, {
     title: 'Submenu',

--- a/assets/src/blocks/TakeActionBoxout/TakeActionBoxoutBlock.js
+++ b/assets/src/blocks/TakeActionBoxout/TakeActionBoxoutBlock.js
@@ -1,64 +1,72 @@
 import {TakeActionBoxoutEditor} from './TakeActionBoxoutEditor.js';
 import {takeActionBoxoutV1} from './deprecated/takeActionBoxoutV1';
 
-const {registerBlockType} = wp.blocks;
+const {registerBlockType, getBlockTypes} = wp.blocks;
 
 const BLOCK_NAME = 'planet4-blocks/take-action-boxout';
 
-export const registerTakeActionBoxoutBlock = () => registerBlockType(BLOCK_NAME, {
-  title: 'Take Action Boxout',
-  icon: 'welcome-widgets-menus',
-  category: 'planet4-blocks',
-  supports: {
-    html: false, // Disable "Edit as HTMl" block option.
-  },
-  // This attributes definition mimics the one in the PHP side.
-  attributes: {
-    take_action_page: {
-      type: 'number',
+export const registerTakeActionBoxoutBlock = () => {
+  const blockAlreadyExists = getBlockTypes().find(block => block.name === BLOCK_NAME);
+
+  if (blockAlreadyExists) {
+    return;
+  }
+
+  registerBlockType(BLOCK_NAME, {
+    title: 'Take Action Boxout',
+    icon: 'welcome-widgets-menus',
+    category: 'planet4-blocks',
+    supports: {
+      html: false, // Disable "Edit as HTMl" block option.
     },
-    title: {
-      type: 'string',
+    // This attributes definition mimics the one in the PHP side.
+    attributes: {
+      take_action_page: {
+        type: 'number',
+      },
+      title: {
+        type: 'string',
+      },
+      excerpt: {
+        type: 'string',
+      },
+      link: {
+        type: 'string',
+      },
+      linkText: {
+        type: 'string',
+      },
+      newTab: {
+        type: 'boolean',
+        default: false,
+      },
+      tag_ids: {
+        type: 'array',
+        default: [],
+      },
+      imageId: {
+        type: 'number',
+        default: '',
+      },
+      imageUrl: {
+        type: 'string',
+        default: '',
+      },
+      imageAlt: {
+        type: 'string',
+        default: '',
+      },
+      stickyOnMobile: {
+        type: 'boolean',
+        default: false,
+      },
     },
-    excerpt: {
-      type: 'string',
+    edit: TakeActionBoxoutEditor,
+    save() {
+      return null;
     },
-    link: {
-      type: 'string',
-    },
-    linkText: {
-      type: 'string',
-    },
-    newTab: {
-      type: 'boolean',
-      default: false,
-    },
-    tag_ids: {
-      type: 'array',
-      default: [],
-    },
-    imageId: {
-      type: 'number',
-      default: '',
-    },
-    imageUrl: {
-      type: 'string',
-      default: '',
-    },
-    imageAlt: {
-      type: 'string',
-      default: '',
-    },
-    stickyOnMobile: {
-      type: 'boolean',
-      default: false,
-    },
-  },
-  edit: TakeActionBoxoutEditor,
-  save() {
-    return null;
-  },
-  deprecated: [
-    takeActionBoxoutV1,
-  ],
-});
+    deprecated: [
+      takeActionBoxoutV1,
+    ],
+  });
+};

--- a/assets/src/blocks/Timeline/TimelineBlock.js
+++ b/assets/src/blocks/Timeline/TimelineBlock.js
@@ -33,8 +33,14 @@ const attributes = {
 };
 
 export const registerTimelineBlock = () => {
-  const {registerBlockType} = wp.blocks;
+  const {registerBlockType, getBlockTypes} = wp.blocks;
   const {RawHTML} = wp.element;
+
+  const blockAlreadyExists = getBlockTypes().find(block => block.name === BLOCK_NAME);
+
+  if (blockAlreadyExists) {
+    return;
+  }
 
   registerBlockType(BLOCK_NAME, {
     title: 'Timeline',


### PR DESCRIPTION
### Description

See [PLANET-7492](https://jira.greenpeace.org/browse/PLANET-7492)
The blocks registered via the `editorIndex` file were sometimes registered twice:

<img width="405" alt="Screenshot 2024-04-09 at 15 20 01" src="https://github.com/greenpeace/planet4-master-theme/assets/6949075/f48e2daa-e9d7-44b9-964f-702027912744">

### Testing

The console warnings should no longer be there when opening the editor. There is still one for a block pattern being registered twice, but Osong is looking into it since he's working on moving another pattern at the moment.