### PR TITLE
PLANET-7490 Update search limit from 6 to 8 on Greenpeace Media

### DIFF
--- a/admin/css/archive-picker.css
+++ b/admin/css/archive-picker.css
@@ -449,7 +449,7 @@
   box-sizing: border-box;
   display: grid;
   grid-gap: 8px;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(4, 1fr);
   margin: 0;
   padding: 8px;
   width: 100%;
@@ -541,7 +541,7 @@
   }
 
   .multiple-search-list {
-    grid-template-columns: repeat(3, 1fr);
+    grid-template-columns: repeat(4, 1fr);
   }
 
   .nav-bulk-select.bulk-enabled {

--- a/assets/src/js/Components/ArchivePicker/MultiSearchOption.js
+++ b/assets/src/js/Components/ArchivePicker/MultiSearchOption.js
@@ -3,7 +3,7 @@ import classNames from 'classnames';
 import {ACTIONS, useArchivePickerContext} from './ArchivePicker';
 
 const {__} = wp.i18n;
-const MAX_SEARCHES = 6;
+const MAX_SEARCHES = 8;
 
 export default function MultiSearchOption() {
   const [localSearchText, setLocalSearchText] = useState([]);


### PR DESCRIPTION
Ref. https://jira.greenpeace.org/browse/PLANET-7490


**Task:**
1. Change the search limit from 6 to 8 IDs/keywords on the Greenpeace Media in the backend.
2. Adjust the form input width accordingly to make sure IDs/keywords are displayed in one line.

**Testing:**
- The Greenpeace Media search should now allow to search an 8 keywords.
You can test it on local or [test-oberon](https://www-dev.greenpeace.org/test-oberon/wp-admin/upload.php?page=media-picker) instance