### PR TITLE
Disable smilies filter

### DIFF
--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -140,6 +140,10 @@ class MasterSite extends TimberSite
         add_action('after_setup_theme', [$this, 'add_image_sizes']);
         add_action('save_post', [$this, 'p4_auto_generate_excerpt'], 10, 2);
 
+        // Disable smilies filter
+        // https://github.com/10up/ElasticPress/issues/3280
+        remove_filter('the_content', 'convert_smilies', 20);
+
         add_action('admin_head', [$this, 'add_help_sidebar']);
 
         remove_action('wp_head', 'print_emoji_detection_script', 7);


### PR DESCRIPTION
Ref: https://github.com/10up/ElasticPress/issues/3280

This was preventing sync from completing in certain use cases.

<details>
  <summary>Exception</summary>
  
```
PHP Fatal error:  Uncaught TypeError: count(): Argument #1 ($value) must be of type Countable|array, bool given in wp-includes/formatting.php:3507
Stack trace:
#0 wp-includes/class-wp-hook.php(324): convert_smilies()
#1 wp-includes/plugin.php(205): WP_Hook->apply_filters()
#2 wp-content/plugins/elasticpress/includes/classes/Indexable/Post/Post.php(506): apply_filters()
#3 wp-content/plugins/elasticpress/includes/classes/Indexable.php(387): ElasticPress\Indexable\Post\Post->prepare_document()
#4 wp-content/plugins/elasticpress/includes/classes/IndexHelper.php(654): ElasticPress\Indexable->bulk_index_dynamically()
#5 wp-content/plugins/elasticpress/includes/classes/IndexHelper.php(436): ElasticPress\IndexHelper->index_next_batch()
#6 wp-content/plugins/elasticpress/includes/classes/IndexHelper.php(324): ElasticPress\IndexHelper->index_objects()
#7 wp-content/plugins/elasticpress/includes/classes/IndexHelper.php(95): ElasticPress\IndexHelper->process_sync_item()
#8 wp-content/plugins/elasticpress/includes/classes/Command.php(838): ElasticPress\IndexHelper->full_index()
#9 [internal function]: ElasticPress\Command->sync()
#10 phar:///app/wp-cli.phar/vendor/wp-cli/wp-cli/php/WP_CLI/Dispatcher/CommandFactory.php(100): call_user_func()
#11 [internal function]: WP_CLI\Dispatcher\CommandFactory::WP_CLI\Dispatcher\{closure}()
#12 phar:///app/wp-cli.phar/vendor/wp-cli/wp-cli/php/WP_CLI/Dispatcher/Subcommand.php(491): call_user_func()
#13 phar:///app/wp-cli.phar/vendor/wp-cli/wp-cli/php/WP_CLI/Runner.php(431): WP_CLI\Dispatcher\Subcommand->invoke()
#14 phar:///app/wp-cli.phar/vendor/wp-cli/wp-cli/php/WP_CLI/Runner.php(454): WP_CLI\Runner->run_command()
#15 phar:///app/wp-cli.phar/vendor/wp-cli/wp-cli/php/WP_CLI/Runner.php(1269): WP_CLI\Runner->run_command_and_exit()
#16 phar:///app/wp-cli.phar/vendor/wp-cli/wp-cli/php/WP_CLI/Bootstrap/LaunchRunner.php(28): WP_CLI\Runner->start()
#17 phar:///app/wp-cli.phar/vendor/wp-cli/wp-cli/php/bootstrap.php(83): WP_CLI\Bootstrap\LaunchRunner->process()
#18 phar:///app/wp-cli.phar/vendor/wp-cli/wp-cli/php/wp-cli.php(32): WP_CLI\bootstrap()
#19 phar:///app/wp-cli.phar/php/boot-phar.php(20): include('...')
#20 /app/wp-cli.phar(4): include('...')
#21 {main}
  thrown in wp-includes/formatting.php on line 3507
```
</details>

---

Fix deployed in Aotearoa dev site and sync through the admin panel now works again
