### PR TITLE
 PLANET-7565: Fix tests broken by WordPress v6.6.x

### DIFF
--- a/tests/e2e/tools/lib/editor.js
+++ b/tests/e2e/tools/lib/editor.js
@@ -21,8 +21,13 @@
 async function openComponentPanel({editor}, panelTitle) {
   await editor.openDocumentSettingsSidebar();
   const editorSettings = await editor.canvas.getByRole('region', {name: 'Editor settings'});
-  await editorSettings.locator('.editor-sidebar__panel-tabs button').first().click();
-  await editorSettings.getByLabel('button', {name: panelTitle, exact: true});
+  await editorSettings.locator('.edit-post-sidebar__panel-tabs button').first().click();
+  const panelButton = await editorSettings.getByRole('button', {name: panelTitle, exact: true});
+  const panelExpanded = await panelButton.getAttribute('aria-expanded');
+  if (panelExpanded === 'false') {
+    await panelButton.click();
+  }
+
   return editorSettings;
 }
 

--- a/tests/e2e/tools/lib/editor.js
+++ b/tests/e2e/tools/lib/editor.js
@@ -21,7 +21,7 @@
 async function openComponentPanel({editor}, panelTitle) {
   await editor.openDocumentSettingsSidebar();
   const editorSettings = await editor.canvas.getByRole('region', {name: 'Editor settings'});
-  await editorSettings.locator('.edit-post-sidebar__panel-tabs button').first().click();
+  await editorSettings.locator('.editor-sidebar__panel-tabs button').first().click();
   const panelButton = await editorSettings.getByRole('button', {name: panelTitle, exact: true});
   const panelExpanded = await panelButton.getAttribute('aria-expanded');
   if (panelExpanded === 'false') {

--- a/tests/e2e/tools/lib/post.js
+++ b/tests/e2e/tools/lib/post.js
@@ -1,5 +1,3 @@
-import {openComponentPanel} from './editor.js';
-
 /**
  * Publishes a post using the provided editor and returns the URL of the published post.
  *
@@ -35,15 +33,15 @@ async function publishPostAndVisit({page, editor}) {
 /**
  * Creates a new post with a featured image set.
  *
- * @param {Object} params - Parameters for creating the post and setting the featured image.
- * @param {Object} params.admin - The admin object used to create a new post.
- * @param {Object} params.editor - The editor object used to interact with the editor.
- * @param {Object} params.params - Additional parameters for creating the post.
+ * @param {Object} p - Parameters for creating the post and setting the featured image.
+ * @param {Object} p.admin - The admin object used to create a new post.
+ * @param {Object} p.editor - The editor object used to interact with the editor.
+ * @param {Object} params - Additional parameters for creating the post.
  * @return {Promise<Object>} The newly created post.
  */
 async function createPostWithFeaturedImage({admin, editor}, params) {
   const newPost = await admin.createNewPost({...params, legacyCanvas: true});
-  const editorSettings = await openComponentPanel({editor}, 'Featured image');
+  const editorSettings = await editor.canvas.getByRole('region', {name: 'Editor settings'});
   await editorSettings.getByRole('button', {name: 'Set featured image'}).click();
   const imageModal = await editor.canvas.getByRole('dialog', {name: 'Featured image'});
   const mediaLibraryTab = await imageModal.locator('#menu-item-browse');


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-7565

<hr>

**DESCRIPTION:**
This PR fixes the failing automated tests after upgrading WordPress to its LTS version ([6.6.1 of 23 July, 2024](https://wordpress.org/download/releases/)).

Whilst the automated tests were fixed on [a previous PR](https://github.com/greenpeace/planet4-master-theme/pull/2334), the changes implemented there are not scalable. WordPress 6.6 removed the Featured Image button from a collapsible tab, so, instead of changing the `openComponentPanel` function (that would break any test requiring a tab to be expanded in the WP editor sidebar) it is better to update the `createPostWithFeaturedImage` function instead. 