### PR TITLE
PLANET-7553 Move Homepage block pattern layout into master theme

### DIFF
--- a/assets/src/block-templates/homepage/block.json
+++ b/assets/src/block-templates/homepage/block.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://schemas.wp.org/trunk/block.json",
+  "apiVersion": 2,
+  "name": "planet4-block-templates/homepage",
+  "title": "Homepage",
+  "category": "planet4-block-templates",
+  "icon": "editor-table",
+  "textdomain": "planet4-blocks-backend"
+}

--- a/assets/src/block-templates/homepage/index.js
+++ b/assets/src/block-templates/homepage/index.js
@@ -1,0 +1,4 @@
+import metadata from './block.json';
+import template from './template';
+
+export {metadata, template};

--- a/assets/src/block-templates/homepage/template.js
+++ b/assets/src/block-templates/homepage/template.js
@@ -1,0 +1,33 @@
+import gravityFormWithText from '../templates/gravity-form-with-text';
+
+const {__} = wp.i18n;
+
+const template = () => (
+  [
+    ['core/group', {}, [
+      ['planet4-blocks/carousel-header'],
+      ['planet4-block-templates/issues', {
+        title: __('The issues we work on', 'planet4-blocks'),
+      }],
+      ['core/spacer', {height: '88px'}],
+      ['planet4-blocks/articles', {
+        article_heading: __('Read our Stories', 'planet4-blocks'),
+      }],
+      ['core/spacer', {height: '56px'}],
+      ['planet4-block-templates/side-image-with-text-and-cta', {
+        title: __('Get to know us', 'planet4-blocks'),
+      }],
+      ['core/spacer', {height: '30px'}],
+      ['planet4-block-templates/side-image-with-text-and-cta', {
+        title: __('We win campaigns', 'planet4-blocks'),
+        mediaPosition: 'right',
+      }],
+      ['core/spacer', {height: '56px'}],
+      ['planet4-blocks/covers'],
+      ['core/spacer', {height: '72px'}],
+      gravityFormWithText(),
+    ]],
+  ]
+);
+
+export default template;

--- a/assets/src/block-templates/template-list.js
+++ b/assets/src/block-templates/template-list.js
@@ -7,6 +7,7 @@ import * as highlightedCta from './highlighted-cta';
 import * as takeAction from './take-action';
 import * as pageHeader from './page-header';
 import * as highLevelTopic from './high-level-topic';
+import * as homepage from './homepage';
 
 export default [
   sideImgTextCta,
@@ -18,4 +19,5 @@ export default [
   takeAction,
   pageHeader,
   highLevelTopic,
+  homepage,
 ];

--- a/assets/src/scss/blocks.scss
+++ b/assets/src/scss/blocks.scss
@@ -19,3 +19,6 @@
 
 // Patterns
 @import "blocks/PageHeader";
+
+// Other
+@import "blocks/WideBlocks";

--- a/assets/src/scss/blocks.scss
+++ b/assets/src/scss/blocks.scss
@@ -20,5 +20,37 @@
 // Patterns
 @import "blocks/PageHeader";
 
+// Native Blocks
+@import "blocks/core-overrides/Image";
+@import "blocks/core-overrides/BlockSpacing";
+@import "blocks/core-overrides/Separator";
+@import "blocks/core-overrides/Table";
+@import "blocks/core-overrides/media-text";
+@import "blocks/core-overrides/columns";
+@import "blocks/core-overrides/Heading";
+
 // Other
 @import "blocks/WideBlocks";
+
+.is-style-space-evenly {
+  gap: 24px !important;
+
+  & > * {
+    flex-grow: 1;
+    flex-basis: 100%;
+    align-self: stretch;
+
+    @include medium-and-up {
+      flex-grow: 0;
+      flex-basis: calc(50% - 12px);
+    }
+
+    @include large-and-up {
+      flex-basis: calc(25% - 18px);
+    }
+  }
+}
+
+.is-style-reset-margin {
+  margin: 0 !important;
+}

--- a/assets/src/scss/blocks/WideBlocks.scss
+++ b/assets/src/scss/blocks/WideBlocks.scss
@@ -1,0 +1,22 @@
+// .block-wide kept for BC of existing content.
+// Can be removed once no content uses it anymore.
+.alignfull, .block-wide {
+  width: 100vw;
+  //     Screen width - block width
+  //  -  --------------------------
+  //                  2
+  margin-left: calc(((100vw - 100%) / 2) * -1);
+
+  html[dir="rtl"] & {
+    margin-right: calc(((100vw - 100%) / 2) * -1);
+  }
+
+  .block-editor & {
+    width: 100%;
+    margin: 0;
+
+    html[dir="rtl"] & {
+      margin: 0;
+    }
+  }
+}

--- a/assets/src/scss/blocks/core-overrides/BlockSpacing.scss
+++ b/assets/src/scss/blocks/core-overrides/BlockSpacing.scss
@@ -1,0 +1,54 @@
+.wp-block-quote,
+.wp-block-file,
+.wp-block-button,
+.page-content > .wp-block-group,
+.page-content > .wp-block-media-text,
+.page-content > h2,
+.page-content > ul > li:last-of-type,
+.page-content > ol > li:last-of-type,
+.page-content > p,
+.post-details > .wp-block-group,
+.post-details > .wp-block-media-text,
+.post-details > h2,
+.post-details > ul > li:last-of-type,
+.post-details > ol > li:last-of-type,
+.post-details > p,
+.post-details > p:first-of-type {
+  margin-top: $sp-1;
+  margin-bottom: $sp-2;
+
+  @include large-and-up {
+    margin-top: $sp-2;
+    margin-bottom: $sp-4;
+  }
+}
+
+.page-content > ul > li,
+.post-details > ul > li,
+.page-content > ol > li,
+.post-details > ol > li {
+  margin-top: $sp-1;
+  margin-bottom: $sp-1;
+
+  @include large-and-up {
+    margin-top: $sp-2;
+    margin-bottom: $sp-2;
+  }
+}
+
+.wp-block-quote,
+.wp-block-file,
+.wp-block-button,
+.page-content > h2,
+.post-details > h2 {
+  display: inline-block;
+}
+
+.page-content > ul,
+.post-details > ul {
+  width: 100%;
+}
+
+.post-details > h2 {
+  padding-top: 0;
+}

--- a/assets/src/scss/blocks/core-overrides/Heading.scss
+++ b/assets/src/scss/blocks/core-overrides/Heading.scss
@@ -1,0 +1,18 @@
+.is-style-chevron::after {
+  content: "";
+  pointer-events: none;
+  margin-inline-start: $sp-1;
+  height: 12px;
+  width: 12px;
+  display: inline-block;
+  mask-image: url("../../public/images/icons/chevron.svg");
+  mask-repeat: no-repeat;
+  mask-size: contain;
+  background-repeat: no-repeat;
+  background-color: currentColor;
+  vertical-align: middle;
+
+  html[dir="rtl"] & {
+    transform: rotate(180deg);
+  }
+}

--- a/assets/src/scss/blocks/core-overrides/HeadingEditor.scss
+++ b/assets/src/scss/blocks/core-overrides/HeadingEditor.scss
@@ -1,0 +1,3 @@
+.is-style-chevron::after {
+  position: relative !important;
+}

--- a/assets/src/scss/blocks/core-overrides/Image.scss
+++ b/assets/src/scss/blocks/core-overrides/Image.scss
@@ -1,0 +1,114 @@
+@mixin rounded-image-size($size) {
+  figure,
+  img {
+    border-radius: 50%;
+    max-height: $size;
+  }
+
+  img {
+    object-fit: cover;
+    aspect-ratio: 1;
+  }
+}
+
+@mixin square-image-size($size) {
+  figure,
+  img {
+    height: $size;
+    width: $size;
+  }
+
+  img {
+    object-fit: cover;
+  }
+}
+
+.wp-block-image {
+  position: relative;
+  width: auto;
+  max-width: 100%;
+  margin-top: $sp-1;
+  margin-bottom: $sp-2;
+
+  &.is-style-rounded-180 {
+    @include rounded-image-size(180px);
+  }
+
+  &.is-style-rounded-90 {
+    @include rounded-image-size(90px);
+  }
+
+  &:not(.force-no-lightbox) img {
+    cursor: pointer;
+  }
+
+  &.force-no-caption figcaption {
+    display: none !important;
+  }
+
+  &.square-40 {
+    @include square-image-size(40px);
+  }
+
+  &.square-80 {
+    @include square-image-size(80px);
+  }
+
+  @include large-and-up {
+    margin-top: $sp-2;
+    margin-bottom: $sp-4;
+  }
+
+  figure {
+    position: relative;
+  }
+
+  &.alignleft {
+    float: left;
+    margin-inline-end: $sp-1;
+  }
+
+  &.alignright {
+    float: right;
+    margin-inline-start: $sp-1;
+  }
+
+  &.aligncenter {
+    margin-left: auto;
+    margin-right: auto;
+  }
+
+  @include medium-and-up {
+    .image-credit {
+      position: absolute;
+      text-align: right;
+      right: 10px;
+      width: 100%;
+      color: var(--white);
+      z-index: 2;
+    }
+  }
+
+  img {
+    height: auto;
+  }
+
+  figcaption {
+    --image-figcaption-- {
+      font-family: var(--font-family-paragraph-secondary);
+      font-size: var(--font-size-s--font-family-tertiary);
+      line-height: var(--line-height-s--font-family-tertiary);
+    }
+    margin-bottom: 0;
+    color: var(--color-text-image_caption);
+    text-align: center;
+  }
+
+  &.caption-alignment-left figcaption {
+    text-align: left;
+  }
+
+  &.caption-alignment-right figcaption {
+    text-align: right;
+  }
+}

--- a/assets/src/scss/blocks/core-overrides/Separator.scss
+++ b/assets/src/scss/blocks/core-overrides/Separator.scss
@@ -1,0 +1,27 @@
+
+.wp-block-separator {
+  border: none;
+  border-bottom: 2px solid var(--color-border-separator);
+  margin-left: auto;
+  margin-right: auto;
+  margin-top: $sp-1;
+  margin-bottom: $sp-2;
+
+  @include large-and-up {
+    margin-top: $sp-2;
+    margin-bottom: $sp-4;
+  }
+
+  &:not(.is-style-wide):not(.is-style-dots) {
+    max-width: 100px;
+  }
+
+  &.has-background:not(.is-style-dots) {
+    border-bottom: none;
+    height: 1px;
+  }
+
+  &.has-background:not(.is-style-wide):not(.is-style-dots) {
+    height: 2px;
+  }
+}

--- a/assets/src/scss/blocks/core-overrides/Table.scss
+++ b/assets/src/scss/blocks/core-overrides/Table.scss
@@ -1,0 +1,79 @@
+
+// Table background colors (header, footer, odd/even rows)
+.wp-block-table {
+  table {
+    // Grey background (defaut)
+    th {
+      background-color: var(--grey-800);
+    }
+
+    tr {
+      background-color: var(--grey-100);
+    }
+
+    tfoot td {
+      background-color: var(--grey-300);
+      font-weight: bold;
+    }
+
+    // Green background
+    &.has-green-background-color {
+      th {
+        background-color: var(--p4-dark-green-800);
+      }
+
+      tr {
+        background-color: var(--beige-100);
+      }
+
+      tfoot td {
+        background-color: var(--beige-300);
+      }
+    }
+
+    // Blue background
+    &.has-blue-background-color {
+      th {
+        background-color: var(--blue-green-800);
+      }
+
+      tr {
+        background-color: var(--beige-100);
+      }
+
+      tfoot td {
+        background-color: var(--beige-300);
+      }
+    }
+  }
+
+  // Table caption
+  figcaption {
+    text-align: center;
+    font-size: var(--font-size-s--font-family-tertiary);
+    font-family: var(--font-family-tertiary);
+    color: var(--color-text-image_caption);
+    line-height: var(--line-height-s--font-family-tertiary);
+  }
+
+  &.is-style-stripes table {
+    // Grey background (defaut)
+    tr:nth-child(odd) {
+      background-color: var(--grey-200);
+    }
+
+    // Green background
+    &.has-green-background-color tr:nth-child(odd) {
+      background-color: var(--beige-200);
+    }
+
+    // Blue background
+    &.has-blue-background-color tr:nth-child(odd) {
+      background-color: var(--beige-200);
+    }
+  }
+
+  &:not(.is-style-stripes) table tbody tr:not(:last-child) {
+    border-bottom: 1px solid var(--white);
+  }
+}

--- a/assets/src/scss/blocks/core-overrides/_columns.scss
+++ b/assets/src/scss/blocks/core-overrides/_columns.scss
@@ -1,0 +1,20 @@
+.wp-block-columns.is-not-stacked-on-mobile.is-style-mobile-carousel {
+  @include large-and-less {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    scrollbar-width: none;
+
+    &::-webkit-scrollbar {
+      display: none;
+    }
+
+    .wp-block-column {
+      flex-basis: auto;
+      flex-shrink: 0;
+    }
+  }
+
+  @include small-and-less {
+    gap: $sp-2;
+  }
+}

--- a/assets/src/scss/blocks/core-overrides/_media-text.scss
+++ b/assets/src/scss/blocks/core-overrides/_media-text.scss
@@ -1,0 +1,101 @@
+@mixin adapt-padding-inline-start($containerWidth) {
+  padding-inline-start: calc(100% - (#{$containerWidth} / 2) + 0.75rem);
+}
+
+@mixin adapt-padding-inline-end($containerWidth) {
+  padding-inline-end: calc(100% - (#{$containerWidth} / 2) + 0.75rem);
+}
+
+.wp-block-media-text {
+  &:not(.force-no-lightbox) img {
+    cursor: pointer;
+  }
+
+  &.is-style-parallax .wp-block-media-text__media {
+    overflow: hidden;
+  }
+
+  // 601px is when the block is no longer stacked
+  @media (max-width: 600px) {
+    &.alignfull .wp-block-media-text__content {
+      max-width: 540px;
+      width: 100%;
+      margin: auto;
+    }
+
+    .wp-block-media-text__content {
+      padding: $sp-2;
+    }
+
+    .wp-block-button,
+    .wp-block-button a {
+      width: 100%;
+    }
+  }
+
+  @media (min-width: 601px) {
+    &.alignfull.has-media-on-the-right .wp-block-media-text__content {
+      @include adapt-padding-inline-start(540px);
+    }
+
+    &.alignfull:not(.has-media-on-the-right) .wp-block-media-text__content {
+      @include adapt-padding-inline-end(540px);
+    }
+
+    &.has-media-on-the-right .wp-block-media-text__content {
+      padding-inline-end: $sp-3;
+    }
+
+    &:not(.has-media-on-the-right) .wp-block-media-text__content {
+      padding-inline-start: $sp-3;
+    }
+  }
+
+  &.alignfull.has-media-on-the-right .wp-block-media-text__content {
+    @include medium-and-up {
+      max-width: none;
+      @include adapt-padding-inline-start(720px);
+    }
+
+    @include large-and-up {
+      @include adapt-padding-inline-start(960px);
+    }
+
+    @include x-large-and-up {
+      @include adapt-padding-inline-start(1140px);
+    }
+
+    @include xx-large-and-up {
+      @include adapt-padding-inline-start(1320px);
+    }
+  }
+
+  &.alignfull:not(.has-media-on-the-right) .wp-block-media-text__content {
+    @include medium-and-up {
+      max-width: none;
+      @include adapt-padding-inline-end(720px);
+    }
+
+    @include large-and-up {
+      @include adapt-padding-inline-end(960px);
+    }
+
+    @include x-large-and-up {
+      @include adapt-padding-inline-end(1140px);
+    }
+
+    @include xx-large-and-up {
+      @include adapt-padding-inline-end(1320px);
+    }
+  }
+
+  @include large-and-up {
+    &.has-media-on-the-right .wp-block-media-text__content {
+      padding-inline-end: $sp-6;
+    }
+
+    &:not(.has-media-on-the-right) .wp-block-media-text__content {
+      padding-inline-start: $sp-6;
+    }
+  }
+}

--- a/src/Patterns/BlockPattern.php
+++ b/src/Patterns/BlockPattern.php
@@ -52,6 +52,7 @@ abstract class BlockPattern
             TakeAction::class,
             PageHeader::class,
             PageHeaderImgLeft::class,
+            Homepage::class,
         ];
     }
 

--- a/src/Patterns/Homepage.php
+++ b/src/Patterns/Homepage.php
@@ -36,8 +36,9 @@ class Homepage extends BlockPattern
             'blockTypes' => [ 'core/post-content' ],
             'categories' => [ 'layouts' ],
             'content' => '
-				<!-- wp:planet4-block-templates/homepage ' . wp_json_encode($params, \JSON_FORCE_OBJECT) . ' /-->
-			',
+                <!-- wp:planet4-block-templates/homepage ' .
+                esc_html(wp_json_encode($params, \JSON_FORCE_OBJECT)) . ' /-->
+            ',
         ];
     }
 }

--- a/src/Patterns/Homepage.php
+++ b/src/Patterns/Homepage.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * Homepage pattern layout class.
+ *
+ * @package P4\MasterTheme\Patterns
+ * @since 0.1
+ */
+
+namespace P4\MasterTheme\Patterns;
+
+/**
+ * This class is used for returning a homepage pattern layout template.
+ *
+ * @package P4\MasterTheme\Patterns
+ */
+class Homepage extends BlockPattern
+{
+    /**
+     * @inheritDoc
+     */
+    public static function get_name(): string
+    {
+        return 'p4/homepage-pattern-layout';
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @param array $params Optional array of parameters for the config.
+     */
+    public static function get_config(array $params = []): array
+    {
+        return [
+            'title' => 'Homepage',
+            'blockTypes' => [ 'core/post-content' ],
+            'categories' => [ 'layouts' ],
+            'content' => '
+				<!-- wp:planet4-block-templates/homepage ' . wp_json_encode($params, \JSON_FORCE_OBJECT) . ' /-->
+			',
+        ];
+    }
+}


### PR DESCRIPTION
Ref. https://jira.greenpeace.org/browse/PLANET-7553

The homepage block pattern layout moves to the theme from the blocks plugin 

[Related PR: ](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/1220)
