### PR TITLE
Generate and save a hashed gp_user_id on form submissions

### DIFF
--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -640,6 +640,14 @@ class MasterSite extends TimberSite
         $context['google_tag_value'] = $options['google_tag_manager_identifier'] ?? '';
         $context['google_tag_domain'] = !empty($options['google_tag_manager_domain']) ?
             $options['google_tag_manager_domain'] : 'www.googletagmanager.com';
+        $context['consent_default_analytics_storage'] =
+            planet4_get_option('consent_default_analytics_storage') ?? 'denied';
+        $context['consent_default_ad_storage'] =
+            planet4_get_option('consent_default_ad_storage') ?? 'denied';
+        $context['consent_default_ad_user_data'] =
+            planet4_get_option('consent_default_ad_user_data') ?? 'denied';
+        $context['consent_default_ad_personalization'] =
+            planet4_get_option('consent_default_ad_personalization') ?? 'denied';
         $context['ab_hide_selector'] = $options['ab_hide_selector'] ?? null;
         $context['facebook_page_id'] = $options['facebook_page_id'] ?? '';
         $context['preconnect_domains'] = [];

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -310,6 +310,68 @@ class Settings
                         'id' => 'enable_reject_all_cookies',
                         'type' => 'checkbox',
                     ],
+                    [
+                        'name' => __('Enable Google Consent Mode', 'planet4-master-theme-backend'),
+                        'desc' => __("Enabling the Consent Mode will affect your setup in Google Tag Manager. The Consent Mode will prevent tags with built-in consent checks (eg. Google Analytics) from running before the user's consent is granted.", 'planet4-master-theme-backend'),
+                        'id' => 'enable_google_consent_mode',
+                        'type' => 'checkbox',
+                    ],
+                    [
+                        'name' => __('Consent default: analytics_storage', 'planet4-master-theme-backend'),
+                        'desc' => __(
+                            'The default value for analytics_storage consent before visitors make their choice in the cookies box (Google Consent Mode V2).',
+                            'planet4-master-theme-backend'
+                        ),
+                        'id' => 'consent_default_analytics_storage',
+                        'type' => 'select',
+                        'default' => 'denied',
+                        'options' => [
+                            'denied' => __('Denied', 'planet4-master-theme-backend'),
+                            'granted' => __('Granted', 'planet4-master-theme-backend'),
+                        ],
+                    ],
+                    [
+                        'name' => __('Consent default: ad_storage', 'planet4-master-theme-backend'),
+                        'desc' => __(
+                            'The default value for ad_storage consent before visitors make their choice in the cookies box (Google Consent Mode V2).',
+                            'planet4-master-theme-backend'
+                        ),
+                        'id' => 'consent_default_ad_storage',
+                        'type' => 'select',
+                        'default' => 'denied',
+                        'options' => [
+                            'denied' => __('Denied', 'planet4-master-theme-backend'),
+                            'granted' => __('Granted', 'planet4-master-theme-backend'),
+                        ],
+                    ],
+                    [
+                        'name' => __('Consent default: ad_user_data', 'planet4-master-theme-backend'),
+                        'desc' => __(
+                            'The default value for ad_user_data consent before visitors make their choice in the cookies box (Google Consent Mode V2).',
+                            'planet4-master-theme-backend'
+                        ),
+                        'id' => 'consent_default_ad_user_data',
+                        'type' => 'select',
+                        'default' => 'denied',
+                        'options' => [
+                            'denied' => __('Denied', 'planet4-master-theme-backend'),
+                            'granted' => __('Granted', 'planet4-master-theme-backend'),
+                        ],
+                    ],
+                    [
+                        'name' => __('Consent default: ad_personalization', 'planet4-master-theme-backend'),
+                        'desc' => __(
+                            'The default value for ad_personalization consent before visitors make their choice in the cookies box (Google Consent Mode V2).',
+                            'planet4-master-theme-backend'
+                        ),
+                        'id' => 'consent_default_ad_personalization',
+                        'type' => 'select',
+                        'default' => 'denied',
+                        'options' => [
+                            'denied' => __('Denied', 'planet4-master-theme-backend'),
+                            'granted' => __('Granted', 'planet4-master-theme-backend'),
+                        ],
+                    ],
                 ],
             ],
             'planet4_settings_social' => [
@@ -419,12 +481,6 @@ class Settings
                         ),
                         'id' => 'analytics_local_google_sheet_id',
                         'type' => 'text',
-                    ],
-                    [
-                        'name' => __('Enable Google Consent Mode', 'planet4-master-theme-backend'),
-                        'desc' => __("Enabling the Consent Mode will affect your setup in Google Tag Manager. The Consent Mode will prevent tags with built-in consent checks (eg. Google Analytics) from running before the user's consent is granted.", 'planet4-master-theme-backend'),
-                        'id' => 'enable_google_consent_mode',
-                        'type' => 'checkbox',
                     ],
                     // New IA special pages.
                     [

--- a/templates/blocks/google_tag_manager.twig
+++ b/templates/blocks/google_tag_manager.twig
@@ -2,6 +2,10 @@
   <script>
     var google_tag_value = '{{ google_tag_value }}';
     var google_tag_domain = '{{ google_tag_domain }}';
+    var consent_default_analytics_storage = '{{ consent_default_analytics_storage }}';
+    var consent_default_ad_storage = '{{ consent_default_ad_storage }}';
+    var consent_default_ad_user_data = '{{ consent_default_ad_user_data }}';
+    var consent_default_ad_personalization = '{{ consent_default_ad_personalization }}';
     window.dataLayer = window.dataLayer || [];
 
     function gtag() { dataLayer.push(arguments); };
@@ -29,18 +33,14 @@
         ad_storage: marketing_consent ? 'granted' : 'denied',
         ad_user_data: marketing_consent ? 'granted' : 'denied',
         ad_personalization: marketing_consent ? 'granted' : 'denied',
-        {% if cookies.enable_analytical_cookies %}
-        ...{'analytics_storage': analytical_consent ? 'granted' : 'denied'}
-        {% endif %}
+        analytics_storage: analytical_consent ? 'granted' : 'denied'
       };
     } else {
       var capabilities = {
-        ad_storage: 'denied',
-        ad_user_data: 'denied',
-        ad_personalization: 'denied',
-        {% if cookies.enable_analytical_cookies %}
-        ...{'analytics_storage': 'denied'}
-        {% endif %}
+        ad_storage: consent_default_ad_storage,
+        ad_user_data: consent_default_ad_user_data,
+        ad_personalization: consent_default_ad_personalization,
+        analytics_storage: consent_default_analytics_storage
       };
     }
     gtag('consent', 'default', capabilities);


### PR DESCRIPTION
The hashed `gp_user_id` is saved to dataLayer and a cookie also called `gp_user_id`. In order to respect user consent and flexibility for different privacy laws, additional settings for default values for Google Consent Mode are also added.

Ref: [Please add a url to the ticket this change is addressing.
](https://github.com/greenpeace/planet4/issues/189)


Instructions for testing:
- It's best to delete all cookies and not click anything in the cookie box before starting.
- In WP Admin go to _Planet4_ -> _Cookies_ and make sure _Enable Google Consent Mode_ is activated.
- Test the 4 following settings if the default values are set correctly in dataLayer (note that these can be overwritten from Tag Manager, so it's best to block it for this part of the testing)
- Submit a form that contains an email address in a field
- If `analytics_storage` is set to `granted` in dataLayer, a cookie should be set containing the hashed email address and dataLayer should also contain the value in a parameter called `gpUserId`
- The hash needs to be the same as [generated by this function](https://gist.github.com/stduerre/f98ed2cd4ac540da1c3389b674a64b90).

Variations:
- It should work with both an email or any other form field (most likely normal text input) in the form, as long as the email address is the only content of the form field. The email field is preferred over other fields.
- `analytics_storage` can be changed by the selection in the cookie box (depending on settings). The current value needs to be respected when saving the `gp_user_id` cookie.
