### PR TITLE
PLANET-7399 Move Reality Check block pattern into master theme

### DIFF
--- a/assets/src/block-templates/reality-check/block.json
+++ b/assets/src/block-templates/reality-check/block.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://schemas.wp.org/trunk/block.json",
+  "apiVersion": 2,
+  "name": "planet4-block-templates/reality-check",
+  "title": "Reality Check",
+  "category": "planet4-block-templates",
+  "textdomain": "planet4-blocks-backend"
+}

--- a/assets/src/block-templates/reality-check/index.js
+++ b/assets/src/block-templates/reality-check/index.js
@@ -1,0 +1,4 @@
+import metadata from './block.json';
+import template from './template';
+
+export {metadata, template};

--- a/assets/src/block-templates/reality-check/template.js
+++ b/assets/src/block-templates/reality-check/template.js
@@ -1,0 +1,33 @@
+import mainThemeUrl from '../main-theme-url';
+
+const {__} = wp.i18n;
+
+const column = ['core/column', {}, [
+  ['core/group', {}, [
+    ['core/image', {
+      align: 'center',
+      className: 'mb-0 force-no-lightbox force-no-caption',
+      url: `${mainThemeUrl}/images/placeholders/placeholder-75x75.jpg`,
+    }],
+    ['core/heading', {
+      style: {typography: {fontSize: '4rem'}},
+      textAlign: 'center',
+      placeholder: __('Enter title', 'planet4-blocks-backend'),
+    }],
+    ['core/paragraph', {
+      align: 'center',
+      placeholder: __('Enter description', 'planet4-blocks-backend'),
+    }],
+    ['core/spacer', {height: '16px'}],
+  ]],
+]];
+
+const template = () => ([
+  ['core/columns', {
+    className: 'block',
+  },
+  [...Array(3).keys()].map(() => column),
+  ],
+]);
+
+export default template;

--- a/assets/src/block-templates/template-list.js
+++ b/assets/src/block-templates/template-list.js
@@ -1,7 +1,9 @@
 import * as sideImgTextCta from './side-image-with-text-and-cta';
 import * as issues from './issues';
+import * as realityCheck from './reality-check';
 
 export default [
   sideImgTextCta,
   issues,
+  realityCheck,
 ];

--- a/src/Patterns/BlockPattern.php
+++ b/src/Patterns/BlockPattern.php
@@ -43,6 +43,7 @@ abstract class BlockPattern
         return [
             SideImageWithTextAndCta::class,
             Issues::class,
+            RealityCheck::class,
         ];
     }
 

--- a/src/Patterns/RealityCheck.php
+++ b/src/Patterns/RealityCheck.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * Reality Check class.
+ *
+ * @package P4\MasterTheme\Patterns
+ * @since 0.1
+ */
+
+namespace P4\MasterTheme\Patterns;
+
+/**
+ * Class Reality Check.
+ *
+ * @package P4\MasterTheme\Patterns
+ */
+class RealityCheck extends BlockPattern
+{
+    /**
+     * Returns the pattern name.
+     */
+    public static function get_name(): string
+    {
+        return 'p4/reality-check';
+    }
+
+    /**
+     * Returns the pattern config.
+     *
+     * @param array $params Optional array of parameters for the config.
+     */
+    public static function get_config(array $params = []): array
+    {
+
+        return [
+            'title' => 'Reality Check',
+            'categories' => [ 'planet4' ],
+            'content' => '
+				<!-- wp:planet4-block-templates/reality-check ' . wp_json_encode($params, \JSON_FORCE_OBJECT) . ' /-->
+			',
+        ];
+    }
+}


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-7399

**Testing:** 

If you comment out this [code](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/blob/main/classes/class-loader.php#L184) and [this](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/blob/main/assets/src/editorIndex.js#L52) in the blocks repo locally, you should still see the Issues Pattern in the editor

<!-- Ref: Please add a url to the ticket this change is addressing.

---

Please provide a brief summary of the change introduced to make review process easier.

Ideally this should also be part of the commit summary.
-->
