### PR TITLE
PLANET-7573: Apply necessary changes to update ElasticPress to version 5.*

### DIFF
--- a/src/ControlPanel.php
+++ b/src/ControlPanel.php
@@ -110,7 +110,7 @@ class ControlPanel
                         'title' => __('Sync Elasticsearch', 'planet4-master-theme-backend'),
                         // If we give 'url' key instead of 'action'
                         // then we will do usual request instead of ajax request.
-                        'url' => 'admin.php?page=elasticpress&do_sync',
+                        'url' => 'admin.php?page=elasticpress-sync',
                         // 'action' => 'ep_index', // Could use this EP action to perform sync asynchronously.
                     ],
                     [

--- a/src/Search/ElasticSearch.php
+++ b/src/Search/ElasticSearch.php
@@ -20,7 +20,7 @@ class ElasticSearch
                 return;
             }
 
-            \ElasticPress\Features::factory()->update_feature('facets', [
+            \ElasticPress\Features::factory()->update_feature('filters', [
                 'active' => true,
                 'match_type' => 'all',
             ]);
@@ -64,6 +64,6 @@ class ElasticSearch
         if (!self::is_active()) {
             return false;
         }
-        return \ElasticPress\Features::factory()->get_registered_feature('facets')->is_active();
+        return \ElasticPress\Features::factory()->get_registered_feature('filters')->is_active();
     }
 }

--- a/src/Search/ElasticSearch.php
+++ b/src/Search/ElasticSearch.php
@@ -20,7 +20,7 @@ class ElasticSearch
                 return;
             }
 
-            \ElasticPress\Features::factory()->update_feature('filters', [
+            \ElasticPress\Features::factory()->update_feature('facets', [
                 'active' => true,
                 'match_type' => 'all',
             ]);
@@ -64,6 +64,6 @@ class ElasticSearch
         if (!self::is_active()) {
             return false;
         }
-        return \ElasticPress\Features::factory()->get_registered_feature('filters')->is_active();
+        return \ElasticPress\Features::factory()->get_registered_feature('facets')->is_active();
     }
 }

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -174,50 +174,6 @@ class Settings
                     ],
                 ],
             ],
-            'planet4_settings_search_content' => [
-                'title' => 'Search content',
-                'fields' => [
-                    [
-                        'name' => __('Include archived content in search for', 'planet4-master-theme-backend'),
-                        'desc' => __(
-                            '<b>Important:</b> On change of Include archive content setting, Please kindly',
-                            'planet4-master-theme-backend'
-                        ) . ' <a href="admin.php?page=elasticpress-sync" target="_blank">Sync Elasticsearch</a>.',
-                        'id' => 'include_archive_content_for',
-                        'type' => 'select',
-                        'default' => 'nobody',
-                        'options' => [
-                            'nobody' => __('Nobody', 'planet4-master-theme-backend'),
-                            'logged_in' => __('Logged in users', 'planet4-master-theme-backend'),
-                            'all' => __('All users', 'planet4-master-theme-backend'),
-                        ],
-                    ],
-                    [
-                        'name' => __('Search content decay', 'planet4-master-theme-backend'),
-                        'desc' => __('Amount of lowering of the relevancy score for older results. Between 0 and 1. The lower this number is, the lower older content will be ranked. See image. <br>We use the exponential function (exp, green curve).<br/> <img style="max-width:350px" alt="ElasticSearch decay function graph" src="https://www.elastic.co/guide/en/elasticsearch/reference/current/images/decay_2d.png">', 'planet4-master-theme-backend'),
-                        'id' => 'epwr_decay',
-                        'type' => 'text',
-                    ],
-                    [
-                        'name' => __('Search content decay scale', 'planet4-master-theme-backend'),
-                        'desc' => __(
-                            'Timescale for lowering the relevance of older results. See image above.',
-                            'planet4-master-theme-backend'
-                        ),
-                        'id' => 'epwr_scale',
-                        'type' => 'text',
-                    ],
-                    [
-                        'name' => __('Search content decay offset', 'planet4-master-theme-backend'),
-                        'desc' => __(
-                            'How old should a post be before relevance is lowered. See image above.',
-                            'planet4-master-theme-backend'
-                        ),
-                        'id' => 'epwr_offset',
-                        'type' => 'text',
-                    ],
-                ],
-            ],
             'planet4_settings_cookies_text' => [
                 'title' => 'Cookies',
                 'fields' => [
@@ -503,6 +459,60 @@ class Settings
             'planet4_settings_features' => Features::get_options_page(),
         ];
 
+        // This option should be visible only if the ElasticPress plugin is activated.
+        $is_elasticpress = function_exists('is_plugin_active') && is_plugin_active('elasticpress/elasticpress.php');
+        if ($is_elasticpress) {
+
+            $search_content = array(
+                'planet4_settings_search_content' => [
+                    'title' => 'Search content',
+                    'fields' => [
+                        [
+                            'name' => __('Include archived content in search for', 'planet4-master-theme-backend'),
+                            'desc' => __(
+                                '<b>Important:</b> On change of Include archive content setting, Please kindly',
+                                'planet4-master-theme-backend'
+                            ) . ' <a href="admin.php?page=elasticpress-sync" target="_blank">Sync Elasticsearch</a>.',
+                            'id' => 'include_archive_content_for',
+                            'type' => 'select',
+                            'default' => 'nobody',
+                            'options' => [
+                                'nobody' => __('Nobody', 'planet4-master-theme-backend'),
+                                'logged_in' => __('Logged in users', 'planet4-master-theme-backend'),
+                                'all' => __('All users', 'planet4-master-theme-backend'),
+                            ],
+                        ],
+                        [
+                            'name' => __('Search content decay', 'planet4-master-theme-backend'),
+                            'desc' => __('Amount of lowering of the relevancy score for older results. Between 0 and 1. The lower this number is, the lower older content will be ranked. See image. <br>We use the exponential function (exp, green curve).<br/> <img style="max-width:350px" alt="ElasticSearch decay function graph" src="https://www.elastic.co/guide/en/elasticsearch/reference/current/images/decay_2d.png">', 'planet4-master-theme-backend'),
+                            'id' => 'epwr_decay',
+                            'type' => 'text',
+                        ],
+                        [
+                            'name' => __('Search content decay scale', 'planet4-master-theme-backend'),
+                            'desc' => __(
+                                'Timescale for lowering the relevance of older results. See image above.',
+                                'planet4-master-theme-backend'
+                            ),
+                            'id' => 'epwr_scale',
+                            'type' => 'text',
+                        ],
+                        [
+                            'name' => __('Search content decay offset', 'planet4-master-theme-backend'),
+                            'desc' => __(
+                                'How old should a post be before relevance is lowered. See image above.',
+                                'planet4-master-theme-backend'
+                            ),
+                            'id' => 'epwr_offset',
+                            'type' => 'text',
+                        ],
+                    ],
+                ],
+            );
+
+            $this->subpages = array_merge($this->subpages, $search_content);
+        }
+        
         // This option should be visible only if the GF Hubspot add-on is activated.
         $is_gf_hubspot_addon = function_exists('is_plugin_active') && is_plugin_active('gravityformshubspot/hubspot.php');
         if ($is_gf_hubspot_addon) {

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -462,7 +462,6 @@ class Settings
         // This option should be visible only if the ElasticPress plugin is activated.
         $is_elasticpress = function_exists('is_plugin_active') && is_plugin_active('elasticpress/elasticpress.php');
         if ($is_elasticpress) {
-
             $search_content = array(
                 'planet4_settings_search_content' => [
                     'title' => 'Search content',
@@ -509,10 +508,8 @@ class Settings
                     ],
                 ],
             );
-
             $this->subpages = array_merge($this->subpages, $search_content);
         }
-        
         // This option should be visible only if the GF Hubspot add-on is activated.
         $is_gf_hubspot_addon = function_exists('is_plugin_active') && is_plugin_active('gravityformshubspot/hubspot.php');
         if ($is_gf_hubspot_addon) {

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -182,7 +182,7 @@ class Settings
                         'desc' => __(
                             '<b>Important:</b> On change of Include archive content setting, Please kindly',
                             'planet4-master-theme-backend'
-                        ) . ' <a href="admin.php?page=elasticpress&do_sync" target="_blank">Sync Elasticsearch</a>.',
+                        ) . ' <a href="admin.php?page=elasticpress-sync" target="_blank">Sync Elasticsearch</a>.',
                         'id' => 'include_archive_content_for',
                         'type' => 'select',
                         'default' => 'nobody',

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -471,7 +471,7 @@ class Settings
                             'desc' => __(
                                 '<b>Important:</b> On change of Include archive content setting, Please kindly',
                                 'planet4-master-theme-backend'
-                            ) . ' <a href="admin.php?page=elasticpress-sync" target="_blank">Sync Elasticsearch</a>.',
+                            ) . ' <a href="admin.php?page=elasticpress-sync">Sync Elasticsearch</a>.',
                             'id' => 'include_archive_content_for',
                             'type' => 'select',
                             'default' => 'nobody',

--- a/tests/e2e/search.spec.js
+++ b/tests/e2e/search.spec.js
@@ -3,14 +3,12 @@ import {test, expect} from './tools/lib/test-utils.js';
 test.useAdminLoggedIn();
 
 test.describe('Greenpeace Search tests', () => {
-
   test('re sync elasticpress', async ({page}) => {
-
     await page.goto('./wp-admin/admin.php?page=elasticpress-sync');
 
     const checkBox = await page.getByRole('checkbox', {name: 'Delete all data and start fresh sync'});
     const startButton = await page.getByRole('button', {name: 'Start sync'});
-    
+
     await checkBox.check();
     await startButton.click();
 
@@ -18,11 +16,11 @@ test.describe('Greenpeace Search tests', () => {
   });
 
   test('check search works', async ({page, requestUtils}) => {
-    const testId = `testsearch-${Math.floor(Math.random() * 10000)}`;//NOSONAR
+    const testId = `testsearch-${Math.floor(Math.random() * 10000)}`; //NOSONAR
     const tagName = `Tag ${testId}`;
     const tagPageTitle = `#Tag ${testId}`;
     const postTitle = `Test Post ${testId}`;
-  
+
     const tagPage = await requestUtils.rest({
       path: '/wp/v2/pages',
       method: 'POST',
@@ -33,7 +31,7 @@ test.describe('Greenpeace Search tests', () => {
         featured_media: 357,
       },
     });
-  
+
     const tag = await requestUtils.rest({
       path: '/wp/v2/tags',
       method: 'POST',
@@ -46,7 +44,7 @@ test.describe('Greenpeace Search tests', () => {
         },
       },
     });
-  
+
     await requestUtils.rest({
       path: '/wp/v2/posts',
       method: 'POST',
@@ -58,18 +56,18 @@ test.describe('Greenpeace Search tests', () => {
         tags: [tag.id],
       },
     });
-  
+
     await page.goto('./');
-  
+
     const searchBox = page.getByPlaceholder('Search');
     await searchBox.click();
     await searchBox.fill(testId);
     await page.keyboard.press('Enter');
-  
+
     const searchResult = await page.innerHTML('.result-statement');
     const searchPage = await page.locator('.search-result-item-headline').allInnerTexts();
     const searchTags = await page.locator('.search-result-item-tag').allInnerTexts();
-  
+
     expect(searchResult).toContain(testId);
     expect(searchPage).toContain(tagPageTitle);
     expect(searchPage).toContain(postTitle);

--- a/tests/e2e/search.spec.js
+++ b/tests/e2e/search.spec.js
@@ -4,15 +4,37 @@ test.useAdminLoggedIn();
 
 test.describe('Greenpeace Search tests', () => {
   test('re sync elasticpress', async ({page}) => {
+    // Go to ElasticSearch sync page
     await page.goto('./wp-admin/admin.php?page=elasticpress-sync');
 
-    const checkBox = await page.getByRole('checkbox', {name: 'Delete all data and start fresh sync'});
-    const startButton = await page.getByRole('button', {name: 'Start sync'});
+    const mainButton = page.locator('.ep-sync-controls button.is-primary');
+    const checkBox = page.locator('#inspector-checkbox-control-0');
+    const syncProgress = page.locator('.ep-sync-progress__details');
 
+    let mainButtonText = await mainButton.allInnerTexts();
+    let syncProgressText = await syncProgress.allInnerTexts();
+
+    // If the sync was already executed, stop it
+    if (mainButtonText.includes('Stop sync')) {
+      expect(syncProgressText.includes('Sync paused'));
+      await mainButton.click();
+      mainButtonText = await mainButton.allInnerTexts();
+    }
+
+    // Click on the checkbox and execute the sync process
     await checkBox.check();
-    await startButton.click();
+    await mainButton.click();
 
-    expect(page.getByText('Sync complete.')).toBeVisible();
+    expect(mainButtonText.includes('Start sync'));
+    expect(syncProgressText.includes('Sync in progress'));
+
+    // Wait for the sync to complete
+    await page.waitForFunction(
+      () => document.querySelector('.ep-sync-progress__details').innerText.includes('Sync complete')
+    );
+
+    syncProgressText = await syncProgress.allInnerTexts();
+    expect(syncProgressText.includes('Sync complete'));
   });
 
   test('check search works', async ({page, requestUtils}) => {

--- a/tests/e2e/search.spec.js
+++ b/tests/e2e/search.spec.js
@@ -2,67 +2,77 @@ import {test, expect} from './tools/lib/test-utils.js';
 
 test.useAdminLoggedIn();
 
-test('check search works', async ({page, requestUtils}) => {
-  const testId = `testsearch-${Math.floor(Math.random() * 10000)}`;//NOSONAR
-  const tagName = `Tag ${testId}`;
-  const tagPageTitle = `#Tag ${testId}`;
-  const postTitle = `Test Post ${testId}`;
+test.describe('Greenpeace Search tests', () => {
 
-  const tagPage = await requestUtils.rest({
-    path: '/wp/v2/pages',
-    method: 'POST',
-    data: {
-      title: tagPageTitle,
-      content: '<!-- wp:paragraph --><p>The redirect page for the new tag</p><!-- /wp:paragraph -->',
-      status: 'publish',
-      featured_media: 357,
-    },
+  test('re sync elasticpress', async ({page}) => {
+
+    await page.goto('./wp-admin/admin.php?page=elasticpress-sync');
+
+    const checkBox = await page.getByRole('checkbox', {name: 'Delete all data and start fresh sync'});
+    const startButton = await page.getByRole('button', {name: 'Start sync'});
+    
+    await checkBox.check();
+    await startButton.click();
+
+    expect(page.getByText('Sync complete.')).toBeVisible();
   });
 
-  const tag = await requestUtils.rest({
-    path: '/wp/v2/tags',
-    method: 'POST',
-    data: {
-      slug: `tag-${testId}`,
-      name: tagName,
-      description: `Description of the tag ${testId}`,
-      meta: {
-        redirect_page: tagPage.id,
+  test('check search works', async ({page, requestUtils}) => {
+    const testId = `testsearch-${Math.floor(Math.random() * 10000)}`;//NOSONAR
+    const tagName = `Tag ${testId}`;
+    const tagPageTitle = `#Tag ${testId}`;
+    const postTitle = `Test Post ${testId}`;
+  
+    const tagPage = await requestUtils.rest({
+      path: '/wp/v2/pages',
+      method: 'POST',
+      data: {
+        title: tagPageTitle,
+        content: '<!-- wp:paragraph --><p>The redirect page for the new tag</p><!-- /wp:paragraph -->',
+        status: 'publish',
+        featured_media: 357,
       },
-    },
-  });
-
-  await requestUtils.rest({
-    path: '/wp/v2/posts',
-    method: 'POST',
-    data: {
-      title: postTitle,
-      content: '<!-- wp:paragraph --><p>This is a search test post</p><!-- /wp:paragraph -->',
-      status: 'publish',
-      featured_media: 357,
-      tags: [tag.id],
-    },
-  });
-
-  await page.goto('./');
-
-  const searchBox = page.getByPlaceholder('Search');
-  await searchBox.click();
-  await searchBox.fill(testId);
-  await page.keyboard.press('Enter');
-
-  const searchResult = await page.innerHTML('.result-statement');
-  const searchPage = await page.locator('.search-result-item-headline').allInnerTexts();
-  const searchTags = await page.locator('.search-result-item-tag').allInnerTexts();
-
-  if (searchResult) {
+    });
+  
+    const tag = await requestUtils.rest({
+      path: '/wp/v2/tags',
+      method: 'POST',
+      data: {
+        slug: `tag-${testId}`,
+        name: tagName,
+        description: `Description of the tag ${testId}`,
+        meta: {
+          redirect_page: tagPage.id,
+        },
+      },
+    });
+  
+    await requestUtils.rest({
+      path: '/wp/v2/posts',
+      method: 'POST',
+      data: {
+        title: postTitle,
+        content: '<!-- wp:paragraph --><p>This is a search test post</p><!-- /wp:paragraph -->',
+        status: 'publish',
+        featured_media: 357,
+        tags: [tag.id],
+      },
+    });
+  
+    await page.goto('./');
+  
+    const searchBox = page.getByPlaceholder('Search');
+    await searchBox.click();
+    await searchBox.fill(testId);
+    await page.keyboard.press('Enter');
+  
+    const searchResult = await page.innerHTML('.result-statement');
+    const searchPage = await page.locator('.search-result-item-headline').allInnerTexts();
+    const searchTags = await page.locator('.search-result-item-tag').allInnerTexts();
+  
     expect(searchResult).toContain(testId);
-  }
-  if (searchPage) {
     expect(searchPage).toContain(tagPageTitle);
     expect(searchPage).toContain(postTitle);
-  }
-  if (searchTags) {
     expect(searchTags).toContain(`#${tagName}`);
-  }
+  });
 });

--- a/tests/e2e/search.spec.js
+++ b/tests/e2e/search.spec.js
@@ -55,8 +55,14 @@ test('check search works', async ({page, requestUtils}) => {
   const searchPage = await page.locator('.search-result-item-headline').allInnerTexts();
   const searchTags = await page.locator('.search-result-item-tag').allInnerTexts();
 
-  expect(searchResult).toContain(testId);
-  expect(searchPage).toContain(tagPageTitle);
-  expect(searchPage).toContain(postTitle);
-  expect(searchTags).toContain(`#${tagName}`);
+  if (searchResult) {
+    expect(searchResult).toContain(testId);
+  }
+  if (searchPage) {
+    expect(searchPage).toContain(tagPageTitle);
+    expect(searchPage).toContain(postTitle);
+  }
+  if (searchTags) {
+    expect(searchTags).toContain(`#${tagName}`);
+  }
 });


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-7573 

<hr>

**DESCRIPTION:**

This PR:
- Updates the links to the ElasticPress sync page, according to the changes implemented in version 5 of this plugin.
- Conditionally adds/hides the `admin.php?page=planet4_settings_search_content` page if ElasticPress is active.
- Updates the search tests.
 
<hr>

**RELATED PR:**

https://github.com/greenpeace/planet4-base/pull/307

<hr>

**POSSIBLE CHANGES:**

Should we conditionally add/hide the `admin.php?page=planet4_settings_search_content` page if ElasticPress is active, @comzeradd ?