### PR TITLE
Skip Media spec test

### DIFF
--- a/tests/e2e/greenpeace-media.spec.js
+++ b/tests/e2e/greenpeace-media.spec.js
@@ -8,6 +8,9 @@ import {
 const TEST_IMAGES = ['GP0STXWME', 'GP0STXWZH'];
 const MEDIA_LIBRARY_PAGE = './wp-admin/admin.php?page=media-picker';
 
+// Temporary fix.
+test.skip();
+
 test.useAdminLoggedIn();
 
 test.describe('Greenpeace Media tests', () => {


### PR DESCRIPTION
The Greenpeace Media (OrangeLogic) APIs are currently down, temporarily skipping the media spec to bypass this check

<!-- Ref: Please add a url to the ticket this change is addressing.

---

Please provide a brief summary of the change introduced to make review process easier.

Ideally this should also be part of the commit summary.
-->
