### PR TITLE
PLANET-7396: Move Highlighted CTA block pattern into master theme

### DIFF
--- a/assets/src/block-templates/highlighted-cta/block.json
+++ b/assets/src/block-templates/highlighted-cta/block.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://schemas.wp.org/trunk/block.json",
+  "apiVersion": 2,
+  "name": "planet4-block-templates/highlighted-cta",
+  "title": "Highlighted CTA",
+  "category": "planet4-block-templates",
+  "textdomain": "planet4-blocks-backend",
+  "attributes": {
+    "titlePlaceholder": { "type": "string" }
+  }
+}

--- a/assets/src/block-templates/highlighted-cta/index.js
+++ b/assets/src/block-templates/highlighted-cta/index.js
@@ -1,0 +1,4 @@
+import metadata from './block.json';
+import template from './template';
+
+export {metadata, template};

--- a/assets/src/block-templates/highlighted-cta/template.js
+++ b/assets/src/block-templates/highlighted-cta/template.js
@@ -6,30 +6,40 @@ const template = ({
   titlePlaceholder = __('Enter text', 'planet4-blocks-backend'),
 }) => [
   [
-    'core/columns',
+    'core/group',
     {
       className: 'block',
-      textColor: 'white',
       backgroundColor: 'dark-green-800',
     },
     [
-      ['core/column', {}, [
-        ['core/image', {
-          align: 'center',
-          className: 'force-no-lightbox force-no-caption',
-          url: `${mainThemeUrl}/images/placeholders/placeholder-80x80.jpg`,
-        }],
-        ['core/heading', {
-          textAlign: 'center',
-          level: 3,
-          placeholder: titlePlaceholder,
-        }],
-        ['core/spacer', {height: '16px'}],
-        ['core/buttons', {layout: {type: 'flex', justifyContent: 'center'}}, [
-          ['core/button', {className: 'is-style-transparent'}],
-        ]],
-        ['core/spacer', {height: '16px'}],
+      ['core/spacer', {height: '40px'}],
+      ['core/image', {
+        align: 'center',
+        className: 'force-no-lightbox force-no-caption',
+        url: `${mainThemeUrl}/images/placeholders/placeholder-80x80.jpg`,
+        width: '80px',
+        height: '80px',
+        style: {
+          spacing: {
+            margin: {
+              top: '0',
+              bottom: '0',
+            },
+          },
+        },
+      }],
+      ['core/spacer', {height: '32px'}],
+      ['core/heading', {
+        textAlign: 'center',
+        level: 3,
+        placeholder: titlePlaceholder,
+        textColor: 'white',
+      }],
+      ['core/spacer', {height: '24px'}],
+      ['core/buttons', {layout: {type: 'flex', justifyContent: 'center'}}, [
+        ['core/button', {className: 'is-style-cta'}],
       ]],
+      ['core/spacer', {height: '40px'}],
     ],
   ],
 ];

--- a/assets/src/block-templates/highlighted-cta/template.js
+++ b/assets/src/block-templates/highlighted-cta/template.js
@@ -1,0 +1,37 @@
+import mainThemeUrl from '../main-theme-url';
+
+const {__} = wp.i18n;
+
+const template = ({
+  titlePlaceholder = __('Enter text', 'planet4-blocks-backend'),
+}) => [
+  [
+    'core/columns',
+    {
+      className: 'block',
+      textColor: 'white',
+      backgroundColor: 'dark-green-800',
+    },
+    [
+      ['core/column', {}, [
+        ['core/image', {
+          align: 'center',
+          className: 'force-no-lightbox force-no-caption',
+          url: `${mainThemeUrl}/images/placeholders/placeholder-80x80.jpg`,
+        }],
+        ['core/heading', {
+          textAlign: 'center',
+          level: 3,
+          placeholder: titlePlaceholder,
+        }],
+        ['core/spacer', {height: '16px'}],
+        ['core/buttons', {layout: {type: 'flex', justifyContent: 'center'}}, [
+          ['core/button', {className: 'is-style-transparent'}],
+        ]],
+        ['core/spacer', {height: '16px'}],
+      ]],
+    ],
+  ],
+];
+
+export default template;

--- a/assets/src/block-templates/template-list.js
+++ b/assets/src/block-templates/template-list.js
@@ -3,6 +3,7 @@ import * as issues from './issues';
 import * as realityCheck from './reality-check';
 import * as quickLinks from './quick-links';
 import * as deepDive from './deep-dive';
+import * as highlightedCta from './highlighted-cta';
 
 export default [
   sideImgTextCta,
@@ -10,4 +11,5 @@ export default [
   realityCheck,
   quickLinks,
   deepDive,
+  highlightedCta,
 ];

--- a/src/Patterns/BlockPattern.php
+++ b/src/Patterns/BlockPattern.php
@@ -46,6 +46,7 @@ abstract class BlockPattern
             RealityCheck::class,
             QuickLinks::class,
             DeepDive::class,
+            HighlightedCta::class,
         ];
     }
 

--- a/src/Patterns/HighlightedCta.php
+++ b/src/Patterns/HighlightedCta.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * Highlighted CTA pattern class.
+ *
+ * @package P4\MasterTheme\Patterns
+ * @since 0.1
+ */
+
+namespace P4\MasterTheme\Patterns;
+
+/**
+ * Class Highlighted CTA.
+ *
+ * @package P4\MasterTheme\Patterns
+ */
+class HighlightedCta extends BlockPattern
+{
+    /**
+     * Returns the pattern name.
+     */
+    public static function get_name(): string
+    {
+        return 'p4/highlighted-cta';
+    }
+
+    /**
+     * Returns the pattern config.
+     *
+     * @param array $params Optional array of parameters for the config.
+     */
+    public static function get_config(array $params = []): array
+    {
+        return [
+            'title' => 'Highlighted CTA',
+            'categories' => [ 'planet4' ],
+            'content' => '
+				<!-- wp:planet4-block-templates/highlighted-cta ' . wp_json_encode($params, \JSON_FORCE_OBJECT) . ' /-->
+			',
+        ];
+    }
+}


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-7396

### Related PRs:
- https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/1203
- https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/1205
- https://github.com/greenpeace/planet4-master-theme/pull/2269
- https://github.com/greenpeace/planet4-master-theme/pull/2270
- https://github.com/greenpeace/planet4-master-theme/pull/2285

Demo page: https://www-dev.greenpeace.org/test-pluto/highlighted-cta-demo-page/

# Description
Move HighlightedCTA block into the theme

## Testing
- Create a new page
- Edit that page
- Click on "+" and click on "Patterns" tab
- The HighlightedCTA block should be visible on that list
In addition to this, make sure the block is properly rendered within the highlighted 