### PR TITLE
PLANET-7398 Move Quick Links block pattern into master theme

### DIFF
--- a/assets/src/block-templates/quick-links/block.json
+++ b/assets/src/block-templates/quick-links/block.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://schemas.wp.org/trunk/block.json",
+  "apiVersion": 2,
+  "name": "planet4-block-templates/quick-links",
+  "title": "Quick Links",
+  "category": "planet4-block-templates",
+  "textdomain": "planet4-blocks-backend",
+  "attributes": {
+    "title": { "type": "string" },
+    "backgroundColor": { "type": "string" }
+  }
+}

--- a/assets/src/block-templates/quick-links/index.js
+++ b/assets/src/block-templates/quick-links/index.js
@@ -1,0 +1,4 @@
+import metadata from './block.json';
+import template from './template';
+
+export {metadata, template};

--- a/assets/src/block-templates/quick-links/template.js
+++ b/assets/src/block-templates/quick-links/template.js
@@ -1,0 +1,45 @@
+import mainThemeUrl from '../main-theme-url';
+
+const {__} = wp.i18n;
+
+const category = ['core/column', {}, [
+  ['core/group', {className: 'group-stretched-link'}, [
+    ['core/image', {
+      align: 'center',
+      className: 'is-style-rounded-90 force-no-lightbox force-no-caption mb-0',
+      width: '90px',
+      height: '90px',
+      url: `${mainThemeUrl}/images/placeholders/placeholder-90x90.jpg`,
+    }],
+    ['core/spacer', {height: '16px'}],
+    ['core/heading', {
+      level: 5,
+      style: {typography: {fontSize: '1rem'}},
+      textAlign: 'center',
+      placeholder: __('Category', 'planet4-blocks-backend'),
+    }],
+  ]],
+]];
+
+const template = ({
+  title = '',
+  backgroundColor = 'beige-100',
+}) => ([
+  ['core/group', {
+    className: 'block',
+    align: 'full',
+    backgroundColor,
+  }, [
+    ['core/group', {className: 'container'}, [
+      ['core/spacer', {height: '24px'}],
+      ['core/heading', {level: 4, placeholder: __('Enter title', 'planet4-blocks-backend'), content: title}],
+      ['core/columns', {
+        isStackedOnMobile: false,
+        className: 'is-style-mobile-carousel',
+      },
+      [...Array(5).keys()].map(() => category)],
+    ]],
+  ]],
+]);
+
+export default template;

--- a/assets/src/block-templates/template-list.js
+++ b/assets/src/block-templates/template-list.js
@@ -1,9 +1,11 @@
 import * as sideImgTextCta from './side-image-with-text-and-cta';
 import * as issues from './issues';
 import * as realityCheck from './reality-check';
+import * as quickLinks from './quick-links';
 
 export default [
   sideImgTextCta,
   issues,
   realityCheck,
+  quickLinks,
 ];

--- a/src/Patterns/BlockPattern.php
+++ b/src/Patterns/BlockPattern.php
@@ -44,6 +44,7 @@ abstract class BlockPattern
             SideImageWithTextAndCta::class,
             Issues::class,
             RealityCheck::class,
+            QuickLinks::class,
         ];
     }
 

--- a/src/Patterns/QuickLinks.php
+++ b/src/Patterns/QuickLinks.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * Quick Links class.
+ *
+ * @package P4\MasterTheme\Patterns
+ * @since 0.1
+ */
+
+namespace P4\MasterTheme\Patterns;
+
+/**
+ * Class Quick Links.
+ *
+ * @package P4\MasterTheme\Patterns
+ */
+class QuickLinks extends BlockPattern
+{
+    /**
+     * Returns the pattern name.
+     */
+    public static function get_name(): string
+    {
+        return 'p4/quick-links';
+    }
+
+    /**
+     * Returns the pattern config.
+     *
+     * @param array $params Optional array of parameters for the config.
+     */
+    public static function get_config(array $params = []): array
+    {
+        return [
+            'title' => 'Quick Links',
+            'categories' => [ 'planet4' ],
+            'content' => '
+				<!-- wp:planet4-block-templates/quick-links ' . wp_json_encode($params, \JSON_FORCE_OBJECT) . ' /-->
+			',
+        ];
+    }
+}


### PR DESCRIPTION
Ref:  https://jira.greenpeace.org/browse/PLANET-7398

**Testing**

If you comment out this [code](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/blob/main/classes/class-loader.php#L184) and [this](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/blob/main/assets/src/editorIndex.js#L52) in the blocks repo locally, you should still see the Issues Pattern in the editor

<!-- Ref: Please add a url to the ticket this change is addressing.

---

Please provide a brief summary of the change introduced to make review process easier.

Ideally this should also be part of the commit summary.
-->
