### PR TITLE
PLANET-7531 Posts/Actions blocks: Show message when no posts found

### DIFF
--- a/assets/src/blocks/ActionsList/index.js
+++ b/assets/src/blocks/ActionsList/index.js
@@ -61,6 +61,9 @@ export const registerActionsListBlock = () => {
           },
         },
       }],
+      ['core/query-no-results', {}, [
+        ['core/paragraph', {content: __('No posts found. (This default text can be edited)', 'planet4-blocks-backend')}],
+      ]],
       ['core/post-template', {lock: {move: true, remove: true}}, [
         ['core/post-featured-image', {isLink: true}],
         ['core/group', {}, [

--- a/assets/src/blocks/PostsList/index.js
+++ b/assets/src/blocks/PostsList/index.js
@@ -66,6 +66,9 @@ export const registerPostsListBlock = () => {
           },
         },
       }],
+      ['core/query-no-results', {}, [
+        ['core/paragraph', {content: __('No posts found. (This default text can be edited)', 'planet4-blocks-backend')}],
+      ]],
       ['core/post-template', {lock: {move: true, remove: true}}, [
         ['core/columns', {}, [
           ['core/post-featured-image', {isLink: true}],

--- a/assets/src/js/app.js
+++ b/assets/src/js/app.js
@@ -9,6 +9,7 @@ import {setupExternalLinks} from './external_links';
 import {setupListingPages} from './listing_pages';
 import {setupQueryLoopCarousel} from './query_loop_carousel';
 import {setupClickabelActionsListCards} from './actions_list_clickable_cards';
+import {removeNoPostText} from './query-no-posts';
 
 function requireAll(r) {
   r.keys().forEach(r);
@@ -24,4 +25,5 @@ setupSearch();
 setupExternalLinks();
 setupListingPages();
 setupQueryLoopCarousel();
+removeNoPostText();
 setupClickabelActionsListCards();

--- a/assets/src/js/query-no-posts.js
+++ b/assets/src/js/query-no-posts.js
@@ -1,0 +1,9 @@
+export const removeNoPostText = () => {
+  const postTitle = document.querySelector('.p4-query-loop .wp-block-heading');
+  const postDescription = document.querySelector('.p4-query-loop p');
+
+  if (postTitle.innerHTML === '' && postDescription.innerHTML === '') {
+    const noResultsText = document.querySelector('.p4-query-loop .wp-block-query-no-results');
+    noResultsText.style.display = 'none';
+  }
+};

--- a/assets/src/js/query_loop_carousel.js
+++ b/assets/src/js/query_loop_carousel.js
@@ -80,9 +80,9 @@ export const setupQueryLoopCarousel = () => {
     } else if (layout.className.includes('grid') || layout.className.includes('list')) {
       // Only apply to Grid and List views
       // Ensure to not only to hide controls nav but also remove it
-      const controlsNav = list.parentNode.querySelector('.wp-block-buttons.carousel-controls');
+      const controlsNav = list?.parentNode.querySelector('.wp-block-buttons.carousel-controls');
 
-      if (list.parentNode.contains(controlsNav)) {
+      if (list?.parentNode.contains(controlsNav)) {
         list.parentNode.removeChild(controlsNav);
       }
     }


### PR DESCRIPTION
**Ref: https://jira.greenpeace.org/browse/PLANET-7531**

**Testing:** 

I added the `core/query-no-results` block to the Posts Lists and Actions List blocks. This gives Editors the freedom to add text or other blocks to display in case the category used to filter the posts returns no posts.

I also added a function to run in the front end to remove the text or block added by the `core/query-no-results` in case the title and description of the Posts/Actions List block are not set.

You can test this locally or on the assigned instance.

<!-- Ref: Please add a url to the ticket this change is addressing.

---

Please provide a brief summary of the change introduced to make review process easier.

Ideally this should also be part of the commit summary.
-->
