### PR TITLE
PLANET-7565: Explicitly import "regenerator-runtime"

### DIFF
--- a/assets/src/frontendIndex.js
+++ b/assets/src/frontendIndex.js
@@ -1,3 +1,5 @@
+import 'regenerator-runtime/runtime';
+
 import {createRoot} from 'react-dom/client';
 import {SubmenuFrontend} from './blocks/Submenu/SubmenuFrontend';
 import {HappypointFrontend} from './blocks/Happypoint/HappypointFrontend';


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-7565

<hr>

**DESCRIPTION:**
After upgrading WordPress to its LTS version ([6.6.1 of 23 July, 2024](https://wordpress.org/download/releases/)) the following errors were found:

1. `Planet 4 Columns` block is not rendered in the front.
2. `Happypoint` block is not rendered in the front.
3. `Submenu` block is not rendered in the front.
4. `Articles` block is not rendered in the front.
5. `Covers` block is not rendered in the front.
6. All the patterns that include the previously mentioned blocks are also affected.

The browser console showed the following error message:

![Screenshot from 2024-07-24 14-13-23](https://github.com/user-attachments/assets/7a586093-4605-4d03-a968-6692f4e29e96)

After research, I found that [removing some polyfills in WordPress 6.6](https://github.com/WordPress/wordpress-develop/commit/f525e665b6ea6e88289d82cad5fc1dfac57db109) caused the problem, and the solution suggested by some users was to explicitly import the `regenerator-runtime/runtime` dependency into the conflicted files:
- https://core.trac.wordpress.org/ticket/60962#comment:17
- https://wordpress.org/support/topic/pods-not-working-with-wordpress-6-6-update/#post-17898547
- https://github.com/WordPress/gutenberg/pull/63091

<hr>

**NOTES:**
A similar change was made in the plugin repository, as well: 
https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/1222
Whilst importing the `regenerator-runtime` dependency only into the plugin is enough to fix the issue, once the P4 plugin is removed, we'll still need the importation in the theme codebase.

<hr>

**TESTING:**
Locally: Run `npx wp-env run cli wp core update --version=6.6` or `npx wp-env run cli wp core update https://wordpress.org/wordpress-6.6.zip` on your terminal