### PR TITLE
PLANET-7499: Apply backend text changes on Gallery block

### DIFF
--- a/assets/src/blocks/Gallery/GalleryEditor.js
+++ b/assets/src/blocks/Gallery/GalleryEditor.js
@@ -76,8 +76,13 @@ const renderEdit = (attributes, setAttributes, isSelected) => {
         <InspectorControls>
           <PanelBody title={__('Settings', 'planet4-blocks-backend')}>
             <div className="wp-block-master-theme-gallery__FocalPointPicker">
-              <p>{__('Select gallery image focal point', 'planet4-blocks-backend')}</p>
-              <ul>
+              <strong className="components-base-control__help">
+                {__('Select gallery image focal point', 'planet4-blocks-backend')}
+              </strong>
+              <p className="components-base-control__help">
+                {__('Adjust the “Left” and “Top” fields to position the focal point of the image in percentage, where 0% is the top/left edge and 100% is the bottom/right edge.', 'planet4-blocks-backend')}
+              </p>
+              <ul className="p-0">
                 {focalPointImages.map((item, index) => (
                   <li key={index}>
                     <FocalPointPicker


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-7499 

This PR updates the backend text of the Gallery block according to [this design](https://www.figma.com/design/5qO8DT0C7r7z2zNtxpOpdH/Gallery-Block?node-id=1-569&t=OT5MAuRfEZaOGfHz-0).