### PR TITLE
PLANET-7491 Add see all link to Posts List block

### DIFF
--- a/assets/src/blocks/PostsList/index.js
+++ b/assets/src/blocks/PostsList/index.js
@@ -9,6 +9,14 @@ export const registerPostsListBlock = () => {
   const {registerBlockVariation} = wp.blocks;
   const {__} = wp.i18n;
 
+  const newsPageLink = window.p4_vars.news_page_link;
+
+  const seeAllLink = ['core/navigation-link', {...!newsPageLink ? {className: 'd-none'} : {
+    url: newsPageLink,
+    label: __('See all stories', 'planet4-blocks-backend'),
+    className: 'see-all-link',
+  }}];
+
   return registerBlockVariation('core/query', {
     name: POSTS_LIST_BLOCK_NAME,
     title: 'Posts List',
@@ -42,7 +50,10 @@ export const registerPostsListBlock = () => {
       },
     },
     innerBlocks: [
-      ['core/heading', {lock: {move: true}, content: __('Related Posts', 'planet4-blocks-backend')}],
+      ['core/group', {layout: {type: 'flex', justifyContent: 'space-between'}}, [
+        ['core/heading', {lock: {move: true}, content: __('Related Posts', 'planet4-blocks-backend')}],
+        seeAllLink,
+      ]],
       ['core/paragraph', {
         lock: {move: true},
         placeholder: __('Enter description', 'planet4-blocks-backend'),
@@ -86,6 +97,7 @@ export const registerPostsListBlock = () => {
         ['core/button', {className: 'carousel-control-prev', text: __('Prev', 'planet4-blocks-backend')}],
         ['core/button', {className: 'carousel-control-next', text: __('Next', 'planet4-blocks-backend')}],
       ]],
+      seeAllLink,
     ],
   });
 };

--- a/assets/src/scss/blocks/PostsList.scss
+++ b/assets/src/scss/blocks/PostsList.scss
@@ -4,6 +4,51 @@
     display: none;
   }
 
+  .see-all-link {
+    list-style: none;
+
+    a {
+      @include shared-link-styles;
+      display: inline-block;
+      font-family: var(--font-family-heading);
+      font-size: 16px;
+
+      &::after {
+        content: "";
+        display: inline-block;
+        background-color: currentColor;
+        pointer-events: none;
+        margin-inline-start: .2rem;
+        height: .7rem;
+        width: .7rem;
+        background-repeat: no-repeat;
+        mask-image: url("../../images/chevron.svg");
+        mask-size: contain;
+        mask-repeat: no-repeat;
+        mask-position: center;
+
+        html[dir="rtl"] & {
+          rotate: 180deg;
+        }
+      }
+    }
+
+    @include large-and-up {
+      display: none;
+      visibility: hidden;
+    }
+  }
+
+  .wp-block-heading + .see-all-link {
+    display: none;
+    visibility: hidden;
+
+    @include large-and-up {
+      display: block;
+      visibility: visible;
+    }
+  }
+
   .taxonomy-post_tag a {
     display: inline-block;
 

--- a/src/MasterBlocks.php
+++ b/src/MasterBlocks.php
@@ -208,7 +208,10 @@ class MasterBlocks
      */
     public function reflect_js_variables(): array
     {
+        $news_page = (int) get_option('page_for_posts');
+
         return [
+            'news_page_link' => $news_page ? get_permalink($news_page) : null,
             'options' => $this->get_p4_options(),
             'features' => $this->get_p4_features(),
             'pages' => $this->get_en_pages(),


### PR DESCRIPTION
### Description

See [PLANET-7491](https://jira.greenpeace.org/browse/PLANET-7491)
This is to replace the load more functionality that we have in the Articles block

### Testing

Either on local or on the [venus test instance](https://www-dev.greenpeace.org/test-venus/), you can add a Posts List block to a page and make sure that the `See all stories` link behaves as expected in all screen sizes.
Make sure to also test the use case where the [News & Stories page](https://www-dev.greenpeace.org/test-venus/wp-admin/options-reading.php) is not set, in that case the new link should not be added to the block (this will only be true for new blocks, existing ones will not be updated).