### PR TITLE
Change tweet to post

### DIFF
--- a/assets/src/blocks/ENForm/ShareButtons.js
+++ b/assets/src/blocks/ENForm/ShareButtons.js
@@ -89,7 +89,7 @@ export const ShareButtons = ({social_params, social_accounts}) => {
 };
 
 const twitterUrl = (link, title, description, account) => {
-  return `https://twitter.com/share?url=${encodeURIComponent(link)}` +
+  return `https://x.com/share?url=${encodeURIComponent(link)}` +
     `&text=${encodeURIComponent(title)}` +
     (description ? ` - ${encodeURIComponent(description)}` : '') +
     (account ? ` via @${encodeURIComponent(account)}&related=${encodeURIComponent(account)}` : '');

--- a/templates/blocks/share_buttons.twig
+++ b/templates/blocks/share_buttons.twig
@@ -55,7 +55,7 @@
     {% endif %}
     <!-- Twitter -->
     {% if all_platforms or share_platforms.twitter %}
-        <a href="https://twitter.com/intent/post?related={{ social_accounts.twitter }}&text={{ social.title|url_encode }}{% if share_text or social.description %} - {{ (share_text ?? social.description)|striptags|url_encode }}{% endif %}, via @{{ social_accounts.twitter }}&url={{ (socialLink ~ '&utm_source=twitter')|url_encode }}"
+        <a href="https://x.com/intent/post?related={{ social_accounts.twitter }}&text={{ social.title|url_encode }}{% if share_text or social.description %} - {{ (share_text ?? social.description)|striptags|url_encode }}{% endif %}, via @{{ social_accounts.twitter }}&url={{ (socialLink ~ '&utm_source=twitter')|url_encode }}"
             onclick="dataLayerPush('Twitter');"
             target="_blank" class="share-btn twitter">
             {{ 'twitter'|svgicon }}

--- a/templates/blocks/share_buttons.twig
+++ b/templates/blocks/share_buttons.twig
@@ -55,7 +55,7 @@
     {% endif %}
     <!-- Twitter -->
     {% if all_platforms or share_platforms.twitter %}
-        <a href="https://twitter.com/intent/tweet?related={{ social_accounts.twitter }}&text={{ social.title|url_encode }}{% if share_text or social.description %} - {{ (share_text ?? social.description)|striptags|url_encode }}{% endif %}, via @{{ social_accounts.twitter }}&url={{ (socialLink ~ '&utm_source=twitter')|url_encode }}"
+        <a href="https://twitter.com/intent/post?related={{ social_accounts.twitter }}&text={{ social.title|url_encode }}{% if share_text or social.description %} - {{ (share_text ?? social.description)|striptags|url_encode }}{% endif %}, via @{{ social_accounts.twitter }}&url={{ (socialLink ~ '&utm_source=twitter')|url_encode }}"
             onclick="dataLayerPush('Twitter');"
             target="_blank" class="share-btn twitter">
             {{ 'twitter'|svgicon }}


### PR DESCRIPTION
### Description

See [Slack](https://greenpeace.slack.com/archives/C0151L0KKNX/p1716900694930299)

X made this change since tweets are now called posts. As far as I understood no other changes are necessary?

**Related PR:** https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/1212
