### PR TITLE
PLANET-7576: Move Planet4 blocks (beta) category

### DIFF
--- a/assets/src/editorIndex.js
+++ b/assets/src/editorIndex.js
@@ -31,9 +31,11 @@ wp.domReady(() => {
   registerBlockTemplates();
 
   // Beta blocks
-  registerActionButtonTextBlock();
-  registerActionsListBlock();
-  registerPostsListBlock();
+  if (window.p4_vars.features.beta_blocks === 'on') {
+    registerActionButtonTextBlock();
+    registerActionsListBlock();
+    registerPostsListBlock();
+  }
 
   // Custom block styles
   registerBlockStyles();

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -4,7 +4,6 @@ namespace P4\MasterTheme;
 
 use P4\MasterTheme\Settings\Features;
 use P4\MasterTheme\Features\Planet4Blocks;
-use P4\MasterTheme\Features\Dev\BetaBlocks;
 use P4\MasterTheme\Patterns\BlockPattern;
 use P4\MasterTheme\View\View;
 use RuntimeException;
@@ -219,10 +218,6 @@ final class Loader
 
         // Load block patterns.
         BlockPattern::register_all();
-
-        if (!BetaBlocks::is_active()) {
-            return;
-        }
 
         new Blocks\ActionButtonText();//NOSONAR
 

--- a/src/MasterBlocks.php
+++ b/src/MasterBlocks.php
@@ -4,6 +4,7 @@ namespace P4\MasterTheme;
 
 use P4\MasterTheme\Controllers\EnsapiController;
 use P4\MasterTheme\Blocks\ENForm;
+use P4\MasterTheme\Features\Dev\BetaBlocks;
 use Twig_SimpleFilter;
 
 /**
@@ -27,6 +28,13 @@ class MasterBlocks
     {
         // Register p4 block categories.
         add_filter('block_categories_all', function ($categories) {
+            if (BetaBlocks::is_active()) {
+                // Adding the "planet4-blocks-beta" category.
+                array_unshift($categories, [
+                    'slug' => 'planet4-blocks-beta',
+                    'title' => 'Planet 4 Blocks - BETA',
+                ]);
+            }
 
             // Adding the "planet4-blocks" category.
             array_unshift($categories, [


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-7576

# Description
Move Planet4 beta blocks category from plugin to theme. This category should be added after we move blcosk from plugin to theme

## Testing
You can validate that the category is shown when click on "+" within the assigned [demo page](https://www-dev.greenpeace.org/test-pandora/planet-4-blocks-beta/).

<!-- Ref: Please add a url to the ticket this change is addressing.

---

Please provide a brief summary of the change introduced to make review process easier.

Ideally this should also be part of the commit summary.
-->
