### PR TITLE
PLANET-7513 Remove the style section from the Carousel Header backend…

### DIFF
--- a/assets/src/blocks/CarouselHeader/CarouselHeaderBlock.js
+++ b/assets/src/blocks/CarouselHeader/CarouselHeaderBlock.js
@@ -4,7 +4,6 @@ import {CarouselHeaderFrontend} from './CarouselHeaderFrontend';
 import {renderToString} from 'react-dom/server';
 
 const {registerBlockType} = wp.blocks;
-const {__} = wp.i18n;
 const {RawHTML} = wp.element;
 
 const BLOCK_NAME = 'planet4-blocks/carousel-header';
@@ -52,13 +51,6 @@ export const registerCarouselHeaderBlock = () =>
       html: false, // Disable "Edit as HTMl" block option.
     },
     attributes,
-    styles: [
-      {
-        name: 'fit-height-to-content',
-        label: __('Fit height to content', 'planet4-blocks-backend'),
-        isDefault: false,
-      },
-    ],
     edit: CarouselHeaderEditor,
     save: ({attributes: saveAttributes}) => {
       const markup = renderToString(<div

--- a/assets/src/scss/blocks/CarouselHeader/CarouselHeaderStyle.scss
+++ b/assets/src/scss/blocks/CarouselHeader/CarouselHeaderStyle.scss
@@ -74,16 +74,6 @@ $medium-image-height: 600px;
   position: relative;
   width: 100vw;
 
-  &.is-style-fit-height-to-content {
-    &.block {
-      display: block;
-    }
-
-    &.block-header {
-      margin-bottom: 0;
-    }
-  }
-
   .carousel-inner {
     position: relative;
     overflow: visible;


### PR DESCRIPTION
**Ref: https://jira.greenpeace.org/browse/PLANET-7513**

**Testing:** 

Using the editor for the Carousel Header block, the style section should no longer exist.

Also, scanned the code base to see if we had any `default`  class styles for _Carousel Header Block_, we don't so removing just the `is-style-fit-height-to-content` class from the stylesheet should make all images in that block have the same styling now.

<!-- Ref: Please add a url to the ticket this change is addressing.

---

Please provide a brief summary of the change introduced to make review process easier.

Ideally this should also be part of the commit summary.
-->
