### PR TITLE
PLANET-7543 Add spinner to Greenpeace Media when searching for images

### DIFF
--- a/admin/css/archive-picker.css
+++ b/admin/css/archive-picker.css
@@ -388,6 +388,7 @@
   font-size: 12px;
   align-items: center;
   white-space: nowrap;
+  line-height: 1.4em;
 }
 
 .multiple-search-item > span {

--- a/admin/css/archive-picker.css
+++ b/admin/css/archive-picker.css
@@ -373,9 +373,7 @@
 }
 
 .multiple-search-form {
-  display: flex;
   height: auto;
-  align-items: flex-start;
   width: 100%;
 }
 
@@ -461,6 +459,11 @@
 }
 
 @media (max-width: 767px) {
+  .multiple-search-form .components-spinner {
+    display: block;
+    margin: auto;
+  }
+
   .picker-list {
     grid-template-columns: repeat(2, 1fr);
   }
@@ -488,6 +491,12 @@
 
   .multiple-search-form {
     margin: 0 8px;
+    display: flex;
+    align-items: flex-start;
+  }
+
+  .multiple-search-form .components-spinner {
+    margin-top: 12px;
   }
 
   .archive-picker.is-open .nav-bulk-select {

--- a/assets/src/js/Components/ArchivePicker/MultiSearchOption.js
+++ b/assets/src/js/Components/ArchivePicker/MultiSearchOption.js
@@ -1,4 +1,5 @@
 import {useRef, useState, useEffect, useCallback, useMemo} from '@wordpress/element';
+import {Spinner} from '@wordpress/components';
 import classNames from 'classnames';
 import {ACTIONS, useArchivePickerContext} from './ArchivePicker';
 
@@ -115,6 +116,7 @@ export default function MultiSearchOption() {
           className="button"
         >{__('Search', 'planet4-master-theme-backend')}</button>
       </nav>
+      {!!searchText.length && loading && <Spinner />}
     </form>
   ), [
     loading,


### PR DESCRIPTION
### Description

See [PLANET-7543](https://jira.greenpeace.org/browse/PLANET-7543)

**Note:** the spinner is different from the one in the ticket's screenshot, but this one is probably the newest WP one and it has been approved by the design team.

### Testing

You can go to Greenpeace Media either on local or on the [jupiter instance](https://www-dev.greenpeace.org/test-jupiter/wp-admin/upload.php?page=media-picker). When you search for a term then the spinner should now appear next to the search input on mobile, and next to the Search button in bigger screens.
