### PR TITLE
Add line-clamp CSS attribute

### DIFF
--- a/assets/src/scss/blocks/ActionsList.scss
+++ b/assets/src/scss/blocks/ActionsList.scss
@@ -98,6 +98,7 @@
     font-size: 20px;
     margin-bottom: 0;
     display: -webkit-box;
+    line-clamp: 2;
     -webkit-line-clamp: 2;
     -webkit-box-orient: vertical;
     overflow: hidden;
@@ -108,6 +109,7 @@
     font-size: 1rem;
     line-height: 1.5rem;
     display: -webkit-box;
+    line-clamp: 3;
     -webkit-line-clamp: 3;
     -webkit-box-orient: vertical;
     overflow: hidden;

--- a/assets/src/scss/blocks/Gallery/styles/GalleryCarousel.scss
+++ b/assets/src/scss/blocks/Gallery/styles/GalleryCarousel.scss
@@ -115,11 +115,7 @@
       display: -webkit-box;
       line-clamp: 3;
       -webkit-line-clamp: 3;
-      /* stylelint-disable property-no-vendor-prefix */
-      /*! autoprefixer: off */
       -webkit-box-orient: vertical;
-      /*! autoprefixer: on */
-      /* stylelint-enable property-no-vendor-prefix */
       overflow: hidden;
     }
   }

--- a/assets/src/scss/blocks/Gallery/styles/GalleryCarousel.scss
+++ b/assets/src/scss/blocks/Gallery/styles/GalleryCarousel.scss
@@ -113,6 +113,7 @@
       line-height: 1.4;
       margin-bottom: 0;
       display: -webkit-box;
+      line-clamp: 3;
       -webkit-line-clamp: 3;
       /* stylelint-disable property-no-vendor-prefix */
       /*! autoprefixer: off */

--- a/assets/src/scss/blocks/PageHeader.scss
+++ b/assets/src/scss/blocks/PageHeader.scss
@@ -60,6 +60,7 @@ $text-column-padding-in: 24px;
   .wp-block-group:first-child {
     display: -webkit-box;
     -webkit-box-orient: vertical;
+    line-clamp: 3;
     -webkit-line-clamp: 3;
     overflow: hidden;
     font-size: $font-size-xxl;
@@ -86,6 +87,7 @@ $text-column-padding-in: 24px;
   p {
     display: -webkit-box;
     -webkit-box-orient: vertical;
+    line-clamp: 8;
     -webkit-line-clamp: 8;
     overflow: hidden;
     margin-bottom: $sp-4;

--- a/assets/src/scss/blocks/PostsList.scss
+++ b/assets/src/scss/blocks/PostsList.scss
@@ -94,6 +94,7 @@
     font-size: 18px;
 
     a {
+      line-clamp: 2;
       -webkit-line-clamp: 2;
     }
 
@@ -166,6 +167,7 @@
       width: 100%;
       margin-bottom: $sp-1;
       font-size: var(--font-size-m--font-family-secondary);
+      line-clamp: 3;
       -webkit-line-clamp: 3;
 
       @include large-and-up {

--- a/assets/src/scss/blocks/TakeActionBoxout/TakeActionBoxoutEditorStyle.scss
+++ b/assets/src/scss/blocks/TakeActionBoxout/TakeActionBoxoutEditorStyle.scss
@@ -11,6 +11,7 @@
 
   // Prevent line clamp on editable stuff, because it's very buggy.
   [contenteditable] {
+    line-clamp: unset !important;
     -webkit-line-clamp: unset !important;
   }
 }

--- a/assets/src/scss/blocks/TakeActionBoxout/TakeActionBoxoutStyle.scss
+++ b/assets/src/scss/blocks/TakeActionBoxout/TakeActionBoxoutStyle.scss
@@ -63,11 +63,7 @@
     display: -webkit-box;
     line-clamp: 2;
     -webkit-line-clamp: 2;
-    /* stylelint-disable property-no-vendor-prefix */
-    /*! autoprefixer: off */
     -webkit-box-orient: vertical;
-    /*! autoprefixer: on */
-    /* stylelint-enable property-no-vendor-prefix */
     overflow: hidden;
     word-break: break-word;
   }
@@ -108,11 +104,7 @@
       display: -webkit-box;
       line-clamp: 1;
       -webkit-line-clamp: 1;
-      /* stylelint-disable property-no-vendor-prefix */
-      /*! autoprefixer: off */
       -webkit-box-orient: vertical;
-      /*! autoprefixer: on */
-      /* stylelint-enable property-no-vendor-prefix */
       overflow: hidden;
       margin: 0;
     }

--- a/assets/src/scss/blocks/TakeActionBoxout/TakeActionBoxoutStyle.scss
+++ b/assets/src/scss/blocks/TakeActionBoxout/TakeActionBoxoutStyle.scss
@@ -61,6 +61,7 @@
     }
     margin-bottom: 0;
     display: -webkit-box;
+    line-clamp: 2;
     -webkit-line-clamp: 2;
     /* stylelint-disable property-no-vendor-prefix */
     /*! autoprefixer: off */
@@ -105,6 +106,7 @@
       }
       color: var(--color-text-body);
       display: -webkit-box;
+      line-clamp: 1;
       -webkit-line-clamp: 1;
       /* stylelint-disable property-no-vendor-prefix */
       /*! autoprefixer: off */
@@ -146,6 +148,7 @@
     }
 
     .boxout-excerpt {
+      line-clamp: 3;
       -webkit-line-clamp: 3;
     }
 

--- a/assets/src/scss/layout/_featured-action.scss
+++ b/assets/src/scss/layout/_featured-action.scss
@@ -48,6 +48,7 @@
   display: -webkit-box;
   -webkit-box-orient: vertical;
   overflow: hidden;
+  line-clamp: 2;
   -webkit-line-clamp: 2;
 }
 

--- a/assets/src/scss/pages/_listing-page.scss
+++ b/assets/src/scss/pages/_listing-page.scss
@@ -111,6 +111,7 @@
   font-size: $font-size-sm;
   margin-bottom: $sp-1;
   line-height: var(--line-height-m--font-family-secondary);
+  line-clamp: 4;
   -webkit-line-clamp: 4;
 }
 
@@ -118,6 +119,7 @@
   font-size: $font-size-lg !important;
 
   a {
+    line-clamp: 2;
     -webkit-line-clamp: 2;
   }
 }
@@ -184,10 +186,12 @@
 
     .query-list-item-content p {
       @include medium-and-up {
+        line-clamp: 2;
         -webkit-line-clamp: 2;
       }
 
       @include large-and-up {
+        line-clamp: 3;
         -webkit-line-clamp: 3;
       }
     }
@@ -218,6 +222,7 @@
 
     .query-list-item-headline a {
       @include large-and-up {
+        line-clamp: 3;
         -webkit-line-clamp: 3;
       }
     }

--- a/assets/src/scss/pages/post/_article-content.scss
+++ b/assets/src/scss/pages/post/_article-content.scss
@@ -234,11 +234,6 @@
         line-clamp: 3;
         -webkit-line-clamp: 3;
       }
-
-      @include x-large-and-up {
-        line-clamp: 3;
-        -webkit-line-clamp: 3;
-      }
     }
 
     .article-list-item-headline,

--- a/assets/src/scss/pages/post/_article-content.scss
+++ b/assets/src/scss/pages/post/_article-content.scss
@@ -216,22 +216,27 @@
       font-family: var(--font-family-heading);
       padding-top: 0;
       padding-bottom: 0;
+      line-clamp: 2;
       -webkit-line-clamp: 2;
     }
 
     .article-list-item-content {
       width: 100%;
+      line-clamp: 3;
       -webkit-line-clamp: 3;
 
       @include medium-and-up {
+        line-clamp: 2;
         -webkit-line-clamp: 2;
       }
 
       @include large-and-up {
+        line-clamp: 3;
         -webkit-line-clamp: 3;
       }
 
       @include x-large-and-up {
+        line-clamp: 3;
         -webkit-line-clamp: 3;
       }
     }


### PR DESCRIPTION
Otherwise we get warnings, this was discussed on [Slack](https://greenpeace-gpi.slack.com/archives/C0160MX64AG/p1725356677015349)

![Screenshot 2024-09-03 at 11 43 39](https://github.com/user-attachments/assets/02f8e33f-4647-4c1f-9423-e7fb1466a9c4)

I've also removed the comment lines around the `-webkit-box-orient` attribute, I'm guessing they were added to these files in the plugin but they seem unnecessary here in the theme.