### PR TITLE
Remove redundant class check

### DIFF
--- a/src/Controllers/Menu/Controller.php
+++ b/src/Controllers/Menu/Controller.php
@@ -8,42 +8,39 @@ namespace P4\MasterTheme\Controllers\Menu;
 
 use P4\MasterTheme\View\View;
 
-if (! class_exists('Controller')) {
+/**
+ * Class Controller
+ *
+ * This class will control all the main functions.
+ */
+abstract class Controller
+{
+    /**
+     * View object
+     */
+    protected View $view;
 
     /**
-     * Class Controller
+     * Creates the controller object.
+     * Avoid putting hooks inside the constructor, to make testing easier.
      *
-     * This class will control all the main functions.
+     * @param View $view The view object.
      */
-    abstract class Controller
+    public function __construct(View $view)
     {
-        /**
-         * View object
-         */
-        protected View $view;
-
-        /**
-         * Creates the controller object.
-         * Avoid putting hooks inside the constructor, to make testing easier.
-         *
-         * @param View $view The view object.
-         */
-        public function __construct(View $view)
-        {
-            $this->view = $view;
-        }
-
-        /**
-         * Hooks the method that Creates the menu item for the current controller.
-         */
-        public function load(): void
-        {
-            add_action('admin_menu', [$this, 'create_admin_menu']);
-        }
-
-        /**
-         * Add the admin menu item.
-         */
-        abstract public function create_admin_menu(): void;
+        $this->view = $view;
     }
+
+    /**
+     * Hooks the method that Creates the menu item for the current controller.
+     */
+    public function load(): void
+    {
+        add_action('admin_menu', [$this, 'create_admin_menu']);
+    }
+
+    /**
+     * Add the admin menu item.
+     */
+    abstract public function create_admin_menu(): void;
 }


### PR DESCRIPTION
This creates conflct issues with plugins that use a class with the same name and not properly use PSR-4.

Example exception from a php library used in many plugins:

```
PHP Fatal error: Cannot declare class Action_Scheduler\Migration\Controller,
because the name is already in use in
action-scheduler/classes/migration/Controller.php on line 21
```

Removing the check, resolves the issue.

<!-- Ref: Please add a url to the ticket this change is addressing.

---

Please provide a brief summary of the change introduced to make review process easier.

Ideally this should also be part of the commit summary.
-->
