### PR TITLE
PLANET-7537 Fix slice offset on Cloudflare hostname

### DIFF
--- a/src/Commands/SaveCloudflareKey.php
+++ b/src/Commands/SaveCloudflareKey.php
@@ -49,9 +49,11 @@ class SaveCloudflareKey extends Command
             WP_CLI::error('CLOUDFLARE_API_KEY constant is not set.');
         }
 
+        // Keep last two parts of the hostname, or three in special cases like .org.au.
         $domain_parts = explode('.', $hostname);
+        $slice = count($domain_parts) - 1;
+        $root_domain = implode('.', array_slice($domain_parts, - $slice));
 
-        $root_domain = implode('.', array_slice($domain_parts, - 2));
         update_option('cloudflare_api_key', CLOUDFLARE_API_KEY);
         update_option('automatic_platform_optimization', [ 'value' => 1 ]);
         update_option('cloudflare_cached_domain_name', $root_domain);


### PR DESCRIPTION
We construct the hostname to use for the Cloudflare API based on the domain name. But our code doesn't work with GPAP domain name because they have one dot more.

Adjusted the relevant code to have a more dynamic way of slicing the domain and work for both cases.

---

Ref: https://jira.greenpeace.org/browse/PLANET-7537

<!-- Ref: Please add a url to the ticket this change is addressing.

---

Please provide a brief summary of the change introduced to make review process easier.

Ideally this should also be part of the commit summary.
-->
