### PR TITLE
PLANET-7516: Fix Analytics Tracking Sidebar component

### DIFF
--- a/assets/src/block-editor/Sidebar/AnalyticsTrackingSidebar.js
+++ b/assets/src/block-editor/Sidebar/AnalyticsTrackingSidebar.js
@@ -1,3 +1,4 @@
+import {useEffect} from '@wordpress/element';
 import {PluginDocumentSettingPanel} from '@wordpress/edit-post';
 import {dispatch, useSelect} from '@wordpress/data';
 import {SelectSidebarField} from '../SidebarFields/SelectSidebarField';
@@ -6,54 +7,46 @@ import {getSidebarFunctions} from './getSidebarFunctions';
 
 const {__} = wp.i18n;
 
-dispatch('core').addEntities([{
-  baseURL: '/planet4/v1/analytics-values',
-  kind: 'planet4/v1',
-  name: 'analytics-values',
-  label: 'Analytics and tracking values',
-}]);
-
-const GLOBAL_PROJECT = 'p4_campaign_name';
-const LOCAL_PROJECT = 'p4_local_project';
-const BASKET = 'p4_basket_name';
-const DEPARTMENT = 'p4_department';
-
 export const AnalyticsTrackingSidebar = {
   getId: () => 'planet4-analytics-sidebar',
   render: () => {
     const {getParams} = getSidebarFunctions();
     const postId = wp.data.select('core/editor').getCurrentPostId();
     const options = useSelect(select => {
-      return select('core').getEntityRecords('planet4/v1', 'analytics-values', {id: postId});
+      return select('core').getEntityRecord('planet4/v1', 'analytics-values');
     });
 
-    const globalOptions = options ? options[0].global_projects : [];
-    const localOptions = options ? options[0].local_projects : [];
-    const basketOptions = options ? options[0].baskets : [];
+    useEffect(() => {
+      dispatch('core').addEntities([{
+        baseURL: '/planet4/v1/analytics-values',
+        baseURLParams: {post_id: postId},
+        kind: 'planet4/v1',
+        name: 'analytics-values',
+        label: 'Analytics and tracking values',
+      }]);
+    }, [postId]);
 
-    return (
-      <>
-        <PluginDocumentSettingPanel
-          name="analytics-panel"
-          title={__('Analytics & Tracking', 'planet4-blocks-backend')}
-        >
-          <SelectSidebarField
-            label={__('Global Project', 'planet4-master-theme-backend')}
-            options={globalOptions}
-            {...getParams(GLOBAL_PROJECT)} />
-          <SelectSidebarField
-            label={__('Local Projects', 'planet4-master-theme-backend')}
-            options={localOptions}
-            {...getParams(LOCAL_PROJECT)} />
-          <SelectSidebarField
-            label={__('Basket Name', 'planet4-master-theme-backend')}
-            options={basketOptions}
-            {...getParams(BASKET)} />
-          <TextSidebarField
-            label={__('Department', 'planet4-master-theme-backend')}
-            {...getParams(DEPARTMENT)} />
-        </PluginDocumentSettingPanel>
-      </>
+    return options && (
+      <PluginDocumentSettingPanel
+        name="analytics-panel"
+        title={__('Analytics & Tracking', 'planet4-blocks-backend')}
+      >
+        <SelectSidebarField
+          label={__('Global Project', 'planet4-master-theme-backend')}
+          options={options.global_projects || []}
+          {...getParams('p4_campaign_name')} />
+        <SelectSidebarField
+          label={__('Local Projects', 'planet4-master-theme-backend')}
+          options={options.local_projects || []}
+          {...getParams('p4_local_project')} />
+        <SelectSidebarField
+          label={__('Basket Name', 'planet4-master-theme-backend')}
+          options={options.baskets || []}
+          {...getParams('p4_basket_name')} />
+        <TextSidebarField
+          label={__('Department', 'planet4-master-theme-backend')}
+          {...getParams('p4_department')} />
+      </PluginDocumentSettingPanel>
     );
   },
 };


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-7516

# Description
When testing WordPress 6.5 the AnalyticsTrackingSidebar stopped working.

I noticed that the problem comes after adding the analytics-values Entity but not sure exactly why this happens. Unfortunately, there is no recent updates of the addEntities function.

## About the issue
Currently we add the analytics-values entity like this
```
dispatch('core').addEntities([{
  baseURL: '/planet4/v1/analytics-values',
  kind: 'planet4/v1',
  name: 'analytics-values',
  label: 'Analytics and tracking values',
}]);
```
And getting the value
```
const options = useSelect(select => {
    return select('core').getEntityRecords('planet4/v1', 'analytics-values', {id: postId});
 });
```
Finally, the endpoint GET http://www.planet4.test/wp-json/planet4/v1/analytics-values?id=:ID is returning the correct value BUT options is always set to an empty Array.

After a big research and testing the issue in WordPress 6.4.* and 6.5.* I detected that the [baseURLParams](https://github.com/WordPress/gutenberg/blob/bd06705979ad63ace26d15de47144c253c3b0fc8/docs/getting-started/data.md) field should be also included when adding a new identity and match exactly against the endpoint.

The other problem is that adding the Entity should be run in to the Scope of the component but never outside.

## Requirements
Run WordPress 6.5

### Resources
[gutenberg#60823](https://github.com/WordPress/gutenberg/pull/60823)
[getentityrecord](https://github.com/WordPress/gutenberg/blob/trunk/docs/reference-guides/data/data-core.md#getentityrecord)
[packages-core-data](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-core-data/)
[useentityrecords-an-easier-way-to-fetch-wordpress-data](https://developer.wordpress.org/news/2023/05/19/useentityrecords-an-easier-way-to-fetch-wordpress-data/)
[External link to a relevant resource](http://#)

# Testing
*Run WP6.5 on your local*

<!-- Ref: Please add a url to the ticket this change is addressing.

---

Please provide a brief summary of the change introduced to make review process easier.

Ideally this should also be part of the commit summary.
-->
