### PR TITLE
PLANET-7549: Move Campaign pattern block to theme

### DIFF
--- a/assets/src/block-templates/campaign/block.json
+++ b/assets/src/block-templates/campaign/block.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://schemas.wp.org/trunk/block.json",
+  "apiVersion": 2,
+  "name": "planet4-block-templates/campaign",
+  "title": "Campaign",
+  "category": "planet4-block-templates",
+  "icon": "editor-table",
+  "textdomain": "planet4-blocks-backend"
+}

--- a/assets/src/block-templates/campaign/index.js
+++ b/assets/src/block-templates/campaign/index.js
@@ -1,0 +1,4 @@
+import metadata from './block.json';
+import template from './template';
+
+export {metadata, template};

--- a/assets/src/block-templates/campaign/template.js
+++ b/assets/src/block-templates/campaign/template.js
@@ -1,0 +1,28 @@
+import gravityFormWithText from '../templates/gravity-form-with-text';
+
+const {__} = wp.i18n;
+
+const template = () => ([
+  ['core/group', {className: 'block'}, [
+    ['planet4-block-templates/page-header', {
+      titlePlaceholder: __('Page header title', 'planet4-blocks-backend'),
+    }],
+    ['core/spacer', {height: '64px'}],
+    ['planet4-block-templates/side-image-with-text-and-cta', {
+      title: __('The problem', 'planet4-blocks'),
+    }],
+    ['core/spacer', {height: '32px'}],
+    ['planet4-block-templates/side-image-with-text-and-cta', {
+      title: __('The solution', 'planet4-blocks'),
+      mediaPosition: 'right',
+    }],
+    ['core/spacer', {height: '32px'}],
+    ['planet4-blocks/covers', {
+      title: __('How you can help', 'planet4-blocks'),
+    }],
+    ['core/spacer', {height: '48px'}],
+    gravityFormWithText(),
+  ]],
+]);
+
+export default template;

--- a/assets/src/block-templates/template-list.js
+++ b/assets/src/block-templates/template-list.js
@@ -10,6 +10,7 @@ import * as highLevelTopic from './high-level-topic';
 import * as homepage from './homepage';
 import * as getInformed from './get-informed';
 import * as deepDiveTopic from './deep-dive-topic';
+import * as campaign from './campaign';
 
 export default [
   sideImgTextCta,
@@ -24,4 +25,5 @@ export default [
   homepage,
   getInformed,
   deepDiveTopic,
+  campaign,
 ];

--- a/src/Patterns/BlockPattern.php
+++ b/src/Patterns/BlockPattern.php
@@ -42,6 +42,7 @@ abstract class BlockPattern
     {
         return [
             BlankPage::class,
+            Campaign::class,
             DeepDive::class,
             DeepDiveTopic::class,
             GetInformed::class,

--- a/src/Patterns/Campaign.php
+++ b/src/Patterns/Campaign.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * Campaign pattern class.
+ *
+ * @package P4\MasterTheme\Patterns
+ * @since 0.1
+ */
+
+namespace P4\MasterTheme\Patterns;
+
+/**
+ * Class Campaign.
+ *
+ * @package P4\MasterTheme\Patterns
+ */
+class Campaign extends BlockPattern
+{
+    /**
+     * @inheritDoc
+     */
+    public static function get_name(): string
+    {
+        return 'p4/campaign-pattern-layout';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function get_config($params = []): array
+    {
+        return [
+            'title' => 'Campaign',
+            'blockTypes' => [ 'core/post-content' ],
+            'categories' => [ 'layouts' ],
+            'content' => '
+				<!-- wp:planet4-block-templates/campaign ' . wp_json_encode($params, \JSON_FORCE_OBJECT) . ' /-->
+			',
+        ];
+    }
+}


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-7549

# Description
Include all related files

Related PRs
- https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/1225

## Testing
Check it out this [demo page](https://www-dev.greenpeace.org/test-venus/block-campaign-demo-page-2/) which is using the [venus](https://github.com/greenpeace/planet4-test-titan/blob/main/composer-local.json#L6-L7) dev instance for testing. 
Also disabled the P4 Gutenberg plugin from [here](https://www-dev.greenpeace.org/test-titan/wp-admin/plugins.php?plugin_status=all&paged=1&s).

