### PR TITLE
PLANET-7565: Fix warnings in WordPress 6.6.x

### DIFF
--- a/assets/src/block-editor/Sidebar/ActionSidebar.js
+++ b/assets/src/block-editor/Sidebar/ActionSidebar.js
@@ -1,4 +1,4 @@
-import {PluginDocumentSettingPanel} from '@wordpress/edit-post';
+import {PluginDocumentSettingPanel} from '@wordpress/editor';
 import {NavigationType} from '../NavigationType/NavigationType';
 import {CheckboxSidebarField} from '../SidebarFields/CheckboxSidebarField';
 import {TextSidebarField} from '../SidebarFields/TextSidebarField';

--- a/assets/src/block-editor/Sidebar/AnalyticsTrackingSidebar.js
+++ b/assets/src/block-editor/Sidebar/AnalyticsTrackingSidebar.js
@@ -1,5 +1,5 @@
 import {useEffect} from '@wordpress/element';
-import {PluginDocumentSettingPanel} from '@wordpress/edit-post';
+import {PluginDocumentSettingPanel} from '@wordpress/editor';
 import {dispatch, useSelect} from '@wordpress/data';
 import {SelectSidebarField} from '../SidebarFields/SelectSidebarField';
 import {TextSidebarField} from '../SidebarFields/TextSidebarField';

--- a/assets/src/block-editor/Sidebar/CampaignSidebar.js
+++ b/assets/src/block-editor/Sidebar/CampaignSidebar.js
@@ -1,4 +1,4 @@
-import {PluginDocumentSettingPanel} from '@wordpress/edit-post';
+import {PluginDocumentSettingPanel} from '@wordpress/editor';
 import {NavigationType} from '../NavigationType/NavigationType';
 import {getSidebarFunctions} from './getSidebarFunctions';
 

--- a/assets/src/block-editor/Sidebar/OpenGraphSidebar.js
+++ b/assets/src/block-editor/Sidebar/OpenGraphSidebar.js
@@ -1,4 +1,4 @@
-import {PluginDocumentSettingPanel} from '@wordpress/edit-post';
+import {PluginDocumentSettingPanel} from '@wordpress/editor';
 import {TextareaSidebarField} from '../SidebarFields/TextareaSidebarField';
 import {ImageSidebarField} from '../SidebarFields/ImageSidebarField';
 import {TextSidebarField} from '../SidebarFields/TextSidebarField';

--- a/assets/src/block-editor/Sidebar/PageHeaderSidebar.js
+++ b/assets/src/block-editor/Sidebar/PageHeaderSidebar.js
@@ -1,4 +1,4 @@
-import {PluginDocumentSettingPanel} from '@wordpress/edit-post';
+import {PluginDocumentSettingPanel} from '@wordpress/editor';
 import {CheckboxSidebarField} from '../SidebarFields/CheckboxSidebarField';
 import {getSidebarFunctions} from './getSidebarFunctions';
 

--- a/assets/src/block-editor/Sidebar/SearchEngineOptimizationsSidebar.js
+++ b/assets/src/block-editor/Sidebar/SearchEngineOptimizationsSidebar.js
@@ -1,4 +1,4 @@
-import {PluginDocumentSettingPanel} from '@wordpress/edit-post';
+import {PluginDocumentSettingPanel} from '@wordpress/editor';
 import {useDispatch, useSelect} from '@wordpress/data';
 import {URLInput} from '../URLInput/URLInput';
 

--- a/assets/src/blocks/ActionsList/index.js
+++ b/assets/src/blocks/ActionsList/index.js
@@ -16,6 +16,7 @@ export const registerActionsListBlock = () => {
   const queryPostType = IS_NEW_IA ? 'p4_action' : 'page';
 
   registerBlockVariation('core/query', {
+    name: ACTIONS_LIST_BLOCK_NAME,
     title: 'Actions List',
     description: __('A list of possible actions', 'planet4-blocks-backend'),
     icon: 'list-view',


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-7565

<hr>

**DESCRIPTION:**
This PR replaces the `PluginDocumentSettingPanel` component of being imported from `@wordpress/edit-post` with `@wordpress/editor` according to the changes introduced by WordPress 6.6 and adds the missing `name` attribute to the `ActionsList`file.

![Screenshot from 2024-07-31 11-11-32](https://github.com/user-attachments/assets/14fa80ff-e15f-4eb7-85ab-2a0ca967417d)

<img width="445" alt="354526334-e79aeb4d-065b-473a-b7fb-8645564bda3a" src="https://github.com/user-attachments/assets/c6d7f4f7-eaea-479d-9d7b-b0f1bc58d769">
