### PR TITLE
Fix p4 variables from Cookies

### DIFF
--- a/assets/src/js/cookies.js
+++ b/assets/src/js/cookies.js
@@ -1,8 +1,8 @@
 /* global dataLayer */
 export const setupCookies = () => {
   window.dataLayer = window.dataLayer || [];
-  const ENABLE_ANALYTICAL_COOKIES = window.p4bk_vars.enable_analytical_cookies;
-  const ENABLE_GOOGLE_CONSENT_MODE = window.p4bk_vars.enable_google_consent_mode;
+  const ENABLE_ANALYTICAL_COOKIES = window.p4_vars.enable_analytical_cookies || false;
+  const ENABLE_GOOGLE_CONSENT_MODE = window.p4_vars.enable_google_consent_mode || false;
 
   // Possible cookie values
   const ONLY_NECESSARY = '1';


### PR DESCRIPTION
No ticket needed

# Description
The issue is raised whenever the P4 Gutenberg plugin is deactivated.
- Also force to set as `Boolean` instead of `undefined`, for a better typing.

## Testing
- Just run the site with the p4 Gutenberg plugin is deactivated