### PR TITLE
PLANET-7540: Clean up auto-save revisions fix

### DIFF
--- a/single-campaign.php
+++ b/single-campaign.php
@@ -34,9 +34,9 @@ do {
 if ($top_level_campaign_id === $post->ID) {
     $campaign_meta = $meta;
 } else {
-    $parent_meta = get_post_meta( $top_level_campaign_id );
-    // Get rid of all metas being in an array.                                      
-    $campaign_meta = array_map( 'reset', $parent_meta );
+    $parent_meta = get_post_meta($top_level_campaign_id);
+    // Get rid of all metas being in an array.
+    $campaign_meta = array_map('reset', $parent_meta);
 }
 
 // This is just an example of how to get children pages, this will probably be done in some kind of menu block.
@@ -56,7 +56,6 @@ $context['$sub_pages'] = array_map(
     },
     $sub_pages
 );
-
 
 $theme_name = $campaign_meta['theme'] ?? $campaign_meta['_campaign_page_template'] ?? null;
 
@@ -93,17 +92,17 @@ $context['social_overrides'] = [];
 foreach (range(1, 5) as $i) {
     $footer_item_key = 'campaign_footer_item' . $i;
 
-    if (!isset($campaign_meta[ $footer_item_key ])) {
+    if (!isset($campaign_meta[$footer_item_key])) {
         continue;
     }
 
-    $campaign_footer_item = maybe_unserialize($campaign_meta[ $footer_item_key ]);
+    $campaign_footer_item = maybe_unserialize($campaign_meta[$footer_item_key]);
     if (!$campaign_footer_item['url'] || !$campaign_footer_item['icon']) {
         continue;
     }
 
-    $context['social_overrides'][ $i ]['url'] = $campaign_footer_item['url'];
-    $context['social_overrides'][ $i ]['icon'] = $campaign_footer_item['icon'];
+    $context['social_overrides'][$i]['url'] = $campaign_footer_item['url'];
+    $context['social_overrides'][$i]['icon'] = $campaign_footer_item['icon'];
 }
 
 Context::set_p4_blocks_datalayer($context, $post);
@@ -120,7 +119,7 @@ if (post_password_required($post->ID)) {
     Timber::render('single-password.twig', $context);
 } else {
     Timber::render(
-        ['single-' . $post->ID . '.twig', 'single-' . $post->post_type . '.twig', 'single.twig' ],
+        ['single-' . $post->ID . '.twig', 'single-' . $post->post_type . '.twig', 'single.twig'],
         $context
     );
 }

--- a/single-campaign.php
+++ b/single-campaign.php
@@ -21,15 +21,8 @@ $context = Timber::get_context();
 $post = Timber::query_post(false, Post::class); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 $context['post'] = $post;
 
-$meta = get_post_meta($post->ID);
-// No need to check the user here as that already happens in wp_get_post_autosave.
-if (isset($_GET['preview'])) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-    $post_preview = wp_get_post_autosave($post->ID);
-    if ($post_preview) {
-        $meta = array_merge($meta, get_post_meta($post_preview->ID));
-    }
-}
-$meta = array_map(fn ($v) => reset($v), $meta);
+// Get the cmb2 custom fields data.
+$meta = $post->custom;
 
 $current_level_campaign_id = $post->ID;
 
@@ -41,8 +34,9 @@ do {
 if ($top_level_campaign_id === $post->ID) {
     $campaign_meta = $meta;
 } else {
-    $campaign_meta = get_post_meta($top_level_campaign_id);
-    $campaign_meta = array_map(fn ($v) => reset($v), $campaign_meta);
+    $parent_meta = get_post_meta( $top_level_campaign_id );
+    // Get rid of all metas being in an array.                                      
+    $campaign_meta = array_map( 'reset', $parent_meta );
 }
 
 // This is just an example of how to get children pages, this will probably be done in some kind of menu block.

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -8,7 +8,6 @@ use P4\MasterTheme\Features\Dev\BetaBlocks;
 use P4\MasterTheme\Patterns\BlockPattern;
 use P4\MasterTheme\View\View;
 use RuntimeException;
-use WP_Post;
 
 /**
  * Class Loader.

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -56,7 +56,6 @@ final class Loader
     {
         $this->load_services($services);
         $this->load_block_services();
-        $this->add_filters();
         Commands::load();
 
         // During PLANET-6373 transition, priority between theme and plugin matters.
@@ -247,49 +246,6 @@ final class Loader
         );
     }
 
-    /**
-     * Add some filters.
-     *
-     */
-    private function add_filters(): void
-    {
-        add_filter('pre_delete_post', [$this, 'do_not_delete_autosave'], 1, 3);
-    }
-
-    /**
-     * Due to a bug in WordPress core the "autosave revision" of a post is created and deleted all of the time.
-     * This is pretty pointless and makes it impractical to add any post meta to that revision.
-     * The logic was probably that some space could be saved it is can be determined that the autosave doesn't differ
-     * from the current post content. However that advantage doesn't weigh up to the overhead of deleting the record and
-     * inserting it again, each time burning through another id of the posts table.
-     *
-     * @see https://core.trac.wordpress.org/ticket/49532
-     *
-     * @param bool|null $delete Whether to go forward with the delete
-     *                     (sic, see original filter where it is null initally, not used here).
-     * @param WP_Post|null $post Post object.
-     * @param bool|null $force_delete Is true when post is not trashed but deleted permanently
-     *                           (always false for revisions but they are deleted anyway).
-     *
-     * @return bool|null If the filter returns anything else than null the post is not deleted.
-     * phpcs:disable WordPress.Security.NonceVerification.Recommended
-     */
-    public function do_not_delete_autosave(
-        bool|null $delete = null,
-        WP_Post|null $post = null,
-        bool|null $force_delete = null
-    ): ?bool {
-        if (
-            $force_delete
-            || (isset($_GET['action']) && 'delete' === $_GET['action'])
-            || (isset($_GET['delete_all']))
-            || !preg_match('/autosave-v\d+$/', $post->post_name)
-        ) {
-            return $delete;
-        }
-
-        return false;
-    }
     // phpcs:enable WordPress.Security.NonceVerification.Recommended
 
     /**


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-7540

This PR reverts the changes introduced [here](https://github.com/greenpeace/planet4-master-theme/commit/acbc3400e8794fdcb4275fba86a2b830e36af5ee#diff-3163ac23cdbb746a9b9bf8dc0a052b7e6e46ac6a40c1c635b61f6bbae7102d20L143) since the problem with previews being saved and deleted multiple times was [fixed by WordPress](https://core.trac.wordpress.org/ticket/49532).

I checked queries using the Query Monitor plugin, the API requests in the Network tab of the browser console, and the records in the `wp_posts` database table, and the preview posts seem to behave correctly.