### PR TITLE
PLANET-7535 Credit is removed when caption is edited

### DIFF
--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -1486,7 +1486,12 @@ class MasterSite extends TimberSite
             $image_credit = ' ©' . $image_credit;
         }
 
-        $caption = wp_get_attachment_caption($image_id) ?? '';
+        $caption = '';
+
+        $pattern = '/<figcaption[^>]*>(.*?)<\/figcaption>/';
+        if (preg_match($pattern, $content, $matches)) {
+            $caption = $matches[1];
+        }
 
         if (empty($credit) || (!empty($caption) && strpos($caption, $image_credit) !== false)) {
             return $content;


### PR DESCRIPTION
**Ref: https://jira.greenpeace.org/browse/PLANET-7535**

**Testing:** 

On local or assigned test-instance, when image captions is edited, credits should still be visible.

This handles two scenarios as implemented.
 - Edit an image in the Media Library. Then add it in the post. The caption should be the new one you just edited.
 - Edit an image directly in the editor. Then the caption displayed should be the one you just edited in the post regardless of what's stored in the Media Library.

<!-- Ref: Please add a url to the ticket this change is addressing.

---

Please provide a brief summary of the change introduced to make review process easier.

Ideally this should also be part of the commit summary.
-->
