### PR TITLE
Add setting for custom Tag Manager scripts URL

### DIFF
--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -655,6 +655,8 @@ class MasterSite extends TimberSite
         // or enforce_cookies_policy setting is not enabled.
         $context['enforce_cookies_policy'] = isset($options['enforce_cookies_policy']) ? true : false;
         $context['google_tag_value'] = $options['google_tag_manager_identifier'] ?? '';
+        $context['google_tag_domain'] = !empty($options['google_tag_manager_domain']) ?
+            $options['google_tag_manager_domain'] : 'www.googletagmanager.com';
         $context['ab_hide_selector'] = $options['ab_hide_selector'] ?? null;
         $context['facebook_page_id'] = $options['facebook_page_id'] ?? '';
         $context['preconnect_domains'] = [];

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -394,6 +394,15 @@ class Settings
                         'type' => 'text',
                     ],
                     [
+                        'name' => __('Google Tag Manager Custom Domain', 'planet4-master-theme-backend'),
+                        'desc' => __(
+                            'Use a custom domain from which Tag Manager scripts are loaded. A Google Tag Manager Web Container must be set up in server-side Tag Manager on the same domain. Leave empty for the default.',
+                            'planet4-master-theme-backend'
+                        ),
+                        'id' => 'google_tag_manager_domain',
+                        'type' => 'text',
+                    ],
+                    [
                         'name' => __('AB Hide Selector', 'planet4-master-theme-backend'),
                         'desc' => __(
                             'When running an AB test it is possible that the original is shown for a short while (called flicker). If this happens you can enter a CSS selector here and matching elements will be hidden until the test is fully loaded.',

--- a/templates/base.twig
+++ b/templates/base.twig
@@ -12,7 +12,7 @@
 >
     {% if google_tag_value %}
         <!-- Google Tag Manager (noscript) -->
-        <noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ google_tag_value }}"
+        <noscript><iframe src="https://{{ google_tag_domain }}/ns.html?id={{ google_tag_value }}"
                           height="0" width="0" style="display:none;visibility:hidden"></iframe>
         </noscript>
         <!-- End Google Tag Manager (noscript) -->

--- a/templates/blocks/google_tag_manager.twig
+++ b/templates/blocks/google_tag_manager.twig
@@ -1,6 +1,7 @@
 {% if google_tag_value %}
   <script>
     var google_tag_value = '{{ google_tag_value }}';
+    var google_tag_domain = '{{ google_tag_domain }}';
     window.dataLayer = window.dataLayer || [];
 
     function gtag() { dataLayer.push(arguments); };
@@ -91,7 +92,7 @@
         var f = d.getElementsByTagName(s)[0],
             j = d.createElement(s), dl = l != 'dataLayer' ? '&l=' + l : '';
         j.async = true;
-        j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
+        j.src = 'https://' + google_tag_domain + '/gtm.js?id=' + i + dl;
         f.parentNode.insertBefore(j, f);
       })(window, document, 'script', 'dataLayer', google_tag_value);
     }


### PR DESCRIPTION
Ref: https://github.com/greenpeace/planet4/issues/187

Adds an additional setting in the Analytics section of P4 settings for a custom domain name to load Tag Manager scripts from. The domain is then used in two places where the tag manager scripts are loaded. When the setting is left empty, the default domain of Tag Manager is used.
