### PR TITLE
Use explicit Wordpress packages

### DIFF
--- a/assets/src/block-editor/ColorPaletteControl/ColorPaletteControl.js
+++ b/assets/src/block-editor/ColorPaletteControl/ColorPaletteControl.js
@@ -1,6 +1,6 @@
 import classnames from 'classnames';
-import {BaseControl, ColorPalette} from '@wordpress/components';
 
+const {BaseControl, ColorPalette} = wp.components;
 const {withInstanceId} = wp.compose;
 
 function ColorPaletteControl({label, className, value, help, instanceId, onChange, options = [], ...passThroughProps}) {

--- a/assets/src/block-editor/ColorPaletteControl/ColorPaletteControl.js
+++ b/assets/src/block-editor/ColorPaletteControl/ColorPaletteControl.js
@@ -1,6 +1,7 @@
 import classnames from 'classnames';
-import {withInstanceId} from '@wordpress/compose';
 import {BaseControl, ColorPalette} from '@wordpress/components';
+
+const {withInstanceId} = wp.compose;
 
 function ColorPaletteControl({label, className, value, help, instanceId, onChange, options = [], ...passThroughProps}) {
   const id = `inspector-color-palette-control-${instanceId}`;

--- a/assets/src/block-editor/HTMLSidebarHelp/HTMLSidebarHelp.js
+++ b/assets/src/block-editor/HTMLSidebarHelp/HTMLSidebarHelp.js
@@ -1,4 +1,4 @@
-import {RawHTML} from '@wordpress/element';
+const {RawHTML} = wp.element;
 
 export const HTMLSidebarHelp = props => (
   <div className="HTMLSidebarHelp">

--- a/assets/src/block-editor/ImageHoverControls/index.js
+++ b/assets/src/block-editor/ImageHoverControls/index.js
@@ -1,4 +1,4 @@
-import {Button} from '@wordpress/components';
+const {Button} = wp.components;
 const {__} = wp.i18n;
 
 export const ImageHoverControls = props => {

--- a/assets/src/block-editor/ImageOrButton/ImageOrButton.js
+++ b/assets/src/block-editor/ImageOrButton/ImageOrButton.js
@@ -1,5 +1,4 @@
-import {MediaUpload, MediaUploadCheck} from '@wordpress/block-editor';
-
+const {MediaUpload, MediaUploadCheck} = wp.blockEditor;
 const {Button} = wp.components;
 
 export const ImageOrButton = props => {

--- a/assets/src/block-editor/ImageOrButton/ImageOrButton.js
+++ b/assets/src/block-editor/ImageOrButton/ImageOrButton.js
@@ -1,5 +1,6 @@
-import {Button} from '@wordpress/components';
 import {MediaUpload, MediaUploadCheck} from '@wordpress/block-editor';
+
+const {Button} = wp.components;
 
 export const ImageOrButton = props => {
   const {

--- a/assets/src/block-editor/NavigationType/NavigationType.js
+++ b/assets/src/block-editor/NavigationType/NavigationType.js
@@ -1,5 +1,4 @@
-import {RadioControl} from '@wordpress/components';
-
+const {RadioControl} = wp.components;
 const {__} = wp.i18n;
 
 const NAVIGATION_TYPE_PLANET4 = 'planet4';

--- a/assets/src/block-editor/PostSelector/PostSelector.js
+++ b/assets/src/block-editor/PostSelector/PostSelector.js
@@ -1,5 +1,4 @@
-import {dispatch, useSelect} from '@wordpress/data';
-
+const {dispatch, useSelect} = wp.data;
 const {FormTokenField} = wp.components;
 const {__} = wp.i18n;
 

--- a/assets/src/block-editor/PostSelector/PostSelector.js
+++ b/assets/src/block-editor/PostSelector/PostSelector.js
@@ -1,5 +1,6 @@
-import {FormTokenField} from '@wordpress/components';
 import {dispatch, useSelect} from '@wordpress/data';
+
+const {FormTokenField} = wp.components;
 const {__} = wp.i18n;
 
 // Allows to query a custom endpoint with select('core') tools

--- a/assets/src/block-editor/QueryLoopBlockExtension/index.js
+++ b/assets/src/block-editor/QueryLoopBlockExtension/index.js
@@ -1,10 +1,10 @@
 import {RadioControl, PanelBody} from '@wordpress/components';
 import {InspectorControls} from '@wordpress/block-editor';
-import {useCallback, useEffect, useMemo, useState} from '@wordpress/element';
 import {POSTS_LIST_BLOCK_NAME, POSTS_LISTS_LAYOUT_TYPES} from '../../blocks/PostsList';
 import {ACTIONS_LIST_BLOCK_NAME, ACTIONS_LIST_LAYOUT_TYPES} from '../../blocks/ActionsList';
 import {PostSelector} from '../../block-editor/PostSelector/PostSelector';
 
+const {useCallback, useEffect, useMemo, useState} = wp.element;
 const {addFilter} = wp.hooks;
 const {__} = wp.i18n;
 

--- a/assets/src/block-editor/QueryLoopBlockExtension/index.js
+++ b/assets/src/block-editor/QueryLoopBlockExtension/index.js
@@ -1,9 +1,9 @@
-import {RadioControl, PanelBody} from '@wordpress/components';
 import {InspectorControls} from '@wordpress/block-editor';
 import {POSTS_LIST_BLOCK_NAME, POSTS_LISTS_LAYOUT_TYPES} from '../../blocks/PostsList';
 import {ACTIONS_LIST_BLOCK_NAME, ACTIONS_LIST_LAYOUT_TYPES} from '../../blocks/ActionsList';
 import {PostSelector} from '../../block-editor/PostSelector/PostSelector';
 
+const {RadioControl, PanelBody} = wp.components;
 const {useCallback, useEffect, useMemo, useState} = wp.element;
 const {addFilter} = wp.hooks;
 const {__} = wp.i18n;

--- a/assets/src/block-editor/QueryLoopBlockExtension/index.js
+++ b/assets/src/block-editor/QueryLoopBlockExtension/index.js
@@ -1,8 +1,8 @@
-import {InspectorControls} from '@wordpress/block-editor';
 import {POSTS_LIST_BLOCK_NAME, POSTS_LISTS_LAYOUT_TYPES} from '../../blocks/PostsList';
 import {ACTIONS_LIST_BLOCK_NAME, ACTIONS_LIST_LAYOUT_TYPES} from '../../blocks/ActionsList';
 import {PostSelector} from '../../block-editor/PostSelector/PostSelector';
 
+const {InspectorControls} = wp.blockEditor;
 const {RadioControl, PanelBody} = wp.components;
 const {useCallback, useEffect, useMemo, useState} = wp.element;
 const {addFilter} = wp.hooks;

--- a/assets/src/block-editor/Sidebar/ActionSidebar.js
+++ b/assets/src/block-editor/Sidebar/ActionSidebar.js
@@ -1,4 +1,3 @@
-import {PluginDocumentSettingPanel} from '@wordpress/editor';
 import {NavigationType} from '../NavigationType/NavigationType';
 import {CheckboxSidebarField} from '../SidebarFields/CheckboxSidebarField';
 import {TextSidebarField} from '../SidebarFields/TextSidebarField';
@@ -9,6 +8,7 @@ const HIDE_PAGE_TITLE = 'p4_hide_page_title_checkbox';
 const BUTTON_TEXT = 'action_button_text';
 
 const {__} = wp.i18n;
+const {PluginDocumentSettingPanel} = wp.editor;
 
 /**
  * Add settings to Action pages

--- a/assets/src/block-editor/Sidebar/AnalyticsTrackingSidebar.js
+++ b/assets/src/block-editor/Sidebar/AnalyticsTrackingSidebar.js
@@ -1,10 +1,10 @@
-import {useEffect} from '@wordpress/element';
 import {PluginDocumentSettingPanel} from '@wordpress/editor';
 import {dispatch, useSelect} from '@wordpress/data';
 import {SelectSidebarField} from '../SidebarFields/SelectSidebarField';
 import {TextSidebarField} from '../SidebarFields/TextSidebarField';
 import {getSidebarFunctions} from './getSidebarFunctions';
 
+const {useEffect} = wp.element;
 const {__} = wp.i18n;
 
 export const AnalyticsTrackingSidebar = {

--- a/assets/src/block-editor/Sidebar/AnalyticsTrackingSidebar.js
+++ b/assets/src/block-editor/Sidebar/AnalyticsTrackingSidebar.js
@@ -1,9 +1,9 @@
 import {PluginDocumentSettingPanel} from '@wordpress/editor';
-import {dispatch, useSelect} from '@wordpress/data';
 import {SelectSidebarField} from '../SidebarFields/SelectSidebarField';
 import {TextSidebarField} from '../SidebarFields/TextSidebarField';
 import {getSidebarFunctions} from './getSidebarFunctions';
 
+const {dispatch, useSelect} = wp.data;
 const {useEffect} = wp.element;
 const {__} = wp.i18n;
 

--- a/assets/src/block-editor/Sidebar/AnalyticsTrackingSidebar.js
+++ b/assets/src/block-editor/Sidebar/AnalyticsTrackingSidebar.js
@@ -1,8 +1,8 @@
-import {PluginDocumentSettingPanel} from '@wordpress/editor';
 import {SelectSidebarField} from '../SidebarFields/SelectSidebarField';
 import {TextSidebarField} from '../SidebarFields/TextSidebarField';
 import {getSidebarFunctions} from './getSidebarFunctions';
 
+const {PluginDocumentSettingPanel} = wp.editor;
 const {dispatch, useSelect} = wp.data;
 const {useEffect} = wp.element;
 const {__} = wp.i18n;

--- a/assets/src/block-editor/Sidebar/CampaignSidebar.js
+++ b/assets/src/block-editor/Sidebar/CampaignSidebar.js
@@ -1,10 +1,10 @@
-import {PluginDocumentSettingPanel} from '@wordpress/editor';
 import {NavigationType} from '../NavigationType/NavigationType';
 import {getSidebarFunctions} from './getSidebarFunctions';
 
-const FIELD_NAVTYPE = 'campaign_nav_type';
-
 const {__} = wp.i18n;
+const {PluginDocumentSettingPanel} = wp.editor;
+
+const FIELD_NAVTYPE = 'campaign_nav_type';
 
 /**
  * Add settings to Campaign pages

--- a/assets/src/block-editor/Sidebar/OpenGraphSidebar.js
+++ b/assets/src/block-editor/Sidebar/OpenGraphSidebar.js
@@ -1,16 +1,16 @@
-import {PluginDocumentSettingPanel} from '@wordpress/editor';
 import {TextareaSidebarField} from '../SidebarFields/TextareaSidebarField';
 import {ImageSidebarField} from '../SidebarFields/ImageSidebarField';
 import {TextSidebarField} from '../SidebarFields/TextSidebarField';
 import {getSidebarFunctions} from './getSidebarFunctions';
+
+const {__} = wp.i18n;
+const {PluginDocumentSettingPanel} = wp.editor;
 
 // The various meta fields
 const OG_TITLE = 'p4_og_title';
 const OG_DESCRIPTION = 'p4_og_description';
 const OG_IMAGE_ID = 'p4_og_image_id';
 const OG_IMAGE_URL = 'p4_og_image';
-
-const {__} = wp.i18n;
 
 /**
  * Open Graph settings for the sidebar

--- a/assets/src/block-editor/Sidebar/PageHeaderSidebar.js
+++ b/assets/src/block-editor/Sidebar/PageHeaderSidebar.js
@@ -1,11 +1,11 @@
-import {PluginDocumentSettingPanel} from '@wordpress/editor';
 import {CheckboxSidebarField} from '../SidebarFields/CheckboxSidebarField';
 import {getSidebarFunctions} from './getSidebarFunctions';
 
+const {__} = wp.i18n;
+const {PluginDocumentSettingPanel} = wp.editor;
+
 // The various meta fields
 const HIDE_PAGE_TITLE = 'p4_hide_page_title_checkbox';
-
-const {__} = wp.i18n;
 
 /**
  * Page header settings for the sidebar

--- a/assets/src/block-editor/Sidebar/SearchEngineOptimizationsSidebar.js
+++ b/assets/src/block-editor/Sidebar/SearchEngineOptimizationsSidebar.js
@@ -1,6 +1,6 @@
-import {PluginDocumentSettingPanel} from '@wordpress/editor';
 import {URLInput} from '../URLInput/URLInput';
 
+const {PluginDocumentSettingPanel} = wp.editor;
 const {useDispatch, useSelect} = wp.data;
 const {__} = wp.i18n;
 

--- a/assets/src/block-editor/Sidebar/SearchEngineOptimizationsSidebar.js
+++ b/assets/src/block-editor/Sidebar/SearchEngineOptimizationsSidebar.js
@@ -1,10 +1,10 @@
 import {PluginDocumentSettingPanel} from '@wordpress/editor';
-import {useDispatch, useSelect} from '@wordpress/data';
 import {URLInput} from '../URLInput/URLInput';
 
-const CANONICAL_URL = 'p4_seo_canonical_url';
-
+const {useDispatch, useSelect} = wp.data;
 const {__} = wp.i18n;
+
+const CANONICAL_URL = 'p4_seo_canonical_url';
 
 export const SearchEngineOptimizationsSidebar = {
   getId: () => 'planet4-seo-sidebar',

--- a/assets/src/block-editor/Sidebar/getSidebarFunctions.js
+++ b/assets/src/block-editor/Sidebar/getSidebarFunctions.js
@@ -1,4 +1,4 @@
-import {useDispatch, useSelect} from '@wordpress/data';
+const {useDispatch, useSelect} = wp.data;
 
 export const getSidebarFunctions = () => {
   const meta = useSelect(select => select('core/editor').getEditedPostAttribute('meta'), []);

--- a/assets/src/block-editor/SidebarFields/CheckboxSidebarField.js
+++ b/assets/src/block-editor/SidebarFields/CheckboxSidebarField.js
@@ -1,4 +1,4 @@
-import {CheckboxControl} from '@wordpress/components';
+const {CheckboxControl} = wp.components;
 
 export const CheckboxSidebarField = ({value, setValue, label}) => (
   <CheckboxControl

--- a/assets/src/block-editor/SidebarFields/ImageSidebarField.js
+++ b/assets/src/block-editor/SidebarFields/ImageSidebarField.js
@@ -1,6 +1,6 @@
-import {MediaUpload, MediaUploadCheck} from '@wordpress/block-editor';
 import {ImageHoverControls} from '../ImageHoverControls';
 
+const {MediaUpload, MediaUploadCheck} = wp.blockEditor;
 const {Button} = wp.components;
 const {__} = wp.i18n;
 

--- a/assets/src/block-editor/SidebarFields/ImageSidebarField.js
+++ b/assets/src/block-editor/SidebarFields/ImageSidebarField.js
@@ -1,7 +1,7 @@
 import {MediaUpload, MediaUploadCheck} from '@wordpress/block-editor';
-import {Button} from '@wordpress/components';
 import {ImageHoverControls} from '../ImageHoverControls';
 
+const {Button} = wp.components;
 const {__} = wp.i18n;
 
 export const ImageSidebarField = ({value, setValue, label}) => (

--- a/assets/src/block-editor/SidebarFields/SelectSidebarField.js
+++ b/assets/src/block-editor/SidebarFields/SelectSidebarField.js
@@ -1,4 +1,4 @@
-import {SelectControl} from '@wordpress/components';
+const {SelectControl} = wp.components;
 
 export const SelectSidebarField = ({options, value, setValue, label}) => (
   <SelectControl

--- a/assets/src/block-editor/SidebarFields/TextSidebarField.js
+++ b/assets/src/block-editor/SidebarFields/TextSidebarField.js
@@ -1,4 +1,4 @@
-import {TextControl} from '@wordpress/components';
+const {TextControl} = wp.components;
 
 export const TextSidebarField = ({value, setValue, label}) => (
   <TextControl

--- a/assets/src/block-editor/SidebarFields/TextareaSidebarField.js
+++ b/assets/src/block-editor/SidebarFields/TextareaSidebarField.js
@@ -1,4 +1,4 @@
-import {TextareaControl} from '@wordpress/components';
+const {TextareaControl} = wp.components;
 
 export const TextareaSidebarField = ({value, setValue, label}) => (
   <TextareaControl

--- a/assets/src/block-editor/URLInput/URLInput.js
+++ b/assets/src/block-editor/URLInput/URLInput.js
@@ -1,5 +1,6 @@
-import {TextControl} from '@wordpress/components';
 import {URLValidationMessage} from '../URLValidationMessage/URLValidationMessage';
+
+const {TextControl} = wp.components;
 
 export const URLInput = props => {
   const {label, placeholder, value, onChange, disabled, help} = props;

--- a/assets/src/block-editor/URLValidationMessage/URLValidationMessage.js
+++ b/assets/src/block-editor/URLValidationMessage/URLValidationMessage.js
@@ -1,4 +1,4 @@
-import {Component} from '@wordpress/element';
+const {Component} = wp.element;
 
 export class URLValidationMessage extends Component {
   isValid(url) {

--- a/assets/src/block-editor/setupCustomSidebar.js
+++ b/assets/src/block-editor/setupCustomSidebar.js
@@ -1,10 +1,11 @@
-import {registerPlugin} from '@wordpress/plugins';
 import {OpenGraphSidebar} from './Sidebar/OpenGraphSidebar';
 import {PageHeaderSidebar} from './Sidebar/PageHeaderSidebar';
 import {ActionSidebar} from './Sidebar/ActionSidebar';
 import {CampaignSidebar} from './Sidebar/CampaignSidebar';
 import {SearchEngineOptimizationsSidebar} from './Sidebar/SearchEngineOptimizationsSidebar';
 import {AnalyticsTrackingSidebar} from './Sidebar/AnalyticsTrackingSidebar';
+
+const {registerPlugin} = wp.plugins;
 
 const sidebarsForPostType = postType => {
   switch (postType) {

--- a/assets/src/block-templates/edit.js
+++ b/assets/src/block-templates/edit.js
@@ -1,4 +1,4 @@
-import {useBlockProps, InnerBlocks} from '@wordpress/block-editor';
+const {useBlockProps, InnerBlocks} = wp.blockEditor;
 
 export default function(template, templateLock = false) {
   return props => {

--- a/assets/src/blocks/Accordion/AccordionEditor.js
+++ b/assets/src/blocks/Accordion/AccordionEditor.js
@@ -1,11 +1,7 @@
 import {InspectorControls, RichText} from '@wordpress/block-editor';
 import {URLInput} from '../../block-editor/URLInput/URLInput';
-import {
-  PanelBody,
-  CheckboxControl,
-  Button,
-} from '@wordpress/components';
 
+const {PanelBody, CheckboxControl, Button} = wp.components;
 const {debounce} = wp.compose;
 const {useState} = wp.element;
 const {__} = wp.i18n;

--- a/assets/src/blocks/Accordion/AccordionEditor.js
+++ b/assets/src/blocks/Accordion/AccordionEditor.js
@@ -1,6 +1,6 @@
-import {InspectorControls, RichText} from '@wordpress/block-editor';
 import {URLInput} from '../../block-editor/URLInput/URLInput';
 
+const {InspectorControls, RichText} = wp.blockEditor;
 const {PanelBody, CheckboxControl, Button} = wp.components;
 const {debounce} = wp.compose;
 const {useState} = wp.element;

--- a/assets/src/blocks/Accordion/AccordionEditor.js
+++ b/assets/src/blocks/Accordion/AccordionEditor.js
@@ -5,8 +5,8 @@ import {
   CheckboxControl,
   Button,
 } from '@wordpress/components';
-import {debounce} from '@wordpress/compose';
 
+const {debounce} = wp.compose;
 const {useState} = wp.element;
 const {__} = wp.i18n;
 

--- a/assets/src/blocks/Accordion/AccordionEditor.js
+++ b/assets/src/blocks/Accordion/AccordionEditor.js
@@ -1,4 +1,3 @@
-import {useState} from '@wordpress/element';
 import {InspectorControls, RichText} from '@wordpress/block-editor';
 import {URLInput} from '../../block-editor/URLInput/URLInput';
 import {
@@ -8,6 +7,7 @@ import {
 } from '@wordpress/components';
 import {debounce} from '@wordpress/compose';
 
+const {useState} = wp.element;
 const {__} = wp.i18n;
 
 // Renders the editor view

--- a/assets/src/blocks/ActionCustomButtonText/edit.js
+++ b/assets/src/blocks/ActionCustomButtonText/edit.js
@@ -1,5 +1,4 @@
-import {useEntityProp} from '@wordpress/core-data';
-
+const {useEntityProp} = wp.data;
 const {__} = wp.i18n;
 
 const DEFAULT_TEXT = window.p4_vars.options.take_action_covers_button_text || __('Take action', 'planet4-blocks');

--- a/assets/src/blocks/ActionCustomButtonText/index.js
+++ b/assets/src/blocks/ActionCustomButtonText/index.js
@@ -1,4 +1,4 @@
-import {registerBlockType} from '@wordpress/blocks';
+const {registerBlockType} = wp.blocks;
 
 import edit from './edit';
 

--- a/assets/src/blocks/CarouselHeader/Caption.js
+++ b/assets/src/blocks/CarouselHeader/Caption.js
@@ -1,4 +1,4 @@
-import {RichText} from '@wordpress/block-editor';
+const {RichText} = wp.blockEditor;
 const {__} = wp.i18n;
 
 export const Caption = ({slide, index, changeSlideAttribute}) => (

--- a/assets/src/blocks/CarouselHeader/CarouselHeaderEditor.js
+++ b/assets/src/blocks/CarouselHeader/CarouselHeaderEditor.js
@@ -1,5 +1,3 @@
-import {useRef} from '@wordpress/element';
-
 // Carousel Header
 import {Slide} from './Slide';
 import {Caption} from './Caption';
@@ -10,6 +8,8 @@ import {CarouselControls} from './CarouselControls';
 import {Sidebar} from './Sidebar';
 import {EditableBackground} from './EditableBackground';
 import {useSelect} from '@wordpress/data';
+
+const {useRef} = wp.element;
 
 export const toSrcSet = sizes => {
   return sizes.map(size => `${size.url || size.source_url} ${size.width}w`).join();

--- a/assets/src/blocks/CarouselHeader/CarouselHeaderEditor.js
+++ b/assets/src/blocks/CarouselHeader/CarouselHeaderEditor.js
@@ -7,8 +7,8 @@ import {CarouselControls} from './CarouselControls';
 // Carousel Header Editor
 import {Sidebar} from './Sidebar';
 import {EditableBackground} from './EditableBackground';
-import {useSelect} from '@wordpress/data';
 
+const {useSelect} = wp.data;
 const {useRef} = wp.element;
 
 export const toSrcSet = sizes => {

--- a/assets/src/blocks/CarouselHeader/CarouselHeaderFrontend.js
+++ b/assets/src/blocks/CarouselHeader/CarouselHeaderFrontend.js
@@ -1,10 +1,10 @@
-import {useRef, useEffect, useState} from '@wordpress/element';
 import {useSlides} from './useSlides';
 import {Slide} from './Slide';
 import {CarouselControls} from './CarouselControls';
 import {SlideBackground} from './SlideBackground';
 import {StaticCaption} from './StaticCaption';
 
+const {useRef, useEffect, useState} = wp.element;
 const isRTL = document.querySelector('html').dir === 'rtl';
 
 const usePageLoaded = () => {

--- a/assets/src/blocks/CarouselHeader/EditableBackground.js
+++ b/assets/src/blocks/CarouselHeader/EditableBackground.js
@@ -1,7 +1,7 @@
-import {MediaUpload, MediaUploadCheck} from '@wordpress/block-editor';
 import {ImagePlaceholder} from './ImagePlaceholder';
 import {toSrcSet} from './CarouselHeaderEditor';
 
+const {MediaUpload, MediaUploadCheck} = wp.blockEditor;
 const {Button, Dropdown} = wp.components;
 const {__} = wp.i18n;
 

--- a/assets/src/blocks/CarouselHeader/EditableBackground.js
+++ b/assets/src/blocks/CarouselHeader/EditableBackground.js
@@ -1,7 +1,8 @@
 import {MediaUpload, MediaUploadCheck} from '@wordpress/block-editor';
 import {ImagePlaceholder} from './ImagePlaceholder';
-import {Button, Dropdown} from '@wordpress/components';
 import {toSrcSet} from './CarouselHeaderEditor';
+
+const {Button, Dropdown} = wp.components;
 const {__} = wp.i18n;
 
 export const EditableBackground = ({

--- a/assets/src/blocks/CarouselHeader/Sidebar.js
+++ b/assets/src/blocks/CarouselHeader/Sidebar.js
@@ -1,10 +1,7 @@
-import {
-  CheckboxControl,
-  PanelBody,
-} from '@wordpress/components';
 import {InspectorControls} from '@wordpress/block-editor';
 import {SidebarSlide} from './SidebarSlide';
 
+const {CheckboxControl, PanelBody} = wp.components;
 const {useState, useRef, useEffect} = wp.element;
 const {__} = wp.i18n;
 

--- a/assets/src/blocks/CarouselHeader/Sidebar.js
+++ b/assets/src/blocks/CarouselHeader/Sidebar.js
@@ -1,4 +1,3 @@
-import {useState, useRef, useEffect} from '@wordpress/element';
 import {
   CheckboxControl,
   PanelBody,
@@ -6,6 +5,7 @@ import {
 import {InspectorControls} from '@wordpress/block-editor';
 import {SidebarSlide} from './SidebarSlide';
 
+const {useState, useRef, useEffect} = wp.element;
 const {__} = wp.i18n;
 
 const getNode = index => (

--- a/assets/src/blocks/CarouselHeader/Sidebar.js
+++ b/assets/src/blocks/CarouselHeader/Sidebar.js
@@ -1,6 +1,6 @@
-import {InspectorControls} from '@wordpress/block-editor';
 import {SidebarSlide} from './SidebarSlide';
 
+const {InspectorControls} = wp.blockEditor;
 const {CheckboxControl, PanelBody} = wp.components;
 const {useState, useRef, useEffect} = wp.element;
 const {__} = wp.i18n;

--- a/assets/src/blocks/CarouselHeader/SidebarSlide.js
+++ b/assets/src/blocks/CarouselHeader/SidebarSlide.js
@@ -5,7 +5,8 @@ import {
   CheckboxControl,
 } from '@wordpress/components';
 import {URLInput} from '../../block-editor/URLInput/URLInput';
-import {useState} from '@wordpress/element';
+
+const {useState} = wp.element;
 const {__} = wp.i18n;
 
 export const SidebarSlide = ({

--- a/assets/src/blocks/CarouselHeader/SidebarSlide.js
+++ b/assets/src/blocks/CarouselHeader/SidebarSlide.js
@@ -1,11 +1,6 @@
-import {
-  PanelRow,
-  PanelBody,
-  FocalPointPicker,
-  CheckboxControl,
-} from '@wordpress/components';
 import {URLInput} from '../../block-editor/URLInput/URLInput';
 
+const {PanelRow, PanelBody, FocalPointPicker, CheckboxControl} = wp.components;
 const {useState} = wp.element;
 const {__} = wp.i18n;
 

--- a/assets/src/blocks/CarouselHeader/Slide.js
+++ b/assets/src/blocks/CarouselHeader/Slide.js
@@ -1,6 +1,4 @@
-import {
-  forwardRef,
-} from '@wordpress/element';
+const {forwardRef} = wp.element;
 
 export const SlideWithRef = ({
   children,

--- a/assets/src/blocks/CarouselHeader/useSlides.js
+++ b/assets/src/blocks/CarouselHeader/useSlides.js
@@ -1,4 +1,4 @@
-import {useEffect, useState} from '@wordpress/element';
+const {useEffect, useState} = wp.element;
 
 const activeClass = 'active';
 

--- a/assets/src/blocks/Columns/ColumnsEditor.js
+++ b/assets/src/blocks/Columns/ColumnsEditor.js
@@ -1,8 +1,3 @@
-import {
-  CheckboxControl,
-  PanelBody,
-  RangeControl,
-} from '@wordpress/components';
 import {useSelect} from '@wordpress/data';
 import {InspectorControls, RichText} from '@wordpress/block-editor';
 import {URLInput} from '../../block-editor/URLInput/URLInput';
@@ -11,6 +6,7 @@ import {Columns} from './Columns';
 import {MAX_COLUMNS_AMOUNT, MIN_COLUMNS_AMOUNT} from './ColumnConstants';
 import {getStyleFromClassName} from '../../functions/getStyleFromClassName';
 
+const {CheckboxControl, PanelBody, RangeControl} = wp.components;
 const {useEffect} = wp.element;
 const {__} = wp.i18n;
 

--- a/assets/src/blocks/Columns/ColumnsEditor.js
+++ b/assets/src/blocks/Columns/ColumnsEditor.js
@@ -1,11 +1,11 @@
 import {useSelect} from '@wordpress/data';
-import {InspectorControls, RichText} from '@wordpress/block-editor';
 import {URLInput} from '../../block-editor/URLInput/URLInput';
 import {EditableColumns} from './EditableColumns';
 import {Columns} from './Columns';
 import {MAX_COLUMNS_AMOUNT, MIN_COLUMNS_AMOUNT} from './ColumnConstants';
 import {getStyleFromClassName} from '../../functions/getStyleFromClassName';
 
+const {InspectorControls, RichText} = wp.blockEditor;
 const {CheckboxControl, PanelBody, RangeControl} = wp.components;
 const {useEffect} = wp.element;
 const {__} = wp.i18n;

--- a/assets/src/blocks/Columns/ColumnsEditor.js
+++ b/assets/src/blocks/Columns/ColumnsEditor.js
@@ -4,15 +4,14 @@ import {
   RangeControl,
 } from '@wordpress/components';
 import {useSelect} from '@wordpress/data';
-import {useEffect} from '@wordpress/element';
 import {InspectorControls, RichText} from '@wordpress/block-editor';
-
 import {URLInput} from '../../block-editor/URLInput/URLInput';
 import {EditableColumns} from './EditableColumns';
 import {Columns} from './Columns';
 import {MAX_COLUMNS_AMOUNT, MIN_COLUMNS_AMOUNT} from './ColumnConstants';
 import {getStyleFromClassName} from '../../functions/getStyleFromClassName';
 
+const {useEffect} = wp.element;
 const {__} = wp.i18n;
 
 const renderEdit = (attributes, toAttribute, setAttributes, isSelected) => {

--- a/assets/src/blocks/Columns/ColumnsEditor.js
+++ b/assets/src/blocks/Columns/ColumnsEditor.js
@@ -1,10 +1,10 @@
-import {useSelect} from '@wordpress/data';
 import {URLInput} from '../../block-editor/URLInput/URLInput';
 import {EditableColumns} from './EditableColumns';
 import {Columns} from './Columns';
 import {MAX_COLUMNS_AMOUNT, MIN_COLUMNS_AMOUNT} from './ColumnConstants';
 import {getStyleFromClassName} from '../../functions/getStyleFromClassName';
 
+const {useSelect} = wp.data;
 const {InspectorControls, RichText} = wp.blockEditor;
 const {CheckboxControl, PanelBody, RangeControl} = wp.components;
 const {useEffect} = wp.element;

--- a/assets/src/blocks/Columns/ColumnsFrontend.js
+++ b/assets/src/blocks/Columns/ColumnsFrontend.js
@@ -1,6 +1,7 @@
-import {useEffect} from '@wordpress/element';
 import {LAYOUT_TASKS} from './ColumnConstants';
 import {Columns} from './Columns';
+
+const {useEffect} = wp.element;
 
 export const ColumnsFrontend = ({columns_block_style, columns_title, columns_description, columns, className}) => {
   const postType = document.body.getAttribute('data-post-type');

--- a/assets/src/blocks/Columns/EditableColumns.js
+++ b/assets/src/blocks/Columns/EditableColumns.js
@@ -1,8 +1,8 @@
 import {LAYOUT_NO_IMAGE, LAYOUT_ICONS, LAYOUT_TASKS, LAYOUT_IMAGES} from './ColumnConstants';
-import {MediaUpload, MediaUploadCheck, RichText} from '@wordpress/block-editor';
 import {ColumnsImagePlaceholder} from './ColumnsImagePlaceholder';
 import {ImageHoverControls} from '../../block-editor/ImageHoverControls';
 
+const {MediaUpload, MediaUploadCheck, RichText} = wp.blockEditor;
 const {Button} = wp.components;
 const {__} = wp.i18n;
 

--- a/assets/src/blocks/Columns/EditableColumns.js
+++ b/assets/src/blocks/Columns/EditableColumns.js
@@ -1,9 +1,9 @@
 import {LAYOUT_NO_IMAGE, LAYOUT_ICONS, LAYOUT_TASKS, LAYOUT_IMAGES} from './ColumnConstants';
 import {MediaUpload, MediaUploadCheck, RichText} from '@wordpress/block-editor';
-import {Button} from '@wordpress/components';
 import {ColumnsImagePlaceholder} from './ColumnsImagePlaceholder';
 import {ImageHoverControls} from '../../block-editor/ImageHoverControls';
 
+const {Button} = wp.components;
 const {__} = wp.i18n;
 
 export const EditableColumns = ({

--- a/assets/src/blocks/Cookies/CookiesFieldResetButton.js
+++ b/assets/src/blocks/Cookies/CookiesFieldResetButton.js
@@ -1,6 +1,5 @@
 const {__} = wp.i18n;
-
-import {Tooltip} from '@wordpress/components';
+const {Tooltip} = wp.components;
 
 const COOKIES_DEFAULT_COPY = window.p4_vars.options.cookies_default_copy || {};
 

--- a/assets/src/blocks/Cookies/CookiesFrontend.js
+++ b/assets/src/blocks/Cookies/CookiesFrontend.js
@@ -1,9 +1,9 @@
 import {FrontendRichText} from '../components/FrontendRichText/FrontendRichText';
 import {removeCookie, useCookie, writeCookie} from './useCookie';
-import {useState, useEffect} from '@wordpress/element';
 import {CookiesFieldResetButton} from './CookiesFieldResetButton';
 
 const {__} = wp.i18n;
+const {useState, useEffect} = wp.element;
 
 const dataLayer = window.dataLayer || [];
 

--- a/assets/src/blocks/Cookies/useCookie.js
+++ b/assets/src/blocks/Cookies/useCookie.js
@@ -1,4 +1,4 @@
-import {useState, useEffect} from '@wordpress/element';
+const {useState, useEffect} = wp.element;
 
 export const readCookie = name => {
   const declarations = document.cookie.split(';');

--- a/assets/src/blocks/Counter/CounterEditor.js
+++ b/assets/src/blocks/Counter/CounterEditor.js
@@ -1,12 +1,8 @@
 import {InspectorControls, RichText} from '@wordpress/block-editor';
-import {
-  TextControl,
-  TextareaControl,
-  PanelBody,
-} from '@wordpress/components';
 import {URLInput} from '../../block-editor/URLInput/URLInput';
 import {CounterFrontend} from './CounterFrontend';
 
+const {TextControl, TextareaControl, PanelBody} = wp.components;
 const {__} = wp.i18n;
 
 export const CounterEditor = ({setAttributes, attributes, isSelected}) => {

--- a/assets/src/blocks/Counter/CounterEditor.js
+++ b/assets/src/blocks/Counter/CounterEditor.js
@@ -1,7 +1,7 @@
-import {InspectorControls, RichText} from '@wordpress/block-editor';
 import {URLInput} from '../../block-editor/URLInput/URLInput';
 import {CounterFrontend} from './CounterFrontend';
 
+const {InspectorControls, RichText} = wp.blockEditor;
 const {TextControl, TextareaControl, PanelBody} = wp.components;
 const {__} = wp.i18n;
 

--- a/assets/src/blocks/Counter/CounterFrontend.js
+++ b/assets/src/blocks/Counter/CounterFrontend.js
@@ -1,5 +1,6 @@
-import {Component} from '@wordpress/element';
 import {getStyleFromClassName} from '../../functions/getStyleFromClassName';
+
+const {Component} = wp.element;
 
 export class CounterFrontend extends Component {
   constructor(props) {

--- a/assets/src/blocks/ENForm/ENFormEditor.js
+++ b/assets/src/blocks/ENForm/ENFormEditor.js
@@ -2,7 +2,7 @@ import {ENFormInPlaceEdit} from './ENFormInPlaceEdit';
 import {ENFormSettings} from './ENFormSettings';
 import {getStyleFromClassName} from '../../functions/getStyleFromClassName';
 
-import {useSelect} from '@wordpress/data';
+const {useSelect} = wp.data;
 
 export const ENFormEditor = ({attributes, setAttributes}) => {
   return (

--- a/assets/src/blocks/ENForm/ENFormFrontend.js
+++ b/assets/src/blocks/ENForm/ENFormFrontend.js
@@ -1,10 +1,9 @@
 import {ShareButtons} from './ShareButtons';
 import {FormGenerator} from './FormGenerator';
-import {useState} from '@wordpress/element';
 import {unescape} from '../../functions/unescape';
-
 import {inputId} from './inputId';
 
+const {useState} = wp.element;
 const {__} = wp.i18n;
 
 export const ENFormFrontend = ({attributes}) => {

--- a/assets/src/blocks/ENForm/ENFormInPlaceEdit.js
+++ b/assets/src/blocks/ENForm/ENFormInPlaceEdit.js
@@ -3,8 +3,8 @@ import {ShareButtons} from './ShareButtons';
 import {RichText, BlockControls} from '@wordpress/block-editor';
 import {ToolbarGroup} from '@wordpress/components';
 import {useSelect} from '@wordpress/data';
-import {useState} from '@wordpress/element';
 
+const {useState} = wp.element;
 const {__} = wp.i18n;
 
 export const ENFormInPlaceEdit = ({attributes, setAttributes}) => {

--- a/assets/src/blocks/ENForm/ENFormInPlaceEdit.js
+++ b/assets/src/blocks/ENForm/ENFormInPlaceEdit.js
@@ -1,7 +1,7 @@
 import {FormGenerator} from './FormGenerator';
 import {ShareButtons} from './ShareButtons';
-import {useSelect} from '@wordpress/data';
 
+const {useSelect} = wp.data;
 const {RichText, BlockControls} = wp.blockEditor;
 const {ToolbarGroup} = wp.components;
 const {useState} = wp.element;

--- a/assets/src/blocks/ENForm/ENFormInPlaceEdit.js
+++ b/assets/src/blocks/ENForm/ENFormInPlaceEdit.js
@@ -1,8 +1,8 @@
 import {FormGenerator} from './FormGenerator';
 import {ShareButtons} from './ShareButtons';
-import {RichText, BlockControls} from '@wordpress/block-editor';
 import {useSelect} from '@wordpress/data';
 
+const {RichText, BlockControls} = wp.blockEditor;
 const {ToolbarGroup} = wp.components;
 const {useState} = wp.element;
 const {__} = wp.i18n;

--- a/assets/src/blocks/ENForm/ENFormInPlaceEdit.js
+++ b/assets/src/blocks/ENForm/ENFormInPlaceEdit.js
@@ -1,9 +1,9 @@
 import {FormGenerator} from './FormGenerator';
 import {ShareButtons} from './ShareButtons';
 import {RichText, BlockControls} from '@wordpress/block-editor';
-import {ToolbarGroup} from '@wordpress/components';
 import {useSelect} from '@wordpress/data';
 
+const {ToolbarGroup} = wp.components;
 const {useState} = wp.element;
 const {__} = wp.i18n;
 

--- a/assets/src/blocks/ENForm/ENFormSettings.js
+++ b/assets/src/blocks/ENForm/ENFormSettings.js
@@ -1,7 +1,7 @@
-import {InspectorControls} from '@wordpress/block-editor';
 import {URLInput} from '../../block-editor/URLInput/URLInput';
 import {ImageOrButton} from '../../block-editor/ImageOrButton/ImageOrButton';
 
+const {InspectorControls} = wp.blockEditor;
 const {BaseControl, FocalPointPicker, PanelBody, SelectControl, ToggleControl} = wp.components;
 const {getCurrentPostType} = wp.data.select('core/editor');
 const {__} = wp.i18n;

--- a/assets/src/blocks/ENForm/ENFormSettings.js
+++ b/assets/src/blocks/ENForm/ENFormSettings.js
@@ -1,8 +1,8 @@
-import {BaseControl, FocalPointPicker, PanelBody, SelectControl, ToggleControl} from '@wordpress/components';
 import {InspectorControls} from '@wordpress/block-editor';
 import {URLInput} from '../../block-editor/URLInput/URLInput';
 import {ImageOrButton} from '../../block-editor/ImageOrButton/ImageOrButton';
 
+const {BaseControl, FocalPointPicker, PanelBody, SelectControl, ToggleControl} = wp.components;
 const {getCurrentPostType} = wp.data.select('core/editor');
 const {__} = wp.i18n;
 

--- a/assets/src/blocks/Gallery/GalleryCarousel.js
+++ b/assets/src/blocks/Gallery/GalleryCarousel.js
@@ -1,8 +1,8 @@
-import {useState, useEffect, useRef} from '@wordpress/element';
 import {IMAGE_SIZES} from './imageSizes';
 import {getCaptionWithCredits} from './getCaptionWithCredits.js';
 
 const {__} = wp.i18n;
+const {useState, useEffect, useRef} = wp.element;
 
 const isRTL = document.querySelector('html').dir === 'rtl';
 

--- a/assets/src/blocks/Gallery/GalleryEditor.js
+++ b/assets/src/blocks/Gallery/GalleryEditor.js
@@ -1,10 +1,10 @@
 import {getGalleryLayout, GALLERY_BLOCK_CLASSES} from './getGalleryLayout';
-import {useSelect} from '@wordpress/data';
 import {GalleryCarousel} from './GalleryCarousel';
 import {GalleryThreeColumns} from './GalleryThreeColumns';
 import {GalleryGrid} from './GalleryGrid';
 import {useGalleryImages} from './useGalleryImages';
 
+const {useSelect} = wp.data;
 const {InspectorControls, MediaPlaceholder, MediaUploadCheck, RichText} = wp.blockEditor;
 const {FocalPointPicker, PanelBody} = wp.components;
 const {__} = wp.i18n;

--- a/assets/src/blocks/Gallery/GalleryEditor.js
+++ b/assets/src/blocks/Gallery/GalleryEditor.js
@@ -4,8 +4,8 @@ import {GalleryCarousel} from './GalleryCarousel';
 import {GalleryThreeColumns} from './GalleryThreeColumns';
 import {GalleryGrid} from './GalleryGrid';
 import {useGalleryImages} from './useGalleryImages';
-import {InspectorControls, MediaPlaceholder, MediaUploadCheck, RichText} from '@wordpress/block-editor';
 
+const {InspectorControls, MediaPlaceholder, MediaUploadCheck, RichText} = wp.blockEditor;
 const {FocalPointPicker, PanelBody} = wp.components;
 const {__} = wp.i18n;
 

--- a/assets/src/blocks/Gallery/GalleryEditor.js
+++ b/assets/src/blocks/Gallery/GalleryEditor.js
@@ -1,4 +1,3 @@
-import {FocalPointPicker, PanelBody} from '@wordpress/components';
 import {getGalleryLayout, GALLERY_BLOCK_CLASSES} from './getGalleryLayout';
 import {useSelect} from '@wordpress/data';
 import {GalleryCarousel} from './GalleryCarousel';
@@ -7,6 +6,7 @@ import {GalleryGrid} from './GalleryGrid';
 import {useGalleryImages} from './useGalleryImages';
 import {InspectorControls, MediaPlaceholder, MediaUploadCheck, RichText} from '@wordpress/block-editor';
 
+const {FocalPointPicker, PanelBody} = wp.components;
 const {__} = wp.i18n;
 
 const renderEdit = (attributes, setAttributes, isSelected) => {

--- a/assets/src/blocks/Gallery/GalleryFrontend.js
+++ b/assets/src/blocks/Gallery/GalleryFrontend.js
@@ -1,4 +1,3 @@
-import {useEffect, useState} from '@wordpress/element';
 import {GalleryCarousel} from './GalleryCarousel';
 import {GalleryThreeColumns} from './GalleryThreeColumns';
 import {GalleryGrid} from './GalleryGrid';
@@ -6,6 +5,8 @@ import {getGalleryLayout, GALLERY_BLOCK_CLASSES} from './getGalleryLayout';
 import {getCaptionWithCredits} from './getCaptionWithCredits.js';
 import {Lightbox} from '../components/Lightbox/Lightbox';
 import {useLightbox} from '../components/Lightbox/useLightbox';
+
+const {useEffect, useState} = wp.element;
 
 const imagesToItems = images => images.map(
   image => ({

--- a/assets/src/blocks/Gallery/useGalleryImages.js
+++ b/assets/src/blocks/Gallery/useGalleryImages.js
@@ -1,9 +1,9 @@
-import {useState, useEffect} from '@wordpress/element';
 import {fetchJson} from '../../functions/fetchJson';
 import {addQueryArgs} from '../../functions/addQueryArgs';
 import {getAbortController} from '../../functions/getAbortController';
 
 const {apiFetch} = wp;
+const {useState, useEffect} = wp.element;
 
 const GALLERY_IMAGE_SIZES = {
   slider: 'retina-large',

--- a/assets/src/blocks/Happypoint/HappypointEditor.js
+++ b/assets/src/blocks/Happypoint/HappypointEditor.js
@@ -1,14 +1,9 @@
-import {
-  InspectorControls,
-  BlockControls,
-  MediaUpload,
-  MediaUploadCheck,
-} from '@wordpress/block-editor';
 import {useSelect} from '@wordpress/data';
 import {HappypointFrontend} from './HappypointFrontend';
 import {USE_EMBED_CODE, USE_IFRAME_URL, USE_NONE} from './HappypointConstants';
 import {OverrideFormHelp} from './OverrideFormHelp';
 
+const {InspectorControls, BlockControls, MediaUpload, MediaUploadCheck} = wp.blockEditor;
 const {debounce} = wp.compose;
 const {useState} = wp.element;
 const {

--- a/assets/src/blocks/Happypoint/HappypointEditor.js
+++ b/assets/src/blocks/Happypoint/HappypointEditor.js
@@ -11,9 +11,7 @@ import {OverrideFormHelp} from './OverrideFormHelp';
 
 const {debounce} = wp.compose;
 const {useState} = wp.element;
-const {__} = wp.i18n;
-
-import {
+const {
   TextControl,
   TextareaControl,
   FocalPointPicker,
@@ -24,7 +22,8 @@ import {
   Button,
   ToolbarGroup,
   ToolbarButton,
-} from '@wordpress/components';
+} = wp.components;
+const {__} = wp.i18n;
 
 export const HappypointEditor = ({attributes, setAttributes, isSelected}) => {
   const {

--- a/assets/src/blocks/Happypoint/HappypointEditor.js
+++ b/assets/src/blocks/Happypoint/HappypointEditor.js
@@ -5,11 +5,11 @@ import {
   MediaUploadCheck,
 } from '@wordpress/block-editor';
 import {useSelect} from '@wordpress/data';
-import {debounce} from '@wordpress/compose';
 import {HappypointFrontend} from './HappypointFrontend';
 import {USE_EMBED_CODE, USE_IFRAME_URL, USE_NONE} from './HappypointConstants';
 import {OverrideFormHelp} from './OverrideFormHelp';
 
+const {debounce} = wp.compose;
 const {useState} = wp.element;
 const {__} = wp.i18n;
 

--- a/assets/src/blocks/Happypoint/HappypointEditor.js
+++ b/assets/src/blocks/Happypoint/HappypointEditor.js
@@ -4,13 +4,13 @@ import {
   MediaUpload,
   MediaUploadCheck,
 } from '@wordpress/block-editor';
-import {useState} from '@wordpress/element';
 import {useSelect} from '@wordpress/data';
 import {debounce} from '@wordpress/compose';
 import {HappypointFrontend} from './HappypointFrontend';
 import {USE_EMBED_CODE, USE_IFRAME_URL, USE_NONE} from './HappypointConstants';
 import {OverrideFormHelp} from './OverrideFormHelp';
 
+const {useState} = wp.element;
 const {__} = wp.i18n;
 
 import {

--- a/assets/src/blocks/Happypoint/HappypointEditor.js
+++ b/assets/src/blocks/Happypoint/HappypointEditor.js
@@ -1,8 +1,8 @@
-import {useSelect} from '@wordpress/data';
 import {HappypointFrontend} from './HappypointFrontend';
 import {USE_EMBED_CODE, USE_IFRAME_URL, USE_NONE} from './HappypointConstants';
 import {OverrideFormHelp} from './OverrideFormHelp';
 
+const {useSelect} = wp.data;
 const {InspectorControls, BlockControls, MediaUpload, MediaUploadCheck} = wp.blockEditor;
 const {debounce} = wp.compose;
 const {useState} = wp.element;

--- a/assets/src/blocks/Happypoint/useHappypointImageData.js
+++ b/assets/src/blocks/Happypoint/useHappypointImageData.js
@@ -1,8 +1,8 @@
-import {useState, useEffect} from '@wordpress/element';
 import {fetchJson} from '../../functions/fetchJson';
 import {addQueryArgs} from '../../functions/addQueryArgs';
 
 const {apiFetch} = wp;
+const {useState, useEffect} = wp.element;
 
 export const useHappypointImageData = imageId => {
   const [imageData, setImageData] = useState({});

--- a/assets/src/blocks/Media/MediaEditor.js
+++ b/assets/src/blocks/Media/MediaEditor.js
@@ -1,7 +1,7 @@
 import {MediaElementVideo} from './MediaElementVideo';
-import {useSelect} from '@wordpress/data';
 import {lacksAttributes} from './MediaBlock';
 
+const {useSelect} = wp.data;
 const {MediaPlaceholder, InspectorControls, RichText} = wp.blockEditor;
 const {__} = wp.i18n;
 const {apiFetch} = wp;

--- a/assets/src/blocks/Media/MediaEditor.js
+++ b/assets/src/blocks/Media/MediaEditor.js
@@ -7,8 +7,8 @@ const {__} = wp.i18n;
 const {apiFetch} = wp;
 const {debounce} = wp.compose;
 const {PanelBody, TextControl} = wp.components;
-const {url: {addQueryArgs}} = wp.url;
-const {element: {Fragment, useCallback}} = wp.element;
+const {addQueryArgs} = wp.url;
+const {Fragment, useCallback} = wp.element;
 
 const MediaInspectorOptions = ({attributes, setAttributes}) => {
   const {media_url} = attributes;

--- a/assets/src/blocks/Media/MediaEditor.js
+++ b/assets/src/blocks/Media/MediaEditor.js
@@ -1,8 +1,8 @@
-import {MediaPlaceholder, InspectorControls, RichText} from '@wordpress/block-editor';
 import {MediaElementVideo} from './MediaElementVideo';
 import {useSelect} from '@wordpress/data';
 import {lacksAttributes} from './MediaBlock';
 
+const {MediaPlaceholder, InspectorControls, RichText} = wp.blockEditor;
 const {__} = wp.i18n;
 const {apiFetch} = wp;
 const {debounce} = wp.compose;

--- a/assets/src/blocks/Media/MediaEditor.js
+++ b/assets/src/blocks/Media/MediaEditor.js
@@ -1,4 +1,3 @@
-import {PanelBody, TextControl} from '@wordpress/components';
 import {MediaPlaceholder, InspectorControls, RichText} from '@wordpress/block-editor';
 import {MediaElementVideo} from './MediaElementVideo';
 import {useSelect} from '@wordpress/data';
@@ -7,6 +6,7 @@ import {lacksAttributes} from './MediaBlock';
 const {__} = wp.i18n;
 const {apiFetch} = wp;
 const {debounce} = wp.compose;
+const {PanelBody, TextControl} = wp.components;
 const {url: {addQueryArgs}} = wp.url;
 const {element: {Fragment, useCallback}} = wp.element;
 

--- a/assets/src/blocks/Media/MediaEditor.js
+++ b/assets/src/blocks/Media/MediaEditor.js
@@ -1,15 +1,14 @@
-import {Fragment, useCallback} from '@wordpress/element';
 import {PanelBody, TextControl} from '@wordpress/components';
 import {MediaPlaceholder, InspectorControls, RichText} from '@wordpress/block-editor';
 import {debounce} from '@wordpress/compose';
-
 import {MediaElementVideo} from './MediaElementVideo';
 import {useSelect} from '@wordpress/data';
 import {lacksAttributes} from './MediaBlock';
 
 const {__} = wp.i18n;
 const {apiFetch} = wp;
-const {addQueryArgs} = wp.url;
+const {url: {addQueryArgs}} = wp.url;
+const {element: {Fragment, useCallback}} = wp.element;
 
 const MediaInspectorOptions = ({attributes, setAttributes}) => {
   const {media_url} = attributes;

--- a/assets/src/blocks/Media/MediaEditor.js
+++ b/assets/src/blocks/Media/MediaEditor.js
@@ -1,12 +1,12 @@
 import {PanelBody, TextControl} from '@wordpress/components';
 import {MediaPlaceholder, InspectorControls, RichText} from '@wordpress/block-editor';
-import {debounce} from '@wordpress/compose';
 import {MediaElementVideo} from './MediaElementVideo';
 import {useSelect} from '@wordpress/data';
 import {lacksAttributes} from './MediaBlock';
 
 const {__} = wp.i18n;
 const {apiFetch} = wp;
+const {debounce} = wp.compose;
 const {url: {addQueryArgs}} = wp.url;
 const {element: {Fragment, useCallback}} = wp.element;
 

--- a/assets/src/blocks/SocialMedia/SocialMediaEditorScript.js
+++ b/assets/src/blocks/SocialMedia/SocialMediaEditorScript.js
@@ -1,9 +1,4 @@
 import {InspectorControls, RichText} from '@wordpress/block-editor';
-import {
-  RadioControl,
-  SelectControl,
-  PanelBody,
-} from '@wordpress/components';
 import {SocialMediaEmbed} from './SocialMediaEmbed';
 import {URLInput} from '../../block-editor/URLInput/URLInput';
 import {HTMLSidebarHelp} from '../../block-editor/HTMLSidebarHelp/HTMLSidebarHelp';
@@ -16,6 +11,7 @@ import {
   ALLOWED_OEMBED_PROVIDERS,
 } from './SocialMediaConstants.js';
 
+const {RadioControl, SelectControl, PanelBody} = wp.components;
 const {__} = wp.i18n;
 const {apiFetch} = wp;
 const {addQueryArgs} = wp.url;

--- a/assets/src/blocks/SocialMedia/SocialMediaEditorScript.js
+++ b/assets/src/blocks/SocialMedia/SocialMediaEditorScript.js
@@ -1,4 +1,3 @@
-import {InspectorControls, RichText} from '@wordpress/block-editor';
 import {SocialMediaEmbed} from './SocialMediaEmbed';
 import {URLInput} from '../../block-editor/URLInput/URLInput';
 import {HTMLSidebarHelp} from '../../block-editor/HTMLSidebarHelp/HTMLSidebarHelp';
@@ -11,6 +10,7 @@ import {
   ALLOWED_OEMBED_PROVIDERS,
 } from './SocialMediaConstants.js';
 
+const {InspectorControls, RichText} = wp.blockEditor;
 const {RadioControl, SelectControl, PanelBody} = wp.components;
 const {__} = wp.i18n;
 const {apiFetch} = wp;

--- a/assets/src/blocks/SocialMedia/SocialMediaEditorScript.js
+++ b/assets/src/blocks/SocialMedia/SocialMediaEditorScript.js
@@ -1,4 +1,3 @@
-import {useEffect} from '@wordpress/element';
 import {InspectorControls, RichText} from '@wordpress/block-editor';
 import {
   RadioControl,
@@ -20,6 +19,7 @@ import {
 const {__} = wp.i18n;
 const {apiFetch} = wp;
 const {addQueryArgs} = wp.url;
+const {useEffect} = wp.element;
 
 const loadScriptAsync = uri => {
   // eslint-disable-next-line no-unused-vars

--- a/assets/src/blocks/Spreadsheet/SpreadsheetEditor.js
+++ b/assets/src/blocks/Spreadsheet/SpreadsheetEditor.js
@@ -1,8 +1,8 @@
 import {InspectorControls} from '@wordpress/block-editor';
 import ColorPaletteControl from '../../block-editor/ColorPaletteControl/ColorPaletteControl';
 import {SpreadsheetFrontend} from './SpreadsheetFrontend';
-import {TextControl, PanelBody} from '@wordpress/components';
 
+const {TextControl, PanelBody} = wp.components;
 const {__} = wp.i18n;
 const {debounce} = wp.compose;
 const {useState} = wp.element;

--- a/assets/src/blocks/Spreadsheet/SpreadsheetEditor.js
+++ b/assets/src/blocks/Spreadsheet/SpreadsheetEditor.js
@@ -1,4 +1,3 @@
-import {useState} from '@wordpress/element';
 import {InspectorControls} from '@wordpress/block-editor';
 import ColorPaletteControl from '../../block-editor/ColorPaletteControl/ColorPaletteControl';
 import {SpreadsheetFrontend} from './SpreadsheetFrontend';
@@ -6,6 +5,7 @@ import {debounce} from '@wordpress/compose';
 import {TextControl, PanelBody} from '@wordpress/components';
 
 const {__} = wp.i18n;
+const {useState} = wp.element;
 
 const colors = [
   {name: 'blue', color: '#167f82'},

--- a/assets/src/blocks/Spreadsheet/SpreadsheetEditor.js
+++ b/assets/src/blocks/Spreadsheet/SpreadsheetEditor.js
@@ -1,7 +1,7 @@
-import {InspectorControls} from '@wordpress/block-editor';
 import ColorPaletteControl from '../../block-editor/ColorPaletteControl/ColorPaletteControl';
 import {SpreadsheetFrontend} from './SpreadsheetFrontend';
 
+const {InspectorControls} = wp.blockEditor;
 const {TextControl, PanelBody} = wp.components;
 const {__} = wp.i18n;
 const {debounce} = wp.compose;

--- a/assets/src/blocks/Spreadsheet/SpreadsheetEditor.js
+++ b/assets/src/blocks/Spreadsheet/SpreadsheetEditor.js
@@ -1,10 +1,10 @@
 import {InspectorControls} from '@wordpress/block-editor';
 import ColorPaletteControl from '../../block-editor/ColorPaletteControl/ColorPaletteControl';
 import {SpreadsheetFrontend} from './SpreadsheetFrontend';
-import {debounce} from '@wordpress/compose';
 import {TextControl, PanelBody} from '@wordpress/components';
 
 const {__} = wp.i18n;
+const {debounce} = wp.compose;
 const {useState} = wp.element;
 
 const colors = [

--- a/assets/src/blocks/Spreadsheet/SpreadsheetFrontend.js
+++ b/assets/src/blocks/Spreadsheet/SpreadsheetFrontend.js
@@ -1,10 +1,10 @@
-import {useState, useEffect} from '@wordpress/element';
 import {ArrowIcon} from './ArrowIcon';
 import {HighlightMatches} from './HighlightMatches';
 import {fetchJson} from '../../functions/fetchJson';
 import {addQueryArgs} from '../../functions/addQueryArgs';
 
 const {apiFetch} = wp;
+const {useState, useEffect} = wp.element;
 const {__} = wp.i18n;
 
 const placeholderData = {

--- a/assets/src/blocks/Submenu/SubmenuEditor.js
+++ b/assets/src/blocks/Submenu/SubmenuEditor.js
@@ -1,4 +1,3 @@
-import {Button, PanelBody} from '@wordpress/components';
 import {SubmenuLevel} from './SubmenuLevel';
 import {SubmenuItems} from './SubmenuItems';
 import {InspectorControls, RichText} from '@wordpress/block-editor';
@@ -8,6 +7,7 @@ import {getHeadingsFromBlocks} from './getHeadingsFromBlocks';
 import {useSelect} from '@wordpress/data';
 import {deepClone} from '../../functions/deepClone';
 
+const {Button, PanelBody} = wp.components;
 const {__} = wp.i18n;
 
 const renderEdit = (attributes, setAttributes) => {

--- a/assets/src/blocks/Submenu/SubmenuEditor.js
+++ b/assets/src/blocks/Submenu/SubmenuEditor.js
@@ -1,12 +1,12 @@
 import {SubmenuLevel} from './SubmenuLevel';
 import {SubmenuItems} from './SubmenuItems';
-import {InspectorControls, RichText} from '@wordpress/block-editor';
 import {getSubmenuStyle} from './getSubmenuStyle';
 import {makeHierarchical} from './makeHierarchical';
 import {getHeadingsFromBlocks} from './getHeadingsFromBlocks';
 import {useSelect} from '@wordpress/data';
 import {deepClone} from '../../functions/deepClone';
 
+const {InspectorControls, RichText} = wp.blockEditor;
 const {Button, PanelBody} = wp.components;
 const {__} = wp.i18n;
 

--- a/assets/src/blocks/Submenu/SubmenuEditor.js
+++ b/assets/src/blocks/Submenu/SubmenuEditor.js
@@ -3,9 +3,9 @@ import {SubmenuItems} from './SubmenuItems';
 import {getSubmenuStyle} from './getSubmenuStyle';
 import {makeHierarchical} from './makeHierarchical';
 import {getHeadingsFromBlocks} from './getHeadingsFromBlocks';
-import {useSelect} from '@wordpress/data';
 import {deepClone} from '../../functions/deepClone';
 
+const {useSelect} = wp.data;
 const {InspectorControls, RichText} = wp.blockEditor;
 const {Button, PanelBody} = wp.components;
 const {__} = wp.i18n;

--- a/assets/src/blocks/Submenu/SubmenuLevel.js
+++ b/assets/src/blocks/Submenu/SubmenuLevel.js
@@ -1,8 +1,4 @@
-import {
-  CheckboxControl,
-  SelectControl,
-} from '@wordpress/components';
-
+const {CheckboxControl, SelectControl} = wp.components;
 const {__} = wp.i18n;
 
 const getHeadingOptions = minLevel => {

--- a/assets/src/blocks/TakeActionBoxout/TakeActionBoxoutEditor.js
+++ b/assets/src/blocks/TakeActionBoxout/TakeActionBoxoutEditor.js
@@ -1,9 +1,9 @@
-import {useSelect} from '@wordpress/data';
 import {URLInput} from '../../block-editor/URLInput/URLInput';
 import {ImageHoverControls} from '../../block-editor/ImageHoverControls';
 import {TakeActionBoxoutFrontend} from './TakeActionBoxoutFrontend';
 import {ImagePlaceholder} from './ImagePlaceholder';
 
+const {useSelect} = wp.data;
 const {RichText, BlockControls, MediaUpload, MediaUploadCheck, InspectorControls} = wp.blockEditor;
 const {
   SelectControl,

--- a/assets/src/blocks/TakeActionBoxout/TakeActionBoxoutEditor.js
+++ b/assets/src/blocks/TakeActionBoxout/TakeActionBoxoutEditor.js
@@ -1,16 +1,10 @@
 import {useSelect} from '@wordpress/data';
-import {
-  RichText,
-  BlockControls,
-  MediaUpload,
-  MediaUploadCheck,
-  InspectorControls,
-} from '@wordpress/block-editor';
 import {URLInput} from '../../block-editor/URLInput/URLInput';
 import {ImageHoverControls} from '../../block-editor/ImageHoverControls';
 import {TakeActionBoxoutFrontend} from './TakeActionBoxoutFrontend';
 import {ImagePlaceholder} from './ImagePlaceholder';
 
+const {RichText, BlockControls, MediaUpload, MediaUploadCheck, InspectorControls} = wp.blockEditor;
 const {
   SelectControl,
   PanelBody,

--- a/assets/src/blocks/TakeActionBoxout/TakeActionBoxoutEditor.js
+++ b/assets/src/blocks/TakeActionBoxout/TakeActionBoxoutEditor.js
@@ -1,14 +1,5 @@
 import {useSelect} from '@wordpress/data';
 import {
-  SelectControl,
-  PanelBody,
-  CheckboxControl,
-  ToolbarGroup,
-  ToolbarButton,
-  Button,
-  ToggleControl,
-} from '@wordpress/components';
-import {
   RichText,
   BlockControls,
   MediaUpload,
@@ -20,6 +11,15 @@ import {ImageHoverControls} from '../../block-editor/ImageHoverControls';
 import {TakeActionBoxoutFrontend} from './TakeActionBoxoutFrontend';
 import {ImagePlaceholder} from './ImagePlaceholder';
 
+const {
+  SelectControl,
+  PanelBody,
+  CheckboxControl,
+  ToolbarGroup,
+  ToolbarButton,
+  Button,
+  ToggleControl,
+} = wp.components;
 const {__} = wp.i18n;
 
 // Planet 4 settings (Planet 4 >> Defaults content >> Take Action Covers default button text).

--- a/assets/src/blocks/Timeline/Timeline.js
+++ b/assets/src/blocks/Timeline/Timeline.js
@@ -1,4 +1,4 @@
-import {useRef, useEffect} from '@wordpress/element';
+const {useRef, useEffect} = wp.element;
 
 export const Timeline = props => {
   const {

--- a/assets/src/blocks/Timeline/TimelineEditorScript.js
+++ b/assets/src/blocks/Timeline/TimelineEditorScript.js
@@ -1,4 +1,3 @@
-import {InspectorControls, RichText} from '@wordpress/block-editor';
 import {URLInput} from '../../block-editor/URLInput/URLInput';
 import {useScript} from '../../hooks/useScript/useScript';
 import {useStyleSheet} from '../../hooks/useStylesheet/useStylesheet';
@@ -7,6 +6,7 @@ import {languages} from './TimelineLanguages';
 import {URLDescriptionHelp} from './URLDescriptionHelp';
 import {isLodash} from '../../functions/isLodash';
 
+const {InspectorControls, RichText} = wp.blockEditor;
 const {PanelBody, SelectControl, CheckboxControl, Tooltip} = wp.components;
 const {debounce} = wp.compose;
 const {useCallback, useState} = wp.element;

--- a/assets/src/blocks/Timeline/TimelineEditorScript.js
+++ b/assets/src/blocks/Timeline/TimelineEditorScript.js
@@ -1,9 +1,3 @@
-import {
-  PanelBody,
-  SelectControl,
-  CheckboxControl,
-  Tooltip,
-} from '@wordpress/components';
 import {InspectorControls, RichText} from '@wordpress/block-editor';
 import {URLInput} from '../../block-editor/URLInput/URLInput';
 import {useScript} from '../../hooks/useScript/useScript';
@@ -13,6 +7,7 @@ import {languages} from './TimelineLanguages';
 import {URLDescriptionHelp} from './URLDescriptionHelp';
 import {isLodash} from '../../functions/isLodash';
 
+const {PanelBody, SelectControl, CheckboxControl, Tooltip} = wp.components;
 const {debounce} = wp.compose;
 const {useCallback, useState} = wp.element;
 const {__} = wp.i18n;

--- a/assets/src/blocks/Timeline/TimelineEditorScript.js
+++ b/assets/src/blocks/Timeline/TimelineEditorScript.js
@@ -11,9 +11,9 @@ import {useStyleSheet} from '../../hooks/useStylesheet/useStylesheet';
 import {Timeline} from './Timeline';
 import {languages} from './TimelineLanguages';
 import {URLDescriptionHelp} from './URLDescriptionHelp';
-import {debounce} from '@wordpress/compose';
 import {isLodash} from '../../functions/isLodash';
 
+const {debounce} = wp.compose;
 const {useCallback, useState} = wp.element;
 const {__} = wp.i18n;
 

--- a/assets/src/blocks/Timeline/TimelineEditorScript.js
+++ b/assets/src/blocks/Timeline/TimelineEditorScript.js
@@ -1,4 +1,3 @@
-import {useCallback, useState} from '@wordpress/element';
 import {
   PanelBody,
   SelectControl,
@@ -6,7 +5,6 @@ import {
   Tooltip,
 } from '@wordpress/components';
 import {InspectorControls, RichText} from '@wordpress/block-editor';
-
 import {URLInput} from '../../block-editor/URLInput/URLInput';
 import {useScript} from '../../hooks/useScript/useScript';
 import {useStyleSheet} from '../../hooks/useStylesheet/useStylesheet';
@@ -16,7 +14,9 @@ import {URLDescriptionHelp} from './URLDescriptionHelp';
 import {debounce} from '@wordpress/compose';
 import {isLodash} from '../../functions/isLodash';
 
+const {useCallback, useState} = wp.element;
 const {__} = wp.i18n;
+
 const TIMELINE_JS_VERSION = '3.8.12';
 
 const positions = [

--- a/assets/src/blocks/components/Lightbox/Lightbox.js
+++ b/assets/src/blocks/components/Lightbox/Lightbox.js
@@ -1,7 +1,7 @@
-import {useEffect, useRef, useState} from '@wordpress/element';
-
 import PhotoSwipe from '../../../../../node_modules/photoswipe/dist/photoswipe.js';
 import PhotoSwipeUI_Default from '../../../../../node_modules/photoswipe/dist/photoswipe-ui-default.js';
+
+const {useEffect, useRef, useState} = wp.element;
 
 // `items` should be an array of object with this shape:
 // [{ src, w, h, title }, ...]

--- a/assets/src/blocks/components/Lightbox/useLightbox.js
+++ b/assets/src/blocks/components/Lightbox/useLightbox.js
@@ -1,4 +1,4 @@
-import {useState} from '@wordpress/element';
+const {useState} = wp.element;
 
 export const useLightbox = () => {
   const [isOpen, setIsOpen] = useState(false);

--- a/assets/src/hooks/useScript/useScript.js
+++ b/assets/src/hooks/useScript/useScript.js
@@ -1,6 +1,7 @@
 // useScript implementation from: https://usehooks.com/useScript/
-import {useEffect, useState} from '@wordpress/element';
 import {addScriptTag} from './addScriptTag';
+
+const {useEffect, useState} = wp.element;
 
 export const useScript = (src, onScriptLoaded, deps = []) => {
   // Keeping track of script loaded and error state

--- a/assets/src/hooks/useStylesheet/useStylesheet.js
+++ b/assets/src/hooks/useStylesheet/useStylesheet.js
@@ -1,6 +1,6 @@
-// useScript implementation from: https://usehooks.com/useScript/
-import {useEffect, useState} from '@wordpress/element';
 import {addLinkTag} from './addLinkTag';
+
+const {useEffect, useState} = wp.element;
 
 export const useStyleSheet = href => {
   // Keeping track of script loaded and error state

--- a/assets/src/js/Components/ArchivePicker/ArchivePicker.js
+++ b/assets/src/js/Components/ArchivePicker/ArchivePicker.js
@@ -1,4 +1,3 @@
-import {Spinner} from '@wordpress/components';
 import classNames from 'classnames';
 import ArchivePickerList from './ArchivePickerList';
 import SingleSidebar from './SingleSidebar';
@@ -11,6 +10,7 @@ import {
   updateCarouselBlockAttributes,
 } from './blockUpdateFunctions';
 
+const {Spinner} = wp.components;
 const {createContext, useContext, useEffect, useState, useCallback, useReducer, useMemo} = wp.element;
 const {apiFetch, url, i18n} = wp;
 const {addQueryArgs} = url;

--- a/assets/src/js/Components/ArchivePicker/ArchivePicker.js
+++ b/assets/src/js/Components/ArchivePicker/ArchivePicker.js
@@ -1,4 +1,3 @@
-import {createContext, useContext, useEffect, useState, useCallback, useReducer, useMemo} from '@wordpress/element';
 import {Spinner} from '@wordpress/components';
 import classNames from 'classnames';
 import ArchivePickerList from './ArchivePickerList';
@@ -12,12 +11,15 @@ import {
   updateCarouselBlockAttributes,
 } from './blockUpdateFunctions';
 
+const {createContext, useContext, useEffect, useState, useCallback, useReducer, useMemo} = wp.element;
 const {apiFetch, url, i18n} = wp;
 const {addQueryArgs} = url;
 const {__} = i18n;
+
 const timeout = delay => {
   return new Promise(resolve => setTimeout(resolve, delay));
 };
+
 const acceptedBlockTypes = ['core/image', 'planet4-blocks/happypoint', 'core/media-text', 'planet4-blocks/carousel-header'];
 
 export const EDITOR_VIEW = 'editor';

--- a/assets/src/js/Components/ArchivePicker/ArchivePickerList.js
+++ b/assets/src/js/Components/ArchivePicker/ArchivePickerList.js
@@ -1,9 +1,9 @@
-import {useCallback, useEffect, useMemo, useState} from '@wordpress/element';
 import classNames from 'classnames';
 import {ACTIONS, useArchivePickerContext} from './ArchivePicker';
 import {toSrcSet} from './sizeFunctions';
 
 const {__} = wp.i18n;
+const {useCallback, useEffect, useMemo, useState} = wp.element;
 
 const sort = indexes => indexes.sort(
   (a, b) => (a > b) ? a : null

--- a/assets/src/js/Components/ArchivePicker/ArchivePickerToolbar.js
+++ b/assets/src/js/Components/ArchivePicker/ArchivePickerToolbar.js
@@ -1,4 +1,4 @@
-import {useMemo} from '@wordpress/element';
+const {useMemo} = wp.element;
 import classNames from 'classnames';
 import {ACTIONS, useArchivePickerContext} from './ArchivePicker';
 import MultiSearchOption from './MultiSearchOption';

--- a/assets/src/js/Components/ArchivePicker/MultiSearchOption.js
+++ b/assets/src/js/Components/ArchivePicker/MultiSearchOption.js
@@ -1,9 +1,10 @@
-import {useRef, useState, useEffect, useCallback, useMemo} from '@wordpress/element';
 import {Spinner} from '@wordpress/components';
 import classNames from 'classnames';
 import {ACTIONS, useArchivePickerContext} from './ArchivePicker';
 
 const {__} = wp.i18n;
+const {useRef, useState, useEffect, useCallback, useMemo} = wp.element;
+
 const MAX_SEARCHES = 8;
 
 export default function MultiSearchOption() {

--- a/assets/src/js/Components/ArchivePicker/MultiSearchOption.js
+++ b/assets/src/js/Components/ArchivePicker/MultiSearchOption.js
@@ -1,8 +1,8 @@
-import {Spinner} from '@wordpress/components';
 import classNames from 'classnames';
 import {ACTIONS, useArchivePickerContext} from './ArchivePicker';
 
 const {__} = wp.i18n;
+const {Spinner} = wp.components;
 const {useRef, useState, useEffect, useCallback, useMemo} = wp.element;
 
 const MAX_SEARCHES = 8;

--- a/assets/src/js/Components/ArchivePicker/MultiSidebar.js
+++ b/assets/src/js/Components/ArchivePicker/MultiSidebar.js
@@ -1,8 +1,8 @@
-import {useMemo} from '@wordpress/element';
 import {toSrcSet} from './sizeFunctions';
 import {ACTIONS, useArchivePickerContext} from './ArchivePicker';
 
 const {__} = wp.i18n;
+const {useMemo} = wp.element;
 
 export default function MultiSidebar() {
   const {selectedImages, dispatch} = useArchivePickerContext();

--- a/assets/src/js/Components/ArchivePicker/SingleSidebar.js
+++ b/assets/src/js/Components/ArchivePicker/SingleSidebar.js
@@ -1,8 +1,8 @@
-import {useMemo, useEffect, useState} from '@wordpress/element';
 import {toSrcSet} from './sizeFunctions';
 import {ACTIONS, ADMIN_VIEW, EDITOR_VIEW, useArchivePickerContext} from './ArchivePicker';
 
 const {__, sprintf} = wp.i18n;
+const {useMemo, useEffect, useState} = wp.element;
 
 const renderDefinition = (key, value) => (
   <div>

--- a/assets/src/js/media_archive.js
+++ b/assets/src/js/media_archive.js
@@ -1,5 +1,6 @@
 import ArchivePicker from './Components/ArchivePicker/ArchivePicker';
-import {createRoot} from '@wordpress/element';
+
+const {createRoot} = wp.element;
 const rootElement = document.getElementById('archive-picker-root');
 
 createRoot(rootElement).render(<ArchivePicker />);

--- a/assets/src/js/media_archive_editor_view.js
+++ b/assets/src/js/media_archive_editor_view.js
@@ -1,7 +1,7 @@
-import {createRoot} from '@wordpress/element';
 import ArchivePicker, {EDITOR_VIEW} from '../js/Components/ArchivePicker/ArchivePicker';
 
 const {__} = wp.i18n;
+const {createRoot} = wp.element;
 const frame = wp.media.view.MediaFrame.Select;
 
 (function() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5561,133 +5561,6 @@
         "requireindex": "^1.2.0"
       }
     },
-    "node_modules/@wordpress/eslint-plugin/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@wordpress/eslint-plugin/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@wordpress/eslint-plugin/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/@wordpress/eslint-plugin/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true,
-      "peer": true
-    },
-    "node_modules/@wordpress/eslint-plugin/node_modules/cross-spawn": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "nice-try": "^1.0.4",
-        "path-key": "^2.0.1",
-        "semver": "^5.5.0",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
-      },
-      "engines": {
-        "node": ">=4.8"
-      }
-    },
-    "node_modules/@wordpress/eslint-plugin/node_modules/cross-spawn/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "dev": true,
-      "peer": true,
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/@wordpress/eslint-plugin/node_modules/eslint": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.8.0.tgz",
-      "integrity": "sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.0.0",
-        "ajv": "^6.10.0",
-        "chalk": "^2.1.0",
-        "cross-spawn": "^6.0.5",
-        "debug": "^4.0.1",
-        "doctrine": "^3.0.0",
-        "eslint-scope": "^5.0.0",
-        "eslint-utils": "^1.4.3",
-        "eslint-visitor-keys": "^1.1.0",
-        "espree": "^6.1.2",
-        "esquery": "^1.0.1",
-        "esutils": "^2.0.2",
-        "file-entry-cache": "^5.0.1",
-        "functional-red-black-tree": "^1.0.1",
-        "glob-parent": "^5.0.0",
-        "globals": "^12.1.0",
-        "ignore": "^4.0.6",
-        "import-fresh": "^3.0.0",
-        "imurmurhash": "^0.1.4",
-        "inquirer": "^7.0.0",
-        "is-glob": "^4.0.0",
-        "js-yaml": "^3.13.1",
-        "json-stable-stringify-without-jsonify": "^1.0.1",
-        "levn": "^0.3.0",
-        "lodash": "^4.17.14",
-        "minimatch": "^3.0.4",
-        "mkdirp": "^0.5.1",
-        "natural-compare": "^1.4.0",
-        "optionator": "^0.8.3",
-        "progress": "^2.0.0",
-        "regexpp": "^2.0.1",
-        "semver": "^6.1.2",
-        "strip-ansi": "^5.2.0",
-        "strip-json-comments": "^3.0.1",
-        "table": "^5.2.3",
-        "text-table": "^0.2.0",
-        "v8-compile-cache": "^2.0.3"
-      },
-      "bin": {
-        "eslint": "bin/eslint.js"
-      },
-      "engines": {
-        "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
     "node_modules/@wordpress/eslint-plugin/node_modules/eslint-plugin-react-hooks": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.7.0.tgz",
@@ -5698,119 +5571,6 @@
       },
       "peerDependencies": {
         "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0"
-      }
-    },
-    "node_modules/@wordpress/eslint-plugin/node_modules/eslint-utils": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
-      "integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "eslint-visitor-keys": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@wordpress/eslint-plugin/node_modules/espree": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-6.2.1.tgz",
-      "integrity": "sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "acorn": "^7.1.1",
-        "acorn-jsx": "^5.2.0",
-        "eslint-visitor-keys": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@wordpress/eslint-plugin/node_modules/file-entry-cache": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
-      "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "flat-cache": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@wordpress/eslint-plugin/node_modules/globals": {
-      "version": "12.4.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
-      "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "type-fest": "^0.8.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@wordpress/eslint-plugin/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@wordpress/eslint-plugin/node_modules/regexpp": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
-      "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">=6.5.0"
-      }
-    },
-    "node_modules/@wordpress/eslint-plugin/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "peer": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/@wordpress/eslint-plugin/node_modules/strip-json-comments": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@wordpress/eslint-plugin/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/@wordpress/hooks": {
@@ -6014,22 +5774,6 @@
         "enzyme": "^3.0.0",
         "react": "^16.0.0-0",
         "react-dom": "^16.0.0-0"
-      }
-    },
-    "node_modules/@wordpress/jest-preset-default/node_modules/react-dom": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
-      "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "scheduler": "^0.19.1"
-      },
-      "peerDependencies": {
-        "react": "^16.14.0"
       }
     },
     "node_modules/@wordpress/jest-preset-default/node_modules/semver": {
@@ -9229,29 +8973,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/cli-cursor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
-      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "restore-cursor": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cli-width": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
-      "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 10"
-      }
-    },
     "node_modules/clipboard": {
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.11.tgz",
@@ -12018,22 +11739,6 @@
       "integrity": "sha512-0btnI/H8f2pavGMN8w40mlSKOfTK2SVJmBfBeVIj3kNw0swwgzyRq0d5TJVOwodFmtvpPeWPN/MCcfuWF0Ezbw==",
       "dev": true
     },
-    "node_modules/figures": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
-      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "escape-string-regexp": "^1.0.5"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -13665,83 +13370,6 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true
-    },
-    "node_modules/inquirer": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.3.3.tgz",
-      "integrity": "sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "ansi-escapes": "^4.2.1",
-        "chalk": "^4.1.0",
-        "cli-cursor": "^3.1.0",
-        "cli-width": "^3.0.0",
-        "external-editor": "^3.0.3",
-        "figures": "^3.0.0",
-        "lodash": "^4.17.19",
-        "mute-stream": "0.0.8",
-        "run-async": "^2.4.0",
-        "rxjs": "^6.6.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0",
-        "through": "^2.3.6"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/inquirer/node_modules/ansi-escapes": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
-      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "type-fest": "^0.21.3"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/inquirer/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/inquirer/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/inquirer/node_modules/type-fest": {
-      "version": "0.21.3",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/internal-slot": {
       "version": "1.0.5",
@@ -17995,13 +17623,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
-    "node_modules/mute-stream": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
-      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
-      "dev": true,
-      "peer": true
-    },
     "node_modules/nan": {
       "version": "2.17.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
@@ -18694,6 +18315,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -20892,6 +20514,7 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dev": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -21208,6 +20831,7 @@
       "version": "16.14.0",
       "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
       "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
+      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -21250,7 +20874,8 @@
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true
     },
     "node_modules/react-remove-scroll": {
       "version": "2.5.5",
@@ -21947,20 +21572,6 @@
       "integrity": "sha512-ZuF55hVUQaaczgOIwqWzkEcEidmlD/xl44x1UZnhOXcYuFN2S6+rcxpG+C1N3So0wvNI3DmJICUFfu2SxhBmvg==",
       "deprecated": "https://github.com/lydell/resolve-url#deprecated",
       "dev": true
-    },
-    "node_modules/restore-cursor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
-      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "onetime": "^5.1.0",
-        "signal-exit": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/ret": {
       "version": "0.1.15",
@@ -29881,8 +29492,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.0.1.tgz",
       "integrity": "sha512-jT/qyKZ9rzLErtrjGgdkMBn2OP8wl0G3sQlBb3YPryvKHsjvINUhVaPFfP+fpBcOkmrVOVEEHQFJ7nbj2TH2gw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@emotion/utils": {
       "version": "1.2.1",
@@ -31341,8 +30951,7 @@
           "version": "1.8.0",
           "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
           "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         },
         "commander": {
           "version": "2.20.3",
@@ -31827,8 +31436,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/@wordpress/babel-plugin-import-jsx-pragma/-/babel-plugin-import-jsx-pragma-2.7.0.tgz",
       "integrity": "sha512-yR+rSyfHKfevW84vKBOERpjEslD/o00CaYMftywVYOjsOQ8GLS6xv/VgDcpQ8JomJ9eRRInLRpeGKTM3lOa4xQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@wordpress/babel-preset-default": {
       "version": "4.20.0",
@@ -32015,8 +31623,7 @@
               "version": "0.15.2",
               "resolved": "https://registry.npmjs.org/reakit-utils/-/reakit-utils-0.15.2.tgz",
               "integrity": "sha512-i/RYkq+W6hvfFmXw5QW7zvfJJT/K8a4qZ0hjA79T61JAFPGt23DsfxwyBbyK91GZrJ9HMrXFVXWMovsKBc1qEQ==",
-              "dev": true,
-              "requires": {}
+              "dev": true
             },
             "reakit-warning": {
               "version": "0.6.2",
@@ -32345,200 +31952,11 @@
         "requireindex": "^1.2.0"
       },
       "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "color-convert": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "color-name": "1.1.3"
-          }
-        },
-        "color-name": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-          "dev": true,
-          "peer": true
-        },
-        "cross-spawn": {
-          "version": "6.0.5",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "nice-try": "^1.0.4",
-            "path-key": "^2.0.1",
-            "semver": "^5.5.0",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
-          },
-          "dependencies": {
-            "semver": {
-              "version": "5.7.2",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-              "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-              "dev": true,
-              "peer": true
-            }
-          }
-        },
-        "eslint": {
-          "version": "6.8.0",
-          "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.8.0.tgz",
-          "integrity": "sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "@babel/code-frame": "^7.0.0",
-            "ajv": "^6.10.0",
-            "chalk": "^2.1.0",
-            "cross-spawn": "^6.0.5",
-            "debug": "^4.0.1",
-            "doctrine": "^3.0.0",
-            "eslint-scope": "^5.0.0",
-            "eslint-utils": "^1.4.3",
-            "eslint-visitor-keys": "^1.1.0",
-            "espree": "^6.1.2",
-            "esquery": "^1.0.1",
-            "esutils": "^2.0.2",
-            "file-entry-cache": "^5.0.1",
-            "functional-red-black-tree": "^1.0.1",
-            "glob-parent": "^5.0.0",
-            "globals": "^12.1.0",
-            "ignore": "^4.0.6",
-            "import-fresh": "^3.0.0",
-            "imurmurhash": "^0.1.4",
-            "inquirer": "^7.0.0",
-            "is-glob": "^4.0.0",
-            "js-yaml": "^3.13.1",
-            "json-stable-stringify-without-jsonify": "^1.0.1",
-            "levn": "^0.3.0",
-            "lodash": "^4.17.14",
-            "minimatch": "^3.0.4",
-            "mkdirp": "^0.5.1",
-            "natural-compare": "^1.4.0",
-            "optionator": "^0.8.3",
-            "progress": "^2.0.0",
-            "regexpp": "^2.0.1",
-            "semver": "^6.1.2",
-            "strip-ansi": "^5.2.0",
-            "strip-json-comments": "^3.0.1",
-            "table": "^5.2.3",
-            "text-table": "^0.2.0",
-            "v8-compile-cache": "^2.0.3"
-          }
-        },
         "eslint-plugin-react-hooks": {
           "version": "1.7.0",
           "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.7.0.tgz",
           "integrity": "sha512-iXTCFcOmlWvw4+TOE8CLWj6yX1GwzT0Y6cUfHHZqWnSk144VmVIRcVGtUAzrLES7C798lmvnt02C7rxaOX1HNA==",
-          "dev": true,
-          "requires": {}
-        },
-        "eslint-utils": {
-          "version": "1.4.3",
-          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
-          "integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "eslint-visitor-keys": "^1.1.0"
-          }
-        },
-        "espree": {
-          "version": "6.2.1",
-          "resolved": "https://registry.npmjs.org/espree/-/espree-6.2.1.tgz",
-          "integrity": "sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "acorn": "^7.1.1",
-            "acorn-jsx": "^5.2.0",
-            "eslint-visitor-keys": "^1.1.0"
-          }
-        },
-        "file-entry-cache": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
-          "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "flat-cache": "^2.0.1"
-          }
-        },
-        "globals": {
-          "version": "12.4.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
-          "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "type-fest": "^0.8.1"
-          }
-        },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-          "dev": true,
-          "peer": true
-        },
-        "regexpp": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
-          "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
-          "dev": true,
-          "peer": true
-        },
-        "semver": {
-          "version": "6.3.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-          "dev": true,
-          "peer": true
-        },
-        "strip-json-comments": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-          "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-          "dev": true,
-          "peer": true
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
+          "dev": true
         }
       }
     },
@@ -32697,19 +32115,6 @@
             "semver": "^5.7.0"
           }
         },
-        "react-dom": {
-          "version": "16.14.0",
-          "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
-          "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "scheduler": "^0.19.1"
-          }
-        },
         "semver": {
           "version": "5.7.2",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
@@ -32733,8 +32138,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-2.2.0.tgz",
       "integrity": "sha512-8Td9vWekCwZCPfWkVWKQllim/F/m0uN1cma3KkBsKxi0liftj/iXpDBDH6wDxsv8z1Gbwq+H9a4D6w7Ob8SqtQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@wordpress/primitives": {
       "version": "3.39.0",
@@ -33635,8 +33039,7 @@
     "acorn-jsx": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
-      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "requires": {}
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="
     },
     "acorn-walk": {
       "version": "6.2.0",
@@ -33695,15 +33098,13 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
       "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ajv-keywords": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ansi-colors": {
       "version": "4.1.3",
@@ -34554,8 +33955,7 @@
       "version": "5.1.3",
       "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.1.3.tgz",
       "integrity": "sha512-fcQztozJ8jToQWXxVuEyXWW+dSo8AiXWKwiSSrKWsRB/Qt+Ewwza+JWoLKiTuQLaEPhdNAJ7+Dosc9DOIqNy7Q==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -35315,23 +34715,6 @@
       "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
       "dev": true
     },
-    "cli-cursor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
-      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "restore-cursor": "^3.1.0"
-      }
-    },
-    "cli-width": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
-      "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
-      "dev": true,
-      "peer": true
-    },
     "clipboard": {
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.11.tgz",
@@ -35650,8 +35033,7 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-4.4.0.tgz",
       "integrity": "sha512-BabizFdC3wBHhbI4kJh0VkQP9GkBfoHPydD0COMce1nJ1kJAB3F2TmJ/I7diULBKtmEWSwEbuN/KDtgnmUUVmw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "create-ecdh": {
       "version": "4.0.4",
@@ -36947,8 +36329,7 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz",
       "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-scope": {
       "version": "5.1.1",
@@ -37567,16 +36948,6 @@
       "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.2.tgz",
       "integrity": "sha512-0btnI/H8f2pavGMN8w40mlSKOfTK2SVJmBfBeVIj3kNw0swwgzyRq0d5TJVOwodFmtvpPeWPN/MCcfuWF0Ezbw==",
       "dev": true
-    },
-    "figures": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
-      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "escape-string-regexp": "^1.0.5"
-      }
     },
     "file-entry-cache": {
       "version": "6.0.1",
@@ -38844,64 +38215,6 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true
-    },
-    "inquirer": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.3.3.tgz",
-      "integrity": "sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "ansi-escapes": "^4.2.1",
-        "chalk": "^4.1.0",
-        "cli-cursor": "^3.1.0",
-        "cli-width": "^3.0.0",
-        "external-editor": "^3.0.3",
-        "figures": "^3.0.0",
-        "lodash": "^4.17.19",
-        "mute-stream": "0.0.8",
-        "run-async": "^2.4.0",
-        "rxjs": "^6.6.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0",
-        "through": "^2.3.6"
-      },
-      "dependencies": {
-        "ansi-escapes": {
-          "version": "4.3.2",
-          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
-          "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "type-fest": "^0.21.3"
-          }
-        },
-        "ansi-regex": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-          "dev": true,
-          "peer": true
-        },
-        "strip-ansi": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "ansi-regex": "^5.0.1"
-          }
-        },
-        "type-fest": {
-          "version": "0.21.3",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-          "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-          "dev": true,
-          "peer": true
-        }
-      }
     },
     "internal-slot": {
       "version": "1.0.5",
@@ -40351,8 +39664,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
       "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "jest-puppeteer": {
       "version": "4.4.0",
@@ -42311,13 +41623,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
-    "mute-stream": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
-      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
-      "dev": true,
-      "peer": true
-    },
     "nan": {
       "version": "2.17.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
@@ -42875,7 +42180,8 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true
     },
     "object-copy": {
       "version": "0.1.0",
@@ -43096,8 +42402,7 @@
           "version": "6.4.0",
           "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.4.0.tgz",
           "integrity": "sha512-jDfsatwWMWN0MODAFuHszfjphEXfNw9JUAhmY4pLu3TyTU+ohUpsbVtbU+1MZn4a47D9kqh03i4eyOm+74+zew==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         },
         "cssnano": {
           "version": "5.1.15",
@@ -43151,8 +42456,7 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-3.1.0.tgz",
           "integrity": "sha512-JQNR19/YZhz4psLX/rQ9M83e3z2Wf/HdJbryzte4a3NSuafyp9w/I4U+hx5C2S9g41qlstH7DEWnZaaj83OuEA==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         },
         "normalize-url": {
           "version": "6.1.0",
@@ -43213,29 +42517,25 @@
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-5.1.2.tgz",
           "integrity": "sha512-+L8208OVbHVF2UQf1iDmRcbdjJkuBF6IS29yBDSiWUIzpYaAhtNl6JYnYm12FnkeCwQqF5LeklOu6rAqgfBZqQ==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         },
         "postcss-discard-duplicates": {
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-5.1.0.tgz",
           "integrity": "sha512-zmX3IoSI2aoenxHV6C7plngHWWhUOV3sP1T8y2ifzxzbtnuhk1EdPwm0S1bIUNaJ2eNbWeGLEwzw8huPD67aQw==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         },
         "postcss-discard-empty": {
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-5.1.1.tgz",
           "integrity": "sha512-zPz4WljiSuLWsI0ir4Mcnr4qQQ5e1Ukc3i7UfE2XcrwKK2LIPIqE5jxMRxO6GbI3cv//ztXDsXwEWT3BHOGh3A==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         },
         "postcss-discard-overridden": {
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-5.1.0.tgz",
           "integrity": "sha512-21nOL7RqWR1kasIVdKs8HNqQJhFxLsyRfAnUDm4Fe4t4mCWL9OJiHvlHPjcd8zc5Myu89b/7wZDnOSjFgeWRtw==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         },
         "postcss-merge-longhand": {
           "version": "5.1.7",
@@ -43303,8 +42603,7 @@
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-5.1.0.tgz",
           "integrity": "sha512-mSgUJ+pd/ldRGVx26p2wz9dNZ7ji6Pn8VWBajMXFf8jk7vUoSrZ2lt/wZR7DtlZYKesmZI680qjr2CeFF2fbUg==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         },
         "postcss-normalize-display-values": {
           "version": "5.1.0",
@@ -44180,8 +43479,7 @@
       "version": "1.16.0",
       "resolved": "https://registry.npmjs.org/postcss-prefix-selector/-/postcss-prefix-selector-1.16.0.tgz",
       "integrity": "sha512-rdVMIi7Q4B0XbXqNUEI+Z4E+pueiu/CS5E6vRCQommzdQ/sgsS4dK42U7GX8oJR+TJOtT+Qv3GkNo6iijUMp3Q==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-reporter": {
       "version": "6.0.1",
@@ -44295,8 +43593,7 @@
       "version": "0.36.2",
       "resolved": "https://registry.npmjs.org/postcss-syntax/-/postcss-syntax-0.36.2.tgz",
       "integrity": "sha512-nBRg/i7E3SOHWxF3PpF5WnJM/jQ1YpY9000OaVXlAQj6Zp/kIqJxEDWIZ67tAd7NLuk7zqN4yqe9nc0oNAOs1w==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-value-parser": {
       "version": "4.2.0",
@@ -44535,6 +43832,7 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -44796,13 +44094,13 @@
       "version": "6.9.9",
       "resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-6.9.9.tgz",
       "integrity": "sha512-l+MBlKZffv/SicxDySKEEh42hR6m5bAHfNu3Tvxks2c4Ah+ldnWjfnVRwxo/nxF27SsUsxDS0raAzFuJNKABXA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "react": {
       "version": "16.14.0",
       "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
       "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -44813,8 +44111,7 @@
       "version": "5.6.1",
       "resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.6.1.tgz",
       "integrity": "sha512-1exovf0uGTGyq5mXQT0zgQ80uvj2PCwvF8zY1RN9/vbJVSjSo3fsB/4L3ObbF7u70NduSiK4xu4Y6q1MHoUGEw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "react-dom": {
       "version": "18.2.0",
@@ -44838,7 +44135,8 @@
     "react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true
     },
     "react-remove-scroll": {
       "version": "2.5.5",
@@ -45395,17 +44693,6 @@
       "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
       "integrity": "sha512-ZuF55hVUQaaczgOIwqWzkEcEidmlD/xl44x1UZnhOXcYuFN2S6+rcxpG+C1N3So0wvNI3DmJICUFfu2SxhBmvg==",
       "dev": true
-    },
-    "restore-cursor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
-      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "onetime": "^5.1.0",
-        "signal-exit": "^3.0.2"
-      }
     },
     "ret": {
       "version": "0.1.15",
@@ -47124,8 +46411,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-2.2.0.tgz",
       "integrity": "sha512-bZ+d4RiNEfmoR74KZtCKmsABdBJr4iXRiCso+6LtMJPw5rd/KnxUWTxht7TbafrTJK1YRjNgnN0iVZaJfc3xJA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "stylelint-config-recommended-scss": {
       "version": "3.3.0",
@@ -48708,8 +47994,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz",
       "integrity": "sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "use-lilius": {
       "version": "2.0.3",
@@ -48724,8 +48009,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.3.tgz",
       "integrity": "sha512-g66/K7ZQGYrI6dy8GLpVcMsBp4s17xNkYJVSMvTEevGy3nDxHOfE6z8BVE22+5G5x7t3+bhzrlTDB7ObrEE0cQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "use-sidecar": {
       "version": "1.1.2",
@@ -48749,8 +48033,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
       "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "user-home": {
       "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5561,6 +5561,133 @@
         "requireindex": "^1.2.0"
       }
     },
+    "node_modules/@wordpress/eslint-plugin/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@wordpress/eslint-plugin/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@wordpress/eslint-plugin/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/@wordpress/eslint-plugin/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/@wordpress/eslint-plugin/node_modules/cross-spawn": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      },
+      "engines": {
+        "node": ">=4.8"
+      }
+    },
+    "node_modules/@wordpress/eslint-plugin/node_modules/cross-spawn/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/@wordpress/eslint-plugin/node_modules/eslint": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.8.0.tgz",
+      "integrity": "sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "ajv": "^6.10.0",
+        "chalk": "^2.1.0",
+        "cross-spawn": "^6.0.5",
+        "debug": "^4.0.1",
+        "doctrine": "^3.0.0",
+        "eslint-scope": "^5.0.0",
+        "eslint-utils": "^1.4.3",
+        "eslint-visitor-keys": "^1.1.0",
+        "espree": "^6.1.2",
+        "esquery": "^1.0.1",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^5.0.1",
+        "functional-red-black-tree": "^1.0.1",
+        "glob-parent": "^5.0.0",
+        "globals": "^12.1.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.0.0",
+        "imurmurhash": "^0.1.4",
+        "inquirer": "^7.0.0",
+        "is-glob": "^4.0.0",
+        "js-yaml": "^3.13.1",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.3.0",
+        "lodash": "^4.17.14",
+        "minimatch": "^3.0.4",
+        "mkdirp": "^0.5.1",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.8.3",
+        "progress": "^2.0.0",
+        "regexpp": "^2.0.1",
+        "semver": "^6.1.2",
+        "strip-ansi": "^5.2.0",
+        "strip-json-comments": "^3.0.1",
+        "table": "^5.2.3",
+        "text-table": "^0.2.0",
+        "v8-compile-cache": "^2.0.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/@wordpress/eslint-plugin/node_modules/eslint-plugin-react-hooks": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.7.0.tgz",
@@ -5571,6 +5698,119 @@
       },
       "peerDependencies": {
         "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0"
+      }
+    },
+    "node_modules/@wordpress/eslint-plugin/node_modules/eslint-utils": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
+      "integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "eslint-visitor-keys": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@wordpress/eslint-plugin/node_modules/espree": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-6.2.1.tgz",
+      "integrity": "sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "acorn": "^7.1.1",
+        "acorn-jsx": "^5.2.0",
+        "eslint-visitor-keys": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@wordpress/eslint-plugin/node_modules/file-entry-cache": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
+      "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "flat-cache": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@wordpress/eslint-plugin/node_modules/globals": {
+      "version": "12.4.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+      "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "type-fest": "^0.8.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@wordpress/eslint-plugin/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@wordpress/eslint-plugin/node_modules/regexpp": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
+      "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=6.5.0"
+      }
+    },
+    "node_modules/@wordpress/eslint-plugin/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@wordpress/eslint-plugin/node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@wordpress/eslint-plugin/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/@wordpress/hooks": {
@@ -5774,6 +6014,22 @@
         "enzyme": "^3.0.0",
         "react": "^16.0.0-0",
         "react-dom": "^16.0.0-0"
+      }
+    },
+    "node_modules/@wordpress/jest-preset-default/node_modules/react-dom": {
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
+      "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2",
+        "scheduler": "^0.19.1"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0"
       }
     },
     "node_modules/@wordpress/jest-preset-default/node_modules/semver": {
@@ -8973,6 +9229,29 @@
         "node": ">=6"
       }
     },
+    "node_modules/cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "restore-cursor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-width": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
+      "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/clipboard": {
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.11.tgz",
@@ -11739,6 +12018,22 @@
       "integrity": "sha512-0btnI/H8f2pavGMN8w40mlSKOfTK2SVJmBfBeVIj3kNw0swwgzyRq0d5TJVOwodFmtvpPeWPN/MCcfuWF0Ezbw==",
       "dev": true
     },
+    "node_modules/figures": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "escape-string-regexp": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -13370,6 +13665,83 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true
+    },
+    "node_modules/inquirer": {
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.3.3.tgz",
+      "integrity": "sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-width": "^3.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^3.0.0",
+        "lodash": "^4.17.19",
+        "mute-stream": "0.0.8",
+        "run-async": "^2.4.0",
+        "rxjs": "^6.6.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "through": "^2.3.6"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/inquirer/node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "type-fest": "^0.21.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/inquirer/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/inquirer/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/inquirer/node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/internal-slot": {
       "version": "1.0.5",
@@ -17623,6 +17995,13 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
+    "node_modules/mute-stream": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+      "dev": true,
+      "peer": true
+    },
     "node_modules/nan": {
       "version": "2.17.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
@@ -18315,7 +18694,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -20514,7 +20892,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -20831,7 +21208,6 @@
       "version": "16.14.0",
       "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
       "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -20874,8 +21250,7 @@
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/react-remove-scroll": {
       "version": "2.5.5",
@@ -21572,6 +21947,20 @@
       "integrity": "sha512-ZuF55hVUQaaczgOIwqWzkEcEidmlD/xl44x1UZnhOXcYuFN2S6+rcxpG+C1N3So0wvNI3DmJICUFfu2SxhBmvg==",
       "deprecated": "https://github.com/lydell/resolve-url#deprecated",
       "dev": true
+    },
+    "node_modules/restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/ret": {
       "version": "0.1.15",
@@ -29492,7 +29881,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.0.1.tgz",
       "integrity": "sha512-jT/qyKZ9rzLErtrjGgdkMBn2OP8wl0G3sQlBb3YPryvKHsjvINUhVaPFfP+fpBcOkmrVOVEEHQFJ7nbj2TH2gw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@emotion/utils": {
       "version": "1.2.1",
@@ -30951,7 +31341,8 @@
           "version": "1.8.0",
           "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
           "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "commander": {
           "version": "2.20.3",
@@ -31436,7 +31827,8 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/@wordpress/babel-plugin-import-jsx-pragma/-/babel-plugin-import-jsx-pragma-2.7.0.tgz",
       "integrity": "sha512-yR+rSyfHKfevW84vKBOERpjEslD/o00CaYMftywVYOjsOQ8GLS6xv/VgDcpQ8JomJ9eRRInLRpeGKTM3lOa4xQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@wordpress/babel-preset-default": {
       "version": "4.20.0",
@@ -31623,7 +32015,8 @@
               "version": "0.15.2",
               "resolved": "https://registry.npmjs.org/reakit-utils/-/reakit-utils-0.15.2.tgz",
               "integrity": "sha512-i/RYkq+W6hvfFmXw5QW7zvfJJT/K8a4qZ0hjA79T61JAFPGt23DsfxwyBbyK91GZrJ9HMrXFVXWMovsKBc1qEQ==",
-              "dev": true
+              "dev": true,
+              "requires": {}
             },
             "reakit-warning": {
               "version": "0.6.2",
@@ -31952,11 +32345,200 @@
         "requireindex": "^1.2.0"
       },
       "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+          "dev": true,
+          "peer": true
+        },
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "5.7.2",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+              "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+              "dev": true,
+              "peer": true
+            }
+          }
+        },
+        "eslint": {
+          "version": "6.8.0",
+          "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.8.0.tgz",
+          "integrity": "sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "ajv": "^6.10.0",
+            "chalk": "^2.1.0",
+            "cross-spawn": "^6.0.5",
+            "debug": "^4.0.1",
+            "doctrine": "^3.0.0",
+            "eslint-scope": "^5.0.0",
+            "eslint-utils": "^1.4.3",
+            "eslint-visitor-keys": "^1.1.0",
+            "espree": "^6.1.2",
+            "esquery": "^1.0.1",
+            "esutils": "^2.0.2",
+            "file-entry-cache": "^5.0.1",
+            "functional-red-black-tree": "^1.0.1",
+            "glob-parent": "^5.0.0",
+            "globals": "^12.1.0",
+            "ignore": "^4.0.6",
+            "import-fresh": "^3.0.0",
+            "imurmurhash": "^0.1.4",
+            "inquirer": "^7.0.0",
+            "is-glob": "^4.0.0",
+            "js-yaml": "^3.13.1",
+            "json-stable-stringify-without-jsonify": "^1.0.1",
+            "levn": "^0.3.0",
+            "lodash": "^4.17.14",
+            "minimatch": "^3.0.4",
+            "mkdirp": "^0.5.1",
+            "natural-compare": "^1.4.0",
+            "optionator": "^0.8.3",
+            "progress": "^2.0.0",
+            "regexpp": "^2.0.1",
+            "semver": "^6.1.2",
+            "strip-ansi": "^5.2.0",
+            "strip-json-comments": "^3.0.1",
+            "table": "^5.2.3",
+            "text-table": "^0.2.0",
+            "v8-compile-cache": "^2.0.3"
+          }
+        },
         "eslint-plugin-react-hooks": {
           "version": "1.7.0",
           "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.7.0.tgz",
           "integrity": "sha512-iXTCFcOmlWvw4+TOE8CLWj6yX1GwzT0Y6cUfHHZqWnSk144VmVIRcVGtUAzrLES7C798lmvnt02C7rxaOX1HNA==",
-          "dev": true
+          "dev": true,
+          "requires": {}
+        },
+        "eslint-utils": {
+          "version": "1.4.3",
+          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
+          "integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "eslint-visitor-keys": "^1.1.0"
+          }
+        },
+        "espree": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/espree/-/espree-6.2.1.tgz",
+          "integrity": "sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "acorn": "^7.1.1",
+            "acorn-jsx": "^5.2.0",
+            "eslint-visitor-keys": "^1.1.0"
+          }
+        },
+        "file-entry-cache": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
+          "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "flat-cache": "^2.0.1"
+          }
+        },
+        "globals": {
+          "version": "12.4.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+          "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "type-fest": "^0.8.1"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+          "dev": true,
+          "peer": true
+        },
+        "regexpp": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
+          "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
+          "dev": true,
+          "peer": true
+        },
+        "semver": {
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+          "dev": true,
+          "peer": true
+        },
+        "strip-json-comments": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+          "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+          "dev": true,
+          "peer": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
         }
       }
     },
@@ -32115,6 +32697,19 @@
             "semver": "^5.7.0"
           }
         },
+        "react-dom": {
+          "version": "16.14.0",
+          "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
+          "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "scheduler": "^0.19.1"
+          }
+        },
         "semver": {
           "version": "5.7.2",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
@@ -32138,7 +32733,8 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-2.2.0.tgz",
       "integrity": "sha512-8Td9vWekCwZCPfWkVWKQllim/F/m0uN1cma3KkBsKxi0liftj/iXpDBDH6wDxsv8z1Gbwq+H9a4D6w7Ob8SqtQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@wordpress/primitives": {
       "version": "3.39.0",
@@ -33039,7 +33635,8 @@
     "acorn-jsx": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
-      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "requires": {}
     },
     "acorn-walk": {
       "version": "6.2.0",
@@ -33098,13 +33695,15 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
       "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ajv-keywords": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ansi-colors": {
       "version": "4.1.3",
@@ -33955,7 +34554,8 @@
       "version": "5.1.3",
       "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.1.3.tgz",
       "integrity": "sha512-fcQztozJ8jToQWXxVuEyXWW+dSo8AiXWKwiSSrKWsRB/Qt+Ewwza+JWoLKiTuQLaEPhdNAJ7+Dosc9DOIqNy7Q==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -34715,6 +35315,23 @@
       "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
       "dev": true
     },
+    "cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "restore-cursor": "^3.1.0"
+      }
+    },
+    "cli-width": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
+      "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
+      "dev": true,
+      "peer": true
+    },
     "clipboard": {
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.11.tgz",
@@ -35033,7 +35650,8 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-4.4.0.tgz",
       "integrity": "sha512-BabizFdC3wBHhbI4kJh0VkQP9GkBfoHPydD0COMce1nJ1kJAB3F2TmJ/I7diULBKtmEWSwEbuN/KDtgnmUUVmw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "create-ecdh": {
       "version": "4.0.4",
@@ -36329,7 +36947,8 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz",
       "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-scope": {
       "version": "5.1.1",
@@ -36948,6 +37567,16 @@
       "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.2.tgz",
       "integrity": "sha512-0btnI/H8f2pavGMN8w40mlSKOfTK2SVJmBfBeVIj3kNw0swwgzyRq0d5TJVOwodFmtvpPeWPN/MCcfuWF0Ezbw==",
       "dev": true
+    },
+    "figures": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.5"
+      }
     },
     "file-entry-cache": {
       "version": "6.0.1",
@@ -38215,6 +38844,64 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true
+    },
+    "inquirer": {
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.3.3.tgz",
+      "integrity": "sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-width": "^3.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^3.0.0",
+        "lodash": "^4.17.19",
+        "mute-stream": "0.0.8",
+        "run-async": "^2.4.0",
+        "rxjs": "^6.6.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "through": "^2.3.6"
+      },
+      "dependencies": {
+        "ansi-escapes": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+          "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "type-fest": "^0.21.3"
+          }
+        },
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+          "dev": true,
+          "peer": true
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        },
+        "type-fest": {
+          "version": "0.21.3",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+          "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+          "dev": true,
+          "peer": true
+        }
+      }
     },
     "internal-slot": {
       "version": "1.0.5",
@@ -39664,7 +40351,8 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
       "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "jest-puppeteer": {
       "version": "4.4.0",
@@ -41623,6 +42311,13 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
+    "mute-stream": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+      "dev": true,
+      "peer": true
+    },
     "nan": {
       "version": "2.17.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
@@ -42180,8 +42875,7 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
     },
     "object-copy": {
       "version": "0.1.0",
@@ -42402,7 +43096,8 @@
           "version": "6.4.0",
           "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.4.0.tgz",
           "integrity": "sha512-jDfsatwWMWN0MODAFuHszfjphEXfNw9JUAhmY4pLu3TyTU+ohUpsbVtbU+1MZn4a47D9kqh03i4eyOm+74+zew==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "cssnano": {
           "version": "5.1.15",
@@ -42456,7 +43151,8 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-3.1.0.tgz",
           "integrity": "sha512-JQNR19/YZhz4psLX/rQ9M83e3z2Wf/HdJbryzte4a3NSuafyp9w/I4U+hx5C2S9g41qlstH7DEWnZaaj83OuEA==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "normalize-url": {
           "version": "6.1.0",
@@ -42517,25 +43213,29 @@
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-5.1.2.tgz",
           "integrity": "sha512-+L8208OVbHVF2UQf1iDmRcbdjJkuBF6IS29yBDSiWUIzpYaAhtNl6JYnYm12FnkeCwQqF5LeklOu6rAqgfBZqQ==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "postcss-discard-duplicates": {
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-5.1.0.tgz",
           "integrity": "sha512-zmX3IoSI2aoenxHV6C7plngHWWhUOV3sP1T8y2ifzxzbtnuhk1EdPwm0S1bIUNaJ2eNbWeGLEwzw8huPD67aQw==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "postcss-discard-empty": {
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-5.1.1.tgz",
           "integrity": "sha512-zPz4WljiSuLWsI0ir4Mcnr4qQQ5e1Ukc3i7UfE2XcrwKK2LIPIqE5jxMRxO6GbI3cv//ztXDsXwEWT3BHOGh3A==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "postcss-discard-overridden": {
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-5.1.0.tgz",
           "integrity": "sha512-21nOL7RqWR1kasIVdKs8HNqQJhFxLsyRfAnUDm4Fe4t4mCWL9OJiHvlHPjcd8zc5Myu89b/7wZDnOSjFgeWRtw==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "postcss-merge-longhand": {
           "version": "5.1.7",
@@ -42603,7 +43303,8 @@
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-5.1.0.tgz",
           "integrity": "sha512-mSgUJ+pd/ldRGVx26p2wz9dNZ7ji6Pn8VWBajMXFf8jk7vUoSrZ2lt/wZR7DtlZYKesmZI680qjr2CeFF2fbUg==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "postcss-normalize-display-values": {
           "version": "5.1.0",
@@ -43479,7 +44180,8 @@
       "version": "1.16.0",
       "resolved": "https://registry.npmjs.org/postcss-prefix-selector/-/postcss-prefix-selector-1.16.0.tgz",
       "integrity": "sha512-rdVMIi7Q4B0XbXqNUEI+Z4E+pueiu/CS5E6vRCQommzdQ/sgsS4dK42U7GX8oJR+TJOtT+Qv3GkNo6iijUMp3Q==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-reporter": {
       "version": "6.0.1",
@@ -43593,7 +44295,8 @@
       "version": "0.36.2",
       "resolved": "https://registry.npmjs.org/postcss-syntax/-/postcss-syntax-0.36.2.tgz",
       "integrity": "sha512-nBRg/i7E3SOHWxF3PpF5WnJM/jQ1YpY9000OaVXlAQj6Zp/kIqJxEDWIZ67tAd7NLuk7zqN4yqe9nc0oNAOs1w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-value-parser": {
       "version": "4.2.0",
@@ -43832,7 +44535,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "requires": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -44094,13 +44796,13 @@
       "version": "6.9.9",
       "resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-6.9.9.tgz",
       "integrity": "sha512-l+MBlKZffv/SicxDySKEEh42hR6m5bAHfNu3Tvxks2c4Ah+ldnWjfnVRwxo/nxF27SsUsxDS0raAzFuJNKABXA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "react": {
       "version": "16.14.0",
       "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
       "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
-      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -44111,7 +44813,8 @@
       "version": "5.6.1",
       "resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.6.1.tgz",
       "integrity": "sha512-1exovf0uGTGyq5mXQT0zgQ80uvj2PCwvF8zY1RN9/vbJVSjSo3fsB/4L3ObbF7u70NduSiK4xu4Y6q1MHoUGEw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "react-dom": {
       "version": "18.2.0",
@@ -44135,8 +44838,7 @@
     "react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "react-remove-scroll": {
       "version": "2.5.5",
@@ -44693,6 +45395,17 @@
       "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
       "integrity": "sha512-ZuF55hVUQaaczgOIwqWzkEcEidmlD/xl44x1UZnhOXcYuFN2S6+rcxpG+C1N3So0wvNI3DmJICUFfu2SxhBmvg==",
       "dev": true
+    },
+    "restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      }
     },
     "ret": {
       "version": "0.1.15",
@@ -46411,7 +47124,8 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-2.2.0.tgz",
       "integrity": "sha512-bZ+d4RiNEfmoR74KZtCKmsABdBJr4iXRiCso+6LtMJPw5rd/KnxUWTxht7TbafrTJK1YRjNgnN0iVZaJfc3xJA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "stylelint-config-recommended-scss": {
       "version": "3.3.0",
@@ -47994,7 +48708,8 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz",
       "integrity": "sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "use-lilius": {
       "version": "2.0.3",
@@ -48009,7 +48724,8 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.3.tgz",
       "integrity": "sha512-g66/K7ZQGYrI6dy8GLpVcMsBp4s17xNkYJVSMvTEevGy3nDxHOfE6z8BVE22+5G5x7t3+bhzrlTDB7ObrEE0cQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "use-sidecar": {
       "version": "1.1.2",
@@ -48033,7 +48749,8 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
       "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "user-home": {
       "version": "2.0.0",


### PR DESCRIPTION
# Description
This PR is required by:
- https://github.com/greenpeace/planet4-master-theme/pull/2188 which is blocking
- https://github.com/greenpeace/planet4-master-theme/pull/2343

Replace `@wordpress/element` with `wp.element`
[@wordpress/element oficial documentation](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-element/)

Replace `@wordpress/components` with `wp.components`
[@wordpress/components oficial documentation](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-components/)

Replace `@wordpress/compose` with `wp.compose`
[@wordpress/compose oficial documentation](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-compose/)

Replace `@wordpress/block-editor` with `wp.blockEditor`
[@wordpress/block-editor oficial documentation](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-block-editor/)
d
Replace `@wordpress/blocks` with `wp.blocks`
[@wordpress/blocks oficial documentation](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-blocks/)

Replace `@wordpress/plugins` with `wp.plugins`
[@wordpress/plugins oficial documentation](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-plugins/)

Replace `@wordpress/data` with `wp.data`
[@wordpress/data oficial documentation](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-data/)

Replace `@wordpress/editor` with `wp.editor`
[@wordpress/editor oficial documentation](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-editor/)
