### PR TITLE
PLANET-7527 Move blocks report into master theme

### DIFF
--- a/src/BlockReportSearch/Block/BlockUsage.php
+++ b/src/BlockReportSearch/Block/BlockUsage.php
@@ -2,8 +2,6 @@
 
 /**
  * Table displaying blocks usage
- *
- * @package P4BKS\Controllers
  */
 
 namespace P4\MasterTheme\BlockReportSearch\Block;

--- a/src/BlockReportSearch/Block/BlockUsage.php
+++ b/src/BlockReportSearch/Block/BlockUsage.php
@@ -1,0 +1,292 @@
+<?php
+
+/**
+ * Table displaying blocks usage
+ *
+ * @package P4BKS\Controllers
+ */
+
+namespace P4\MasterTheme\BlockReportSearch\Block;
+
+use WP_Block_Parser;
+use P4\MasterTheme\BlockReportSearch\BlockSearch;
+use P4\MasterTheme\BlockReportSearch\Block\Query\Parameters;
+
+/**
+ * Present block usage, using native WordPress table
+ */
+class BlockUsage
+{
+    /**
+     * @var BlockSearch
+     */
+    private $search;
+
+    /**
+     * @var WP_Block_Parser
+     */
+    private $parser;
+
+    /**
+     * @var int[]
+     */
+    private $posts_ids;
+
+    /**
+     * @var WP_Post[]
+     */
+    private $posts;
+
+    /**
+     * @var array
+     */
+    private $blocks;
+
+    /**
+     * @param BlockSearch     $search Search class.
+     * @param WP_Block_Parser $parser Block parser.
+     */
+    public function __construct(
+        ?BlockSearch $search = null,
+        ?WP_Block_Parser $parser = null
+    ) {
+        $this->search = $search ?? new BlockSearch();
+        $this->parser = $parser ?? new WP_Block_Parser();
+    }
+
+    /**
+     * @param Parameters $params Query parameters.
+     * @return array
+     */
+    public function get_blocks(Parameters $params): array
+    {
+        $this->posts_ids = $this->search->get_posts($params);
+
+        return $this->get_filtered_blocks($this->posts_ids, $params);
+    }
+
+    /**
+     * @param Parameters $params Query parameters.
+     * @return int[]
+     */
+    public function get_posts(Parameters $params): array
+    {
+        $block_list = $this->get_blocks($this->posts_ids, $params);
+
+        return array_unique(array_column($block_list, 'post_id'));
+    }
+
+    /**
+     * @param int[]      $posts_ids Posts IDs.
+     * @param Parameters $params Query parameters.
+     * @return array
+     */
+    private function get_filtered_blocks($posts_ids, Parameters $params)
+    {
+        $this->fetch_blocks($posts_ids, $params);
+        $this->filter_blocks($params);
+        $this->sort_blocks($params->order());
+
+        return $this->blocks;
+    }
+
+    /**
+     * @param int[]      $posts_ids Posts IDs.
+     * @param Parameters $params Query parameters.
+     */
+    private function fetch_blocks(array $posts_ids, Parameters $params): void
+    {
+        $posts_args = [
+            'include' => $posts_ids,
+            'orderby' => empty($params->order()) ? null : array_fill_keys($params->order(), 'ASC'),
+            'post_status' => $params->post_status(),
+            'post_type' => $params->post_type(),
+        ];
+
+        $this->posts = get_posts($posts_args) ?? [];
+
+        $block_listblock_list = [];
+        foreach ($this->posts as $post) {
+            $block_listblock_list = array_merge($block_listblock_list, $this->parse_post($post));
+        }
+        $this->blocks = $block_listblock_list;
+    }
+
+    /**
+     * Filter parsed search items
+     *
+     * @param Parameters $params Query parameters.
+     * @return array
+     */
+    private function filter_blocks(Parameters $params): void
+    {
+        if (
+            empty($params->namespace())
+            && empty($params->name())
+            && empty($params->content())
+        ) {
+            return;
+        }
+
+        $filtered = $this->blocks;
+
+        $text = $params->content();
+        $filters = [
+            'block_ns' => $params->namespace(),
+            'block_type' => $params->name(),
+            'local_name' => false !== strpos($params->name(), '/')
+                ? explode('/', $params->name())[1]
+                : $params->name(),
+        ];
+
+        if (! empty($filters['block_type'])) {
+            $filtered = array_filter(
+                $filtered,
+                function ($i) use ($filters) {
+                    return $i['block_type'] === $filters['block_type']
+                        || $i['local_name'] === $filters['local_name'];
+                }
+            );
+        } elseif (! empty($filters['block_ns'])) {
+            $filtered = array_filter(
+                $filtered,
+                function ($i) use ($filters) {
+                    return $i['block_ns'] === $filters['block_ns'];
+                }
+            );
+        }
+
+        if (! empty($text)) {
+            $filtered = array_filter(
+                $filtered,
+                function ($i) use ($text) {
+                    return strpos($i['block_type'], $text) !== false
+						//phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
+                        || strpos(serialize($i['block_attrs']), $text) !== false;
+                }
+            );
+        }
+
+        $this->blocks = $filtered;
+    }
+
+    /**
+     * Sort parsed blocks
+     *
+     * @param null|array $sort  Sort dimensions.
+     * @return array
+     */
+    private function sort_blocks(?array $sort = []): void
+    {
+        if (empty($sort)) {
+            return;
+        }
+
+        $args = [];
+        $block_list = $this->blocks;
+        foreach ($sort as $name) {
+            $args[] = array_column($block_list, $name);
+            $args[] = SORT_NATURAL;
+        }
+        $args[] = &$block_list;
+
+        array_multisort(...$args);
+
+        $this->blocks = $block_list;
+    }
+
+    /**
+     * Parse posts content to blocks.
+     *
+     * @param object $post WP_Post.
+     * @return array[]
+     */
+    private function parse_post($post): array
+    {
+        $output = $this->parser->parse($post->post_content);
+
+        $block_list = array_filter(
+            $output,
+            function ($block) {
+                return ! empty($block['blockName']);
+            }
+        );
+
+        $items = [];
+        while (! empty($block_list)) {
+            $block = array_shift($block_list);
+            $items[] = $this->format_block_data($block, $post);
+
+            if (empty($block['innerBlocks'])) {
+                continue;
+            }
+
+            $block_list = array_merge($block_list, $block['innerBlocks']);
+        }
+
+        return $items;
+    }
+
+    /**
+     * Format block information.
+     *
+     * @param array  $block A block.
+     * @param object $post  WP_Post.
+     * @return array[]
+     */
+    private function format_block_data(array $block, $post): array
+    {
+        $type = $block['blockName'];
+        $attrs = $block['attrs'] ?? [];
+        $has_ns = strpos($type, '/') !== false;
+
+        [ $namespace, $local_name ] = $has_ns ? explode('/', $type) : [ 'core', $type ];
+
+        $classes = empty($attrs['className']) ? [] : explode(' ', $attrs['className']);
+        $styles = array_filter(
+            array_map(
+                function ($c): ?string {
+                    return 'is-style-' === substr($c, 0, 9) ? substr($c, 9) : null;
+                },
+                $classes
+            )
+        );
+
+        return [
+            'post_id' => $post->ID,
+            'post_title' => $post->post_title
+                ? $post->post_title : __('(no title)', 'planet4-blocks-backend'),
+            'post_status' => $post->post_status,
+            'post_type' => $post->post_type,
+            'post_date' => $post->post_date,
+            'post_modified' => $post->post_modified,
+            'post_status' => $post->post_status,
+            'guid' => $post->guid,
+            'block_ns' => $namespace,
+            'block_type' => $type,
+            'local_name' => $local_name,
+            'block_attrs' => $attrs,
+            'block_styles' => $styles,
+        ];
+    }
+
+    /**
+     * Block count in search result.
+     *
+     * @return int
+     */
+    public function block_count(): int
+    {
+        return count($this->blocks);
+    }
+
+    /**
+     * Post count in search result.
+     *
+     * @return int
+     */
+    public function post_count(): int
+    {
+        return count($this->posts_ids);
+    }
+}

--- a/src/BlockReportSearch/Block/BlockUsage.php
+++ b/src/BlockReportSearch/Block/BlockUsage.php
@@ -17,30 +17,17 @@ use P4\MasterTheme\BlockReportSearch\Block\Query\Parameters;
  */
 class BlockUsage
 {
-    /**
-     * @var BlockSearch
-     */
-    private $search;
+    private BlockSearch $search;
 
-    /**
-     * @var WP_Block_Parser
-     */
-    private $parser;
+    private WP_Block_Parser $parser;
 
-    /**
-     * @var int[]
-     */
+    // phpcs:ignore SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingAnyTypeHint
     private $posts_ids;
 
-    /**
-     * @var WP_Post[]
-     */
+    // phpcs:ignore SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingAnyTypeHint
     private $posts;
 
-    /**
-     * @var array
-     */
-    private $blocks;
+    private array $blocks;
 
     /**
      * @param BlockSearch     $search Search class.
@@ -56,7 +43,6 @@ class BlockUsage
 
     /**
      * @param Parameters $params Query parameters.
-     * @return array
      */
     public function get_blocks(Parameters $params): array
     {
@@ -79,9 +65,8 @@ class BlockUsage
     /**
      * @param int[]      $posts_ids Posts IDs.
      * @param Parameters $params Query parameters.
-     * @return array
      */
-    private function get_filtered_blocks($posts_ids, Parameters $params)
+    private function get_filtered_blocks(array $posts_ids, Parameters $params): array
     {
         $this->fetch_blocks($posts_ids, $params);
         $this->filter_blocks($params);
@@ -173,7 +158,7 @@ class BlockUsage
     /**
      * Sort parsed blocks
      *
-     * @param null|array $sort  Sort dimensions.
+     * @param array|null $sort  Sort dimensions.
      * @return array
      */
     private function sort_blocks(?array $sort = []): void
@@ -201,7 +186,7 @@ class BlockUsage
      * @param object $post WP_Post.
      * @return array[]
      */
-    private function parse_post($post): array
+    private function parse_post(\WP_Post $post): array
     {
         $output = $this->parser->parse($post->post_content);
 
@@ -234,7 +219,7 @@ class BlockUsage
      * @param object $post  WP_Post.
      * @return array[]
      */
-    private function format_block_data(array $block, $post): array
+    private function format_block_data(array $block, \WP_Post $post): array
     {
         $type = $block['blockName'];
         $attrs = $block['attrs'] ?? [];
@@ -272,8 +257,6 @@ class BlockUsage
 
     /**
      * Block count in search result.
-     *
-     * @return int
      */
     public function block_count(): int
     {
@@ -282,8 +265,6 @@ class BlockUsage
 
     /**
      * Post count in search result.
-     *
-     * @return int
      */
     public function post_count(): int
     {

--- a/src/BlockReportSearch/Block/BlockUsageApi.php
+++ b/src/BlockReportSearch/Block/BlockUsageApi.php
@@ -2,8 +2,6 @@
 
 /**
  * Table displaying blocks usage
- *
- * @package P4BKS\Controllers
  */
 
 namespace P4\MasterTheme\BlockReportSearch\Block;

--- a/src/BlockReportSearch/Block/BlockUsageApi.php
+++ b/src/BlockReportSearch/Block/BlockUsageApi.php
@@ -1,0 +1,93 @@
+<?php
+
+/**
+ * Table displaying blocks usage
+ *
+ * @package P4BKS\Controllers
+ */
+
+namespace P4\MasterTheme\BlockReportSearch\Block;
+
+use P4\MasterTheme\BlockReportSearch\Block\Query\Parameters;
+
+/**
+ * Block usage API
+ */
+class BlockUsageApi
+{
+    public const DEFAULT_POST_STATUS = [ 'publish' ];
+
+    private BlockUsage $usage;
+
+    private Parameters $params;
+
+    /**
+     * @var array[] Blocks.
+     */
+    private $items;
+
+    /**
+     * Constructor
+     */
+    public function __construct()
+    {
+        $this->usage = new BlockUsage();
+        $this->params = ( new Parameters() )
+            ->with_post_status(self::DEFAULT_POST_STATUS)
+            ->with_post_type(
+                \get_post_types(
+                    [
+                        'public' => true,
+                        'exclude_from_search' => false,
+                    ]
+                )
+            );
+    }
+
+    /**
+     * Count blocks by type and style
+     *
+     * If style is not specified, an empty key 'n/a' is used.
+     */
+    public function get_count(): array
+    {
+        if (null === $this->items) {
+            $this->fetch_items();
+        }
+
+        $types = array_unique(
+            array_column($this->items, 'block_type')
+        );
+        $blocks = array_fill_keys(
+            $types,
+            [
+                'total' => 0,
+                'styles' => [],
+            ]
+        );
+        ksort($blocks);
+
+        foreach ($this->items as $item) {
+            $styles = empty($item['block_styles']) ? [ 'n/a' ] : $item['block_styles'];
+            foreach ($styles as $style) {
+                $type = $item['block_type'];
+                if (! isset($blocks[ $type ]['styles'][ $style ])) {
+                    $blocks[ $type ]['styles'][ $style ] = 0;
+                }
+                $blocks[ $type ]['styles'][ $style ]++;
+                $blocks[ $type ]['total']++;
+            }
+            ksort($blocks[ $type ]['styles']);
+        }
+
+        return $blocks;
+    }
+
+    /**
+     * Fetch parsed blocks
+     */
+    private function fetch_items(): void
+    {
+        $this->items = $this->usage->get_blocks($this->params);
+    }
+}

--- a/src/BlockReportSearch/Block/BlockUsageApi.php
+++ b/src/BlockReportSearch/Block/BlockUsageApi.php
@@ -21,9 +21,7 @@ class BlockUsageApi
 
     private Parameters $params;
 
-    /**
-     * @var array[] Blocks.
-     */
+    // phpcs:ignore SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingAnyTypeHint
     private $items;
 
     /**

--- a/src/BlockReportSearch/Block/BlockUsageTable.php
+++ b/src/BlockReportSearch/Block/BlockUsageTable.php
@@ -14,9 +14,11 @@ use WP_Block_Type_Registry;
 use P4\MasterTheme\BlockReportSearch\RowActions;
 use P4\MasterTheme\BlockReportSearch\Block\Query\Parameters;
 
+// phpcs:disable PSR1.Files.SideEffects.FoundWithSymbols
 if (! class_exists('WP_List_Table')) {
     require_once ABSPATH . '/wp-admin/includes/class-wp-list-table.php';
 }
+// phpcs:enable PSR1.Files.SideEffects.FoundWithSymbols
 
 /**
  * Show block usage, using native WordPress table
@@ -31,77 +33,60 @@ class BlockUsageTable extends WP_List_Table
 
     public const PLURAL = 'blocks';
 
-    /**
-     * @var BlockUsage
-     */
-    private $block_usage;
+    private BlockUsage $block_usage;
 
-    /**
-     * @var WP_Block_Type_Registry
-     */
-    private $block_registry;
+    private WP_Block_Type_Registry $block_registry;
 
-    /**
-     * @var string[] Search filters requested.
-     */
+    // phpcs:ignore SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingAnyTypeHint
     private $search_params = [];
 
-    /**
-     * @var string Group column.
-     */
-    private $group_by = self::DEFAULT_GROUP_BY;
+    private string $group_by = self::DEFAULT_GROUP_BY;
 
-    /**
-     * @var string[]|null Sort order.
-     */
-    private $sort_by = [ 'post_title', 'post_id' ];
+    private ?array $sort_by = [ 'post_title', 'post_id' ];
 
-    /**
-     * @var string[]
-     */
-    private $allowed_groups = [ 'block_type', 'post_id', 'post_title' ];
+    private array $allowed_groups = [ 'block_type', 'post_id', 'post_title' ];
 
     /**
      * @var string[]|null Columns name => title.
      */
-    private $columns = null;
+    private ?array $columns = null;
 
     /**
      * @var string|null Latest row content displayed.
      */
-    private $latest_row = null;
+    private ?string $latest_row = null;
 
     /**
      * @var string[]|null Blocks namespaces.
      */
-    private $blocks_ns = null;
+    private ?array $blocks_ns = null;
 
     /**
      * @var string[]|null Blocks types.
      */
-    private $blocks_types = null;
+    private ?array $blocks_types = null;
 
     /**
      * @var string[]|null Blocks registered.
      */
-    private $blocks_registered = null;
+    private ?array $blocks_registered = null;
 
     /**
      * @var string[]|null Blocks allowed.
      */
-    private $blocks_allowed = null;
+    private ?array $blocks_allowed = null;
 
     /**
      * @var ?string Special filter.
      */
-    private $special = null;
+    private ?string $special = null;
 
     /**
      * @param array $args Args.
      * @throws InvalidArgumentException Throws on missing parameter.
      * @see WP_List_Table::__construct()
      */
-    public function __construct($args = [])
+    public function __construct(array $args = [])
     {
         $args['plural'] = self::PLURAL;
         parent::__construct($args);
@@ -233,7 +218,7 @@ class BlockUsageTable extends WP_List_Table
     /**
      * Set the registered blocks list.
      */
-    private function set_registered_blocks()
+    private function set_registered_blocks(): void
     {
         $names = array_keys(
             $this->block_registry->get_all_registered()
@@ -245,7 +230,7 @@ class BlockUsageTable extends WP_List_Table
     /**
      * Set the allowed blocks list.
      */
-    private function set_allowed_blocks()
+    private function set_allowed_blocks(): void
     {
         $post_types = array_filter(
             get_post_types([ 'show_in_rest' => true ]),
@@ -272,7 +257,7 @@ class BlockUsageTable extends WP_List_Table
     /**
      * Columns list for table.
      */
-    public function get_columns()
+    public function get_columns(): ?array
     {
         if (null !== $this->columns) {
             return $this->columns;
@@ -300,7 +285,7 @@ class BlockUsageTable extends WP_List_Table
     /**
      * All, hidden and sortable columns.
      */
-    private function get_column_headers()
+    private function get_column_headers(): array
     {
         return [
             $this->get_columns(),
@@ -312,7 +297,7 @@ class BlockUsageTable extends WP_List_Table
     /**
      * Available grouping as views.
      */
-    protected function get_views()
+    protected function get_views(): array
     {
         $link_tpl = '<a href="%s">%s</a>';
         $active_link_tpl = '<a class="current" href="%s">%s</a>';
@@ -338,7 +323,7 @@ class BlockUsageTable extends WP_List_Table
     /**
      * Displays the list of views available on this table.
      */
-    public function views()
+    public function views(): void
     {
         parent::views();
 
@@ -374,7 +359,7 @@ class BlockUsageTable extends WP_List_Table
     /**
      * Select blocks namespaces.
      */
-    private function blockns_dropdown()
+    private function blockns_dropdown(): void
     {
         sort($this->blocks_ns);
         $filter = $this->search_params->namespace() ?? null;
@@ -395,7 +380,7 @@ class BlockUsageTable extends WP_List_Table
     /**
      * Select blocks types.
      */
-    private function blocktype_dropdown()
+    private function blocktype_dropdown(): void
     {
         sort($this->blocks_types);
         $filter = $this->search_params->name() ?? null;
@@ -434,8 +419,9 @@ class BlockUsageTable extends WP_List_Table
      * Add filters to table.
      *
      * @param string $which Tablenav identifier.
+     * @phpcs:disable SlevomatCodingStandard.Functions.UnusedParameter.UnusedParameter, SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
      */
-    protected function extra_tablenav($which)
+    protected function extra_tablenav($which): void
     {
         echo '<div class="actions">';
         $this->blockns_dropdown();
@@ -454,18 +440,20 @@ class BlockUsageTable extends WP_List_Table
      * Add pagination information to table.
      *
      * @param string $which Tablenav identifier.
+     * @phpcs:disable SlevomatCodingStandard.Functions.UnusedParameter.UnusedParameter, SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
      */
-    protected function pagination($which)
+    protected function pagination($which): void
     {
         echo esc_html(parent::pagination('top'));
     }
+    // @phpcs:enable SlevomatCodingStandard.Functions.UnusedParameter.UnusedParameter, SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
 
     /**
      * Default column value representation.
      *
      * @param array  $item Item.
      * @param string $column_name Column name.
-     *
+     * @phpcs:disable SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
      * @return mixed
      */
     public function column_default($item, $column_name)
@@ -477,7 +465,7 @@ class BlockUsageTable extends WP_List_Table
      * Block option display.
      *
      * @param array $item Item.
-     * @return string
+     * @phpcs:disable SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
      */
     public function column_block_attrs($item): string
     {
@@ -486,7 +474,7 @@ class BlockUsageTable extends WP_List_Table
             return '';
         }
 
-		//phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
+		//phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r , Squiz.PHP.DiscouragedFunctions.Discouraged
         $content = print_r($content, true);
         $content = trim(substr($content, 5, strlen($content)));
 
@@ -505,7 +493,7 @@ class BlockUsageTable extends WP_List_Table
      * Block styles display.
      *
      * @param array $item Item.
-     * @return string
+     * @phpcs:disable SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
      */
     public function column_block_styles($item): string
     {
@@ -519,7 +507,7 @@ class BlockUsageTable extends WP_List_Table
      * Post title display.
      *
      * @param array $item Item.
-     * @return string
+     * @phpcs:disable SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
      */
     public function column_post_title($item): string
     {
@@ -544,7 +532,7 @@ class BlockUsageTable extends WP_List_Table
      * Post ID display.
      *
      * @param array $item Item.
-     * @return string
+     * @phpcs:disable SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
      */
     public function column_post_id($item): string
     {
@@ -559,8 +547,9 @@ class BlockUsageTable extends WP_List_Table
      * Full row display, edited for grouping functionality.
      *
      * @param array $item Item.
+     * @phpcs:disable SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
      */
-    public function single_row($item)
+    public function single_row($item): void
     {
         $cols = $this->get_columns();
         $colspan = count($cols);
@@ -588,7 +577,7 @@ class BlockUsageTable extends WP_List_Table
      * @param string $column_name Current column name.
      * @param string $primary     Primary column name.
      *
-	 * phpcs:disable WordPress.WP.I18n.TextDomainMismatch
+	 * phpcs:disable WordPress.WP.I18n.TextDomainMismatch, SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint, SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingAnyTypeHint
      */
     protected function handle_row_actions($item, $column_name, $primary)
     {
@@ -596,13 +585,15 @@ class BlockUsageTable extends WP_List_Table
             ( new RowActions() )->get_post_actions($item, $column_name, $primary)
         );
     }
+    // phpcs:enable SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingAnyTypeHint
 
     /**
      * Show only top tablenav (duplicate form post bug)
      *
      * @param string $which Tablenav identifier.
+     * phpcs:disable SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
      */
-    protected function display_tablenav($which)
+    protected function display_tablenav($which): void
     {
         if ('bottom' === $which) {
             echo '<div class="tablenav bottom">';
@@ -612,6 +603,7 @@ class BlockUsageTable extends WP_List_Table
         }
         parent::display_tablenav($which);
     }
+    // phpcs:enable SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
 
     /**
      * Search parameters
@@ -637,7 +629,7 @@ class BlockUsageTable extends WP_List_Table
         // Add redirection for filter action.
         add_action(
             'admin_action_' . self::ACTION_NAME,
-            function () {
+            function (): void {
                 $nonce = $_GET['_wpnonce'] ?? null;
                 if (! wp_verify_nonce($nonce, 'bulk-' . self::PLURAL)) {
                     wp_safe_redirect(self::url());

--- a/src/BlockReportSearch/Block/BlockUsageTable.php
+++ b/src/BlockReportSearch/Block/BlockUsageTable.php
@@ -2,8 +2,6 @@
 
 /**
  * Table displaying blocks usage
- *
- * @package P4BKS\Controllers
  */
 
 namespace P4\MasterTheme\BlockReportSearch\Block;

--- a/src/BlockReportSearch/Block/BlockUsageTable.php
+++ b/src/BlockReportSearch/Block/BlockUsageTable.php
@@ -50,9 +50,9 @@ class BlockUsageTable extends WP_List_Table
     private ?array $columns = null;
 
     /**
-     * @var string|null Latest row content displayed.
+     * @var string|int|null Latest row content displayed.
      */
-    private ?string $latest_row = null;
+    private $latest_row = null;
 
     /**
      * @var string[]|null Blocks namespaces.

--- a/src/BlockReportSearch/Block/BlockUsageTable.php
+++ b/src/BlockReportSearch/Block/BlockUsageTable.php
@@ -1,0 +1,663 @@
+<?php
+
+/**
+ * Table displaying blocks usage
+ *
+ * @package P4BKS\Controllers
+ */
+
+namespace P4\MasterTheme\BlockReportSearch\Block;
+
+use InvalidArgumentException;
+use WP_List_Table;
+use WP_Block_Type_Registry;
+use P4\MasterTheme\BlockReportSearch\RowActions;
+use P4\MasterTheme\BlockReportSearch\Block\Query\Parameters;
+
+if (! class_exists('WP_List_Table')) {
+    require_once ABSPATH . '/wp-admin/includes/class-wp-list-table.php';
+}
+
+/**
+ * Show block usage, using native WordPress table
+ */
+class BlockUsageTable extends WP_List_Table
+{
+    public const ACTION_NAME = 'block_usage';
+
+    public const DEFAULT_GROUP_BY = 'block_type';
+
+    public const DEFAULT_POST_STATUS = [ 'publish', 'private', 'draft', 'pending', 'future' ];
+
+    public const PLURAL = 'blocks';
+
+    /**
+     * @var BlockUsage
+     */
+    private $block_usage;
+
+    /**
+     * @var WP_Block_Type_Registry
+     */
+    private $block_registry;
+
+    /**
+     * @var string[] Search filters requested.
+     */
+    private $search_params = [];
+
+    /**
+     * @var string Group column.
+     */
+    private $group_by = self::DEFAULT_GROUP_BY;
+
+    /**
+     * @var string[]|null Sort order.
+     */
+    private $sort_by = [ 'post_title', 'post_id' ];
+
+    /**
+     * @var string[]
+     */
+    private $allowed_groups = [ 'block_type', 'post_id', 'post_title' ];
+
+    /**
+     * @var string[]|null Columns name => title.
+     */
+    private $columns = null;
+
+    /**
+     * @var string|null Latest row content displayed.
+     */
+    private $latest_row = null;
+
+    /**
+     * @var string[]|null Blocks namespaces.
+     */
+    private $blocks_ns = null;
+
+    /**
+     * @var string[]|null Blocks types.
+     */
+    private $blocks_types = null;
+
+    /**
+     * @var string[]|null Blocks registered.
+     */
+    private $blocks_registered = null;
+
+    /**
+     * @var string[]|null Blocks allowed.
+     */
+    private $blocks_allowed = null;
+
+    /**
+     * @var ?string Special filter.
+     */
+    private $special = null;
+
+    /**
+     * @param array $args Args.
+     * @throws InvalidArgumentException Throws on missing parameter.
+     * @see WP_List_Table::__construct()
+     */
+    public function __construct($args = [])
+    {
+        $args['plural'] = self::PLURAL;
+        parent::__construct($args);
+
+        $this->block_usage = $args['block_usage'] ?? null;
+        $this->block_registry = $args['block_registry'] ?? null;
+
+        if (! ( $this->block_usage instanceof BlockUsage )) {
+            throw new InvalidArgumentException(
+                'Table requires a BlockUsage instance.'
+            );
+        }
+        if (! ( $this->block_registry instanceof WP_Block_Type_Registry )) {
+            throw new InvalidArgumentException(
+                'Table requires a WP_Block_Type_Registry instance.'
+            );
+        }
+    }
+
+    /**
+     * Prepares table data.
+     *
+     * @param Parameters $search_params Search parameters.
+     * @param string     $group_by      Grouping dimension.
+     * @param ?string    $special  Unregistered blocks only.
+     */
+    public function prepare_items(
+        ?Parameters $search_params = null,
+        ?string $group_by = null,
+        ?string $special = null
+    ): void {
+        if (in_array($group_by, $this->allowed_groups, true)) {
+            $this->group_by = $group_by;
+        }
+
+        $this->search_params = $search_params
+            ->with_post_status(self::DEFAULT_POST_STATUS)
+            ->with_post_type(
+                array_filter(
+                    \get_post_types([ 'show_in_rest' => true ]),
+                    fn ($t) => \post_type_supports($t, 'editor')
+                )
+            )
+            ->with_order(array_merge([ $this->group_by ], $this->sort_by));
+
+        $items = $this->block_usage->get_blocks($this->search_params);
+
+        $this->special = $special;
+        if ('unregistered' === $this->special) {
+            $items = $this->filter_for_unregistered($items);
+        }
+        if ('unallowed' === $this->special) {
+            $items = $this->filter_for_unallowed($items);
+        }
+
+        // Pagination handling.
+        $total_items = count($items);
+        $per_page = 50;
+        $current_page = $this->get_pagenum();
+        $this->items = array_slice($items, ( ( $current_page - 1 ) * $per_page ), $per_page);
+        $this->set_pagination_args(
+            [
+                'total_items' => $total_items,
+                'per_page' => $per_page,
+                'total_pages' => ceil($total_items / $per_page),
+            ]
+        );
+
+        $this->set_block_filters();
+        $this->_column_headers = $this->get_column_headers();
+    }
+
+    /**
+     * Filter items to keep unregistered blocks only.
+     *
+     * @param array $items Blocks not registered.
+     */
+    private function filter_for_unregistered(array $items): array
+    {
+        $this->set_registered_blocks();
+        return array_filter(
+            $items,
+            fn ($i) => ! in_array($i['block_type'], $this->blocks_registered, true) && 'core-embed' !== $i['block_ns']
+        );
+    }
+
+    /**
+     * Filter items to keep unallowed blocks only.
+     *
+     * @param array $items Blocks not registered.
+     */
+    private function filter_for_unallowed(array $items): array
+    {
+        $this->set_allowed_blocks();
+        return array_filter(
+            $items,
+            fn ($i) => ! in_array($i['block_type'], $this->blocks_allowed, true)
+        );
+    }
+
+    /**
+     * Set dropdown filters content.
+     */
+    private function set_block_filters(): void
+    {
+        $this->set_registered_blocks();
+        $this->set_allowed_blocks();
+        $this->blocks_types = array_unique(
+            array_merge(
+                $this->blocks_registered,
+                $this->blocks_allowed
+            )
+        );
+
+        $namespaces = array_filter(
+            array_unique(
+                array_map(
+                    static function (string $name) {
+                        return explode('/', $name)[0] ?? null;
+                    },
+                    $this->blocks_types
+                )
+            )
+        );
+        sort($namespaces);
+        $this->blocks_ns = $namespaces;
+    }
+
+    /**
+     * Set the registered blocks list.
+     */
+    private function set_registered_blocks()
+    {
+        $names = array_keys(
+            $this->block_registry->get_all_registered()
+        );
+        sort($names);
+        $this->blocks_registered = $names;
+    }
+
+    /**
+     * Set the allowed blocks list.
+     */
+    private function set_allowed_blocks()
+    {
+        $post_types = array_filter(
+            get_post_types([ 'show_in_rest' => true ]),
+            fn ($t) => post_type_supports($t, 'editor')
+        );
+
+        $allowed = [];
+        foreach ($post_types as $type) {
+            $context = new \WP_Block_Editor_Context(
+                [ 'post' => (object) [ 'post_type' => $type ] ]
+            );
+            $on_type = get_allowed_block_types($context);
+            if (! is_array($on_type)) {
+                $on_type = $on_type ? $this->blocks_registered : [];
+            }
+            $allowed = array_merge($allowed, array_values($on_type));
+        }
+
+        $allowed = array_unique($allowed);
+        sort($allowed);
+        $this->blocks_allowed = $allowed;
+    }
+
+    /**
+     * Columns list for table.
+     */
+    public function get_columns()
+    {
+        if (null !== $this->columns) {
+            return $this->columns;
+        }
+
+        $default_columns = [
+            'post_title' => 'Title',
+            'block_type' => 'Block',
+            'block_styles' => 'Style',
+            'block_attrs' => 'Attributes',
+            'post_date' => 'Created',
+            'post_modified' => 'Modified',
+            'post_id' => 'ID',
+            'post_status' => 'Status',
+        ];
+
+        $this->columns = array_merge(
+            [ $this->group_by => $default_columns[ $this->group_by ] ],
+            $default_columns
+        );
+
+        return $this->columns;
+    }
+
+    /**
+     * All, hidden and sortable columns.
+     */
+    private function get_column_headers()
+    {
+        return [
+            $this->get_columns(),
+            [],
+            [ 'post_title', 'post_date', 'post_modified' ],
+        ];
+    }
+
+    /**
+     * Available grouping as views.
+     */
+    protected function get_views()
+    {
+        $link_tpl = '<a href="%s">%s</a>';
+        $active_link_tpl = '<a class="current" href="%s">%s</a>';
+        return [
+            'block_type' => sprintf(
+                'block_type' === $this->group_by ? $active_link_tpl : $link_tpl,
+                add_query_arg('group', 'block_type'),
+                'Group by block name'
+            ),
+            'post_title' => sprintf(
+                'post_title' === $this->group_by ? $active_link_tpl : $link_tpl,
+                add_query_arg('group', 'post_title'),
+                'Group by post title'
+            ),
+            'post_id' => sprintf(
+                'post_id' === $this->group_by ? $active_link_tpl : $link_tpl,
+                add_query_arg('group', 'post_id'),
+                'Group by post ID'
+            ),
+        ];
+    }
+
+    /**
+     * Displays the list of views available on this table.
+     */
+    public function views()
+    {
+        parent::views();
+
+        $link_tpl = '<a href="%s">%s</a>';
+        $active_link_tpl = '<a class="current" href="%s">%s</a>';
+        $unique_views = [
+            'unregistered' => sprintf(
+                'unregistered' === $this->special ? $active_link_tpl : $link_tpl,
+                'unregistered' === $this->special
+                    ? self::url()
+                    : add_query_arg([ 'unregistered' => '' ], self::url()),
+                'Not registered'
+            ),
+            'unallowed' => sprintf(
+                'unallowed' === $this->special ? $active_link_tpl : $link_tpl,
+                'unallowed' === $this->special
+                    ? self::url()
+                    : add_query_arg([ 'unallowed' => '' ], self::url()),
+                'Not allowed'
+            ),
+        ];
+
+        $views = [];
+        echo '<div style="clear: both;"><ul class="subsubsub" style="margin: 0;">';
+        foreach ($unique_views as $class => $view) {
+            $views[ $class ] = "\t<li class='$class'>$view";
+        }
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+        echo implode(" |</li>\n", $views) . "</li>\n";
+        echo '</ul></div>';
+    }
+
+    /**
+     * Select blocks namespaces.
+     */
+    private function blockns_dropdown()
+    {
+        sort($this->blocks_ns);
+        $filter = $this->search_params->namespace() ?? null;
+
+        echo '<select name="namespace" id="filter-by-ns" onchange="filterBlockNames();">';
+        echo '<option value="">- All namespaces -</option>';
+        foreach ($this->blocks_ns as $ns) {
+            echo sprintf(
+                '<option value="%s" %s>%s</option>',
+                esc_attr($ns),
+                esc_attr($filter === $ns ? 'selected' : ''),
+                esc_html($ns)
+            );
+        }
+        echo '</select>';
+    }
+
+    /**
+     * Select blocks types.
+     */
+    private function blocktype_dropdown()
+    {
+        sort($this->blocks_types);
+        $filter = $this->search_params->name() ?? null;
+
+        echo '<select name="name" id="filter-by-name">';
+        echo '<option value="">- All blocks -</option>';
+        foreach ($this->blocks_types as $type) {
+            echo sprintf(
+                '<option value="%s" %s>%s</option>',
+                esc_attr($type),
+                esc_attr($filter === $type ? 'selected' : ''),
+                esc_html($type)
+            );
+        }
+        echo '</select>';
+
+        echo "<script>
+			const filterBlockNames = () => {
+				let selectedNs = document.getElementById('filter-by-ns').selectedOptions[0].value;
+				let select = document.getElementById('filter-by-name');
+				for (let option of select.options) {
+					let display = selectedNs.length <= 0
+						|| option.value.length <= 0
+						|| option.value.startsWith(`\${selectedNs}/`);
+					option.style.display = display ? 'inline' : 'none';
+				}
+				if ( selectedNs.length >= 1 ) {
+					select.value = '';
+				}
+			}
+			filterBlockNames();
+		</script>";
+    }
+
+    /**
+     * Add filters to table.
+     *
+     * @param string $which Tablenav identifier.
+     */
+    protected function extra_tablenav($which)
+    {
+        echo '<div class="actions">';
+        $this->blockns_dropdown();
+        $this->blocktype_dropdown();
+        submit_button(
+            __('Filter', 'planet4-blocks-backend'),
+            '',
+            'filter_action',
+            false,
+            [ 'id' => 'block-query-submit' ]
+        );
+        echo '</div>';
+    }
+
+    /**
+     * Add pagination information to table.
+     *
+     * @param string $which Tablenav identifier.
+     */
+    protected function pagination($which)
+    {
+        echo esc_html(parent::pagination('top'));
+    }
+
+    /**
+     * Default column value representation.
+     *
+     * @param array  $item Item.
+     * @param string $column_name Column name.
+     *
+     * @return mixed
+     */
+    public function column_default($item, $column_name)
+    {
+        return $item[ $column_name ] ?? '';
+    }
+
+    /**
+     * Block option display.
+     *
+     * @param array $item Item.
+     * @return string
+     */
+    public function column_block_attrs($item): string
+    {
+        $content = $item['block_attrs'] ?? null;
+        if (empty($content)) {
+            return '';
+        }
+
+		//phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
+        $content = print_r($content, true);
+        $content = trim(substr($content, 5, strlen($content)));
+
+        return sprintf(
+            '<span title="%s">%s</span>',
+            esc_attr($content),
+            esc_html(
+                strlen($content) > 30
+                ? substr($content, 0, 30) . '...'
+                : $content
+            )
+        );
+    }
+
+    /**
+     * Block styles display.
+     *
+     * @param array $item Item.
+     * @return string
+     */
+    public function column_block_styles($item): string
+    {
+        return sprintf(
+            '%s',
+            implode(',', $item['block_styles'])
+        );
+    }
+
+    /**
+     * Post title display.
+     *
+     * @param array $item Item.
+     * @return string
+     */
+    public function column_post_title($item): string
+    {
+        $content = $item['post_title'] ?? null;
+        if (empty($content)) {
+            return '';
+        }
+
+        $title_tpl = '%2$s';
+        $link_tpl = '<a href="%s" title="%s">%s</a>';
+        $page_uri = get_page_uri($item['post_id']);
+
+        return sprintf(
+            empty($page_uri) ? $title_tpl : $link_tpl,
+            $page_uri,
+            esc_attr($content),
+            ( strlen($content) > 45 ? substr($content, 0, 45) . '...' : $content )
+        );
+    }
+
+    /**
+     * Post ID display.
+     *
+     * @param array $item Item.
+     * @return string
+     */
+    public function column_post_id($item): string
+    {
+        return sprintf(
+            '<a href="%s">%s</a>',
+            get_edit_post_link($item['post_id']),
+            $item['post_id']
+        );
+    }
+
+    /**
+     * Full row display, edited for grouping functionality.
+     *
+     * @param array $item Item.
+     */
+    public function single_row($item)
+    {
+        $cols = $this->get_columns();
+        $colspan = count($cols);
+        $first_col = array_key_first($cols);
+
+        if ($this->latest_row !== $item[ $first_col ]) {
+            echo '<tr>';
+            echo sprintf(
+                '<th colspan="%s"><strong>%s</strong></th>',
+                esc_attr($colspan),
+                esc_html($item[ $first_col ])
+            );
+            echo '</tr>';
+        }
+
+        $this->latest_row = $item[ $first_col ];
+        $item[ $first_col ] = '';
+        parent::single_row($item);
+    }
+
+    /**
+     * Add action links to a row
+     *
+     * @param array  $item        Item.
+     * @param string $column_name Current column name.
+     * @param string $primary     Primary column name.
+     *
+	 * phpcs:disable WordPress.WP.I18n.TextDomainMismatch
+     */
+    protected function handle_row_actions($item, $column_name, $primary)
+    {
+        return $this->row_actions(
+            ( new RowActions() )->get_post_actions($item, $column_name, $primary)
+        );
+    }
+
+    /**
+     * Show only top tablenav (duplicate form post bug)
+     *
+     * @param string $which Tablenav identifier.
+     */
+    protected function display_tablenav($which)
+    {
+        if ('bottom' === $which) {
+            echo '<div class="tablenav bottom">';
+            echo esc_html(parent::pagination($which));
+            echo '</div>';
+            return;
+        }
+        parent::display_tablenav($which);
+    }
+
+    /**
+     * Search parameters
+     */
+    public function get_search_params(): Parameters
+    {
+        return $this->search_params;
+    }
+
+    /**
+     * Table URL
+     */
+    public static function url(): string
+    {
+        return admin_url('admin.php?page=plugin_blocks_report');
+    }
+
+    /**
+     * Set table hooks
+     */
+    public static function set_hooks(): void
+    {
+        // Add redirection for filter action.
+        add_action(
+            'admin_action_' . self::ACTION_NAME,
+            function () {
+                $nonce = $_GET['_wpnonce'] ?? null;
+                if (! wp_verify_nonce($nonce, 'bulk-' . self::PLURAL)) {
+                    wp_safe_redirect(self::url());
+                    exit;
+                }
+
+                $redirect_query = remove_query_arg(
+                    [ '_wp_http_referer', '_wpnonce', 'action', 'filter_action' ],
+                    \wp_parse_url($_SERVER['REQUEST_URI'], PHP_URL_QUERY)
+                );
+                \parse_str($redirect_query, $args);
+                $args = array_filter(
+                    $args,
+                    fn($e) => ! empty($e) && '0' !== $e
+                );
+
+                wp_safe_redirect(add_query_arg($args, self::url()));
+                exit;
+            },
+            10
+        );
+    }
+}

--- a/src/BlockReportSearch/Block/Query.php
+++ b/src/BlockReportSearch/Block/Query.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * Block search query
+ *
+ * @package P4BKS\Search\Block
+ */
+
+namespace P4\MasterTheme\BlockReportSearch\Block;
+
+/**
+ * Query interface
+ * Allows using SQL or Elastic implementation
+ */
+interface Query
+{
+    /**
+     * Return a list of post ids
+     *
+     * @param Query\Parameters ...$params_list A list of parameters.
+     * @return int[]
+     */
+    public function get_posts(Query\Parameters ...$params_list): array;
+}

--- a/src/BlockReportSearch/Block/Query.php
+++ b/src/BlockReportSearch/Block/Query.php
@@ -2,8 +2,6 @@
 
 /**
  * Block search query
- *
- * @package P4BKS\Search\Block
  */
 
 namespace P4\MasterTheme\BlockReportSearch\Block;

--- a/src/BlockReportSearch/Block/Query/Parameters.php
+++ b/src/BlockReportSearch/Block/Query/Parameters.php
@@ -1,0 +1,202 @@
+<?php
+
+/**
+ * Block search query parameters
+ *
+ * @package P4BKS\Search\Block
+ */
+
+namespace P4\MasterTheme\BlockReportSearch\Block\Query;
+
+/**
+ * Parameter bag for Query interface
+ */
+class Parameters
+{
+    /**
+     * @var string
+     */
+    private $namespace;
+
+    /**
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @var array
+     */
+    private $attributes;
+
+    /**
+     * @var string
+     */
+    private $content;
+
+    /**
+     * @var string[]
+     */
+    private $post_status;
+
+    /**
+     * @var string[]
+     */
+    private $post_type;
+
+    /**
+     * @var string[]
+     */
+    private $order;
+
+    /**
+     * @var string[]
+     */
+    const DEFAULT_POST_STATUS = [ 'publish', 'private' ];
+
+    /**
+     * Generate a query param object from an array.
+     *
+     * @param array $params The parameters.
+     *
+     * @return self Parameters
+     */
+    public static function from_array(array $params): self
+    {
+        $query = new self();
+
+        foreach ($params as $field => $value) {
+            if (null === $value) {
+                continue;
+            }
+
+            $query = $query->with($field, $value);
+        }
+
+        return $query;
+    }
+
+    /**
+     * Generate query param object from HTTP request.
+     *
+     * @param array $request The request parameters.
+     *
+     * @return self Parameters
+     */
+    public static function from_request(array $request): self
+    {
+        $text_search = ! empty($request['s']) ? $request['s'] : null;
+
+        if (! empty($request['name'])) {
+            $request['namespace'] = null;
+        }
+
+        return self::from_array(
+            [
+                'namespace' => $request['namespace'] ?? null,
+                'name' => $request['name'] ?? null,
+                'content' => $text_search,
+                'attributes' => $request['attributes'] ?? [ $text_search ],
+                'post_status' => $request['post_status'] ?? self::DEFAULT_POST_STATUS,
+                'post_type' => $request['post_type'] ?? null,
+                'order' => $request['order'] ?? null,
+            ]
+        );
+    }
+
+    /**
+     *
+     *
+     * @param string $name The name.
+     * @param array  $args The arguments.
+     *
+     * @throws \BadMethodCallException Method does not exists.
+     *
+     * @return mixed
+     */
+    public function __call(string $name, array $args)
+    {
+        if (strpos($name, 'with_') === 0) {
+            $property = substr($name, 5);
+            return $this->with($property, $args[0]);
+        }
+
+        throw new \BadMethodCallException('Method ' . $name . ' does not exist.');
+    }
+
+    /**
+     * Sets parameter
+     *
+     * @param string $name  The name.
+     * @param mixed  $value The value.
+     *
+     * @throws \BadMethodCallException Property not allowed.
+     *
+     * @return self Immutable parameter object.
+     */
+    public function with(string $name, $value = null): self
+    {
+        $allowed = [ 'namespace', 'name', 'attributes', 'content', 'post_status', 'post_type', 'order' ];
+        if (! in_array($name, $allowed, true)) {
+            throw new \BadMethodCallException('Property ' . $name . ' does not exist.');
+        }
+
+        $this->$name = $value ?? null;
+        return $this;
+    }
+
+    /**
+     * Block namespace.
+     */
+    public function namespace(): ?string
+    {
+        return $this->namespace;
+    }
+
+    /**
+     * Full block name.
+     */
+    public function name(): ?string
+    {
+        return $this->name;
+    }
+
+    /**
+     * Block attributes.
+     */
+    public function attributes(): ?array
+    {
+        return $this->attributes;
+    }
+
+    /**
+     * Block options content.
+     */
+    public function content(): ?string
+    {
+        return $this->content;
+    }
+
+    /**
+     * List of required post status.
+     */
+    public function post_status(): ?array
+    {
+        return $this->post_status ?? self::DEFAULT_POST_STATUS;
+    }
+
+    /**
+     * List of required post types.
+     */
+    public function post_type(): ?array
+    {
+        return $this->post_type ?? null;
+    }
+
+    /**
+     * Columns names to sort on.
+     */
+    public function order(): ?array
+    {
+        return $this->order;
+    }
+}

--- a/src/BlockReportSearch/Block/Query/Parameters.php
+++ b/src/BlockReportSearch/Block/Query/Parameters.php
@@ -13,45 +13,28 @@ namespace P4\MasterTheme\BlockReportSearch\Block\Query;
  */
 class Parameters
 {
-    /**
-     * @var string
-     */
+    // phpcs:ignore SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingAnyTypeHint
     private $namespace;
 
-    /**
-     * @var string
-     */
+    // phpcs:ignore SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingAnyTypeHint
     private $name;
 
-    /**
-     * @var array
-     */
+    // phpcs:ignore SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingAnyTypeHint
     private $attributes;
 
-    /**
-     * @var string
-     */
+    // phpcs:ignore SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingAnyTypeHint
     private $content;
 
-    /**
-     * @var string[]
-     */
+    // phpcs:ignore SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingAnyTypeHint
     private $post_status;
 
-    /**
-     * @var string[]
-     */
+    // phpcs:ignore SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingAnyTypeHint
     private $post_type;
 
-    /**
-     * @var string[]
-     */
+    // phpcs:ignore SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingAnyTypeHint
     private $order;
 
-    /**
-     * @var string[]
-     */
-    const DEFAULT_POST_STATUS = [ 'publish', 'private' ];
+    private const DEFAULT_POST_STATUS = [ 'publish', 'private' ];
 
     /**
      * Generate a query param object from an array.

--- a/src/BlockReportSearch/Block/Query/Parameters.php
+++ b/src/BlockReportSearch/Block/Query/Parameters.php
@@ -2,8 +2,6 @@
 
 /**
  * Block search query parameters
- *
- * @package P4BKS\Search\Block
  */
 
 namespace P4\MasterTheme\BlockReportSearch\Block\Query;

--- a/src/BlockReportSearch/Block/Sql/Like.php
+++ b/src/BlockReportSearch/Block/Sql/Like.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * Block search regex
+ *
+ * @package P4BKS\Search\Block
+ */
+
+namespace P4\MasterTheme\BlockReportSearch\Block\Sql;
+
+use P4\MasterTheme\BlockReportSearch\Block\Query\Parameters;
+
+/**
+ * Regular expression used in SQL query
+ */
+class Like
+{
+    private Parameters $params;
+
+    /**
+     * @param Parameters $params Query parameters.
+     */
+    public function __construct(Parameters $params)
+    {
+        $this->params = $params;
+    }
+
+    /**
+     * @todo: $params->attributes not implemented.
+     */
+    public function __toString(): string
+    {
+        $block_ns = $this->params->namespace();
+        $block_name = $this->params->name();
+
+        if ('core' === $block_ns) {
+            $block = '%';
+        } elseif ($block_name && 0 === strpos($block_name, 'core/')) {
+            $block = explode('/', $block_name)[1];
+        } else {
+            $name = $block_name ? $block_name : '%';
+            $block = $block_ns ? $block_ns . '/%' : $name;
+        }
+        $attrs = $this->params->content() ? '%' . $this->params->content() . '%' : '%';
+
+        return sprintf('%%<!-- wp:%s %s', $block, $attrs);
+    }
+}

--- a/src/BlockReportSearch/Block/Sql/Like.php
+++ b/src/BlockReportSearch/Block/Sql/Like.php
@@ -2,8 +2,6 @@
 
 /**
  * Block search regex
- *
- * @package P4BKS\Search\Block
  */
 
 namespace P4\MasterTheme\BlockReportSearch\Block\Sql;

--- a/src/BlockReportSearch/Block/Sql/Regex.php
+++ b/src/BlockReportSearch/Block/Sql/Regex.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * Block search regex
+ *
+ * @package P4BKS\Search\Block
+ */
+
+namespace P4\MasterTheme\BlockReportSearch\Block\Sql;
+
+use P4\MasterTheme\BlockReportSearch\Block\Query\Parameters;
+
+/**
+ * Regular expression used in SQL query
+ */
+class Regex
+{
+    private Parameters $params;
+
+    /**
+     * @param Parameters $params Query parameters.
+     */
+    public function __construct(Parameters $params)
+    {
+        $this->params = $params;
+    }
+
+    /**
+     * @todo: $params->attributes not implemented.
+     */
+    public function __toString(): string
+    {
+        $block_ns = $this->params->namespace();
+        $block_name = $this->params->name();
+
+        if ('core' === $block_ns) {
+            $block = '[^/]*';
+        } elseif (0 === strpos($block_name, 'core/')) {
+            $block = explode('/', $block_name)[1];
+        } else {
+            $name = $block_name ? $block_name : '.*';
+            $block = $block_ns ? $block_ns . '/.*' : $name;
+        }
+        $attrs = $this->params->content() ? '.*' . $this->params->content() . '.*' : '.*';
+
+        return sprintf('.*<!-- wp:%s ?%s/?-->.*', $block, $attrs);
+    }
+}

--- a/src/BlockReportSearch/Block/Sql/Regex.php
+++ b/src/BlockReportSearch/Block/Sql/Regex.php
@@ -2,8 +2,6 @@
 
 /**
  * Block search regex
- *
- * @package P4BKS\Search\Block
  */
 
 namespace P4\MasterTheme\BlockReportSearch\Block\Sql;

--- a/src/BlockReportSearch/Block/Sql/SqlQuery.php
+++ b/src/BlockReportSearch/Block/Sql/SqlQuery.php
@@ -1,0 +1,116 @@
+<?php
+
+/**
+ * Block search SQL query
+ *
+ * @package P4BKS\Search\Block
+ */
+
+namespace P4\MasterTheme\BlockReportSearch\Block\Sql;
+
+use P4\MasterTheme\BlockReportSearch\Block;
+use P4\MasterTheme\SqlParameters;
+use wpdb;
+
+/**
+ * SQL implementation of Query interface
+ */
+class SqlQuery implements Block\Query
+{
+    private wpdb $db;
+
+    /**
+     * @param wpdb|null $db Database singleton.
+     */
+    public function __construct(?wpdb $db = null)
+    {
+        global $wpdb;
+
+        $this->db = $db ? $db : $wpdb;
+    }
+
+    /**
+     * @param Block\Query\Parameters ...$params_list Query parameters.
+     * @return int[] List of posts IDs.
+     */
+    public function get_posts(Block\Query\Parameters ...$params_list): array
+    {
+        $query = $this->get_sql_query(...$params_list);
+        $results = $this->db->get_results($query);
+
+        return array_map(
+            function ($r) {
+                return (int) $r->ID;
+            },
+            $results
+        );
+    }
+
+    /**
+     * @param Block\Query\Parameters ...$params_list Query parameters.
+     * @return string SQL query string
+     * @throws \UnexpectedValueException Empty prepared query.
+     */
+    private function get_sql_query(Block\Query\Parameters ...$params_list): string
+    {
+        // Prepare query parameters.
+        $like = [];
+        $status = [];
+        $type = [];
+        $order = [];
+        foreach ($params_list as $params) {
+            $like[] = ( new Like($params) )->__toString();
+            $status = array_merge($status, $params->post_status() ?? []);
+            $type = array_merge($type, $params->post_type() ?? []);
+            $order = array_merge($order, $params->order() ?? []);
+        }
+        $status = array_unique(array_filter($status));
+        $type = array_unique(array_filter($type));
+        $order = $this->parse_order(array_unique(array_filter($order)));
+
+        // Prepare query.
+        $sql_params = new SqlParameters();
+        $sql = 'SELECT ID
+			FROM ' . $sql_params->identifier($this->db->posts) . '
+			WHERE post_status IN ' . $sql_params->string_list($status);
+        if (! empty($type)) {
+            $sql .= ' AND post_type IN ' . $sql_params->string_list($type);
+        }
+        foreach ($like as $l) {
+            $sql .= ' AND post_content LIKE ' . $sql_params->string($l) . ' ';
+        }
+        if (! empty($order)) {
+            $sql .= ' ORDER BY ' . implode(',', $order);
+        }
+
+        $query = $this->db->prepare($sql, $sql_params->get_values());
+        if (empty($query)) {
+            throw new \UnexpectedValueException('Search query is invalid');
+        }
+
+        return $query;
+    }
+
+    /**
+     * Parse and filter order parameter
+     *
+     * @param string[] $order List of sort columns.
+     * @return string[]
+     */
+    private function parse_order(array $order): array
+    {
+        $parsed = [];
+        foreach ($order as $k) {
+            switch ($k) {
+                case 'block_type':
+                    break;
+                case 'post_id':
+                    $parsed[] = 'ID';
+                    break;
+                default:
+                    $parsed[] = $k;
+            }
+        }
+        return $parsed;
+    }
+}

--- a/src/BlockReportSearch/Block/Sql/SqlQuery.php
+++ b/src/BlockReportSearch/Block/Sql/SqlQuery.php
@@ -2,8 +2,6 @@
 
 /**
  * Block search SQL query
- *
- * @package P4BKS\Search\Block
  */
 
 namespace P4\MasterTheme\BlockReportSearch\Block\Sql;

--- a/src/BlockReportSearch/BlockSearch.php
+++ b/src/BlockReportSearch/BlockSearch.php
@@ -1,9 +1,7 @@
 <?php
 
 /**
- * Block search
- *
- * @package P4BKS\Search
+ * Block report search
  */
 
 namespace P4\MasterTheme\BlockReportSearch;

--- a/src/BlockReportSearch/BlockSearch.php
+++ b/src/BlockReportSearch/BlockSearch.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * Block search
+ *
+ * @package P4BKS\Search
+ */
+
+namespace P4\MasterTheme\BlockReportSearch;
+
+use P4\MasterTheme\BlockReportSearch\Block\Query;
+use P4\MasterTheme\BlockReportSearch\Block\Sql\SqlQuery;
+use P4\MasterTheme\BlockReportSearch\Block\Query\Parameters;
+
+/**
+ * Search for posts containing specific blocks
+ */
+class BlockSearch
+{
+    private Query $query;
+
+    /**
+     * @param Query|null $query implementation of Query interface.
+     */
+    public function __construct(?Query $query = null)
+    {
+        $this->query = $query ?? new SqlQuery();
+    }
+
+    /**
+     * @param Parameters $params Query parameters.
+     * @return int[] list of posts IDs.
+     */
+    public function get_posts(Parameters $params): array
+    {
+        return $this->query->get_posts($params);
+    }
+
+    /**
+     * @param string $block_name Query parameters.
+     * @return int[] list of posts IDs.
+     */
+    public function get_posts_with_block(string $block_name): array
+    {
+        return $this->get_posts(
+            ( new Parameters() )->with_name($block_name)
+        );
+    }
+}

--- a/src/BlockReportSearch/Pattern/ContentStructure.php
+++ b/src/BlockReportSearch/Pattern/ContentStructure.php
@@ -2,8 +2,6 @@
 
 /**
  * Table displaying patterns usage
- *
- * @package P4BKS\Search
  */
 
 namespace P4\MasterTheme\BlockReportSearch\Pattern;

--- a/src/BlockReportSearch/Pattern/ContentStructure.php
+++ b/src/BlockReportSearch/Pattern/ContentStructure.php
@@ -1,0 +1,181 @@
+<?php
+
+/**
+ * Table displaying patterns usage
+ *
+ * @package P4BKS\Search
+ */
+
+namespace P4\MasterTheme\BlockReportSearch\Pattern;
+
+use WP_Block_Parser;
+
+/**
+ * Prepare pattern usage, using native WordPress table
+ */
+class ContentStructure
+{
+    private WP_Block_Parser $parser;
+
+    private string $content;
+
+    private array $tree;
+
+    private string $signature;
+
+    /**
+     * Constructor.
+     */
+    public function __construct()
+    {
+        $this->parser = new WP_Block_Parser();
+    }
+
+    /**
+     * Parse content as structure.
+     *
+     * @param string $content Post content.
+     */
+    public function parse_content(string $content): void
+    {
+        $this->content = $content;
+        $this->make_content_tree($this->content);
+        $this->make_structure_signature($this->tree);
+    }
+
+    /**
+     * @return string|null Content
+     */
+    public function get_content(): ?string
+    {
+        return $this->content;
+    }
+
+    /**
+     * @return array Content tree
+     */
+    public function get_content_tree(): array
+    {
+        return $this->tree;
+    }
+
+    /**
+     * @return string Content signature
+     */
+    public function get_content_signature(): string
+    {
+        return $this->signature;
+    }
+
+    /**
+     * Make tree structure from content.
+     *
+     * @param string $content Post content.
+     */
+    public function make_content_tree(string $content): void
+    {
+        $parsed = $this->parser->parse($content);
+        $tree = [];
+        while (! empty($parsed)) {
+            /** @var array $block */
+            $block = array_shift($parsed);
+            $tree[] = $this->make_tree($block);
+        }
+
+        $this->tree = array_values(array_filter($tree));
+    }
+
+    /**
+     * Make signature from tree structure.
+     *
+     * @param array $tree Tree.
+     */
+    public function make_structure_signature(array $tree): void
+    {
+        $this->normalize_tree_for_signature($tree);
+        $signature = json_encode($tree); // phpcs:ignore WordPress.WP.AlternativeFunctions
+
+        $this->signature = trim($signature, '[]');
+    }
+
+    /**
+     * Normalize tree to remove duplications.
+     *
+     * @param array $tree Tree.
+     */
+    public function normalize_tree_for_signature(array &$tree): void
+    {
+        // No classes in content signature.
+        if (isset($tree['classes'])) {
+            unset($tree['classes']);
+        }
+
+        foreach ($tree as $key => &$node) {
+            // No classes in content signature.
+            if (isset($node['classes'])) {
+                unset($node['classes']);
+            }
+
+            if (empty($node['children']) || ! is_array($node['children'])) {
+                continue;
+            }
+
+            if ('core/columns' === $node['name']) {
+                $columns_count = count($node['children']);
+                $unique_columns = array_unique($node['children'], \SORT_REGULAR);
+                $unique_count = count($unique_columns);
+
+                if (1 === $unique_count && $columns_count > $unique_count) {
+                    $node['children'] = $unique_columns;
+                }
+            }
+
+            if ('core/group' === $node['name']) {
+                $subgroups_count = count($node['children']);
+                $unique_subgroups = array_unique($node['children'], \SORT_REGULAR);
+                $unique_count = count($unique_subgroups);
+
+                if (1 === $unique_count && $subgroups_count > $unique_count) {
+                    $node['children'] = $unique_subgroups;
+                }
+            }
+
+            if (empty($node['children'])) {
+                continue;
+            }
+
+            $this->normalize_tree_for_signature($node['children']);
+        }
+    }
+
+    /**
+     * Make blocks tree
+     *
+     * @param array $block Block.
+     *
+     * @return array|null Tree representation of block content.
+     */
+    public function make_tree(array $block): ?array
+    {
+        if (empty($block['blockName'])) {
+            return null;
+        }
+
+        return [
+            'name' => $block['blockName'],
+            'classes' => array_filter(
+                explode(' ', $block['attrs']['className'] ?? '')
+            ),
+            'children' => empty($block['innerBlocks'])
+                ? null
+                : array_values(
+                    array_filter(
+                        array_map(
+                            fn ($b) => $this->make_tree($b),
+                            $block['innerBlocks']
+                        )
+                    )
+                ),
+        ];
+    }
+}

--- a/src/BlockReportSearch/Pattern/PatternData.php
+++ b/src/BlockReportSearch/Pattern/PatternData.php
@@ -1,0 +1,114 @@
+<?php
+
+/**
+ * Pattern search
+ *
+ * @package P4BKS\Search
+ */
+
+namespace P4\MasterTheme\BlockReportSearch\Pattern;
+
+use P4\MasterTheme\Blocks\BlockList;
+use WP_Block_Patterns_Registry;
+
+/**
+ * Container class for pattern data
+ */
+class PatternData
+{
+    // Native properties.
+    // Cf. WP_Block_Patterns_Registry::register().
+
+    public string $name;
+
+    public string $title;
+
+    public string $content;
+
+    public ?string $description = null;
+
+    public ?int $viewport_width = null;
+
+    /**
+     * @var ?string[]
+     */
+    public ?array $block_types = null;
+
+    /**
+     * @var ?string[]
+     */
+    public ?array $post_types = null;
+
+    /**
+     * @var string[]
+     */
+    public ?array $keywords;
+
+    // Extended properties.
+
+    /**
+     * @var string Specific class name for the pattern
+     */
+    public string $classname;
+
+    /**
+     * @var array Pattern structure
+     */
+    public array $structure;
+
+    /**
+     * @var string Pattern signature
+     */
+    public string $signature;
+
+    /**
+     * @var string[] Unique blocks in pattern
+     */
+    public array $block_list;
+
+    /**
+     * @param string $name Pattern name.
+     */
+    public static function from_name(string $name): self
+    {
+        return self::from_pattern(
+            ( WP_Block_Patterns_Registry::get_instance() )->get_registered($name)
+        );
+    }
+
+    /**
+     * @param array $pattern Pattern data from registry.
+     */
+    public static function from_pattern(array $pattern): self
+    {
+        $data = new self();
+
+        $data->name = $pattern['name'];
+        $data->title = $pattern['title'];
+        $data->content = $pattern['content'] ?? '';
+
+        $data->description = $pattern['description'] ?? null;
+        $data->viewport_width = $pattern['viewportWidth'] ?? null;
+        $data->block_types = $pattern['blockTypes'] ?? null;
+        $data->post_types = $pattern['postTypes'] ?? null;
+        $data->keywords = $pattern['keywords'] ?? null;
+
+        $struct = new ContentStructure();
+        $struct->parse_content($data->content);
+
+        $data->structure = $struct->get_content_tree();
+        $data->signature = $struct->get_content_signature();
+        $data->block_list = BlockList::parse_block_list($data->content);
+        $data->classname = self::make_classname($data->name);
+
+        return $data;
+    }
+
+    /**
+     * @param string $name Pattern name.
+     */
+    public static function make_classname(string $name): string
+    {
+        return 'is-pattern-' . preg_replace('#[^_a-zA-Z0-9-]#', '-', $name);
+    }
+}

--- a/src/BlockReportSearch/Pattern/PatternData.php
+++ b/src/BlockReportSearch/Pattern/PatternData.php
@@ -2,8 +2,6 @@
 
 /**
  * Pattern search
- *
- * @package P4BKS\Search
  */
 
 namespace P4\MasterTheme\BlockReportSearch\Pattern;

--- a/src/BlockReportSearch/Pattern/PatternUsage.php
+++ b/src/BlockReportSearch/Pattern/PatternUsage.php
@@ -1,0 +1,202 @@
+<?php
+
+/**
+ * Table displaying patterns usage
+ *
+ * @package P4BKS\Search
+ */
+
+namespace P4\MasterTheme\BlockReportSearch\Pattern;
+
+use WP_Block_Parser;
+use WP_Block_Patterns_Registry;
+use WP_Post;
+use P4\MasterTheme\BlockReportSearch\PatternSearch;
+use P4\MasterTheme\BlockReportSearch\Pattern\Query\Parameters;
+use P4\MasterTheme\Patterns\BlockPattern;
+
+/**
+ * Prepare pattern usage, using native WordPress table
+ */
+class PatternUsage
+{
+    private PatternSearch $search;
+
+    private WP_Block_Parser $parser;
+
+    private WP_Block_Patterns_Registry $registry;
+
+    /**
+     * @param PatternSearch|null   $search Search class.
+     * @param WP_Block_Parser|null $parser Block parser.
+     */
+    public function __construct(
+        ?PatternSearch $search = null,
+        ?WP_Block_Parser $parser = null
+    ) {
+        $this->search = $search ?? new PatternSearch();
+        $this->parser = $parser ?? new WP_Block_Parser();
+        $this->registry = WP_Block_Patterns_Registry::get_instance();
+    }
+
+    /**
+     * @param Parameters $params Search parameters.
+     * @param array      $opts   Options.
+     */
+    public function get_patterns(Parameters $params, array $opts = []): array
+    {
+        $opts = array_merge(
+            [
+                'use_struct' => true,
+                'use_class' => true,
+                'use_templates' => true,
+            ],
+            $opts
+        );
+
+        $posts_ids = $this->search->get_posts($params, $opts);
+
+        return $this->get_filtered_patterns($posts_ids, $params, $opts);
+    }
+
+    /**
+     * @param int[]      $posts_ids Posts ids.
+     * @param Parameters $params    Search parameters.
+     * @param array      $opts      Parsing options.
+     */
+    private function get_filtered_patterns(
+        array $posts_ids,
+        Parameters $params,
+        array $opts
+    ): array {
+        $chunks = array_chunk($posts_ids, 50);
+
+        $post_args = [
+            'orderby' => empty($params->order()) ? null : array_fill_keys($params->order(), 'ASC'),
+            'post_status' => $params->post_status(),
+            'post_type' => $params->post_type(),
+        ];
+
+        if ($opts['use_templates']) {
+            $templates = self::patterns_templates_lookup_table();
+        }
+
+        $patterns = [];
+        foreach ($chunks as $chunk) {
+            /** @var WP_Post[] $posts */
+            $posts = get_posts(array_merge([ 'include' => $chunk ], $post_args));
+
+            foreach ($posts as $post) {
+                $post_struct = new ContentStructure();
+                $post_struct->parse_content($post->post_content ?? '');
+
+                foreach ($params->name() as $pattern_name) {
+                    $pattern = PatternData::from_name($pattern_name);
+
+                    // struct matches.
+                    if ($opts['use_struct']) {
+                        $struct_occ = substr_count(
+                            $post_struct->get_content_signature(),
+                            $pattern->signature
+                        );
+                        if ($struct_occ > 0) {
+                            $patterns[] = $this->format_pattern_data(
+                                $pattern,
+                                $post,
+                                $struct_occ,
+                                'structure'
+                            );
+                        }
+                    }
+
+                    // class matches.
+                    if ($opts['use_class']) {
+                        $class_occ = round(
+                            substr_count($post->post_content, $pattern->classname) / 2
+                        );
+                        if ($class_occ > 0) {
+                            $patterns[] = $this->format_pattern_data(
+                                $pattern,
+                                $post,
+                                $class_occ,
+                                'classname'
+                            );
+                        }
+                    }
+
+                    if (!$opts['use_templates'] || empty($templates[ $pattern->name ])) {
+                        continue;
+                    }
+
+                    $template_occ = substr_count(
+                        $post->post_content,
+                        '<!-- wp:' . $templates[ $pattern->name ] . ' '
+                    );
+                    if ($template_occ <= 0) {
+                        continue;
+                    }
+
+                    $patterns[] = $this->format_pattern_data(
+                        $pattern,
+                        $post,
+                        $template_occ,
+                        'template'
+                    );
+                }
+            }
+        }
+
+        return $patterns;
+    }
+
+    /**
+     * @param PatternData $pattern     PatternData   Pattern.
+     * @param WP_Post     $post        WP_Post Post.
+     * @param int         $occurrences Pattern occurrences.
+     * @param string      $match_type  Match type.
+     */
+    private function format_pattern_data(
+        PatternData $pattern,
+        WP_Post $post,
+        int $occurrences,
+        string $match_type
+    ): array {
+        return [
+            'post_title' => $post->post_title,
+            'pattern_name' => $pattern->name,
+            'pattern_title' => $pattern->title,
+            'pattern_occ' => $occurrences ?? 1,
+            'post_date' => $post->post_date,
+            'post_modified' => $post->post_modified,
+            'post_id' => $post->ID,
+            'post_status' => $post->post_status,
+            'match_type' => $match_type,
+        ];
+    }
+
+    /**
+     * Return pattern to template match
+     *
+     */
+    public static function patterns_templates_lookup_table(): array
+    {
+        $patterns = BlockPattern::get_List();
+        $lookup = [];
+        foreach ($patterns as $pattern) {
+            $config = $pattern::get_config();
+
+            $template = preg_match(
+                '#^<!-- ?wp:(planet4-block-templates\/[^ ]*) #',
+                trim($config['content']),
+                $matches
+            );
+            if (empty($matches[1])) {
+                continue;
+            }
+
+            $lookup[ $pattern::get_name() ] = $matches[1];
+        }
+
+        return $lookup;
+    }
+}

--- a/src/BlockReportSearch/Pattern/PatternUsage.php
+++ b/src/BlockReportSearch/Pattern/PatternUsage.php
@@ -2,8 +2,6 @@
 
 /**
  * Table displaying patterns usage
- *
- * @package P4BKS\Search
  */
 
 namespace P4\MasterTheme\BlockReportSearch\Pattern;

--- a/src/BlockReportSearch/Pattern/PatternUsageApi.php
+++ b/src/BlockReportSearch/Pattern/PatternUsageApi.php
@@ -1,0 +1,106 @@
+<?php
+
+/**
+ * Table displaying blocks usage
+ *
+ * @package P4BKS\Search
+ */
+
+namespace P4\MasterTheme\BlockReportSearch\Pattern;
+
+use WP_Block_Patterns_Registry;
+use P4\MasterTheme\Patterns\BlankPage;
+use P4\MasterTheme\BlockReportSearch\Pattern\Query\Parameters;
+
+/**
+ * Pattern usage API
+ */
+class PatternUsageApi
+{
+    public const DEFAULT_POST_STATUS = [ 'publish' ];
+
+    /**
+     * @var PatternUsage
+     */
+    private $usage;
+
+    /**
+     * @var Parameters
+     */
+    private $params;
+
+    /**
+     * @var array[] Blocks.
+     */
+    private $items;
+
+    /**
+     * Constructor
+     */
+    public function __construct()
+    {
+        $this->usage = new PatternUsage();
+        $this->params = ( new Parameters() )
+            ->with_name($this->pattern_names())
+            ->with_post_type($this->allowed_post_types())
+            ->with_post_status(self::DEFAULT_POST_STATUS);
+    }
+
+    /**
+     * Count patterns
+     */
+    public function get_count(): array
+    {
+        if (null === $this->items) {
+            $this->fetch_items();
+        }
+
+        $names = $this->pattern_names();
+        $patterns = array_fill_keys($names, [ 'total' => 0 ]);
+        ksort($patterns);
+
+        foreach ($this->items as $item) {
+            $patterns[ $item['pattern_name'] ]['total']++;
+        }
+
+        return $patterns;
+    }
+
+    /**
+     * Fetch parsed blocks
+     */
+    private function fetch_items(): void
+    {
+        $this->items = $this->usage->get_patterns(
+            $this->params,
+            [ 'use_struct' => false ]
+        );
+    }
+
+    /**
+     * Get all patterns names
+     */
+    private function pattern_names(): array
+    {
+        return array_filter(
+            array_column(
+                ( WP_Block_Patterns_Registry::get_instance() )->get_all_registered(),
+                'name'
+            ),
+            fn ($name) => BlankPage::get_name() !== $name
+        );
+    }
+
+    /**
+     * Get post types that can contain patterns
+     *
+     * @return string[]
+     */
+    private function allowed_post_types(): array
+    {
+        return array_filter(
+            get_post_types([ 'show_in_rest' => true ]),
+            fn ($t) => post_type_supports($t, 'editor')
+        );
+    }
+}

--- a/src/BlockReportSearch/Pattern/PatternUsageApi.php
+++ b/src/BlockReportSearch/Pattern/PatternUsageApi.php
@@ -19,19 +19,11 @@ class PatternUsageApi
 {
     public const DEFAULT_POST_STATUS = [ 'publish' ];
 
-    /**
-     * @var PatternUsage
-     */
-    private $usage;
+    private PatternUsage $usage;
 
-    /**
-     * @var Parameters
-     */
-    private $params;
+    private Parameters $params;
 
-    /**
-     * @var array[] Blocks.
-     */
+    // phpcs:ignore SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingAnyTypeHint
     private $items;
 
     /**

--- a/src/BlockReportSearch/Pattern/PatternUsageApi.php
+++ b/src/BlockReportSearch/Pattern/PatternUsageApi.php
@@ -2,8 +2,6 @@
 
 /**
  * Table displaying blocks usage
- *
- * @package P4BKS\Search
  */
 
 namespace P4\MasterTheme\BlockReportSearch\Pattern;

--- a/src/BlockReportSearch/Pattern/PatternUsageTable.php
+++ b/src/BlockReportSearch/Pattern/PatternUsageTable.php
@@ -1,0 +1,422 @@
+<?php
+
+/**
+ * Table displaying patterns usage
+ *
+ * @package P4BKS\Search
+ */
+
+namespace P4\MasterTheme\BlockReportSearch\Pattern;
+
+use InvalidArgumentException;
+use WP_List_Table;
+use WP_Block_Patterns_Registry;
+use P4\MasterTheme\Patterns\BlankPage;
+use P4\MasterTheme\BlockReportSearch\RowActions;
+use P4\MasterTheme\BlockReportSearch\Pattern\Query\Parameters;
+
+if (! class_exists('WP_List_Table')) {
+    require_once ABSPATH . '/wp-admin/includes/class-wp-list-table.php';
+}
+
+/**
+ * Show pattern usage, using native WordPress table
+ */
+class PatternUsageTable extends WP_List_Table
+{
+    public const ACTION_NAME = 'pattern_usage';
+
+    public const DEFAULT_GROUP_BY = 'pattern_name';
+
+    public const DEFAULT_POST_STATUS = [ 'publish', 'private', 'draft', 'pending', 'future' ];
+
+    public const PLURAL = 'patterns';
+
+    /**
+     * @var PatternUsage
+     */
+    private $pattern_usage;
+
+    /**
+     * @var array
+     */
+    private $pattern_registry;
+
+    /**
+     * @var Parameters Search filters requested.
+     */
+    private $search_params;
+
+    /**
+     * @var string Group column.
+     */
+    private $group_by = self::DEFAULT_GROUP_BY;
+
+    /**
+     * @var string[]
+     */
+    private $allowed_groups = [ 'pattern_name', 'post_id', 'post_title' ];
+
+    /**
+     * @var string[]|null Columns name => title.
+     */
+    private $columns = null;
+
+    /**
+     * @var string|null Latest row content displayed.
+     */
+    private $latest_row = null;
+
+    /**
+     * @var string[]|null Pattern names.
+     */
+    private $pattern_names = null;
+
+
+    /**
+     * @param array $args Args.
+     * @throws InvalidArgumentException Throws on missing parameter.
+     * @see WP_List_Table::__construct()
+     */
+    public function __construct($args = [])
+    {
+        $args['plural'] = self::PLURAL;
+        parent::__construct($args);
+
+        $this->pattern_usage = $args['pattern_usage'] ?? null;
+        $this->pattern_registry = $args['pattern_registry'] ?? null;
+
+        if (! ( $this->pattern_usage instanceof PatternUsage )) {
+            throw new InvalidArgumentException(
+                'Table requires a PatternUsage instance.'
+            );
+        }
+        if (! ( $this->pattern_registry instanceof WP_Block_Patterns_Registry )) {
+            throw new InvalidArgumentException(
+                'Table requires a WP_Block_Patterns_Registry instance.'
+            );
+        }
+
+        $this->pattern_names = array_filter(
+            array_column(
+                $this->pattern_registry->get_all_registered(),
+                'name'
+            ),
+            fn ($name) => BlankPage::get_name() !== $name
+        );
+    }
+
+    /**
+     * @param null|Parameters $search_params Search parameters.
+     * @param null|string     $group_by      Group.
+     */
+    public function prepare_items(
+        ?Parameters $search_params = null,
+        ?string $group_by = null
+    ): void {
+        if (in_array($group_by, $this->allowed_groups, true)) {
+            $this->group_by = $group_by;
+        }
+
+        $this->search_params = $search_params
+            ->with_post_type($this->allowed_post_types())
+            ->with_post_status(self::DEFAULT_POST_STATUS);
+
+        $items = $this->get_items();
+        usort($items, fn ($a, $b) => $a[ $this->group_by ] <=> $b[ $this->group_by ]);
+
+        // Pagination handling.
+        $total_items = count($items);
+        $per_page = 50;
+        $current_page = $this->get_pagenum();
+        $this->items = array_slice($items, ( ( $current_page - 1 ) * $per_page ), $per_page);
+        $this->set_pagination_args(
+            [
+                'total_items' => $total_items,
+                'per_page' => $per_page,
+                'total_pages' => ceil($total_items / $per_page),
+            ]
+        );
+
+        $this->_column_headers = $this->get_column_headers();
+    }
+
+    /**
+     * Get patterns to display
+     */
+    private function get_items(): array
+    {
+        $search_params = clone $this->search_params;
+        if (empty($search_params->name())) {
+            $search_params = $search_params->with_name(
+                $this->pattern_names
+            );
+        }
+
+        return $this->pattern_usage->get_patterns($search_params);
+    }
+
+    /**
+     * Allowed post types to search for
+     */
+    private function allowed_post_types(): array
+    {
+        return array_filter(
+            get_post_types([ 'show_in_rest' => true ]),
+            fn ($t) => post_type_supports($t, 'editor')
+        );
+    }
+
+    /**
+     * Pattern select
+     */
+    private function patternname_dropdown()
+    {
+        sort($this->pattern_names);
+        $filter = $this->search_params->name() ?? [];
+
+        echo '<select name="name" id="filter-by-name">';
+        echo '<option value="">'
+            . esc_html(__('- All patterns -', 'planet4-blocks-backend'))
+            . '</option>';
+        foreach ($this->pattern_names as $name) {
+            echo sprintf(
+                '<option value="%s" %s>%s</option>',
+                esc_attr($name),
+                esc_attr(in_array($name, $filter, true) ? 'selected' : ''),
+                esc_html($name)
+            );
+        }
+        echo '</select>';
+    }
+
+    /**
+     * Add filters to table.
+     *
+     * @param string $which Tablenav identifier.
+     */
+    protected function extra_tablenav($which)
+    {
+        echo '<div class="actions">';
+        $this->patternname_dropdown();
+        submit_button(
+            __('Filter', 'planet4-blocks-backend'),
+            '',
+            'filter_action',
+            false,
+            [ 'id' => 'pattern-query-submit' ]
+        );
+        echo '</div>';
+    }
+
+    /**
+     * Add pagination information to table.
+     *
+     * @param string $which Tablenav identifier.
+     */
+    protected function pagination($which)
+    {
+        parent::pagination('top');
+    }
+
+    /**
+     * Show only top tablenav (duplicate form post bug)
+     *
+     * @param string $which Tablenav identifier.
+     */
+    protected function display_tablenav($which)
+    {
+        if ('bottom' === $which) {
+            echo '<div class="tablenav bottom">';
+            parent::pagination($which);
+            echo '</div>';
+            return;
+        }
+        parent::display_tablenav($which);
+    }
+
+    /**
+     * Add action links to a row
+     *
+     * @param array  $item        Item.
+     * @param string $column_name Current column name.
+     * @param string $primary     Primary column name.
+     *
+	 * phpcs:disable WordPress.WP.I18n.TextDomainMismatch
+     */
+    protected function handle_row_actions($item, $column_name, $primary)
+    {
+        return $this->row_actions(
+            ( new RowActions() )->get_post_actions($item, $column_name, $primary)
+        );
+    }
+
+    /**
+     * Columns list for table.
+     */
+    public function get_columns()
+    {
+        if (null !== $this->columns) {
+            return $this->columns;
+        }
+
+        $default_columns = [
+            'pattern_name' => 'Pattern',
+            'post_title' => 'Title',
+            'match_type' => 'Match',
+            'pattern_occ' => 'Count',
+            'post_date' => 'Created',
+            'post_modified' => 'Modified',
+            'post_id' => 'ID',
+            'post_status' => 'Status',
+        ];
+
+        $this->columns = array_merge(
+            [ $this->group_by => $default_columns[ $this->group_by ] ],
+            $default_columns
+        );
+
+        return $this->columns;
+    }
+
+    /**
+     * Available grouping as views.
+     */
+    protected function get_views()
+    {
+        $link_tpl = '<a href="%s">%s</a>';
+        $active_link_tpl = '<a class="current" href="%s">%s</a>';
+        return [
+            'pattern_name' => sprintf(
+                'pattern_name' === $this->group_by ? $active_link_tpl : $link_tpl,
+                add_query_arg('group', 'pattern_name'),
+                __('Group by pattern name', 'planet4-blocks-backend')
+            ),
+            'post_title' => sprintf(
+                'post_title' === $this->group_by ? $active_link_tpl : $link_tpl,
+                add_query_arg('group', 'post_title'),
+                __('Group by post title', 'planet4-blocks-backend')
+            ),
+            'post_id' => sprintf(
+                'post_id' === $this->group_by ? $active_link_tpl : $link_tpl,
+                add_query_arg('group', 'post_id'),
+                __('Group by post ID', 'planet4-blocks-backend')
+            ),
+        ];
+    }
+
+    /**
+     * All, hidden and sortable columns.
+     */
+    private function get_column_headers()
+    {
+        return [
+            $this->get_columns(),
+            [],
+            [ 'post_title', 'post_date', 'post_modified' ],
+        ];
+    }
+
+    /**
+     * Post title display.
+     *
+     * @param array $item Item.
+     * @return string
+     */
+    public function column_post_title($item): string
+    {
+        $content = $item['post_title'] ?? null;
+        if (empty($content)) {
+            return '';
+        }
+
+        $title_tpl = '%2$s';
+        $link_tpl = '<a href="%s" title="%s">%s</a>';
+        $page_uri = get_page_uri($item['post_id']);
+
+        return sprintf(
+            empty($page_uri) ? $title_tpl : $link_tpl,
+            $page_uri,
+            esc_attr($content),
+            ( strlen($content) > 45 ? substr($content, 0, 45) . '...' : $content )
+        );
+    }
+
+    /**
+     * Full row display, edited for grouping functionality.
+     *
+     * @param array $item Item.
+     */
+    public function single_row($item)
+    {
+        $cols = $this->get_columns();
+        $colspan = count($cols);
+        $first_col = array_key_first($cols);
+
+        if ($this->latest_row !== $item[ $first_col ]) {
+            echo '<tr>';
+            echo sprintf(
+                '<th colspan="%s"><strong>%s</strong></th>',
+                esc_attr($colspan),
+                esc_html($item[ $first_col ])
+            );
+            echo '</tr>';
+        }
+
+        $this->latest_row = $item[ $first_col ];
+        $item[ $first_col ] = '';
+        parent::single_row($item);
+    }
+
+    /**
+     * Default column value representation.
+     *
+     * @param array  $item Item.
+     * @param string $column_name Column name.
+     *
+     * @return mixed
+     */
+    public function column_default($item, $column_name)
+    {
+        return $item[ $column_name ] ?? '';
+    }
+
+    /**
+     * Table URL
+     */
+    public static function url(): string
+    {
+        return admin_url('admin.php?page=plugin_patterns_report');
+    }
+
+    /**
+     * Add redirection for filter action
+     */
+    public static function set_hooks(): void
+    {
+        add_action(
+            'admin_action_' . self::ACTION_NAME,
+            function () {
+                $nonce = $_GET['_wpnonce'] ?? null;
+                if (! \wp_verify_nonce($nonce, 'bulk-' . self::PLURAL)) {
+                    \wp_safe_redirect(self::url());
+                    exit;
+                }
+
+                $redirect_query = remove_query_arg(
+                    [ '_wp_http_referer', '_wpnonce', 'action', 'filter_action' ],
+                    \wp_parse_url($_SERVER['REQUEST_URI'], \PHP_URL_QUERY)
+                );
+                \parse_str($redirect_query, $args);
+                $args = array_filter(
+                    $args,
+                    fn($e) => ! empty($e) && '0' !== $e
+                );
+
+                \wp_safe_redirect(add_query_arg($args, self::url()));
+                exit;
+            },
+            10
+        );
+    }
+}

--- a/src/BlockReportSearch/Pattern/PatternUsageTable.php
+++ b/src/BlockReportSearch/Pattern/PatternUsageTable.php
@@ -2,8 +2,6 @@
 
 /**
  * Table displaying patterns usage
- *
- * @package P4BKS\Search
  */
 
 namespace P4\MasterTheme\BlockReportSearch\Pattern;

--- a/src/BlockReportSearch/Pattern/PatternUsageTable.php
+++ b/src/BlockReportSearch/Pattern/PatternUsageTable.php
@@ -54,9 +54,9 @@ class PatternUsageTable extends WP_List_Table
     private ?array $columns = null;
 
     /**
-     * @var string|null Latest row content displayed.
+     * @var string|int|null Latest row content displayed.
      */
-    private ?string $latest_row = null;
+    private $latest_row = null;
 
     /**
      * @var string[]|null Pattern names.

--- a/src/BlockReportSearch/Pattern/PatternUsageTable.php
+++ b/src/BlockReportSearch/Pattern/PatternUsageTable.php
@@ -15,9 +15,11 @@ use P4\MasterTheme\Patterns\BlankPage;
 use P4\MasterTheme\BlockReportSearch\RowActions;
 use P4\MasterTheme\BlockReportSearch\Pattern\Query\Parameters;
 
+// phpcs:disable PSR1.Files.SideEffects.FoundWithSymbols
 if (! class_exists('WP_List_Table')) {
     require_once ABSPATH . '/wp-admin/includes/class-wp-list-table.php';
 }
+// phpcs:enable PSR1.Files.SideEffects.FoundWithSymbols
 
 /**
  * Show pattern usage, using native WordPress table
@@ -32,45 +34,36 @@ class PatternUsageTable extends WP_List_Table
 
     public const PLURAL = 'patterns';
 
-    /**
-     * @var PatternUsage
-     */
-    private $pattern_usage;
+    private PatternUsage $pattern_usage;
 
-    /**
-     * @var array
-     */
-    private $pattern_registry;
+    private WP_Block_Patterns_Registry $pattern_registry;
 
-    /**
-     * @var Parameters Search filters requested.
-     */
-    private $search_params;
+    private Parameters $search_params;
 
     /**
      * @var string Group column.
      */
-    private $group_by = self::DEFAULT_GROUP_BY;
+    private string $group_by = self::DEFAULT_GROUP_BY;
 
     /**
      * @var string[]
      */
-    private $allowed_groups = [ 'pattern_name', 'post_id', 'post_title' ];
+    private array $allowed_groups = [ 'pattern_name', 'post_id', 'post_title' ];
 
     /**
      * @var string[]|null Columns name => title.
      */
-    private $columns = null;
+    private ?array $columns = null;
 
     /**
      * @var string|null Latest row content displayed.
      */
-    private $latest_row = null;
+    private ?string $latest_row = null;
 
     /**
      * @var string[]|null Pattern names.
      */
-    private $pattern_names = null;
+    private ?array $pattern_names = null;
 
 
     /**
@@ -78,7 +71,7 @@ class PatternUsageTable extends WP_List_Table
      * @throws InvalidArgumentException Throws on missing parameter.
      * @see WP_List_Table::__construct()
      */
-    public function __construct($args = [])
+    public function __construct(array $args = [])
     {
         $args['plural'] = self::PLURAL;
         parent::__construct($args);
@@ -107,8 +100,8 @@ class PatternUsageTable extends WP_List_Table
     }
 
     /**
-     * @param null|Parameters $search_params Search parameters.
-     * @param null|string     $group_by      Group.
+     * @param Parameters|null $search_params Search parameters.
+     * @param string|null     $group_by      Group.
      */
     public function prepare_items(
         ?Parameters $search_params = null,
@@ -170,7 +163,7 @@ class PatternUsageTable extends WP_List_Table
     /**
      * Pattern select
      */
-    private function patternname_dropdown()
+    private function patternname_dropdown(): void
     {
         sort($this->pattern_names);
         $filter = $this->search_params->name() ?? [];
@@ -194,8 +187,9 @@ class PatternUsageTable extends WP_List_Table
      * Add filters to table.
      *
      * @param string $which Tablenav identifier.
+     * @phpcs:disable SlevomatCodingStandard.Functions.UnusedParameter.UnusedParameter, SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
      */
-    protected function extra_tablenav($which)
+    protected function extra_tablenav($which): void
     {
         echo '<div class="actions">';
         $this->patternname_dropdown();
@@ -213,18 +207,21 @@ class PatternUsageTable extends WP_List_Table
      * Add pagination information to table.
      *
      * @param string $which Tablenav identifier.
+     * @phpcs:disable SlevomatCodingStandard.Functions.UnusedParameter.UnusedParameter, SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
      */
-    protected function pagination($which)
+    protected function pagination($which): void
     {
         parent::pagination('top');
     }
+    // @phpcs:enable SlevomatCodingStandard.Functions.UnusedParameter.UnusedParameter
 
     /**
      * Show only top tablenav (duplicate form post bug)
      *
      * @param string $which Tablenav identifier.
+     * @phpcs:disable SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
      */
-    protected function display_tablenav($which)
+    protected function display_tablenav($which): void
     {
         if ('bottom' === $which) {
             echo '<div class="tablenav bottom">';
@@ -242,7 +239,7 @@ class PatternUsageTable extends WP_List_Table
      * @param string $column_name Current column name.
      * @param string $primary     Primary column name.
      *
-	 * phpcs:disable WordPress.WP.I18n.TextDomainMismatch
+	 * phpcs:disable WordPress.WP.I18n.TextDomainMismatch, SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint, SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingAnyTypeHint
      */
     protected function handle_row_actions($item, $column_name, $primary)
     {
@@ -250,11 +247,12 @@ class PatternUsageTable extends WP_List_Table
             ( new RowActions() )->get_post_actions($item, $column_name, $primary)
         );
     }
+    // phpcs:enable SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingAnyTypeHint, SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
 
     /**
      * Columns list for table.
      */
-    public function get_columns()
+    public function get_columns(): ?array
     {
         if (null !== $this->columns) {
             return $this->columns;
@@ -282,7 +280,7 @@ class PatternUsageTable extends WP_List_Table
     /**
      * Available grouping as views.
      */
-    protected function get_views()
+    protected function get_views(): array
     {
         $link_tpl = '<a href="%s">%s</a>';
         $active_link_tpl = '<a class="current" href="%s">%s</a>';
@@ -308,7 +306,7 @@ class PatternUsageTable extends WP_List_Table
     /**
      * All, hidden and sortable columns.
      */
-    private function get_column_headers()
+    private function get_column_headers(): array
     {
         return [
             $this->get_columns(),
@@ -321,7 +319,7 @@ class PatternUsageTable extends WP_List_Table
      * Post title display.
      *
      * @param array $item Item.
-     * @return string
+     * @phpcs:disable SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
      */
     public function column_post_title($item): string
     {
@@ -346,8 +344,9 @@ class PatternUsageTable extends WP_List_Table
      * Full row display, edited for grouping functionality.
      *
      * @param array $item Item.
+     * @phpcs:disable SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
      */
-    public function single_row($item)
+    public function single_row($item): void
     {
         $cols = $this->get_columns();
         $colspan = count($cols);
@@ -375,11 +374,13 @@ class PatternUsageTable extends WP_List_Table
      * @param string $column_name Column name.
      *
      * @return mixed
+     * @phpcs:disable SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
      */
     public function column_default($item, $column_name)
     {
         return $item[ $column_name ] ?? '';
     }
+    // phpcs:enable SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
 
     /**
      * Table URL
@@ -396,7 +397,7 @@ class PatternUsageTable extends WP_List_Table
     {
         add_action(
             'admin_action_' . self::ACTION_NAME,
-            function () {
+            function (): void {
                 $nonce = $_GET['_wpnonce'] ?? null;
                 if (! \wp_verify_nonce($nonce, 'bulk-' . self::PLURAL)) {
                     \wp_safe_redirect(self::url());

--- a/src/BlockReportSearch/Pattern/Query/Parameters.php
+++ b/src/BlockReportSearch/Pattern/Query/Parameters.php
@@ -18,9 +18,7 @@ namespace P4\MasterTheme\BlockReportSearch\Pattern\Query;
  */
 class Parameters
 {
-    /**
-     * @var string[]
-     */
+    // phpcs:ignore SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingAnyTypeHint
     private $name;
 
     /**
@@ -33,9 +31,7 @@ class Parameters
      */
     private array $post_type;
 
-    /**
-     * @var string[]
-     */
+    // phpcs:ignore SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingAnyTypeHint
     private $order;
 
     private const DEFAULT_POST_STATUS = [ 'publish', 'private' ];

--- a/src/BlockReportSearch/Pattern/Query/Parameters.php
+++ b/src/BlockReportSearch/Pattern/Query/Parameters.php
@@ -2,8 +2,6 @@
 
 /**
  * Pattern search query parameters
- *
- * @package P4BKS\Search
  */
 
 namespace P4\MasterTheme\BlockReportSearch\Pattern\Query;

--- a/src/BlockReportSearch/Pattern/Query/Parameters.php
+++ b/src/BlockReportSearch/Pattern/Query/Parameters.php
@@ -1,0 +1,159 @@
+<?php
+
+/**
+ * Pattern search query parameters
+ *
+ * @package P4BKS\Search
+ */
+
+namespace P4\MasterTheme\BlockReportSearch\Pattern\Query;
+
+/**
+ * Parameter bag for Query interface
+ *
+ * @method self with_name(string[] $name)
+ * @method self with_post_status(string[] $status)
+ * @method self with_post_type(string[] $type)
+ * @method self with_order(string[] $order)
+ */
+class Parameters
+{
+    /**
+     * @var string[]
+     */
+    private $name;
+
+    /**
+     * @var string[]
+     */
+    private array $post_status;
+
+    /**
+     * @var string[]
+     */
+    private array $post_type;
+
+    /**
+     * @var string[]
+     */
+    private $order;
+
+    private const DEFAULT_POST_STATUS = [ 'publish', 'private' ];
+
+    /**
+     * Generate a query param object from an array.
+     *
+     * @param array $params The parameters.
+     *
+     * @return self Parameters
+     */
+    public static function from_array(array $params): self
+    {
+        $query = new self();
+
+        foreach ($params as $field => $value) {
+            if (null === $value) {
+                continue;
+            }
+
+            $query = $query->with($field, $value);
+        }
+
+        return $query;
+    }
+
+    /**
+     * Generate query param object from HTTP request.
+     *
+     * @param array $request The request parameters.
+     *
+     * @return self Parameters
+     */
+    public static function from_request(array $request): self
+    {
+        $name = $request['name'] ?? null;
+        if ($name) {
+            $name = is_array($name) ? $name : [ $name ];
+        }
+
+        return self::from_array(
+            [
+                'name' => $name,
+                'post_status' => $request['post_status'] ?? self::DEFAULT_POST_STATUS,
+                'post_type' => $request['post_type'] ?? null,
+                'order' => $request['order'] ?? null,
+            ]
+        );
+    }
+
+    /**
+     *
+     *
+     * @param string $name The name.
+     * @param array  $args The arguments.
+     *
+     * @throws \BadMethodCallException Method does not exist.
+     */
+    public function __call(string $name, array $args): Parameters
+    {
+        if (strpos($name, 'with_') === 0) {
+            $property = substr($name, 5);
+            return $this->with($property, $args[0]);
+        }
+
+        throw new \BadMethodCallException('Method ' . $name . ' does not exist.');
+    }
+
+    /**
+     * Sets parameter
+     *
+     * @param string $name  The name.
+     * @param mixed  $value The value.
+     *
+     * @throws \BadMethodCallException Property not allowed.
+     *
+     * @return self Immutable parameter object.
+     */
+    public function with(string $name, $value = null): self
+    {
+        $allowed = [ 'name', 'post_status', 'post_type', 'order' ];
+        if (! in_array($name, $allowed, true)) {
+            throw new \BadMethodCallException('Property ' . $name . ' does not exist.');
+        }
+
+        $this->$name = $value ?? null;
+        return $this;
+    }
+
+    /**
+     * Pattern name.
+     */
+    public function name(): ?array
+    {
+        return $this->name;
+    }
+
+    /**
+     * List of required post status.
+     */
+    public function post_status(): ?array
+    {
+        return $this->post_status ?? self::DEFAULT_POST_STATUS;
+    }
+
+    /**
+     * List of required post types.
+     */
+    public function post_type(): ?array
+    {
+        return $this->post_type ?? null;
+    }
+
+    /**
+     * Columns names to sort on.
+     */
+    public function order(): ?array
+    {
+        return $this->order;
+    }
+}

--- a/src/BlockReportSearch/PatternSearch.php
+++ b/src/BlockReportSearch/PatternSearch.php
@@ -1,0 +1,173 @@
+<?php
+
+/**
+ * Pattern search
+ *
+ * @package P4BKS\Search
+ */
+
+namespace P4\MasterTheme\BlockReportSearch;
+
+use P4\MasterTheme\BlockReportSearch\Block\Query\Parameters as BlockSearchParameters;
+use P4\MasterTheme\BlockReportSearch\Block\Sql\SqlQuery as BlockSqlQuery;
+use P4\MasterTheme\BlockReportSearch\Pattern\PatternData;
+use P4\MasterTheme\BlockReportSearch\Pattern\PatternUsage;
+use P4\MasterTheme\BlockReportSearch\Pattern\Query\Parameters;
+use P4\MasterTheme\SqlParameters;
+
+/**
+ * Search for posts containing specific patterns
+ */
+class PatternSearch
+{
+    public const DEFAULT_POST_TYPE = [ 'post', 'page' ];
+
+    public const DEFAULT_POST_STATUS = [ 'publish', 'private', 'draft', 'pending', 'future' ];
+
+    /**
+     * @param Parameters $params Query parameters.
+     * @param array      $opts   Search Options.
+     * @return int[] list of posts IDs.
+     */
+    public function get_posts(Parameters $params, array $opts = []): array
+    {
+        $opts = array_merge(
+            [
+                'use_struct' => true,
+                'use_class' => true,
+                'use_templates' => true,
+            ],
+            $opts
+        );
+
+        $patterns = array_map(
+            fn ($pattern) => PatternData::from_name($pattern),
+            $params->name()
+        );
+
+        return array_unique(
+            array_filter(
+                array_merge(
+                    $opts['use_class'] ? $this->query_by_pattern_classname($params, ...$patterns) : [],
+                    $opts['use_struct'] ? $this->query_by_pattern_blocks($params, ...$patterns) : [],
+                    $opts['use_templates'] ? $this->query_by_pattern_template($params, ...$patterns) : []
+                )
+            )
+        );
+    }
+
+    /**
+     * Search templates by namespace to reduce query count.
+     *
+     * @param Parameters  $params          Search parameters.
+     * @param PatternData ...$pattern_data Pattern data.
+     * @return int[] List of posts IDs.
+     */
+    private function query_by_pattern_template(
+        Parameters $params,
+        PatternData ...$pattern_data
+    ): array {
+        // Query posts with all blocks of tree.
+        $templates = PatternUsage::patterns_templates_lookup_table();
+        $block_query = new BlockSqlQuery();
+
+        $pattern_names = array_map(fn($p) => $p->name, $pattern_data);
+        $template_names = array_map(fn($n) => $templates[ $n ], $pattern_names);
+        $template_ns = array_filter(array_unique(array_map(fn($n) => explode('/', $n)[0] ?? null, $template_names)));
+
+        $post_ids = [];
+        foreach ($template_ns as $ns) {
+            $block_params = BlockSearchParameters::from_array(
+                [
+                    'namespace' => $ns,
+                    'post_status' => $params->post_status() ?? self::DEFAULT_POST_STATUS,
+                    'post_type' => $params->post_type() ?? self::DEFAULT_POST_TYPE,
+                ]
+            );
+
+            $post_ids = array_merge($post_ids, $block_query->get_posts($block_params));
+        }
+
+        return array_unique($post_ids);
+    }
+
+    /**
+     * @param Parameters  $params          Search parameters.
+     * @param PatternData ...$pattern_data Pattern data.
+     * @return int[] List of posts IDs.
+     */
+    private function query_by_pattern_blocks(
+        Parameters $params,
+        PatternData ...$pattern_data
+    ): array {
+        // Query posts with all blocks of tree.
+        $block_query = new BlockSqlQuery();
+
+        $post_ids = [];
+        foreach ($pattern_data as $pattern) {
+            $block_params = array_map(
+                fn ($block_name) => BlockSearchParameters::from_array(
+                    [
+                        'name' => $block_name,
+                        'post_status' => $params->post_status() ?? self::DEFAULT_POST_STATUS,
+                        'post_type' => $params->post_type() ?? self::DEFAULT_POST_TYPE,
+                    ]
+                ),
+                $pattern->block_list
+            );
+
+            $post_ids = array_merge($post_ids, $block_query->get_posts(...$block_params));
+        }
+
+        return array_unique($post_ids);
+    }
+
+    /**
+     * Query posts by pattern classname.
+     *
+     * @param Parameters  $params          Search parameters.
+     * @param PatternData ...$pattern_data Pattern data.
+     * @return int[] List of posts IDs.
+     */
+    private function query_by_pattern_classname(
+        Parameters $params,
+        PatternData ...$pattern_data
+    ): array {
+        $classes = array_map(
+            fn ($p) => $p->classname,
+            $pattern_data
+        );
+        if (empty($classes)) {
+            return [];
+        }
+
+        global $wpdb;
+
+        $like = array_map(fn ($c) => "post_content LIKE '%%$c%%'", $classes);
+        $like = implode(' OR ', $like);
+
+        $sql_params = new SqlParameters();
+        $query = 'SELECT ID
+			FROM ' . $sql_params->identifier($wpdb->posts) . '
+			WHERE post_status IN ' . $sql_params->string_list(
+                $params->post_status() ?? self::DEFAULT_POST_STATUS
+            ) . '
+			AND post_type IN ' . $sql_params->string_list(
+                $params->post_type() ?? self::DEFAULT_POST_TYPE
+            ) . '
+			AND ( ' . $like . ' )';
+
+        $results = $wpdb->get_results(
+			$wpdb->prepare( $query, $sql_params->get_values() ) // phpcs:ignore
+        );
+
+        if (! is_array($results)) {
+            return [];
+        }
+
+        return array_map(
+            fn ($r) => (int) $r->ID,
+            $results
+        );
+    }
+}

--- a/src/BlockReportSearch/PatternSearch.php
+++ b/src/BlockReportSearch/PatternSearch.php
@@ -2,8 +2,6 @@
 
 /**
  * Pattern search
- *
- * @package P4BKS\Search
  */
 
 namespace P4\MasterTheme\BlockReportSearch;

--- a/src/BlockReportSearch/RowActions.php
+++ b/src/BlockReportSearch/RowActions.php
@@ -1,0 +1,79 @@
+<?php
+
+/**
+ * Display post actions in table
+ *
+ * @package P4BKS\Search
+ */
+
+namespace P4\MasterTheme\BlockReportSearch;
+
+/**
+ * Row actions
+ */
+class RowActions
+{
+    /**
+     * Add action links to a row
+     *
+     * @param array  $item        Item.
+     * @param string $column_name Current column name.
+     * @param string $primary     Primary column name.
+     *
+	 * phpcs:disable WordPress.WP.I18n.TextDomainMismatch
+     */
+    public function get_post_actions(array $item, string $column_name, string $primary): array
+    {
+        if ($column_name !== $primary) {
+            return [];
+        }
+
+        $id = (int) $item['post_id'];
+        $title = $item['post_title'];
+        $actions = [];
+
+        $actions['edit'] = sprintf(
+            '<a href="%s" aria-label="%s">%s</a>',
+            get_edit_post_link($item['post_id']),
+            /* translators: %s: Post title. */
+            esc_attr(sprintf(__('Edit &#8220;%s&#8221;', 'default'), $title)),
+            __('Edit', 'default')
+        );
+
+        if (in_array($item['post_status'], [ 'pending', 'draft', 'future' ], true)) {
+            $preview_link = get_preview_post_link($id);
+            $actions['view'] = sprintf(
+                '<a href="%s" rel="bookmark" aria-label="%s">%s</a>',
+                esc_url($preview_link),
+                /* translators: %s: Post title. */
+                esc_attr(sprintf(__('Preview &#8220;%s&#8221;', 'default'), $title)),
+                __('Preview', 'default')
+            );
+        } elseif ('trash' !== $item['post_status']) {
+            $actions['view'] = sprintf(
+                '<a href="%s" rel="bookmark" aria-label="%s">%s</a>',
+                get_permalink($item['post_id']),
+                /* translators: %s: Post title. */
+                esc_attr(sprintf(__('View &#8220;%s&#8221;', 'default'), $title)),
+                __('View', 'default')
+            );
+        }
+
+        $actions['clone'] = '<a href="' . duplicate_post_get_clone_post_link($id, 'display', false) .
+            '" aria-label="' . esc_attr(
+            /* translators: %s: Post title. */
+                sprintf(__('Clone &#8220;%s&#8221;', 'duplicate-post'), $title)
+            ) . '">' .
+            esc_html_x('Clone', 'verb', 'duplicate-post') . '</a>';
+
+        $actions['edit_as_new_draft'] = '<a href="' . duplicate_post_get_clone_post_link($id) .
+            '" aria-label="' . esc_attr(
+            /* translators: %s: Post title. */
+                sprintf(__('New draft of &#8220;%s&#8221;', 'duplicate-post'), $title)
+            ) . '">' .
+            esc_html__('New Draft', 'duplicate-post') .
+            '</a>';
+
+        return $actions;
+    }
+}

--- a/src/BlockReportSearch/RowActions.php
+++ b/src/BlockReportSearch/RowActions.php
@@ -2,8 +2,6 @@
 
 /**
  * Display post actions in table
- *
- * @package P4BKS\Search
  */
 
 namespace P4\MasterTheme\BlockReportSearch;

--- a/src/Commands/DuplicatedPostmeta.php
+++ b/src/Commands/DuplicatedPostmeta.php
@@ -1,0 +1,86 @@
+<?php
+
+/**
+ * Detect and remove duplicate postmeta command
+ */
+
+namespace P4\MasterTheme\Commands;
+
+/**
+ * Class for detect and remove duplicate postmeta records.
+ */
+class DuplicatedPostmeta
+{
+    /**
+     * List of meta_key check in duplicate list.
+     *
+     * @const array META_KEY_LIST.
+     */
+    public const META_KEY_LIST = [
+        'sm_cloud',
+        'weight',
+        '_credit_text',
+        '_wp_attachment_image_alt',
+        '_searchwp_last_index',
+        '_media_restriction',
+    ];
+
+    /**
+     * Remove duplicate postmeta records
+     *
+     */
+    public static function remove(): int
+    {
+
+        global $wpdb;
+
+		// phpcs:disable
+		$sql = "DELETE t1 FROM wp_postmeta t1
+				INNER JOIN wp_postmeta t2
+				WHERE  t1.meta_id < t2.meta_id
+				AND  t1.meta_key = t2.meta_key
+				AND t1.post_id = t2.post_id
+				AND t1.meta_key IN (" . self::generate_placeholders( self::META_KEY_LIST, 1 ) . ")";
+
+		$prepared_sql = $wpdb->prepare( $sql, self::META_KEY_LIST );
+
+		return $wpdb->query( $prepared_sql );
+		// phpcs:enable
+    }
+
+    /**
+     * Detect duplicate postmeta records
+     *
+     */
+    public static function detect()
+    {
+
+        global $wpdb;
+
+		// phpcs:disable
+		$sql = "SELECT `meta_key`, COUNT(post_id) AS all_count , COUNT(DISTINCT post_id) AS unique_count
+				FROM `wp_postmeta`
+				GROUP by `meta_key`
+				HAVING all_count <> unique_count
+				ORDER BY `all_count` DESC";
+
+		return $wpdb->get_results( $sql );
+		// phpcs:enable
+    }
+
+    /**
+     * Generate a bunch of placeholders for use in an IN query.
+     *
+     * @param array $items The items to generate placeholders for.
+     * @param int   $start_index The start index to use for creating the placeholders.
+     * @return string The generated placeholders string.
+     */
+    private static function generate_placeholders(array $items, int $start_index): string
+    {
+        $placeholders = [];
+        foreach (range($start_index, count($items) + $start_index - 1) as $i) {
+            $placeholders[] = "'%$i\$s'";
+        }
+        return implode(',', $placeholders);
+    }
+}

--- a/src/Commands/DuplicatedPostmeta.php
+++ b/src/Commands/DuplicatedPostmeta.php
@@ -52,7 +52,7 @@ class DuplicatedPostmeta
      * Detect duplicate postmeta records
      *
      */
-    public static function detect()
+    public static function detect(): ?array
     {
 
         global $wpdb;

--- a/src/Controllers/Menu/BlocksReportController.php
+++ b/src/Controllers/Menu/BlocksReportController.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * Blocks report Settings Controller
+ */
+
+namespace P4\MasterTheme\Controllers\Menu;
+
+/**
+ * Class BlocksReportController
+ */
+class BlocksReportController extends Controller
+{
+    public const P4BKS_REPORTS_SLUG_NAME = 'plugin_blocks_report';
+
+    /**
+     * Create menu/submenu entry.
+     */
+    public function create_admin_menu(): void
+    {
+        $current_user = wp_get_current_user();
+
+        if (( !in_array('administrator', $current_user->roles, true) && !in_array('editor', $current_user->roles, true) ) || !current_user_can('edit_posts')) {
+            return;
+        }
+
+        add_menu_page(
+            __('Blocks', 'planet4-blocks-backend'),
+            __('Blocks', 'planet4-blocks-backend'),
+            'edit_posts',
+            self::P4BKS_REPORTS_SLUG_NAME,
+            null,
+            'dashicons-layout'
+        );
+    }
+}

--- a/src/Controllers/Menu/BlocksReportController.php
+++ b/src/Controllers/Menu/BlocksReportController.php
@@ -20,7 +20,11 @@ class BlocksReportController extends Controller
     {
         $current_user = wp_get_current_user();
 
-        if (( !in_array('administrator', $current_user->roles, true) && !in_array('editor', $current_user->roles, true) ) || !current_user_can('edit_posts')) {
+        if (
+            ( !in_array('administrator', $current_user->roles, true) &&
+            !in_array('editor', $current_user->roles, true) ) ||
+            !current_user_can('edit_posts')
+        ) {
             return;
         }
 

--- a/src/Controllers/Menu/BlocksUsageController.php
+++ b/src/Controllers/Menu/BlocksUsageController.php
@@ -67,7 +67,7 @@ class BlocksUsageController extends Controller
     /**
      * Generates blocks/pages report.
      */
-    public function plugin_blocks_report_rest_api()
+    public function plugin_blocks_report_rest_api(): ?array
     {
         global $wpdb;
 
@@ -125,7 +125,11 @@ class BlocksUsageController extends Controller
     {
         $current_user = wp_get_current_user();
 
-        if (( !in_array('administrator', $current_user->roles, true) && !in_array('editor', $current_user->roles, true) ) || !current_user_can('edit_posts')) {
+        if (
+            ( !in_array('administrator', $current_user->roles, true) &&
+            !in_array('editor', $current_user->roles, true) ) ||
+            !current_user_can('edit_posts')
+        ) {
             return;
         }
 

--- a/src/Controllers/Menu/BlocksUsageController.php
+++ b/src/Controllers/Menu/BlocksUsageController.php
@@ -1,0 +1,228 @@
+<?php
+
+/**
+ * Blocks Usage class
+ *
+ * @package P4BKS\Controllers\Menu
+ * @since 1.40.0
+ */
+
+namespace P4\MasterTheme\Controllers\Menu;
+
+use P4\MasterTheme\SqlParameters;
+use P4\MasterTheme\BlockReportSearch\Block\BlockUsage;
+use P4\MasterTheme\BlockReportSearch\Block\BlockUsageTable;
+use P4\MasterTheme\BlockReportSearch\Block\BlockUsageApi;
+use P4\MasterTheme\BlockReportSearch\Block\Query\Parameters as BlockParameters;
+use P4\MasterTheme\BlockReportSearch\Pattern\Query\Parameters as PatternParameters;
+use P4\MasterTheme\BlockReportSearch\Pattern\PatternUsage;
+use P4\MasterTheme\BlockReportSearch\Pattern\PatternUsageTable;
+use P4\MasterTheme\BlockReportSearch\Pattern\PatternUsageApi;
+use WP_Block_Type_Registry;
+use WP_Block_Patterns_Registry;
+use P4\MasterTheme\View\View;
+
+/**
+ * Class BlocksUsageController
+ */
+class BlocksUsageController extends Controller
+{
+    /**
+     * Blocks_Usage_Controller constructor.
+     *
+     * @param View $view The view object.
+     */
+    public function __construct(View $view)
+    {
+        parent::__construct($view);
+        $this->hooks();
+    }
+
+    /**
+     * Class hooks.
+     */
+    private function hooks(): void
+    {
+        add_action('rest_api_init', [ $this, 'plugin_blocks_report_register_rest_route' ]);
+        BlockUsageTable::set_hooks();
+        PatternUsageTable::set_hooks();
+    }
+
+    /**
+     * Register API route for report of blocks usage in pages/posts.
+     */
+    public function plugin_blocks_report_register_rest_route(): void
+    {
+        register_rest_route(
+            'plugin_blocks/v3',
+            '/plugin_blocks_report/',
+            [
+                'methods' => 'GET',
+                'callback' => [ $this, 'plugin_blocks_report_rest_api' ],
+                'permission_callback' => '__return_true',
+            ]
+        );
+    }
+
+    /**
+     * Generates blocks/pages report.
+     */
+    public function plugin_blocks_report_rest_api()
+    {
+        global $wpdb;
+
+        $use_cache = ! current_user_can('manage_options');
+        $cache_key = 'plugin_blocks/v3/plugin_blocks_report';
+        if ($use_cache) {
+            $report = wp_cache_get($cache_key, 'api', false, $found);
+            if ($found) {
+                return $report;
+            }
+        }
+
+        $types = \get_post_types(
+            [
+                'public' => true,
+                'exclude_from_search' => false,
+            ]
+        );
+
+        // Get posts types counts.
+        $params = new SqlParameters();
+        $sql = 'SELECT post_type, count(ID) AS post_count
+            FROM ' . $params->identifier($wpdb->posts) . '
+            WHERE post_status = ' . $params->string('publish') . '
+                AND post_type IN ' . $params->string_list($types) . '
+            GROUP BY post_type';
+        $results = $wpdb->get_results(
+            // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+            $wpdb->prepare($sql, $params->get_values()),
+            \ARRAY_A
+        );
+
+        $post_types = array_combine(
+            array_column($results, 'post_type'),
+            array_map('intval', array_column($results, 'post_count'))
+        );
+
+        // Group results.
+        $block_api = new BlockUsageApi();
+        $pattern_api = new PatternUsageApi();
+        $report = [
+            'block_types' => $block_api->get_count(),
+            'block_patterns' => $pattern_api->get_count(),
+            'post_types' => $post_types,
+        ];
+        wp_cache_set($cache_key, $report, 'api', 60 * 5);
+
+        return $report;
+    }
+
+    /**
+     * Create menu/submenu entry.
+     */
+    public function create_admin_menu(): void
+    {
+        $current_user = wp_get_current_user();
+
+        if (( !in_array('administrator', $current_user->roles, true) && !in_array('editor', $current_user->roles, true) ) || !current_user_can('edit_posts')) {
+            return;
+        }
+
+        add_submenu_page(
+            BlocksReportController::P4BKS_REPORTS_SLUG_NAME,
+            __('Report', 'planet4-blocks-backend'),
+            __('Report', 'planet4-blocks-backend'),
+            'edit_posts',
+            'plugin_blocks_report',
+            [ $this, 'plugin_blocks_report' ]
+        );
+
+        add_submenu_page(
+            BlocksReportController::P4BKS_REPORTS_SLUG_NAME,
+            __('Pattern Report', 'planet4-blocks-backend'),
+            __('Pattern Report', 'planet4-blocks-backend'),
+            'edit_posts',
+            'plugin_patterns_report',
+            [ $this, 'plugin_patterns_report' ]
+        );
+    }
+
+    /**
+     * Block usage report page.
+     */
+    public function plugin_blocks_report(): void
+    {
+        // Nonce verify.
+        if (isset($_REQUEST['filter_action'])) {
+            check_admin_referer('bulk-' . BlockUsageTable::PLURAL);
+        }
+
+        // Create table.
+        $args = [
+            'block_usage' => new BlockUsage(),
+            'block_registry' => WP_Block_Type_Registry::get_instance(),
+        ];
+        $table = new BlockUsageTable($args);
+
+        // Prepare data.
+        $special_filter = isset($_REQUEST['unregistered']) ? 'unregistered'
+            : ( isset($_REQUEST['unallowed']) ? 'unallowed' : null );
+        $table->prepare_items(
+            BlockParameters::from_request($_REQUEST),
+            $_REQUEST['group'] ?? null,
+            $special_filter
+        );
+
+        // Display data.
+        echo '<div class="wrap">
+            <h1 class="wp-heading-inline">Block usage</h1>
+            <hr class="wp-header-end">';
+
+        echo '<form id="blocks-report" method="get">';
+        $table->views();
+        $table->search_box('Search in block attributes', 'blocks-report');
+        $table->display();
+        echo '<input type="hidden" name="action"
+            value="' . esc_attr(BlockUsageTable::ACTION_NAME) . '"/>';
+        echo '</form>';
+        echo '</div>';
+    }
+
+    /**
+     * Pattern usage report page.
+     */
+    public function plugin_patterns_report(): void
+    {
+        // Nonce verify.
+        if (isset($_REQUEST['filter_action'])) {
+            check_admin_referer('bulk-' . PatternUsageTable::PLURAL);
+        }
+
+        // Create table.
+        $args = [
+            'pattern_usage' => new PatternUsage(),
+            'pattern_registry' => WP_Block_Patterns_Registry::get_instance(),
+        ];
+        $table = new PatternUsageTable($args);
+
+        // Prepare data.
+        $table->prepare_items(
+            PatternParameters::from_request($_REQUEST),
+            $_REQUEST['group'] ?? null
+        );
+
+        // Display data.
+        echo '<div class="wrap">
+            <h1 class="wp-heading-inline">Pattern usage</h1>
+            <hr class="wp-header-end">';
+
+        echo '<form id="patterns-report" method="get">';
+        $table->views();
+        $table->display();
+        echo '<input type="hidden" name="action"
+            value="' . esc_attr(PatternUsageTable::ACTION_NAME) . '"/>';
+        echo '</form>';
+        echo '</div>';
+    }
+}

--- a/src/Controllers/Menu/BlocksUsageController.php
+++ b/src/Controllers/Menu/BlocksUsageController.php
@@ -2,9 +2,6 @@
 
 /**
  * Blocks Usage class
- *
- * @package P4BKS\Controllers\Menu
- * @since 1.40.0
  */
 
 namespace P4\MasterTheme\Controllers\Menu;

--- a/src/Controllers/Menu/ClassicBlocksUsage.php
+++ b/src/Controllers/Menu/ClassicBlocksUsage.php
@@ -2,9 +2,6 @@
 
 /**
  * Blocks Usage class
- *
- * @package P4BKS\Controllers\Menu
- * @since 1.40.0
  */
 
 namespace P4\MasterTheme\Controllers\Menu;

--- a/src/Controllers/Menu/ClassicBlocksUsage.php
+++ b/src/Controllers/Menu/ClassicBlocksUsage.php
@@ -1,0 +1,86 @@
+<?php
+
+/**
+ * Blocks Usage class
+ *
+ * @package P4BKS\Controllers\Menu
+ * @since 1.40.0
+ */
+
+namespace P4\MasterTheme\Controllers\Menu;
+
+/**
+ * Show posts using classic blocks.
+ */
+class ClassicBlocksUsage extends Controller
+{
+    /**
+     * Create menu/submenu entry.
+     */
+    public function create_admin_menu(): void
+    {
+
+        $current_user = wp_get_current_user();
+
+        if (!in_array('administrator', $current_user->roles, true) || !current_user_can('manage_options')) {
+            return;
+        }
+
+        add_submenu_page(
+            BlocksReportController::P4BKS_REPORTS_SLUG_NAME,
+            __('Classic block usage', 'planet4-blocks-backend'),
+            __('Classic block usage', 'planet4-blocks-backend'),
+            'manage_options',
+            'classic_block_usage',
+            [ $this, 'classic_block_usage' ]
+        );
+    }
+
+    /**
+     * Show all posts that use classic "blocks", which isn't really a block but the absence of one.
+     * All consecutive content that is not inside of a block comment is regarded as a single classic block when parsed.
+     * So in order to find classic blocks, we parse the content as blocks and then check for all blocks where the name
+     * is null and the content is more than just whitespace.
+     */
+    public function classic_block_usage(): void
+    {
+        $all_posts = get_posts(
+            [
+                'post_type' => [ 'post', 'page', 'campaign' ],
+                'numberposts' => - 1,
+            ]
+        );
+
+        $has_classic_block = static function ($post) {
+            $blocks = parse_blocks($post->post_content);
+            foreach ($blocks as $block) {
+                if (null === $block['blockName'] && '' !== trim($block['innerHTML'])) {
+                    return true;
+                }
+            }
+
+            return false;
+        };
+
+        $with_classic_blocks = array_filter($all_posts, $has_classic_block);
+
+        // Copied this code from https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/blob/add-classic-block-to-report/classes/controller/menu/class-blocks-usage-controller.php#L107-L107.
+        // So disabling CS here as well as this is only a temporary dev tool.
+		//phpcs:disable
+		echo '<hr>';
+		echo '<h2>Posts using classic blocks</h2>';
+		echo '<p>Following posts are detected to use classic blocks. It is recommended to convert them to new blocks.</p>';
+		echo '<p>You can convert classic blocks in the post editor by following the steps described in <a target="_blank" href="https://planet4.greenpeace.org/create/manage/convert-posts-to-gutenberg-editor/">this article</a>.</p>';
+		echo '<table>';
+		echo '<tr style="text-align: left">
+							<th>' . __( 'ID', 'planet4-blocks-backend' ) . '</th>
+							<th>' . __( 'Title', 'planet4-blocks-backend' ) . '</th>
+					</tr>';
+		foreach ( $with_classic_blocks as $post_with_classic ) {
+			echo  '<tr><td><a href="' . get_permalink( $post_with_classic->ID ) . '" >' . $post_with_classic->ID . '</a></td>';
+			echo  '<td><a href="post.php?post=' . $post_with_classic->ID . '&action=edit" >' . $post_with_classic->post_title . '</a></td></tr>';
+		}
+		echo '</table>';
+		//phpcs:enable
+    }
+}

--- a/src/Controllers/Menu/PostmetaCheckController.php
+++ b/src/Controllers/Menu/PostmetaCheckController.php
@@ -54,8 +54,10 @@ class PostmetaCheckController extends Controller
         }
 
         if ($deleted_rows) {
+            // phpcs:disable Generic.Files.LineLength.MaxExceeded
             // translators: %d = The duplicate postmeta count.
             $data['message'] = sprintf(__('Remove %d duplicate postmeta records successfully.', 'planet4-blocks-backend'), $deleted_rows);
+            // phpcs:enable Generic.Files.LineLength.MaxExceeded
         } else {
             $data['message'] = __('No whitelisted duplicate postmeta records found.', 'planet4-blocks-backend');
         }

--- a/src/Controllers/Menu/PostmetaCheckController.php
+++ b/src/Controllers/Menu/PostmetaCheckController.php
@@ -1,0 +1,77 @@
+<?php
+
+/**
+ * Post meta duplicate records check class
+ */
+
+namespace P4\MasterTheme\Controllers\Menu;
+
+use P4\MasterTheme\Commands\DuplicatedPostmeta;
+
+/**
+ * Class PostmetaCheckController
+ */
+class PostmetaCheckController extends Controller
+{
+    /**
+     * Create menu/submenu entry.
+     */
+    public function create_admin_menu(): void
+    {
+        $current_user = wp_get_current_user();
+        if (!in_array('administrator', $current_user->roles, true)) {
+            return;
+        }
+
+        add_submenu_page(
+            BlocksReportController::P4BKS_REPORTS_SLUG_NAME,
+            __('Postmeta Check', 'planet4-blocks-backend'),
+            __('Postmeta Check', 'planet4-blocks-backend'),
+            'manage_options',
+            'postmeta_report',
+            [ $this, 'postmeta_check' ]
+        );
+    }
+
+    /**
+     * Handle form submit.
+     *
+     * @param mixed[] $data The form data.
+     */
+    public function handle_submit(array &$data): void
+    {
+        $remove_duplicate_postmeta = filter_input(INPUT_POST, 'delete_duplicate_postmeta', FILTER_SANITIZE_NUMBER_INT);
+        if ('POST' !== $_SERVER['REQUEST_METHOD'] || !$remove_duplicate_postmeta) {
+            return;
+        }
+        //phpcs:ignore WordPress.Security.NonceVerification.Recommended
+        try {
+            $deleted_rows = DuplicatedPostmeta::remove();
+        } catch (\Error $e) {
+            $data['message'] = $e->getMessage();
+        } catch (\Exception $e) {
+            $data['message'] = __('Exception: ', 'planet4-blocks-backend') . $e->getMessage();
+        }
+
+        if ($deleted_rows) {
+            // translators: %d = The duplicate postmeta count.
+            $data['message'] = sprintf(__('Remove %d duplicate postmeta records successfully.', 'planet4-blocks-backend'), $deleted_rows);
+        } else {
+            $data['message'] = __('No whitelisted duplicate postmeta records found.', 'planet4-blocks-backend');
+        }
+    }
+
+    /**
+     * Render the admin page with duplicate postmeta details.
+     */
+    public function postmeta_check(): void
+    {
+        $data = [];
+
+        $this->handle_submit($data);
+        $data['duplicate_postmeta'] = DuplicatedPostmeta::detect();
+        $data['postmeta_keys'] = DuplicatedPostmeta::META_KEY_LIST;
+
+        $this->view->block('duplicate-postmeta-report', $data, 'twig', '');
+    }
+}

--- a/src/Controllers/Menu/ReusableBlocksController.php
+++ b/src/Controllers/Menu/ReusableBlocksController.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * Reusable Blocks class
+ *
+ * @package P4GBKS\Controllers\Menu;
+ */
+
+namespace P4\MasterTheme\Controllers\Menu;
+
+/**
+ * Class Reusable_Blocks_Controller
+ */
+class ReusableBlocksController extends Controller
+{
+    /**
+     * Post type name.
+     */
+    const POST_TYPE = 'wp_block';
+
+    /**
+     * Create menu/submenu entry.
+     */
+    public function create_admin_menu(): void
+    {
+
+        $current_user = wp_get_current_user();
+
+        if (( !in_array('administrator', $current_user->roles, true) && !in_array('editor', $current_user->roles, true) ) || !current_user_can('edit_posts')) {
+            return;
+        }
+
+        add_submenu_page(
+            BlocksReportController::P4BKS_REPORTS_SLUG_NAME,
+            __('All Reusable blocks', 'planet4-blocks-backend'),
+            __('All Reusable blocks', 'planet4-blocks-backend'),
+            'edit_posts',
+            'edit.php?post_type=' . self::POST_TYPE
+        );
+    }
+}

--- a/src/Controllers/Menu/ReusableBlocksController.php
+++ b/src/Controllers/Menu/ReusableBlocksController.php
@@ -2,8 +2,6 @@
 
 /**
  * Reusable Blocks class
- *
- * @package P4GBKS\Controllers\Menu;
  */
 
 namespace P4\MasterTheme\Controllers\Menu;

--- a/src/Controllers/Menu/ReusableBlocksController.php
+++ b/src/Controllers/Menu/ReusableBlocksController.php
@@ -16,7 +16,7 @@ class ReusableBlocksController extends Controller
     /**
      * Post type name.
      */
-    const POST_TYPE = 'wp_block';
+    private const POST_TYPE = 'wp_block';
 
     /**
      * Create menu/submenu entry.
@@ -26,7 +26,11 @@ class ReusableBlocksController extends Controller
 
         $current_user = wp_get_current_user();
 
-        if (( !in_array('administrator', $current_user->roles, true) && !in_array('editor', $current_user->roles, true) ) || !current_user_can('edit_posts')) {
+        if (
+            ( !in_array('administrator', $current_user->roles, true) &&
+            !in_array('editor', $current_user->roles, true) ) ||
+            !current_user_can('edit_posts')
+        ) {
             return;
         }
 

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -165,6 +165,11 @@ final class Loader
             $services[] = Controllers\Menu\EnSettingsController::class;
             $services[] = Controllers\Api\RestController::class;
         }
+        $services[] = Controllers\Menu\BlocksReportController::class;
+        $services[] = Controllers\Menu\BlocksUsageController::class;
+        $services[] = Controllers\Menu\ClassicBlocksUsage::class;
+        $services[] = Controllers\Menu\ReusableBlocksController::class;
+        $services[] = Controllers\Menu\PostmetaCheckController::class;
 
         $view = new View();
         foreach ($services as $service) {

--- a/src/Migrations/M009PopulateCookiesFields.php
+++ b/src/Migrations/M009PopulateCookiesFields.php
@@ -7,7 +7,7 @@ namespace P4\MasterTheme\Migrations;
 use P4\MasterTheme\MigrationRecord;
 use P4\MasterTheme\MigrationScript;
 use P4\MasterTheme\Settings;
-use P4GBKS\Search\BlockSearch;
+use P4\MasterTheme\BlockReportSearch\BlockSearch;
 use WP_Block_Parser;
 
 /**
@@ -23,7 +23,7 @@ class M009PopulateCookiesFields extends MigrationScript
      */
     public static function execute(MigrationRecord $record): void
     {
-        if (! class_exists('P4GBKS\Search\BlockSearch')) {
+        if (! class_exists('P4\MasterTheme\BlockReportSearch\BlockSearch')) {
             echo 'P4 Gutenberg plugin is not available.';
             return;
         }

--- a/templates/duplicate-postmeta-report.twig
+++ b/templates/duplicate-postmeta-report.twig
@@ -1,0 +1,56 @@
+{% block duplicate_postmeta_report %}
+
+	<div id="duplicate_postmeta_div" class="wrap">
+		<h2>{{ __( 'Duplicate Postmeta', 'planet4-blocks-backend' ) }}</h2>
+		</div>
+		<p>{{ __( 'Whitelisted meta_key\'s for delete operation', 'planet4-blocks-backend' ) }} - </p>
+		{% for postmeta_key in postmeta_keys %}
+			<p> - {{ postmeta_key }}</p>
+		{% endfor %}
+
+		<form id="p4bks_duplicate_postmeta_form" name="p4bks_duplicate_postmeta_form" method="post">
+		<p class="submit">
+			<input type="hidden" name="delete_duplicate_postmeta" value="1">
+			<input type="submit" name="remove_duplicate_postmenta" id="p4bks_remove_duplicate_button" class="button button-primary" value="{{ __( 'Remove Duplicate Postmeta', 'planet4-blocks-backend' ) }}">
+			<BR><BR>
+			<span class="convert-blocks-response cp-success">{{ message }}</span>
+			</p>
+		</form>
+		<div class="clear"></div>
+
+		<hr>
+		<h2>{{ __( 'Duplicate postmeta report', 'planet4-blocks-backend' ) }}</h2>
+		<table>
+		<tr>
+			<th style="padding: 0px 50px 0px 0px;">{{ __( 'No.', 'planet4-blocks-backend' ) }}</th>
+			<th>{{ __( 'meta_key', 'planet4-blocks-backend' ) }}</th>
+			<th>{{ __( 'Duplicate count', 'planet4-blocks-backend' ) }}</th>
+		</tr>
+		{% set total_count = 0 %}
+		{% for result in duplicate_postmeta %}
+			{% set duplicate_count = result.all_count - result.unique_count %}
+			{% set total_count = total_count + duplicate_count %}
+			<tr>
+				<td>{{ loop.index }}</td>
+				<td>{{ result.meta_key }} {% if result.meta_key in postmeta_keys %} * {% endif %} </td>
+				<td>{{ duplicate_count }}</td>
+			</tr>
+		{% endfor %}
+		{% if not duplicate_postmeta %}
+			<tr><td colspan="3"></td></tr>
+			<tr>
+				<td colspan="3">{{ __( 'No duplicate postmeta records found.', 'planet4-blocks-backend' ) }}</td>
+			</tr>
+		{% else %}
+			<tr>
+				<td></td>
+				<td><strong>{{ __( 'Total', 'planet4-blocks-backend' ) }}</strong></td>
+				<td><strong>{{ total_count }}</strong></td>
+			</tr>
+			<tr>
+				<td colspan="3">{{ __( 'The * indicates whitelisted metakey\'s for delete operation.', 'planet4-blocks-backend' ) }}</td>
+			</tr>
+		{% endif %}
+		</table>
+
+{% endblock %}


### PR DESCRIPTION
Ref. https://jira.greenpeace.org/browse/PLANET-7527

> Requirements
> 
>     Migrate Blocks Report code to master theme.
>     That should also include classic blocks report functionality.
>     Verify that the API endpoints also work with the plugin de-activated.

The following folder name is changed during the migration to the master theme:
[classes/search](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/tree/main/classes/search) => [src/BlockReportSearch ](https://github.com/greenpeace/planet4-master-theme/tree/PLANET-7527-move-block-report/src/BlockReportSearch)



**Testing:**
- You can test this [PR](https://github.com/greenpeace/planet4-master-theme/pull/2303) along with blocks repo [PR](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/1215) on Local environment or on [test-venus](https://www-dev.greenpeace.org/test-venus/wp-admin/?page=plugin_blocks_report) test instance
- ~~De-activate the Blocks plugin, and check all [blocks reports](https://www-dev.greenpeace.org/test-sinope/wp-admin/?page=plugin_blocks_report), It should work as expected~~ The blocks report functionality should work as as expected
- The Plugins [blocks report API](https://www-dev.greenpeace.org/test-venus/wp-json/plugin_blocks/v3/plugin_blocks_report/) should work as expected.
