### PR TITLE
PLANET-7536 Add share text to WhatsApp share button

### DIFF
--- a/templates/blocks/share_buttons.twig
+++ b/templates/blocks/share_buttons.twig
@@ -37,7 +37,7 @@
 <div class="share-buttons">
     <!-- Whatsapp -->
     {% if all_platforms or share_platforms.whatsapp %}
-        <a href="https://wa.me/?text={{ (socialLink ~ '&utm_source=whatsapp')|url_encode }}"
+        <a href="https://wa.me/?text={% if share_text or social.description %}{{ (share_text ?? social.description)|striptags|url_encode }} {% endif %}{{ (socialLink ~ '&utm_source=whatsapp')|url_encode }}"
             onclick="dataLayerPush('Whatsapp');"
             target="_blank" class="share-btn whatsapp">
             {{ 'whatsapp'|svgicon }}

--- a/tests/e2e/gravity-forms.spec.js
+++ b/tests/e2e/gravity-forms.spec.js
@@ -68,7 +68,7 @@ test.describe('Gravity Forms tests', () => {
     await expect(confirmationMessage).toContainText(CONFIRMATION_MESSAGE);
 
     // Check that the entry has been registered as expected.
-    await page.goto('./wp-admin/admin.php?page=gf_entries');
+    await page.goto(`./wp-admin/admin.php?page=gf_entries&id=${createdForm.id}`);
     const latestEntry = page.locator('#the-list > tr.entry_row').first();
     await expect(latestEntry).toBeVisible();
     await expect(latestEntry.locator('td[data-colname="First name"]')).toContainText(TEST_FIRST_NAME);


### PR DESCRIPTION
### Description

See [PLANET-7536](https://jira.greenpeace.org/browse/PLANET-7536)

This was requested via [Slack](https://greenpeace.slack.com/archives/C0151L0KKNX/p1717068747633409), we mentioned it in the past but didn't implement it even though it should be doable.

### Testing

There should now be a WhatsApp share text in the following scenarios:
- [Gravity Forms with a share text](https://www-dev.greenpeace.org/test-nix/gravity-forms-sharing/)
- [Post with OG description](https://www-dev.greenpeace.org/test-nix/press/1113/duis-posuere-6/)

In other situations there will still be no text added to the share link.