### PR TITLE
PLANET-7362 Write a Greenpeace Media e2e test for importing images

### DIFF
--- a/tests/e2e/greenpeace-media.spec.js
+++ b/tests/e2e/greenpeace-media.spec.js
@@ -5,8 +5,7 @@ import {
   waitForLibraryLoad,
 } from './tools/lib/media-library.js';
 
-const IMAGE_1 = 'GP0STXWME';
-const IMAGE_2 = 'GP0STXWZH';
+const TEST_IMAGES = ['GP0STXWME', 'GP0STXWZH'];
 const MEDIA_LIBRARY_PAGE = './wp-admin/admin.php?page=media-picker';
 
 test.useAdminLoggedIn();
@@ -49,13 +48,13 @@ test.describe('Greenpeace Media tests', () => {
 
     // Search for 2 specific images.
     const images = page.locator('.picker-list > li');
-    await searchImages(page, IMAGE_1);
-    await expect(images).toHaveCount(1);
-    await searchImages(page, IMAGE_2);
-    await expect(images).toHaveCount(2);
-    await page.getByRole('button', {name: 'Bulk Select'}).click();
+    for (let index = 0; index < 2; index++) {
+      await searchImages(page, TEST_IMAGES[index]);
+      await expect(images).toHaveCount(index + 1);
+    }
 
     // Select the 2 images.
+    await page.getByRole('button', {name: 'Bulk Select'}).click();
     for (let index = 0; index < 2; index++) {
       await images.nth(index).click();
     }
@@ -69,7 +68,9 @@ test.describe('Greenpeace Media tests', () => {
     // Delete the images from the library.
     await page.reload();
     await waitForLibraryLoad(page);
-    await deleteImageFromLibrary(page, IMAGE_1);
-    await deleteImageFromLibrary(page, IMAGE_2);
+    await deleteImageFromLibrary(page, TEST_IMAGES[0]);
+    await page.goto(MEDIA_LIBRARY_PAGE);
+    await waitForLibraryLoad(page);
+    await deleteImageFromLibrary(page, TEST_IMAGES[1]);
   });
 });

--- a/tests/e2e/greenpeace-media.spec.js
+++ b/tests/e2e/greenpeace-media.spec.js
@@ -1,0 +1,75 @@
+import {test, expect} from './tools/lib/test-utils.js';
+import {
+  searchImages,
+  deleteImageFromLibrary,
+  waitForLibraryLoad,
+} from './tools/lib/media-library.js';
+
+const IMAGE_1 = 'GP0STXWME';
+const IMAGE_2 = 'GP0STXWZH';
+
+test.useAdminLoggedIn();
+
+test.describe('Greenpeace Media tests', () => {
+  test('import an image to the Library using a search term', async ({page}) => {
+    // Make sure to close any alerts.
+    page.on('dialog', dialog => dialog.accept());
+
+    // Go to the Media Library and wait for the page to load.
+    await page.goto('./wp-admin/admin.php?page=media-picker');
+    await waitForLibraryLoad(page);
+
+    // Search for an image to import.
+    await searchImages(page, 'Rainbow Warrior');
+    const image = page.locator('.picker-list > li')
+      .filter({hasNotText: 'Added to Media Library'})
+      .first();
+    await image.click();
+    await expect(image).toHaveClass('is-selected');
+    const sidebar = page.locator('.archive-picker-sidebar');
+    await expect(sidebar).toBeVisible();
+
+    // Import the image.
+    await sidebar.getByRole('button', {name: 'Import to Library'}).click();
+    await expect(sidebar.getByText('Processing...')).toBeVisible();
+    await expect(sidebar.getByText('Added to Library')).toBeVisible();
+
+    // Delete the image from the library.
+    await deleteImageFromLibrary(page);
+  });
+
+  test('bulk select and upload two images using identifiers', async ({page}) => {
+    // Make sure to close any alerts.
+    page.on('dialog', dialog => dialog.accept());
+
+    // Go to the Media Library and wait for the page to load.
+    await page.goto('./wp-admin/admin.php?page=media-picker');
+    await waitForLibraryLoad(page);
+
+    // Search for 2 specific images.
+    const images = page.locator('.picker-list > li');
+    await searchImages(page, IMAGE_1);
+    await expect(images).toHaveCount(1);
+    await searchImages(page, IMAGE_2);
+    await expect(images).toHaveCount(2);
+    await page.getByRole('button', {name: 'Bulk Select'}).click();
+
+    // Select the 2 images.
+    for (let index = 0; index < 2; index++) {
+      const toSelect = images.nth(index);
+      await toSelect.click();
+    }
+
+    // Bulk upload them.
+    await page.getByRole('button', {name: 'Bulk Upload'}).click();
+    const loadingMessage = page.getByText('Processing 2 images');
+    await expect(loadingMessage).toBeVisible();
+    await expect(loadingMessage).toBeHidden();
+
+    // Delete the images from the library.
+    await page.reload();
+    await waitForLibraryLoad(page);
+    await deleteImageFromLibrary(page, IMAGE_1);
+    await deleteImageFromLibrary(page, IMAGE_2);
+  });
+});

--- a/tests/e2e/greenpeace-media.spec.js
+++ b/tests/e2e/greenpeace-media.spec.js
@@ -56,14 +56,15 @@ test.describe('Greenpeace Media tests', () => {
     // Select the 2 images.
     await page.getByRole('button', {name: 'Bulk Select'}).click();
     for (let index = 0; index < 2; index++) {
-      await images.nth(index).click();
+      const image = images.nth(index);
+      await image.click();
+      await expect(image).toHaveClass('is-selected');
     }
 
     // Bulk upload them.
     await page.getByRole('button', {name: 'Bulk Upload'}).click();
-    const loadingMessage = page.getByText('Processing 2 images');
-    await expect(loadingMessage).toBeVisible();
-    await expect(loadingMessage).toBeHidden();
+    await expect(page.getByText('Processing 2 images')).toBeVisible();
+    await expect(page.getByPlaceholder('Search')).toBeVisible();
 
     // Delete the images from the library.
     await page.reload();

--- a/tests/e2e/greenpeace-media.spec.js
+++ b/tests/e2e/greenpeace-media.spec.js
@@ -7,6 +7,7 @@ import {
 
 const IMAGE_1 = 'GP0STXWME';
 const IMAGE_2 = 'GP0STXWZH';
+const MEDIA_LIBRARY_PAGE = './wp-admin/admin.php?page=media-picker';
 
 test.useAdminLoggedIn();
 
@@ -16,7 +17,7 @@ test.describe('Greenpeace Media tests', () => {
     page.on('dialog', dialog => dialog.accept());
 
     // Go to the Media Library and wait for the page to load.
-    await page.goto('./wp-admin/admin.php?page=media-picker');
+    await page.goto(MEDIA_LIBRARY_PAGE);
     await waitForLibraryLoad(page);
 
     // Search for an image to import.
@@ -43,7 +44,7 @@ test.describe('Greenpeace Media tests', () => {
     page.on('dialog', dialog => dialog.accept());
 
     // Go to the Media Library and wait for the page to load.
-    await page.goto('./wp-admin/admin.php?page=media-picker');
+    await page.goto(MEDIA_LIBRARY_PAGE);
     await waitForLibraryLoad(page);
 
     // Search for 2 specific images.
@@ -56,8 +57,7 @@ test.describe('Greenpeace Media tests', () => {
 
     // Select the 2 images.
     for (let index = 0; index < 2; index++) {
-      const toSelect = images.nth(index);
-      await toSelect.click();
+      await images.nth(index).click();
     }
 
     // Bulk upload them.

--- a/tests/e2e/greenpeace-media.spec.js
+++ b/tests/e2e/greenpeace-media.spec.js
@@ -33,7 +33,7 @@ test.describe('Greenpeace Media tests', () => {
     // Import the image.
     await sidebar.getByRole('button', {name: 'Import to Library'}).click();
     await expect(sidebar.getByText('Processing...')).toBeVisible();
-    await expect(sidebar.getByText('Added to Library')).toBeVisible();
+    await expect(sidebar.locator('.sidebar-action')).toBeVisible();
 
     // Delete the image from the library.
     await deleteImageFromLibrary(page);

--- a/tests/e2e/tools/lib/media-library.js
+++ b/tests/e2e/tools/lib/media-library.js
@@ -16,9 +16,10 @@ async function searchImages(page, searchTerm) {
 
 /**
  * Deletes an image from the Library.
+ * The image id is optional, it's not needed if the image is already selected.
  *
- * @param {Object} page    - The page object for interacting with the browser.
- * @param {string} imageId - The image to be deleted.
+ * @param {Object} page      - The page object for interacting with the browser.
+ * @param {string} [imageId] - The image to be deleted (optional).
  */
 async function deleteImageFromLibrary(page, imageId) {
   const sidebar = page.locator('.archive-picker-sidebar');
@@ -27,11 +28,12 @@ async function deleteImageFromLibrary(page, imageId) {
     await searchImages(page, imageId);
     const image = page.locator('.picker-list > li');
 
-    // Select the image and open its link via the sidebar.
+    // Select the image.
     await image.click();
-    await expect(sidebar).toBeVisible();
   }
 
+  // Open image link via the sidebar.
+  await expect(sidebar).toBeVisible();
   await sidebar.locator('.sidebar-action').click();
 
   // Delete the image and wait for confirmation.

--- a/tests/e2e/tools/lib/media-library.js
+++ b/tests/e2e/tools/lib/media-library.js
@@ -41,10 +41,6 @@ async function deleteImageFromLibrary(page, imageId) {
   await expect(deleteLink).toBeVisible();
   await deleteLink.click();
   await expect(page.getByText('Media file permanently deleted.')).toBeVisible();
-
-  // Go back to the Media Library.
-  await page.goto('./wp-admin/admin.php?page=media-picker');
-  await waitForLibraryLoad(page);
 }
 
 /**

--- a/tests/e2e/tools/lib/media-library.js
+++ b/tests/e2e/tools/lib/media-library.js
@@ -1,0 +1,59 @@
+import {expect} from './test-utils.js';
+
+/**
+ * Searches for images in the Library based on a search term or image id.
+ *
+ * @param {Object} page       - The page object for interacting with the browser.
+ * @param {string} searchTerm - The term to be searched, can be an image id.
+ */
+async function searchImages(page, searchTerm) {
+  const searchInput = page.getByPlaceholder('Search');
+
+  await searchInput.fill(searchTerm);
+  await page.keyboard.press('Enter');
+  await waitForLibraryLoad(page);
+}
+
+/**
+ * Deletes an image from the Library.
+ *
+ * @param {Object} page    - The page object for interacting with the browser.
+ * @param {string} imageId - The image to be deleted.
+ */
+async function deleteImageFromLibrary(page, imageId) {
+  const sidebar = page.locator('.archive-picker-sidebar');
+  if (imageId) {
+    // Search for the image.
+    await searchImages(page, imageId);
+    const image = page.locator('.picker-list > li');
+
+    // Select the image and open its link via the sidebar.
+    await image.click();
+    await expect(sidebar).toBeVisible();
+  }
+
+  await sidebar.locator('.sidebar-action').click();
+
+  // Delete the image and wait for confirmation.
+  const deleteLink = page.getByText('Delete permanently');
+  await expect(deleteLink).toBeVisible();
+  await deleteLink.click();
+  await expect(page.getByText('Media file permanently deleted.')).toBeVisible();
+
+  // Go back to the Media Library.
+  await page.goto('./wp-admin/admin.php?page=media-picker');
+  await waitForLibraryLoad(page);
+}
+
+/**
+ * Waits for the Library page to be fully loaded, based on the spinner.
+ *
+ * @param {Object} page - The page object for interacting with the browser.
+ */
+async function waitForLibraryLoad(page) {
+  const spinner = page.locator('.archive-picker-loading');
+  await expect(spinner).toBeVisible();
+  await expect(spinner).toBeHidden();
+}
+
+export {searchImages, deleteImageFromLibrary, waitForLibraryLoad};


### PR DESCRIPTION
### Description

See [PLANET-7362](https://jira.greenpeace.org/browse/PLANET-7362)

**Test Steps**

1. Login to the Admin Panel.
2. Navigate to Media > Greenpeace Media.
3. Search for a term (eg. "Rainbow Warrior").
4. Pick the first image and import to the Library.
5. Assert that after some time the Processing... message is replaced with a link to the imported image.
6. Search for an image identifier (eg. GP0STXWME) and assert there is one result displayed.
7. Append one more image identified (eg. GP0STXWZH) and assert that now are two images displayed.
8. Click on "Bulk Select" and select both images.
9. Click on "Bulk Upload".
10. Assert that after some time the Processing 2 images message is hidden and the search box is shown again.
11. Remove the imported images from the Library.