### PR TITLE
PLANET-7548: Move Action pattern block to theme

### DIFF
--- a/assets/src/block-templates/action/block.json
+++ b/assets/src/block-templates/action/block.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://schemas.wp.org/trunk/block.json",
+  "apiVersion": 2,
+  "name": "planet4-block-templates/action",
+  "title": "Action",
+  "category": "planet4-block-templates",
+  "icon": "editor-table",
+  "textdomain": "planet4-blocks-backend"
+}

--- a/assets/src/block-templates/action/index.js
+++ b/assets/src/block-templates/action/index.js
@@ -1,0 +1,4 @@
+import metadata from './block.json';
+import template from './template';
+
+export {metadata, template};

--- a/assets/src/block-templates/action/template.js
+++ b/assets/src/block-templates/action/template.js
@@ -1,0 +1,38 @@
+import gravityFormWithText from '../templates/gravity-form-with-text';
+
+const {__} = wp.i18n;
+
+const template = () => ([
+  ['core/group', {className: 'block'}, [
+    gravityFormWithText('white'),
+    ['core/group', {
+      backgroundColor: 'beige-100',
+      align: 'full',
+      style: {
+        spacing: {
+          padding: {
+            top: '80px',
+            bottom: '80px',
+          },
+        },
+      },
+    }, [
+      ['core/group', {className: 'container'}, [
+        ['planet4-block-templates/side-image-with-text-and-cta', {
+          title: __('The problem', 'planet4-blocks'),
+          mediaPosition: 'right',
+        }],
+      ]],
+    ]],
+    ['planet4-blocks/covers', {
+      cover_type: 'take-action',
+    }],
+    ['core/separator', {backgroundColor: 'grey-20'}],
+    ['planet4-block-templates/quick-links', {
+      title: __('Explore by topics', 'planet4-blocks'),
+      backgroundColor: 'white',
+    }],
+  ]],
+]);
+
+export default template;

--- a/assets/src/block-templates/template-list.js
+++ b/assets/src/block-templates/template-list.js
@@ -11,6 +11,7 @@ import * as homepage from './homepage';
 import * as getInformed from './get-informed';
 import * as deepDiveTopic from './deep-dive-topic';
 import * as campaign from './campaign';
+import * as action from './action';
 
 export default [
   sideImgTextCta,
@@ -26,4 +27,5 @@ export default [
   getInformed,
   deepDiveTopic,
   campaign,
+  action,
 ];

--- a/src/Patterns/Action.php
+++ b/src/Patterns/Action.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * Action pattern class.
+ *
+ * @package P4\MasterTheme\Patterns
+ * @since 0.1
+ */
+
+ namespace P4\MasterTheme\Patterns;
+
+/**
+ * Class Action.
+ *
+ * @package P4\MasterTheme\Patterns
+ */
+class Action extends BlockPattern
+{
+    /**
+     * @inheritDoc
+     */
+    public static function get_name(): string
+    {
+        return 'p4/action-pattern-layout';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function get_config($params = []): array
+    {
+        return [
+            'title' => 'Action',
+            'categories' => [ 'layouts' ],
+            'blockTypes' => [ 'core/post-content' ],
+            'postTypes' => [ 'page', 'p4_action', 'campaign' ],
+            'content' => '
+				<!-- wp:planet4-block-templates/action ' . wp_json_encode($params, \JSON_FORCE_OBJECT) . ' /-->
+			',
+        ];
+    }
+}

--- a/src/Patterns/BlockPattern.php
+++ b/src/Patterns/BlockPattern.php
@@ -42,6 +42,7 @@ abstract class BlockPattern
     {
         return [
             BlankPage::class,
+            Action::class,
             Campaign::class,
             DeepDive::class,
             DeepDiveTopic::class,


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-7548

# Description
Include all related files

Related PRs
- https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/1227

## Testing
Check it out this [demo page](https://www-dev.greenpeace.org/test-pluto/take-pattern-block-demo-page/) which is using the assigned dev instance for testing. 
Also disabled the P4 Gutenberg plugin from [here](https://www-dev.greenpeace.org/test-pluto/wp-admin/plugins.php?plugin_status=all&paged=1&s).

