### PR TITLE
POC: Playing around with defer / sync WP strategies

### DIFF
--- a/assets/src/js/async-element.js
+++ b/assets/src/js/async-element.js
@@ -1,0 +1,12 @@
+(() => {
+  /*eslint-disable no-console*/
+  console.log('async-elements loaded.');
+  const elements = ['async'];
+
+  for (const element of elements) {
+    const el = document.createElement('h3');
+    el.className = element;
+    el.innerHTML = `${element} element`;
+    document.querySelector('.page-header-title').insertAdjacentElement('afterend', el);
+  }
+})();

--- a/assets/src/js/async-script.js
+++ b/assets/src/js/async-script.js
@@ -1,0 +1,7 @@
+(() => {
+  /*eslint-disable no-console*/
+  console.log('async-script loaded.');
+  for (const element of [['async', 'green']]) {
+    document.querySelector(`.${element[0]}`).style.color = element[1];
+  }
+})();

--- a/assets/src/js/defer-element.js
+++ b/assets/src/js/defer-element.js
@@ -1,0 +1,12 @@
+(() => {
+  /*eslint-disable no-console*/
+  console.log('defer-element loaded.');
+  const elements = ['defer'];
+
+  for (const element of elements) {
+    const el = document.createElement('h3');
+    el.className = element;
+    el.innerHTML = `${element} element`;
+    document.querySelector('.page-header-title').insertAdjacentElement('afterend', el);
+  }
+})();

--- a/assets/src/js/defer-script.js
+++ b/assets/src/js/defer-script.js
@@ -1,0 +1,7 @@
+(() => {
+  /*eslint-disable no-console*/
+  console.log('defer-script loaded.');
+  for (const element of [['defer', 'purple']]) {
+    document.querySelector(`.${element[0]}`).style.color = element[1];
+  }
+})();

--- a/functions.php
+++ b/functions.php
@@ -489,3 +489,56 @@ if (class_exists('\\Sentry\\Options')) {
         return $options;
     });
 }
+
+wp_register_script(
+    'async-script',
+    get_template_directory_uri() . '/assets/build/async_script.js',
+    array(),
+    '1.0.0',
+    array(
+        'in_footer' => false,
+        'strategy' => 'async'
+    )
+);
+
+
+wp_register_script(
+    'async-element',
+    get_template_directory_uri() . '/assets/build/async_element.js',
+    array(),
+    '1.0.0',
+    // true,
+    array(
+        'in_footer' => false,
+        'strategy' => 'async'
+    )
+);
+
+wp_register_script(
+    'defer-script',
+    get_template_directory_uri() . '/assets/build/defer_script.js',
+    array(),
+    '1.0.0',
+    array(
+        'in_footer' => false,
+        'strategy' => 'defer'
+    )
+);
+
+
+wp_register_script(
+    'defer-element',
+    get_template_directory_uri() . '/assets/build/defer_element.js',
+    array(),
+    '1.0.0',
+    // true,
+    array(
+        'in_footer' => false,
+        'strategy' => 'defer'
+    )
+);
+
+wp_enqueue_script('async-element');
+wp_enqueue_script('async-script');
+wp_enqueue_script('defer-element');
+wp_enqueue_script('defer-script');

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,6 +19,10 @@ const mediaQueryAliases = {
 module.exports = {
   ...defaultConfig,
   entry: {
+    defer_script: './assets/src/js/defer-script.js',
+    defer_element: './assets/src/js/defer-element.js',
+    async_script: './assets/src/js/async-script.js',
+    async_element: './assets/src/js/async-element.js',
     index: './assets/src/js/app.js',
     style: './assets/src/scss/style.scss',
     post: './assets/src/scss/post.scss',


### PR DESCRIPTION
Taken from [here](https://docs.google.com/document/d/1qZfQZCCtoA9lyo4Uyof3l0dYXbqtrru5KznyEHMuLOg/edit).

Demo page: https://www-dev.greenpeace.org/test-sinope/get-informed/

# Description
As a part of an experiment, I've tested the functionality of defer/sync WordPress strategies by registering scripts.

![1699370054733](https://github.com/greenpeace/planet4-master-theme/assets/77975803/31b8e86d-5f55-4261-aaba-930e65110a50)

_According to the official Mozilla documentation:_

### Deferred scripts
Scripts marked for deferred execution — via the defer script attribute — are only executed once the DOM tree has fully loaded (but before the DOMContentLoaded and window load events). Deferred scripts are executed in the same order they were printed/added in the DOM, unlike asynchronous scripts.

### Asynchronous scripts
Scripts marked for asynchronous execution — via the async script attribute — are executed as soon as they are loaded by the browser. Asynchronous scripts do not have a guaranteed execution order, as script B (although added to the DOM after script A) may execute first given that it may complete loading prior to script A. Such scripts may execute either before the DOM has been fully constructed or after the DOMContentLoaded event.

## Potential ideas for solutions
- Improve[ Largest Contentful Paint (LCP)](https://web.dev/articles/lcp) performance
![good-lcp-values](https://github.com/greenpeace/planet4-master-theme/assets/77975803/3f66638f-2f43-4112-ba9c-3282d40a8798)
- Take a decision of how/what is the best way of including JS script.

## Testing
- Change browser throttling to `Regular 2G`, also test with `Wi-Fi`
- Disable cache
- If you clean cache and reload the page you'll see that the `async` element is not working always as expected

## Conclusion
Of course `defer` is the best approach for loading JS scripts since we're ensure that we're able to interact with added into a DOM since it's been fully loaded. However, for scripts that are independent of other scripts, such as tracking scripts, `async` is the best approach