### PR TITLE
Fix search clear button rtl position

### DIFF
--- a/assets/src/scss/pages/search/_search-bar.scss
+++ b/assets/src/scss/pages/search/_search-bar.scss
@@ -56,6 +56,11 @@
     @include large-and-up {
       top: $sp-2;
     }
+
+    html[dir="rtl"] & {
+      right: auto;
+      left: $sp-3;
+    }
   }
 
   .search-btn {


### PR DESCRIPTION
Just changing its left/right position to work for RTL languages.

---

### Testing

I deployed the fix on a dev site:
[Production](https://www.greenpeace.org/mena/ar/?s=climate&orderby=_score) vs [Development](https://www-dev.greenpeace.org/mena/ar/?s=climate&orderby=_score)
