### PR TITLE
PLANET-7551: Move GetInformed pattern block to theme

### DIFF
--- a/assets/src/block-templates/get-informed/block.json
+++ b/assets/src/block-templates/get-informed/block.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://schemas.wp.org/trunk/block.json",
+  "apiVersion": 2,
+  "name": "planet4-block-templates/get-informed",
+  "title": "Get Informed",
+  "category": "planet4-block-templates",
+  "icon": "editor-table",
+  "textdomain": "planet4-blocks-backend"
+}

--- a/assets/src/block-templates/get-informed/index.js
+++ b/assets/src/block-templates/get-informed/index.js
@@ -1,0 +1,4 @@
+import metadata from './block.json';
+import template from './template';
+
+export {metadata, template};

--- a/assets/src/block-templates/get-informed/template.js
+++ b/assets/src/block-templates/get-informed/template.js
@@ -1,0 +1,37 @@
+import gravityFormWithText from '../templates/gravity-form-with-text';
+
+const {__} = wp.i18n;
+
+const template = () => ([
+  ['core/group', {className: 'block'}, [
+    ['planet4-block-templates/quick-links', {
+      title: __('Explore by topics', 'planet4-blocks'),
+    }],
+    ['planet4-block-templates/side-image-with-text-and-cta', {
+      title: __('Topic 1', 'planet4-blocks'),
+    }],
+    ['planet4-block-templates/side-image-with-text-and-cta', {
+      title: __('Topic 2', 'planet4-blocks'),
+      mediaPosition: 'right',
+    }],
+    ['planet4-block-templates/side-image-with-text-and-cta', {
+      title: __('Topic 3', 'planet4-blocks'),
+    }],
+    ['planet4-block-templates/issues', {
+      title: __('The issues we work on', 'planet4-blocks'),
+    }],
+    ['planet4-blocks/articles', {
+      article_heading: __('Our recent victories', 'planet4-blocks'),
+    }],
+    ['planet4-blocks/gallery', {
+      className: 'is-style-grid',
+      gallery_block_title: __('Our latest actions around the world', 'planet4-blocks'),
+    }],
+    ['planet4-blocks/articles', {
+      article_heading: __('Latest news & stories', 'planet4-blocks'),
+    }],
+    gravityFormWithText(),
+  ]],
+]);
+
+export default template;

--- a/assets/src/block-templates/template-list.js
+++ b/assets/src/block-templates/template-list.js
@@ -8,6 +8,7 @@ import * as takeAction from './take-action';
 import * as pageHeader from './page-header';
 import * as highLevelTopic from './high-level-topic';
 import * as homepage from './homepage';
+import * as getInformed from './get-informed';
 
 export default [
   sideImgTextCta,
@@ -20,4 +21,5 @@ export default [
   pageHeader,
   highLevelTopic,
   homepage,
+  getInformed,
 ];

--- a/src/Patterns/BlockPattern.php
+++ b/src/Patterns/BlockPattern.php
@@ -43,16 +43,17 @@ abstract class BlockPattern
         return [
             BlankPage::class,
             DeepDive::class,
+            GetInformed::class,
             HighLevelTopic::class,
             HighlightedCta::class,
+            Homepage::class,
             Issues::class,
+            PageHeader::class,
+            PageHeaderImgLeft::class,
             QuickLinks::class,
             RealityCheck::class,
             SideImageWithTextAndCta::class,
             TakeAction::class,
-            PageHeader::class,
-            PageHeaderImgLeft::class,
-            Homepage::class,
         ];
     }
 

--- a/src/Patterns/GetInformed.php
+++ b/src/Patterns/GetInformed.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * Get Informed pattern class.
+ *
+ * @package P4\MasterTheme\Patterns
+ * @since 0.1
+ */
+
+namespace P4\MasterTheme\Patterns;
+
+/**
+ * Class Get Informed.
+ *
+ * @package P4\MasterTheme\Patterns
+ */
+class GetInformed extends BlockPattern
+{
+    /**
+     * @inheritDoc
+     */
+    public static function get_name(): string
+    {
+        return 'p4/get-informed-pattern-layout';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function get_config($params = []): array
+    {
+        return [
+            'title' => 'Get Informed',
+            'blockTypes' => [ 'core/post-content' ],
+            'categories' => [ 'layouts' ],
+            'content' => '
+				<!-- wp:planet4-block-templates/get-informed ' . wp_json_encode($params, \JSON_FORCE_OBJECT) . ' /-->
+			',
+        ];
+    }
+}


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-7551

# Description
Include all related files

Related PRs
- https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/1224

## Testing
Check it out this [demo page](https://www-dev.greenpeace.org/test-titan/getinformed-demo-page/) which is using the [titan](https://github.com/greenpeace/planet4-test-titan/blob/main/composer-local.json#L6-L7) dev instance for testing. 
Also disabled the P4 Gutenberg plugin from [here](https://www-dev.greenpeace.org/test-titan/wp-admin/plugins.php?plugin_status=all&paged=1&s).

