### PR TITLE
PLANET-7561 Move Blank Page pattern to the theme

### DIFF
--- a/src/Patterns/BlankPage.php
+++ b/src/Patterns/BlankPage.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * BlankPage pattern class.
+ *
+ * @package P4\MasterTheme\Patterns
+ * @since 0.1
+ */
+
+ namespace P4\MasterTheme\Patterns;
+
+/**
+ * This class is used for returning a blank page with a default content.
+ *
+ * @package P4\MasterTheme\Patterns
+ */
+class BlankPage extends BlockPattern
+{
+    /**
+     * @inheritDoc
+     */
+    public static function get_name(): string
+    {
+        return 'p4/blank-page-pattern-layout';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    // phpcs:ignore SlevomatCodingStandard.Functions.UnusedParameter -- get_config abstract function.
+    public static function get_config(array $params = []): array
+    {
+        return [
+            'title' => 'Blank page',
+            'blockTypes' => ['core/post-content'],
+            'categories' => ['layouts'],
+            'content' => '
+                <!-- wp:paragraph {"placeholder":"' . __('Enter text', 'planet4-blocks-backend') . '"} -->
+                <p></p>
+                <!-- /wp:paragraph -->
+            ',
+        ];
+    }
+}

--- a/src/Patterns/BlockPattern.php
+++ b/src/Patterns/BlockPattern.php
@@ -41,12 +41,13 @@ abstract class BlockPattern
     public static function get_list(): array
     {
         return [
-            SideImageWithTextAndCta::class,
-            Issues::class,
-            RealityCheck::class,
-            QuickLinks::class,
+            BlankPage::class,
             DeepDive::class,
             HighlightedCta::class,
+            Issues::class,
+            QuickLinks::class,
+            RealityCheck::class,
+            SideImageWithTextAndCta::class,
             TakeAction::class,
         ];
     }

--- a/src/Patterns/DeepDive.php
+++ b/src/Patterns/DeepDive.php
@@ -17,7 +17,7 @@ namespace P4\MasterTheme\Patterns;
 class DeepDive extends BlockPattern
 {
     /**
-     * Returns the pattern name.
+     * @inheritDoc
      */
     public static function get_name(): string
     {
@@ -25,9 +25,7 @@ class DeepDive extends BlockPattern
     }
 
     /**
-     * Returns the pattern config.
-     *
-     * @param array $params Optional array of parameters for the config.
+     * @inheritDoc
      */
     public static function get_config(array $params = []): array
     {

--- a/src/Patterns/HighlightedCta.php
+++ b/src/Patterns/HighlightedCta.php
@@ -17,7 +17,7 @@ namespace P4\MasterTheme\Patterns;
 class HighlightedCta extends BlockPattern
 {
     /**
-     * Returns the pattern name.
+     * @inheritDoc
      */
     public static function get_name(): string
     {
@@ -25,9 +25,7 @@ class HighlightedCta extends BlockPattern
     }
 
     /**
-     * Returns the pattern config.
-     *
-     * @param array $params Optional array of parameters for the config.
+     * @inheritDoc
      */
     public static function get_config(array $params = []): array
     {

--- a/src/Patterns/Issues.php
+++ b/src/Patterns/Issues.php
@@ -17,7 +17,7 @@ namespace P4\MasterTheme\Patterns;
 class Issues extends BlockPattern
 {
     /**
-     * Returns the pattern name.
+     * @inheritDoc
      */
     public static function get_name(): string
     {
@@ -25,9 +25,7 @@ class Issues extends BlockPattern
     }
 
     /**
-     * Returns the pattern config.
-     *
-     * @param array $params Optional array of parameters for the config.
+     * @inheritDoc
      */
     public static function get_config(array $params = []): array
     {

--- a/src/Patterns/QuickLinks.php
+++ b/src/Patterns/QuickLinks.php
@@ -17,7 +17,7 @@ namespace P4\MasterTheme\Patterns;
 class QuickLinks extends BlockPattern
 {
     /**
-     * Returns the pattern name.
+     * @inheritDoc
      */
     public static function get_name(): string
     {
@@ -25,9 +25,7 @@ class QuickLinks extends BlockPattern
     }
 
     /**
-     * Returns the pattern config.
-     *
-     * @param array $params Optional array of parameters for the config.
+     * @inheritDoc
      */
     public static function get_config(array $params = []): array
     {

--- a/src/Patterns/RealityCheck.php
+++ b/src/Patterns/RealityCheck.php
@@ -17,7 +17,7 @@ namespace P4\MasterTheme\Patterns;
 class RealityCheck extends BlockPattern
 {
     /**
-     * Returns the pattern name.
+     * @inheritDoc
      */
     public static function get_name(): string
     {
@@ -25,9 +25,7 @@ class RealityCheck extends BlockPattern
     }
 
     /**
-     * Returns the pattern config.
-     *
-     * @param array $params Optional array of parameters for the config.
+     * @inheritDoc
      */
     public static function get_config(array $params = []): array
     {

--- a/src/Patterns/SideImageWithTextAndCta.php
+++ b/src/Patterns/SideImageWithTextAndCta.php
@@ -17,7 +17,7 @@ namespace P4\MasterTheme\Patterns;
 class SideImageWithTextAndCta extends BlockPattern
 {
     /**
-     * Returns the pattern name.
+     * @inheritDoc
      */
     public static function get_name(): string
     {
@@ -25,9 +25,7 @@ class SideImageWithTextAndCta extends BlockPattern
     }
 
     /**
-     * Returns the pattern config.
-     *
-     * @param array $params Optional array of parameters for the config.
+     * @inheritDoc
      */
     public static function get_config(array $params = []): array
     {


### PR DESCRIPTION
### Description

See [PLANET-7561](https://jira.greenpeace.org/browse/PLANET-7561)

It used to be in the plugin, see [related PR](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/1217)

### Testing

Either on local or on the [umbriel test instance](https://www-dev.greenpeace.org/test-umbriel/), you should be able to add a Blank Page pattern just like before.