### PR TITLE
PLANET-7552 Move High Level Topic block pattern layout into master theme

### DIFF
--- a/assets/src/block-templates/high-level-topic/block.json
+++ b/assets/src/block-templates/high-level-topic/block.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://schemas.wp.org/trunk/block.json",
+  "apiVersion": 2,
+  "name": "planet4-block-templates/high-level-topic",
+  "title": "High-Level Topic",
+  "category": "planet4-block-templates",
+  "icon": "editor-table",
+  "textdomain": "planet4-blocks-backend"
+}

--- a/assets/src/block-templates/high-level-topic/index.js
+++ b/assets/src/block-templates/high-level-topic/index.js
@@ -1,0 +1,4 @@
+import metadata from './block.json';
+import template from './template';
+
+export {metadata, template};

--- a/assets/src/block-templates/high-level-topic/template.js
+++ b/assets/src/block-templates/high-level-topic/template.js
@@ -1,0 +1,47 @@
+import gravityFormWithText from '../templates/gravity-form-with-text';
+
+const {__} = wp.i18n;
+
+const template = () => ([
+  ['core/group', {className: 'block'}, [
+    ['planet4-block-templates/page-header', {
+      titlePlaceholder: __('Page header title', 'planet4-blocks-backend'),
+      mediaPosition: 'right',
+    }],
+    ['core/spacer', {height: '64px'}],
+    ['planet4-block-templates/reality-check'],
+    ['planet4-block-templates/side-image-with-text-and-cta', {
+      title: __('The problem', 'planet4-blocks'),
+      alignFull: true,
+    }],
+    ['planet4-block-templates/deep-dive', {
+      title: __('Better understand the issues [deep dive topics]', 'planet4-blocks'),
+      backgroundColor: 'white',
+    }],
+    ['planet4-block-templates/side-image-with-text-and-cta', {
+      title: __('What we do', 'planet4-blocks'),
+      mediaPosition: 'right',
+      alignFull: true,
+    }],
+    ['planet4-block-templates/highlighted-cta', {
+      titlePlaceholder: __('Featured action title', 'planet4-blocks'),
+    }],
+    ['planet4-blocks/covers', {
+      cover_type: 'take-action',
+      title: __('How you can help', 'planet4-blocks'),
+    }],
+    ['planet4-blocks/articles', {
+      article_heading: __('Latest news & stories', 'planet4-blocks'),
+    }],
+    ['planet4-blocks/covers', {
+      title: __('Latest investigations', 'planet4-blocks'),
+    }],
+    gravityFormWithText(),
+    ['planet4-block-templates/quick-links', {
+      title: __('Explore by topics', 'planet4-blocks'),
+      backgroundColor: 'white',
+    }],
+  ]],
+]);
+
+export default template;

--- a/assets/src/block-templates/template-list.js
+++ b/assets/src/block-templates/template-list.js
@@ -6,6 +6,7 @@ import * as deepDive from './deep-dive';
 import * as highlightedCta from './highlighted-cta';
 import * as takeAction from './take-action';
 import * as pageHeader from './page-header';
+import * as highLevelTopic from './high-level-topic';
 
 export default [
   sideImgTextCta,
@@ -16,4 +17,5 @@ export default [
   highlightedCta,
   takeAction,
   pageHeader,
+  highLevelTopic,
 ];

--- a/assets/src/block-templates/templates/gravity-form-with-text.js
+++ b/assets/src/block-templates/templates/gravity-form-with-text.js
@@ -1,0 +1,36 @@
+const {__} = wp.i18n;
+
+const gravityFormWithText = backgroundColor => (
+  ['core/group', {
+    backgroundColor: backgroundColor || 'beige-100',
+    align: 'full',
+    style: {
+      spacing: {
+        padding: {
+          top: '80px',
+          bottom: '50px',
+        },
+      },
+    },
+  }, [
+    ['core/group', {className: 'container'}, [
+      ['core/columns', {}, [
+        ['core/column', {}, [
+          ['core/heading', {
+            level: 2,
+            style: {typography: {fontSize: '40px'}},
+            placeholder: __('Enter title', 'planet4-blocks-backend'),
+          }],
+          ['core/paragraph', {
+            placeholder: __('Enter description', 'planet4-blocks-backend'),
+          }],
+        ]],
+        ['core/column', {}, [
+          ['gravityforms/form', {title: false, description: false}],
+        ]],
+      ]],
+    ]],
+  ]]
+);
+
+export default gravityFormWithText;

--- a/src/Patterns/BlockPattern.php
+++ b/src/Patterns/BlockPattern.php
@@ -43,6 +43,7 @@ abstract class BlockPattern
         return [
             BlankPage::class,
             DeepDive::class,
+            HighLevelTopic::class,
             HighlightedCta::class,
             Issues::class,
             QuickLinks::class,

--- a/src/Patterns/HighLevelTopic.php
+++ b/src/Patterns/HighLevelTopic.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * High Level Topic pattern class.
+ *
+ * @package P4\MasterTheme\Patterns
+ * @since 0.1
+ */
+
+ namespace P4\MasterTheme\Patterns;
+
+/**
+ * Class High Level Topic.
+ *
+ * @package P4\MasterTheme\Patterns
+ */
+class HighLevelTopic extends BlockPattern
+{
+    /**
+     * Returns the pattern name.
+     */
+    public static function get_name(): string
+    {
+        return 'p4/high-level-topic-pattern-layout';
+    }
+
+    /**
+     * Returns the pattern config.
+     *
+     * @param array $params Optional array of parameters for the config.
+     */
+    public static function get_config(array $params = []): array
+    {
+        return [
+            'title' => 'High-Level Topic',
+            'categories' => [ 'layouts' ],
+            'blockTypes' => [ 'core/post-content' ],
+            'content' => '
+                <!-- wp:planet4-block-templates/high-level-topic '
+                    . wp_json_encode($params, \JSON_FORCE_OBJECT) .
+                ' /-->
+            ',
+        ];
+    }
+}


### PR DESCRIPTION
### Description

See [PLANET-7552](https://jira.greenpeace.org/browse/PLANET-7552)

We also remove it from the plugin: https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/1223