### PR TITLE
PLANET-7500: Backend text changes on Happypoint block

### DIFF
--- a/assets/src/blocks/Happypoint/HappypointEditor.js
+++ b/assets/src/blocks/Happypoint/HappypointEditor.js
@@ -182,12 +182,21 @@ export const HappypointEditor = ({attributes, setAttributes, isSelected}) => {
               }
               {id && 0 < id &&
                 <div className="wp-block-master-theme-happypoint__FocalPointPicker">
+                  <strong className="components-base-control__help">
+                    {__('Select image focal point', 'planet4-blocks-backend')}
+                  </strong>
+                  <p className="components-base-control__help">
+                    {__('Drag the mouse to the focal area or input the position with numbers for more precision.', 'planet4-blocks-backend')}
+                  </p>
                   <FocalPointPicker
                     url={imageUrl}
                     dimensions={dimensions}
                     value={focal_point_params}
                     onChange={onFocalPointChange}
-                    label={__('Select focus point for background image', 'planet4-blocks-backend')}
+                    help={__(
+                      'Drag "left" to move across the horizontal axis and slide "top" upwards to move through the vertical axis.',
+                      'planet4-blocks-backend'
+                    )}
                   />
                 </div>
               }


### PR DESCRIPTION
Ref https://jira.greenpeace.org/browse/PLANET-7500

<hr>

This PR copies the changes applied to [this PR](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/1218) to not lose them once the block is removed from the plugin or the plugin is disabled.