### PR TITLE
PLANET-7503: Fix selector to exclude submenu header in submenu block

### DIFF
--- a/assets/src/blocks/Submenu/getHeadingsFromDom.js
+++ b/assets/src/blocks/Submenu/getHeadingsFromDom.js
@@ -9,7 +9,7 @@ export const getHeadingsFromDom = selectedLevels => {
   }
 
   // Get all heading tags that we need to query
-  const headingsSelector = selectedLevels.map(level => `:not(.submenu-block) h${level.heading}`);
+  const headingsSelector = selectedLevels.map(level => `:not(.submenu-block) > h${level.heading}`);
 
   const usedAnchors = [];
 


### PR DESCRIPTION
The h2 of the submenu block has ancestors that match :not(.submenu-block), that's why it was included in the results. By only looking for direct ancestors that match :not(.submenu-block) it is excluded as intended.

Ref: https://jira.greenpeace.org/browse/PLANET-7503