### PR TITLE
PoC for preloading responsive images for blocks

### DIFF
--- a/assets/src/blocks/CarouselHeader/SlideBackground.js
+++ b/assets/src/blocks/CarouselHeader/SlideBackground.js
@@ -1,12 +1,44 @@
+function parseWidths(srcset) {
+  const entries = srcset.split(',').map(entry => entry.trim());
+  const widths = entries.map(entry => {
+    const width = entry.split(' ')[1];
+    return width?.replace('w', 'px');
+  });
+  return widths;
+}
+
+function createSizesAttribute(widths) {
+  return widths.map(width => {
+    return `(max-width: ${parseInt(width)}px) ${width}`;
+  }).join(', ');
+}
+
 export const SlideBackground = ({slide, decoding}) => {
   const {image_url, image_srcset, focal_points, image_alt} = slide;
+  const image_widths = parseWidths(image_srcset);
+  const image_sizes = createSizesAttribute(image_widths);
+
+  // Preload the images
+  if (image_srcset && image_sizes) {
+    const preloadLink = document.createElement('link');
+    preloadLink.rel = 'preload';
+    preloadLink.as = 'image';
+    preloadLink.href = image_url;
+    preloadLink.setAttribute('imagesrcset', image_srcset);
+    preloadLink.setAttribute('imagesizes', image_sizes.concat(', 100vw'));
+    document.head.appendChild(preloadLink);
+  }
+
   return (
     <div className="background-holder">
       <img
         src={image_url}
         style={{objectPosition: `${(focal_points?.x || .5) * 100}% ${(focal_points?.y || .5) * 100}%`}}
         srcSet={image_srcset}
+        sizes={image_sizes}
         alt={image_alt}
+        // eslint-disable-next-line react/no-unknown-property
+        fetchpriority="high"
         {...decoding ? {decoding: 'async'} : {}}
       />
     </div>


### PR DESCRIPTION
Ref: PoC for [Preloading big images](https://web.dev/articles/preload-responsive-images) (eg. Carousel Header, Page Header pattern) while using imagesrcset.


Some implementations propose using `<link rel="preload" as="image" href="images/example-medium.jpg" media="(max-width: 1023px)">`, while others suggest  replacing the `media` with a `sizes` attribute instead. 

**Testing**

If you disable caching on the Network tab and enable 3G, then you reload the page there are two visible scenarios
- The first case, which is the normal way our websites currently load is, you see the images load at the same time the page shows, so for a split second the Carousel Header has an empty image.
- Second case, with the current implementation, when you reload the page, the first image in the Carousel Header block is being pre-loaded as the page loads, meaning by the time the page becomes visible, the image is present.

This implementation is good for blocks or scenarios where we control what images are being displayed. 

<!-- Ref: Please add a url to the ticket this change is addressing.

---

Please provide a brief summary of the change introduced to make review process easier.

Ideally this should also be part of the commit summary.
-->
