### PR TITLE
PLANET-7366 Add filter hook for overriding Sendgrid from address

### DIFF
--- a/src/Sendgrid.php
+++ b/src/Sendgrid.php
@@ -27,9 +27,13 @@ class Sendgrid
             return;
         }
 
+        if (defined('SENDGRID_NRO_API_KEY') && !empty(SENDGRID_NRO_API_KEY)) {
+            $sendgrid_nro_api_key = SENDGRID_NRO_API_KEY;
+        }
+
         $phpmailer->Host = self::HOST;
         $phpmailer->Username = self::USERNAME;
-        $phpmailer->Password = SENDGRID_API_KEY;
+        $phpmailer->Password = $sendgrid_nro_api_key ?? SENDGRID_API_KEY;
         // Filter hook to change the sendgrid From address.
         $phpmailer->From = apply_filters('planet4_sendgrid_sender', self::SENDER);
 

--- a/src/Sendgrid.php
+++ b/src/Sendgrid.php
@@ -30,7 +30,8 @@ class Sendgrid
         $phpmailer->Host = self::HOST;
         $phpmailer->Username = self::USERNAME;
         $phpmailer->Password = SENDGRID_API_KEY;
-        $phpmailer->From = self::SENDER;
+        // Filter hook to change the sendgrid From address.
+        $phpmailer->From = apply_filters('planet4_sendgrid_sender', self::SENDER);
 
         $phpmailer->IsSMTP();
         $phpmailer->Port = self::PORT_TLS;


### PR DESCRIPTION
Filter name: planet4_sendgrid_sender

Ref. https://jira.greenpeace.org/browse/PLANET-7366

**Usage:**
```
// The filter callback function.
function update_planet4_sendgrid_sender( $sender ) {
    // (maybe) change $sender.
    return $sender;
}
add_filter( 'planet4_sendgrid_sender', 'update_planet4_sendgrid_sender', 10, 1 );
```

[Documentation link](https://github.com/greenpeace/planet4-docs/blob/master/docs/tech/hooks.md)
