### PR TITLE
PLANET-7454 Implement GF variables in page load

### DIFF
--- a/assets/src/js/gravityforms-client-side.js
+++ b/assets/src/js/gravityforms-client-side.js
@@ -16,9 +16,10 @@
   // eslint-disable-next-line no-undef
   p4GfClientSideConfig.populate.forEach(field => {
     const value = urlParams.get(field.parameter);
+    const element = document.getElementById(field.fieldId);
 
-    if (value !== null) {
-      document.getElementById(field.fieldId).value = value;
+    if (element && value !== null) {
+      element.value = value;
     }
   });
 })();

--- a/assets/src/js/gravityforms-client-side.js
+++ b/assets/src/js/gravityforms-client-side.js
@@ -1,13 +1,24 @@
-(() => {
-  if (typeof p4GfClientSideConfig !== 'undefined') {
-    const urlParams = new URLSearchParams(window.location.search);
-    // eslint-disable-next-line no-undef
-    p4GfClientSideConfig.populate.forEach(field => {
-      const value = urlParams.get(field.parameter);
+/* global dataLayer */
 
-      if (value !== null) {
-        document.getElementById(field.fieldId).value = value;
-      }
-    });
+(() => {
+  if (typeof p4GfClientSideConfig === 'undefined') {
+    return;
   }
+
+  window.addEventListener('DOMContentLoaded', () => {
+    dataLayer.push({
+      // eslint-disable-next-line no-undef
+      ...p4GfClientSideConfig.formData,
+    });
+  });
+
+  const urlParams = new URLSearchParams(window.location.search);
+  // eslint-disable-next-line no-undef
+  p4GfClientSideConfig.populate.forEach(field => {
+    const value = urlParams.get(field.parameter);
+
+    if (value !== null) {
+      document.getElementById(field.fieldId).value = value;
+    }
+  });
 })();

--- a/src/GravityFormsExtensions.php
+++ b/src/GravityFormsExtensions.php
@@ -646,7 +646,7 @@ class GravityFormsExtensions
     {
         $supported_field_types = ['GF_Field_Hidden'];
 
-        $gf_fronted_populate = [];
+        $gf_frontend_populate = [];
 
         foreach ($form['fields'] as $field) {
             if (!$field->allowsPrepopulate || !in_array(get_class($field), $supported_field_types)) {
@@ -662,14 +662,22 @@ class GravityFormsExtensions
 
             $field_id = $dom_field[0]->getAttribute('id');
 
-            $gf_fronted_populate[] = [
+            $gf_frontend_populate[] = [
                 'parameter' => $field->inputName,
                 'fieldId' => $field_id,
                 'fieldType' => get_class($field),
             ];
         }
 
-        $gf_fronted_config['populate'] = $gf_fronted_populate;
+        $gf_frontend_config = [
+            "populate" => $gf_frontend_populate,
+            "formData" => [
+                "formID" => $form['id'],
+                "gGoal" => ($form['p4_gf_type'] ?? self::DEFAULT_GF_TYPE),
+                "formTitle" => $form['title'],
+                "formPlugin" => "Gravity Form",
+            ],
+        ];
 
         $theme_dir = get_template_directory_uri();
         $gf_client_side_file = $theme_dir . '/assets/build/gravityforms-client-side.js';
@@ -682,7 +690,7 @@ class GravityFormsExtensions
             true
         );
 
-        wp_localize_script('p4-gf-client-side', 'p4GfClientSideConfig', $gf_fronted_config);
+        wp_localize_script('p4-gf-client-side', 'p4GfClientSideConfig', $gf_frontend_config);
 
         return $form;
     }


### PR DESCRIPTION
### Description

See [PLANET-7454](https://jira.greenpeace.org/browse/PLANET-7454)

We want them to be available before form submission

### Testing

You can make sure that the dataLayer new values are correctly added on any page with a Gravity Forms form, such as [this one](https://www-dev.greenpeace.org/test-pluto/gravity-forms-test/) 

![Screenshot from 2024-09-10 09-59-07](https://github.com/user-attachments/assets/7a1194d7-f974-4925-9f1d-3f03653a5136)
