### PR TITLE
PLANET-7480 Stop hiding page header when Query Loop block is used

### DIFF
--- a/src/Context.php
+++ b/src/Context.php
@@ -26,7 +26,7 @@ class Context
         $context['header_button_link'] = $page_meta_data['p4_button_link'] ?? '';
         $context['header_button_link_checkbox'] = $page_meta_data['p4_button_link_checkbox'] ?? '';
         $context['hide_page_title'] = 'on' === ( $page_meta_data['p4_hide_page_title_checkbox'] ?? null )
-            || has_block('post-title');
+            || (has_block('post-title') && !has_block('query'));
     }
 
     /**


### PR DESCRIPTION
**Ref: https://jira.greenpeace.org/browse/PLANET-7480**

**Testting:**

Pages with the Query Loop block should now have a Page header on the frontend

<!-- Ref: Please add a url to the ticket this change is addressing.

---

Please provide a brief summary of the change introduced to make review process easier.

Ideally this should also be part of the commit summary.
-->
