### PR TITLE
PLANET-7515: Accordion block design fixes on mobile

### DIFF
--- a/assets/src/scss/blocks/Accordion/AccordionStyle.scss
+++ b/assets/src/scss/blocks/Accordion/AccordionStyle.scss
@@ -49,7 +49,7 @@
       font-size: $font-size-sm;
       border-radius: 4px;
       font-weight: var(--font-weight-regular);
-      line-height: 1;
+      line-height: 20px;
       margin-top: 0;
       margin-bottom: $sp-2;
       border-width: 1px;
@@ -105,7 +105,7 @@
     }
 
     .accordion-btn {
-      margin: $sp-3 10% 0 10%;
+      margin: $sp-3 0 0 0;
       line-height: 2.5;
       width: 80%;
     }
@@ -117,6 +117,7 @@
         padding-inline-start: $sp-3;
         font-size: var(--font-size-m--font-family-primary);
         margin-bottom: $sp-3;
+        line-height: 1;
 
         &:after {
           height: 1.25rem;
@@ -135,7 +136,6 @@
 
       .accordion-btn {
         width: 40%;
-        margin: $sp-3 0 0 0;
       }
     }
   }

--- a/assets/src/scss/blocks/Accordion/AccordionStyle.scss
+++ b/assets/src/scss/blocks/Accordion/AccordionStyle.scss
@@ -105,8 +105,8 @@
     }
 
     .accordion-btn {
-      margin: $sp-3 0 0 0;
-      line-height: var(--font-size-2xl--font-family-primary);
+      margin: $sp-3 0 0;
+      line-height: 2.5;
       width: 80%;
     }
   }

--- a/assets/src/scss/blocks/Accordion/AccordionStyle.scss
+++ b/assets/src/scss/blocks/Accordion/AccordionStyle.scss
@@ -49,7 +49,7 @@
       font-size: $font-size-sm;
       border-radius: 4px;
       font-weight: var(--font-weight-regular);
-      line-height: var(--font-size-m--font-family-primary);
+      line-height: var(--line-height-xs--font-family-primary);
       margin-top: 0;
       margin-bottom: $sp-2;
       border-width: 1px;
@@ -106,7 +106,7 @@
 
     .accordion-btn {
       margin: $sp-3 0 0 0;
-      line-height: 2.5;
+      line-height: var(--font-size-2xl--font-family-primary);
       width: 80%;
     }
   }
@@ -117,7 +117,7 @@
         padding-inline-start: $sp-3;
         font-size: var(--font-size-m--font-family-primary);
         margin-bottom: $sp-3;
-        line-height: 1;
+        line-height: var(--line-height-m--font-family-primary);
 
         &:after {
           height: 1.25rem;

--- a/assets/src/scss/blocks/Accordion/AccordionStyle.scss
+++ b/assets/src/scss/blocks/Accordion/AccordionStyle.scss
@@ -49,7 +49,7 @@
       font-size: $font-size-sm;
       border-radius: 4px;
       font-weight: var(--font-weight-regular);
-      line-height: 20px;
+      line-height: var(--font-size-m--font-family-primary);
       margin-top: 0;
       margin-bottom: $sp-2;
       border-width: 1px;


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-7515

This PR introduces the following changes on mobile to the Accordion Block:
- The line height of the accordion header was increased to 20px.
- The CTA buttons were left aligned.

<hr>

**Before:**
![Test-Page-Greenpeace](https://github.com/user-attachments/assets/e581cccb-edf6-442b-be05-220871911357) 

<hr>

**After:**
![Test-Page-Greenpeace(1)](https://github.com/user-attachments/assets/e4bcb8d8-7736-40a5-a899-403fa3e2f12e)