### PR TITLE
PLANET-7533 Fix Type error in function param

### DIFF
--- a/src/Controllers/Menu/EnformPostController.php
+++ b/src/Controllers/Menu/EnformPostController.php
@@ -227,10 +227,10 @@ class EnformPostController extends Controller
      * Creates a Meta box for the Selected Components of the current EN Form.
      *
      * @param string   $post_type The current post type (unused).
-     * @param \WP_Post $post The currently Added/Edited EN Form.
+     * @param WP_Post|WP_Comment $post The currently Added/Edited EN Form.
      * phpcs:disable SlevomatCodingStandard.Functions.UnusedParameter
      */
-    public function add_form_meta_box(string $post_type, \WP_Post $post): void
+    public function add_form_meta_box(string $post_type, $post): void
     {
         add_meta_box(
             'meta-box-form',
@@ -258,10 +258,10 @@ class EnformPostController extends Controller
      * Creates a Meta box for the Selected Components of the current EN Form.
      *
      * @param string   $post_type The current post type (unused).
-     * @param \WP_Post $post The currently Added/Edited EN Form.
+     * @param WP_Post|WP_Comment $post The currently Added/Edited EN Form.
      * phpcs:disable SlevomatCodingStandard.Functions.UnusedParameter
      */
-    public function add_selected_meta_box(string $post_type, \WP_Post $post): void
+    public function add_selected_meta_box(string $post_type, $post): void
     {
         add_meta_box(
             'meta-box-selected',
@@ -294,10 +294,10 @@ class EnformPostController extends Controller
      * Adds available fields custom meta box to p4en_form edit post page.
      *
      * @param string   $post_type The current post type (unused).
-     * @param \WP_Post $post The currently Added/Edited EN Form.
+     * @param WP_Post|WP_Comment $post The currently Added/Edited EN Form.
      * phpcs:disable SlevomatCodingStandard.Functions.UnusedParameter
      */
-    public function add_fields_meta_box(string $post_type, \WP_Post $post): void
+    public function add_fields_meta_box(string $post_type, $post): void
     {
         add_meta_box(
             'fields_list_box',

--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -966,10 +966,10 @@ class MasterSite extends TimberSite
      * that is used for applying weight to the current Post/Page in search results.
      *
      * @param string  $post_type Post type.
-     * @param WP_Post $post      Post object.
+     * @param WP_Post|WP_Comment $post      Post object.
      * phpcs:disable SlevomatCodingStandard.Functions.UnusedParameter -- add_meta_boxes callback
      */
-    public function add_meta_box_search(string $post_type, WP_Post $post): void
+    public function add_meta_box_search(string $post_type, $post): void
     {
         add_meta_box(
             'meta-box-search',


### PR DESCRIPTION
Ref. https://jira.greenpeace.org/browse/PLANET-7533

This PR will fix below Function param Type error -

> Fatal error: Uncaught TypeError: P4\MasterTheme\MasterSite::add_meta_box_search(): Argument #2 ($post) must be of type WP_Post, WP_Comment given, called in /var/www/html/wp-includes/class-wp-hook.php on line 324 and defined in /var/www/html/wp-content/themes/planet4-master-theme/src/MasterSite.php:972 Stack trace: #0 /var/www/html/wp-includes/class-wp-hook.php(324): P4\MasterTheme\MasterSite->add_meta_box_search('comment', Object(WP_Comment)) #1 /var/www/html/wp-includes/class-wp-hook.php(348): WP_Hook->apply_filters(NULL, Array) #2 /var/www/html/wp-includes/plugin.php(517): WP_Hook->do_action(Array) #3 /var/www/html/wp-admin/edit-form-comment.php(257): do_action('add_meta_boxes', 'comment', Object(WP_Comment)) #4 /var/www/html/wp-admin/comment.php(92): require('/var/www/html/w...') #5 {main} thrown in /var/www/html/wp-content/themes/planet4-master-theme/src/MasterSite.php on line 972 Warning: Trying to access array offset on value of type bool in /var/www/html/wp-includes/class-wp-recovery-mode-email-service.php on line 367 Warning: Trying to access array offset on value of type bool in /var/www/html/wp-includes/class-wp-recovery-mode-email-service.php on line 368


The same issue was also reported on the WP doc-
https://developer.wordpress.org/reference/hooks/add_meta_boxes/#user-contributed-notes
