### PR TITLE
Add alt attribute to nav-items

### DIFF
--- a/templates/burger-menu-items.twig
+++ b/templates/burger-menu-items.twig
@@ -12,6 +12,7 @@
             <a
                 class="nav-link"
                 href="{{ item.get_link }}"
+                target="{{ item.target }}"
                 data-ga-category="Menu Navigation"
                 data-ga-action="{{ link_ga_action }}"
                 data-ga-label="{{ page_category }}">
@@ -48,6 +49,7 @@
                     <a
                         class="nav-link"
                         href="{{ item.get_link }}"
+                        target="{{ item.target }}"
                         data-ga-category="Submenu Navigation"
                         data-ga-action="{{ link_ga_action }}"
                         data-ga-label="{{ page_category }}">

--- a/templates/burger-menu.twig
+++ b/templates/burger-menu.twig
@@ -28,6 +28,7 @@
                     <a
                         class="nav-link"
                         href="{{ site.url }}"
+                        target="{{ item.target }}"
                         data-ga-category="Menu Navigation"
                         data-ga-action="Home"
                         data-ga-label="{{ page_category }}">
@@ -50,6 +51,7 @@
         <a
             class="btn btn-donate"
             href="{{ donate_menu_items[0].link }}"
+            target="{{ item.target }}"
             data-ga-category="Menu Navigation"
             data-ga-action="Donate"
             data-ga-label="{{ page_category }}">

--- a/templates/desktop-menu.twig
+++ b/templates/desktop-menu.twig
@@ -13,6 +13,7 @@
                     <a
                             class="nav-link"
                             href="{{ item.get_link }}"
+                            target="{{ item.target }}"
                             data-ga-category="Menu Navigation"
                             data-ga-action="{{ link_ga_action }}"
                             data-ga-label="{{ page_category }}">

--- a/templates/footer.twig
+++ b/templates/footer.twig
@@ -15,6 +15,7 @@
                         <li>
                             <a
                                 href="{{ primary.url }}"
+                                target="{{ item.target }}"
                                 data-ga-category="Footer Navigation"
                                 data-ga-action="Footer Links"
                                 data-ga-label="{{ primary.title }}"
@@ -32,6 +33,7 @@
                         <li>
                             <a
                                 href="{{ secondary.url }}"
+                                target="{{ item.target }}"
                                 data-ga-category="Footer Navigation"
                                 data-ga-action="Footer Links"
                                 data-ga-label="{{ secondary.title }}"

--- a/templates/navigation-bar.twig
+++ b/templates/navigation-bar.twig
@@ -61,6 +61,7 @@
                     <a
                         class="nav-link"
                         href="{{ item.get_link }}"
+                        target="{{ item.target }}"
                         data-ga-category="Menu Navigation"
                         data-ga-action="{{ item.title }}"
                         data-ga-label="{{ page_category }}">

--- a/templates/navigation-bar_min.twig
+++ b/templates/navigation-bar_min.twig
@@ -10,7 +10,10 @@
                 {% if key == 0 %}
                     <li class="nav-item {{ item.class }}">
                 {% endif %}
-                    <a class="nav-link" href="{{ item.get_link }}">{{ item.title|striptags|trim|slice(0, 2) }}</a>
+                    <a class="nav-link"
+                        href="{{ item.get_link }}"
+                        target="{{ item.target }}"
+                    >{{ item.title|striptags|trim|slice(0, 2) }}</a>
                 {% if key == (languages - 1) %}
                     </li>
                 {% endif %}

--- a/templates/navigation-submenu.twig
+++ b/templates/navigation-submenu.twig
@@ -12,6 +12,7 @@
             <a
                 class="nav-link"
                 href="{{ item.get_link }}"
+                target="{{ item.target }}"
                 data-ga-category="Submenu Navigation"
                 data-ga-action="{{ item.title }}"
                 data-ga-label="{{ page_category }}">


### PR DESCRIPTION
Comes from https://greenpeace-gpi.slack.com/archives/C0160MX64AG/p1715929906416189

# Description
It depends on "Open in a new tab" option

## Testing
- Go to /menus
- Choose the main navigation
- Edit any sub item by selecting "Open in a new tab"
- Then save
- Test the menu from the site


<!-- Ref: Please add a url to the ticket this change is addressing.

---

Please provide a brief summary of the change introduced to make review process easier.

Ideally this should also be part of the commit summary.
-->
