### PR TITLE
PLANET-7575: Rename social media events

### DIFF
--- a/assets/src/blocks/ENForm/ShareButtons.js
+++ b/assets/src/blocks/ENForm/ShareButtons.js
@@ -28,7 +28,8 @@ export const ShareButtons = ({social_params, social_accounts}) => {
 
   const share = (action, label) => {
     window.dataLayer.push({
-      event: 'uaevent',
+      event: 'page_shared',
+      channel: action,
       eventCategory: 'Social Share',
       eventAction: action,
       eventLabel: label,

--- a/assets/src/blocks/ENForm/ShareButtons.js
+++ b/assets/src/blocks/ENForm/ShareButtons.js
@@ -27,12 +27,21 @@ export const ShareButtons = ({social_params, social_accounts}) => {
   } = social_params;
 
   const share = (action, label) => {
-    window.dataLayer.push({
-      event: 'page_shared',
-      channel: action,
+    const shared = {
       eventCategory: 'Social Share',
       eventAction: action,
       eventLabel: label,
+    };
+
+    window.dataLayer.push({
+      event: 'uaevent',
+      ...shared,
+    });
+
+    window.dataLayer.push({
+      event: 'page_shared',
+      channel: action,
+      ...shared,
     });
   };
 

--- a/src/GravityFormsExtensions.php
+++ b/src/GravityFormsExtensions.php
@@ -282,6 +282,7 @@ class GravityFormsExtensions
             "gaeventlabel_thickbox" => "{form_title} ID: {form_id}",
             "gaeventgoalid" => "",
             "gaeventgoal" => "Submission: " . $form['title'],
+            "channel" => "",
             "gaeventcategory" => "",
             "gaeventaction" => "",
             "gaeventlabel" => "{form_title} ID: {form_id}",

--- a/templates/blocks/share_buttons.twig
+++ b/templates/blocks/share_buttons.twig
@@ -1,42 +1,38 @@
 {% block javascripts %}
-    <script>
-        window.addEventListener('DOMContentLoaded', () => {
-            if (typeof dataLayer === 'undefined') {
-                return;
-            }
-
-            const dataLayerPush = platform => dataLayer.push({
-                event: 'page_shared',
-                channel: platform,
+<script>
+    if(!window.dataLayerPush) {
+        window.dataLayerPush = platform => {
+            const shared = {
                 eventCategory: 'Social Share',
                 eventAction: platform,
                 eventLabel: '{{ social.link }}',
-            });
-            window.dataLayerPush = dataLayerPush;
-
-            // If the native share functionality is not available on the device,
-            // we don't show the corresponding share button.
-            if (!navigator.share) {
-                return;
-            }
-
-            const nativeShareButtons = document.querySelectorAll('.share-buttons .share-btn.native');
-            nativeShareButtons.forEach(nativeShareButton => nativeShareButton.style.display = 'block');
-
-            window.nativeShare = async () => {
-                try {
-                    await navigator.share({
-                        title: '{{ social.title }}',
-                        url: '{{ share_url ?? social.link }}',
-                        text: '{{ share_text ?? social.description }}',
-                    });
-                    dataLayerPush('Native');
-                } catch (err) {
-                    console.log(err);
-                }
             };
-        });
-    </script>
+
+            dataLayer.push({event: 'uaevent', ...shared});
+            dataLayer.push({event: 'page_shared', channel: platform, ...shared});
+        };
+    }
+
+    // If the native share functionality is not available on the device,
+    // we don't show the corresponding share button.
+    if (navigator.share) {
+        const nativeShareButtons = document.querySelectorAll('.share-buttons .share-btn.native');
+        nativeShareButtons.forEach(nativeShareButton => nativeShareButton.style.display = 'block');
+
+        window.nativeShare = async () => {
+            try {
+                await navigator.share({
+                    title: '{{ social.title }}',
+                    url: '{{ share_url ?? social.link }}',
+                    text: '{{ share_text ?? social.description }}',
+                });
+                dataLayerPush('Native');
+            } catch (err) {
+                console.log(err);
+            }
+        };
+    }
+</script>
 {% endblock %}
 
 {% set socialLink = (share_url ?? social.link) ~ '?utm_medium=' ~ utm_medium ~ utm_content_param ~ utm_campaign_param %}

--- a/templates/blocks/share_buttons.twig
+++ b/templates/blocks/share_buttons.twig
@@ -6,7 +6,8 @@
             }
 
             const dataLayerPush = platform => dataLayer.push({
-                event: 'uaevent',
+                event: 'page_shared',
+                channel: platform,
                 eventCategory: 'Social Share',
                 eventAction: platform,
                 eventLabel: '{{ social.link }}',


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-7575

# Description

- Rename `uaevent` to `page_shared` (see the **Update** section)
- Add new `channel` 

### Post page
<img width="1437" alt="Screen Shot 2024-08-15 at 06 45 58" src="https://github.com/user-attachments/assets/767e1a9b-4cac-4c3f-859e-ecf9aba302bb">

### GF Form
<img width="1430" alt="Screen Shot 2024-08-15 at 06 53 23" src="https://github.com/user-attachments/assets/b82c4bd8-940f-4874-bfcd-b6cd038d0b6c">


## Testing
Check it out the shared demo pages and test if the values are properly fired.
- [Post page](https://www-dev.greenpeace.org/test-atlas/story/1445/test-demo-page/)
- [GF demo page](https://www-dev.greenpeace.org/test-atlas/datalayer-values-demo-page/)

## Update
We will need to [keep both events](https://github.com/greenpeace/planet4-master-theme/pull/2351/commits/4b9d36f7a9ebda35dd35269d660b8ebbbc3901ea) (for now) until the data team make the changes on GTM


<!-- Ref: Please add a url to the ticket this change is addressing.

---

Please provide a brief summary of the change introduced to make review process easier.

Ideally this should also be part of the commit summary.
-->
