### PR TITLE
PLANET-7263 Media Archive: add in editor option for P4 blocks

### DIFF
--- a/admin/css/archive-picker.css
+++ b/admin/css/archive-picker.css
@@ -332,6 +332,7 @@
   position: absolute;
   top: 0;
   right: 0;
+  background-color: transparent;
 }
 
 #archive-picker-root .picker-sidebar-header .close-sidebar {
@@ -340,7 +341,7 @@
 
 .media-modal-content .picker-sidebar-header .close-sidebar {
   right: 35px;
-  background: url("../../images/arrow-right.svg");
+  background-image: url("../../images/arrow-right.svg");
 }
 
 .multiple-search-item .delete-icon {

--- a/assets/src/blocks/CarouselHeader/CarouselHeaderBlock.js
+++ b/assets/src/blocks/CarouselHeader/CarouselHeaderBlock.js
@@ -36,6 +36,10 @@ const attributes = {
       return {isValid, messages};
     },
   },
+  currentImageIndex: {
+    type: 'integer',
+    default: 0,
+  },
 };
 
 export const registerCarouselHeaderBlock = () =>

--- a/assets/src/blocks/CarouselHeader/CarouselHeaderEditor.js
+++ b/assets/src/blocks/CarouselHeader/CarouselHeaderEditor.js
@@ -27,6 +27,10 @@ export const CarouselHeaderEditor = ({setAttributes, attributes}) => {
     setAttributes({slides: newSlides});
   };
 
+  const updateCurrentImageIndex = index => {
+    setAttributes({currentImageIndex: index});
+  };
+
   const changeSlideImage = (index, imageId, imageUrl, imageAlt, srcSet) => {
     const newSlides = [...slides];
     newSlides[index].image = imageId;
@@ -112,6 +116,7 @@ export const CarouselHeaderEditor = ({setAttributes, attributes}) => {
                 image_id={slide.image}
                 index={index}
                 changeSlideImage={changeSlideImage}
+                updateCurrentImageIndex={updateCurrentImageIndex}
                 addSlide={addSlide}
                 removeSlide={removeSlide}
                 slides={slides}

--- a/assets/src/blocks/CarouselHeader/EditableBackground.js
+++ b/assets/src/blocks/CarouselHeader/EditableBackground.js
@@ -12,6 +12,7 @@ export const EditableBackground = ({
   index,
   focalPoints,
   changeSlideImage,
+  updateCurrentImageIndex,
   addSlide,
   removeSlide,
   slides,
@@ -57,6 +58,7 @@ export const EditableBackground = ({
                   onClick={() => {
                     mediaUploadInstance.open();
                     onToggle();
+                    updateCurrentImageIndex(index);
                   }}
                 >
                   {image_url ?

--- a/assets/src/js/Components/ArchivePicker/ArchivePicker.js
+++ b/assets/src/js/Components/ArchivePicker/ArchivePicker.js
@@ -5,7 +5,12 @@ import ArchivePickerList from './ArchivePickerList';
 import SingleSidebar from './SingleSidebar';
 import MultiSidebar from './MultiSidebar';
 import ArchivePickerToolbar from './ArchivePickerToolbar';
-import {updateImageBlockAttributes, updateHappyPointAttributes} from './blockUpdateFunctions';
+import {
+  updateImageBlockAttributes,
+  updateHappyPointAttributes,
+  updateMediaAndTextAttributes,
+  updateCarouselBlockAttributes,
+} from './blockUpdateFunctions';
 
 const {apiFetch, url, i18n} = wp;
 const {addQueryArgs} = url;
@@ -13,7 +18,7 @@ const {__} = i18n;
 const timeout = delay => {
   return new Promise(resolve => setTimeout(resolve, delay));
 };
-const acceptedBlockTypes = ['core/image', 'planet4-blocks/happypoint'];
+const acceptedBlockTypes = ['core/image', 'planet4-blocks/happypoint', 'core/media-text', 'planet4-blocks/carousel-header'];
 
 export const EDITOR_VIEW = 'editor';
 export const ADMIN_VIEW = 'admin';
@@ -293,18 +298,23 @@ export default function ArchivePicker({view = ADMIN_VIEW}) {
     }
   }, []);
 
+  const processImageForBlock = async (imageID, updateAttributeFunction) => {
+    const uploadedImage = await getImageDetails(imageID);
+    const updatedAttributes = updateAttributeFunction(uploadedImage, currentBlock);
+    await wp.data.dispatch('core/block-editor').updateBlock(currentBlock.clientId, updatedAttributes);
+  };
+
   const processImageToAddToEditor = async id => {
     dispatch({type: ACTIONS.ADD_IMAGE_TO_POST});
     try {
       if (currentBlock.name === 'core/image') {
-        // Get current Image details from WP
-        const uploadedImage = await getImageDetails(id);
-        // Get Updated Atrributes
-        const updatedAttributes = updateImageBlockAttributes(uploadedImage, currentBlock);
-        await wp.data.dispatch('core/block-editor').updateBlock(currentBlock.clientId, updatedAttributes);
-      }
-
-      if (currentBlock.name === 'planet4-blocks/happypoint') {
+        await processImageForBlock(id, updateImageBlockAttributes);
+      } else if (currentBlock.name === 'planet4-blocks/carousel-header') {
+        await processImageForBlock(id, updateCarouselBlockAttributes);
+      } else if (currentBlock.name === 'core/media-text') {
+        await processImageForBlock(id, updateMediaAndTextAttributes);
+      } else {
+        // Happypoint Block
         const updatedAttributes = updateHappyPointAttributes(id);
         await wp.data.dispatch('core/block-editor').updateBlock(currentBlock.clientId, updatedAttributes);
       }
@@ -434,7 +444,7 @@ export default function ArchivePicker({view = ADMIN_VIEW}) {
                   className="tooltip"
                   dangerouslySetInnerHTML={{
                     __html: __(
-                      'The <strong>Media Archive</strong> pulls images from <a target="_blank" href="https://media.greenpeace.org/">media.greenpeace.org</a>. You can import these images into your Wordpress Media Library and Post/Page. If you have further questions, you can visit the <a target="_blank" href="https://planet4.greenpeace.org/manage/administer/media-archive/">Media Archive Page</a> in the Handbook.', 'planet4-master-theme-backend'
+                      'The <strong>Greenpeace Media</strong> pulls images from <a target="_blank" href="https://media.greenpeace.org/">media.greenpeace.org</a>. You can import these images into your Wordpress Media Library and Post/Page. If you have further questions, you can visit the <a target="_blank" href="https://planet4.greenpeace.org/manage/administer/media-archive/">Greenpeace Media Page</a> in the Handbook.', 'planet4-master-theme-backend'
                     ),
                   }}
                 />
@@ -477,7 +487,7 @@ export default function ArchivePicker({view = ADMIN_VIEW}) {
                       className="tooltip"
                       dangerouslySetInnerHTML={{
                         __html: __(
-                          'The <strong>Media Archive</strong> pulls images from <a target="_blank" href="https://media.greenpeace.org/">media.greenpeace.org</a>. You can import these images into your Wordpress Media Library and Post/Page. If you have further questions, you can visit the <a target="_blank" href="https://planet4.greenpeace.org/manage/administer/media-archive/">Media Archive Page</a> in the Handbook.', 'planet4-master-theme-backend'
+                          'The <strong>Greenpeace Media</strong> pulls images from <a target="_blank" href="https://media.greenpeace.org/">media.greenpeace.org</a>. You can import these images into your Wordpress Media Library and Post/Page. If you have further questions, you can visit the <a target="_blank" href="https://planet4.greenpeace.org/manage/administer/media-archive/">Greenpeace Media Page</a> in the Handbook.', 'planet4-master-theme-backend'
                         ),
                       }}
                     />

--- a/assets/src/js/Components/ArchivePicker/blockUpdateFunctions.js
+++ b/assets/src/js/Components/ArchivePicker/blockUpdateFunctions.js
@@ -22,7 +22,7 @@ export const updateImageBlockAttributes = (image, currentBlock) => {
     }
   }
 
-  const updatedAttributes = {
+  return {
     attributes: {
       id: image.id,
       url: image.source_url,
@@ -31,11 +31,57 @@ export const updateImageBlockAttributes = (image, currentBlock) => {
     },
     originalContent: div.innerHTML,
   };
-
-  return updatedAttributes;
 };
 
 export const updateHappyPointAttributes = id => {
   // Need to update only the id property for the Happy Point block
   return {attributes: {id}};
+};
+
+export const updateMediaAndTextAttributes = (image, currentBlock) => {
+  const div = document.createElement('div');
+
+  if (currentBlock.originalContent) {
+    div.innerHTML = currentBlock.originalContent;
+    div.querySelector('img').setAttribute('class', `wp-image-${image.id}`);
+    div.querySelector('img').src = image.source_url;
+  } else {
+    div.innerHTML = `
+      <div class="wp-block-media-text is-stacked-on-mobile"><figure class="wp-block-media-text__media"><img src=${image.source_url} alt=${image.alt_text} class="wp-image-${image.id} size-full"/></figure><div class="wp-block-media-text__content"></div></div>
+    `;
+  }
+
+  return {
+    attributes: {
+      mediaLink: image.link,
+      mediaUrl: image.source_url,
+      mediaAlt: image.alt_text,
+      mediaId: image.id,
+      mediaType: 'image',
+    },
+    originalContent: div.innerHTML,
+  };
+};
+
+export const updateCarouselBlockAttributes = (image, currentBlock) => {
+  const slides = currentBlock.attributes.slides;
+  const currentImageIndex = currentBlock.attributes.currentImageIndex;
+  const {thumbnail, medium_large, medium, large, full} = image.media_details.sizes;
+  const imageSrcSet = `
+  ${thumbnail.source_url} ${thumbnail.width}w,
+  ${medium_large.source_url} ${medium_large.width}w,
+  ${medium.source_url} ${medium.width}w,
+  ${large.source_url} ${large.width}w,
+  ${full.source_url} ${full.width}w,
+  `;
+
+  slides[currentImageIndex].image = image.id;
+  slides[currentImageIndex].image_url = image.source_url;
+  slides[currentImageIndex].image_srcset = imageSrcSet;
+
+  return {
+    attributes: {
+      slides,
+    },
+  };
 };

--- a/src/Blocks/CarouselHeader.php
+++ b/src/Blocks/CarouselHeader.php
@@ -86,6 +86,10 @@ class CarouselHeader extends BaseBlock
                             ],
                         ],
                     ],
+                    'currentImageIndex' => [
+                        'type' => 'integer',
+                        'default' => 0,
+                    ],
                 ],
             ]
         );


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-7263

**Testing:** 

- Added option to use _Greenpeace Media_ to upload images for the `core/media-text` block.
- All blocks using `core/image` or `core/media-text` for images now have access to the Greenpeace Media
- `planet4-blocks/carousel-header` also has access to the Greenpeace Media.


<!-- Ref: Please add a url to the ticket this change is addressing.

---

Please provide a brief summary of the change introduced to make review process easier.

Ideally this should also be part of the commit summary.
-->
