### PR TITLE
 PLANET-7565: Fix tests broken by WordPress v6.6.x

### DIFF
--- a/tests/e2e/tools/lib/editor.js
+++ b/tests/e2e/tools/lib/editor.js
@@ -21,13 +21,8 @@
 async function openComponentPanel({editor}, panelTitle) {
   await editor.openDocumentSettingsSidebar();
   const editorSettings = await editor.canvas.getByRole('region', {name: 'Editor settings'});
-  await editorSettings.locator('.edit-post-sidebar__panel-tabs button').first().click();
-  const panelButton = await editorSettings.getByRole('button', {name: panelTitle, exact: true});
-  const panelExpanded = await panelButton.getAttribute('aria-expanded');
-  if (panelExpanded === 'false') {
-    await panelButton.click();
-  }
-
+  await editorSettings.locator('.editor-sidebar__panel-tabs button').first().click();
+  await editorSettings.getByLabel('button', {name: panelTitle, exact: true});
   return editorSettings;
 }
 

--- a/tests/e2e/tools/lib/post.js
+++ b/tests/e2e/tools/lib/post.js
@@ -1,5 +1,13 @@
 import {openComponentPanel} from './editor.js';
 
+/**
+ * Publishes a post using the provided editor and returns the URL of the published post.
+ *
+ * @param {Object} params - Parameters for publishing the post.
+ * @param {Object} params.page - The page object for interacting with the browser.
+ * @param {Object} params.editor - The editor object used to publish the post.
+ * @return {Promise<string>} The URL of the published post.
+ */
 async function publishPost({page, editor}) {
   await editor.publishPost();
 
@@ -11,12 +19,28 @@ async function publishPost({page, editor}) {
   return urlString;
 }
 
+/**
+ * Publishes a post and then navigates to the published post's URL.
+ *
+ * @param {Object} params - Parameters for publishing the post and visiting the URL.
+ * @param {Object} params.page - The page object for interacting with the browser.
+ * @param {Object} params.editor - The editor object used to publish the post.
+ */
 async function publishPostAndVisit({page, editor}) {
   const urlString = await publishPost({page, editor});
 
   await page.goto(urlString);
 }
 
+/**
+ * Creates a new post with a featured image set.
+ *
+ * @param {Object} params - Parameters for creating the post and setting the featured image.
+ * @param {Object} params.admin - The admin object used to create a new post.
+ * @param {Object} params.editor - The editor object used to interact with the editor.
+ * @param {Object} params.params - Additional parameters for creating the post.
+ * @return {Promise<Object>} The newly created post.
+ */
 async function createPostWithFeaturedImage({admin, editor}, params) {
   const newPost = await admin.createNewPost({...params, legacyCanvas: true});
   const editorSettings = await openComponentPanel({editor}, 'Featured image');


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-7565

<hr>

**DESCRIPTION:**
This PR fixes the failing automated tests after upgrading WordPress to its LTS version ([6.6.1 of 23 July, 2024](https://wordpress.org/download/releases/)). 
It also adds some missing JSDocs.

<hr>

**TESTING:**
Use the Gutenberg instance: https://www-dev.greenpeace.org/gutenberg/ (it is already using WordPress v6.6.1)