### PR TITLE
PLANET-7495 Remove extra padding in highlighted text

### DIFF
--- a/assets/src/scss/base/_typography.scss
+++ b/assets/src/scss/base/_typography.scss
@@ -136,3 +136,7 @@ a --link-- {
 a:focus:not(:focus-visible) {
   outline: 0;
 }
+
+mark {
+  padding: 0;
+}


### PR DESCRIPTION
### Description

See [PLANET-7495](https://jira.greenpeace.org/browse/PLANET-7495)
This seems to be added by Bootstrap

### Testing