### PR TITLE
PLANET-7458 Fix Actions List and Posts List carousel layout in RTL sites

### DIFF
--- a/assets/src/scss/blocks/PostsList.scss
+++ b/assets/src/scss/blocks/PostsList.scss
@@ -150,7 +150,7 @@
       content: ".";
       font-size: calc(var(--font-size-m--font-family-primary) + 5px);
       margin-top: -6px;
-      margin-left: $sp-x;
+      margin-inline-start: $sp-x;
     }
   }
 

--- a/assets/src/scss/layout/_query-loop-overrides.scss
+++ b/assets/src/scss/layout/_query-loop-overrides.scss
@@ -16,10 +16,6 @@
       width: 100%;
     }
 
-    .carousel-inner {
-      display: flex;
-    }
-
     .wp-block-post {
       margin-bottom: 0;
     }
@@ -31,6 +27,7 @@
       }
 
       .carousel-inner {
+        display: flex;
         overflow-x: scroll;
         scrollbar-width: none;
         scroll-behavior: smooth;
@@ -68,7 +65,7 @@
         display: flex;
         position: absolute;
         height: 48px;
-        width: calc(100% + calc($sp-3*2));
+        width: calc(100% + calc($sp-3 * 2));
         top: 0;
         bottom: 0;
         margin: auto;


### PR DESCRIPTION
### Description

See [PLANET-7458](https://jira.greenpeace.org/browse/PLANET-7458)
It seems removing the `flex` display does the trick

### Testing

Add a Posts List or Actions List to a page with the carousel layout, then in the frontend you can manually add `dir="rtl"` to the html element. On `main` branch the block should be blank but on this branch it should display as expected.

On the janus instance I've created [this page](https://www-dev.greenpeace.org/test-janus/the-list-blocks/) with both blocks that you can check as well.