### PR TITLE
Hide GravityForms update message

### DIFF
--- a/admin/css/dashboard.css
+++ b/admin/css/dashboard.css
@@ -23,3 +23,7 @@
 .cp-error {
   color: #be2d26;
 }
+
+#gf_dashboard_message {
+  display: none;
+}


### PR DESCRIPTION
Since we have automatic updates off, this message may be confusing for website admins.

### Testing
- Currently we do get this message even on local env as there is an update available for GF (see screenshot below).
- Switching to this branch, the message should no longer be visible.

![image](https://github.com/greenpeace/planet4-master-theme/assets/939357/5faeb546-f270-4a59-98d7-c643bb61f061)

