### PR TITLE
Add stretched link variations from plugin

### DIFF
--- a/assets/src/block-variations/index.js
+++ b/assets/src/block-variations/index.js
@@ -1,0 +1,22 @@
+const {registerBlockVariation} = wp.blocks;
+const {__} = wp.i18n;
+
+/*
+ This file will register general block variations. In case of register a very
+ specific block variation, such as PostsList or ActionsList ,you can create an isolated file.
+*/
+
+export const registerBlockVariations = () => {
+  // Group Stretched Link variation
+  registerBlockVariation('core/group', {
+    name: 'group-stretched-link',
+    title: __('Stretched Link', 'planet4-blocks-backend'),
+    description: __('Make the entire block contents clickable, using the first link inside.', 'planet4-blocks-backend'),
+    attributes: {className: 'group-stretched-link'},
+    scope: ['inserter', 'transform'],
+    isActive: blockAttributes => {
+      return blockAttributes.className === 'group-stretched-link';
+    },
+    icon: 'admin-links',
+  });
+};

--- a/assets/src/editorIndex.js
+++ b/assets/src/editorIndex.js
@@ -10,6 +10,7 @@ import {registerMediaBlock} from './blocks/Media/MediaBlock';
 import {registerBlockTemplates} from './block-templates/register';
 import {registerTimelineBlock} from './blocks/Timeline/TimelineBlock';
 import {registerColumnsBlock} from './blocks/Columns/ColumnsBlock';
+import {registerBlockVariations} from './block-variations';
 
 wp.domReady(() => {
   // Make sure to unregister the posts-list native variation before registering planet4-blocks/posts-list
@@ -30,6 +31,9 @@ wp.domReady(() => {
   // Beta blocks
   registerActionsListBlock();
   registerPostsListBlock();
+
+  // Block variations
+  registerBlockVariations();
 });
 
 setupCustomSidebar();

--- a/assets/src/scss/editorStyle.scss
+++ b/assets/src/scss/editorStyle.scss
@@ -42,3 +42,6 @@
 @import "blocks/Submenu/SubmenuEditorStyle";
 @import "blocks/TakeActionBoxout/TakeActionBoxoutEditorStyle";
 @import "blocks/Timeline/TimelineEditorStyle";
+
+// Variations
+@import "variations/stretched-link/edit";

--- a/assets/src/scss/style.scss
+++ b/assets/src/scss/style.scss
@@ -85,6 +85,9 @@ Text Domain: planet4-master-theme
 
 @import "layout/query-loop-overrides";
 
+// Variations
+@import "variations/stretched-link";
+
 // Hide WPML footer language switcher.
 .wpml-ls-statics-footer {
   display: none;

--- a/assets/src/scss/variations/stretched-link/edit.scss
+++ b/assets/src/scss/variations/stretched-link/edit.scss
@@ -1,0 +1,4 @@
+.group-stretched-link {
+  outline: 1px dashed grey;
+  outline-offset: 2px;
+}

--- a/assets/src/scss/variations/stretched-link/index.scss
+++ b/assets/src/scss/variations/stretched-link/index.scss
@@ -1,0 +1,35 @@
+.group-stretched-link {
+  position: relative;
+
+  [class*="is-style-rounded-"].force-no-caption {
+    overflow: hidden;
+    border-radius: 50%;
+    transform: translateZ(0); // This is needed for Safari, otherwise the animation looks off.
+
+    img {
+      transition: transform .2s ease-in-out;
+    }
+  }
+
+  &:hover {
+    [class*="is-style-rounded-"] img {
+      transform: scale(1.3);
+    }
+  }
+
+  // Ensure it's only applying to the first link.
+  a:first-of-type {
+    &:before {
+      content: "";
+      position: absolute;
+      top: 0;
+      left: 0;
+      bottom: 0;
+      right: 0;
+    }
+
+    &:after {
+      display: none;
+    }
+  }
+}


### PR DESCRIPTION
No ticket needed.

# Description
[Stretched link variations styles](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/tree/9cd9a3cfe4f8b401b2fddd2fe40fcebb51610f0f/assets/src/variations/stretched-link) and [block variation in JS](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/blob/e980c81583a3ffdf32ad86d718e0e6495caa1d9e/assets/src/editorIndex.js#L37-L50) are Required in master theme.

Also required by:
- https://github.com/greenpeace/planet4-master-theme/pull/2258
- https://github.com/greenpeace/planet4-master-theme/pull/2259

<!-- Ref: Please add a url to the ticket this change is addressing.

---

Please provide a brief summary of the change introduced to make review process easier.

Ideally this should also be part of the commit summary.
-->
