### PR TITLE
PLANET-7524 Add noindex meta tag on pages that are excluded from search

### DIFF
--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -299,6 +299,27 @@ class MasterSite extends TimberSite
             }
         );
 
+        // Add noindex meta tag on pages that are excluded from search
+        add_action(
+            'wp_head',
+            function (): void {
+                if (!is_singular()) {
+                    return;
+                }
+
+                global $post;
+
+                $exclude_from_search = get_post_meta($post->ID, 'ep_exclude_from_search', true);
+
+                if (!$exclude_from_search) {
+                    return;
+                }
+
+                echo '<meta name="robots" content="noindex">' . PHP_EOL;
+            },
+            10
+        );
+
         AuthorPage::hooks();
         Search\Search::hooks();
         Sendgrid::hooks();


### PR DESCRIPTION
**Ref: https://jira.greenpeace.org/browse/PLANET-7524**

**Testing:**

Pages that have the exclude from search option enabled now have the meta tag added to the head.

<!-- Ref: Please add a url to the ticket this change is addressing.

---

Please provide a brief summary of the change introduced to make review process easier.

Ideally this should also be part of the commit summary.
-->
