### PR TITLE
Revert Greenpeace Media specs

### DIFF
--- a/tests/e2e/greenpeace-media.spec.js
+++ b/tests/e2e/greenpeace-media.spec.js
@@ -8,9 +8,6 @@ import {
 const TEST_IMAGES = ['GP0STXWME', 'GP0STXWZH'];
 const MEDIA_LIBRARY_PAGE = './wp-admin/admin.php?page=media-picker';
 
-// Temporary fix.
-test.skip();
-
 test.useAdminLoggedIn();
 
 test.describe('Greenpeace Media tests', () => {


### PR DESCRIPTION
# Description
Previously skipped since the GP Media Library was down for a couple of days
Here is the [code](https://github.com/greenpeace/planet4-master-theme/commit/552837e45445964ae861cd9fcfb9fe4594840952#diff-9e4f3da89e97d282f270086927e379ce93af2a6172b7535a86489bf4ca3007d6R11-R13) to revert.

<!-- Ref: Please add a url to the ticket this change is addressing.

---

Please provide a brief summary of the change introduced to make review process easier.

Ideally this should also be part of the commit summary.
-->
