### PR TITLE
PLANET-7592 Re-implement related articles with Query Loop block

### DIFF
--- a/assets/src/js/app.js
+++ b/assets/src/js/app.js
@@ -10,6 +10,7 @@ import {setupListingPages} from './listing_pages';
 import {setupQueryLoopCarousel} from './query_loop_carousel';
 import {setupClickabelActionsListCards} from './actions_list_clickable_cards';
 import {removeNoPostText} from './query-no-posts';
+import {removeRelatedPostsSection} from './remove_related_section_no_posts';
 
 function requireAll(r) {
   r.keys().forEach(r);
@@ -26,4 +27,5 @@ setupExternalLinks();
 setupListingPages();
 setupQueryLoopCarousel();
 removeNoPostText();
+removeRelatedPostsSection();
 setupClickabelActionsListCards();

--- a/assets/src/js/remove_related_section_no_posts.js
+++ b/assets/src/js/remove_related_section_no_posts.js
@@ -1,0 +1,8 @@
+export const removeRelatedPostsSection = () => {
+  // Remove Related Posts section when Query loop returns no posts.
+  const section = document.querySelector('.post-articles-block');
+
+  if (section && !section.querySelector('.p4-query-loop .wp-block-post-template')) {
+    section.style.display = 'none';
+  }
+};

--- a/assets/src/scss/pages/post/_post.scss
+++ b/assets/src/scss/pages/post/_post.scss
@@ -79,7 +79,8 @@
   }
 }
 
-.articles-block {
+.articles-block,
+.post-articles-block {
   border-top: 1px solid rgba($grey-500, 0.5);
   padding-top: 16px;
 
@@ -88,6 +89,17 @@
   }
 }
 
+.post-articles-block {
+  margin-top: 30px;
+  padding-left: 0;
+  padding-right: 0;
+  padding-bottom: 0;
+}
+
 .post-tags {
   margin-bottom: $sp-2;
+}
+
+.related-posts-block {
+  margin-bottom: 20px;
 }

--- a/functions.php
+++ b/functions.php
@@ -249,6 +249,7 @@ function register_more_blocks(): void
         ]
     );
     // Like the core block but with an appropriate sizes attribute.
+     // phpcs:disable Generic.Files.LineLength.MaxExceeded
     register_block_type(
         'p4/post-featured-image',
         [
@@ -264,7 +265,7 @@ function register_more_blocks(): void
                     // For example, it could already access displayLayout from Query block to know how many columns are
                     // being rendered. If it then also knows the flex gap and container width, it should have all needed
                     // info to support a large amount of cases.
-                    [ 'sizes' => '(min-width: 1600px) 389px, (min-width: 1200px) 335px, (min-width: 1000px) 281px, (min-width: 780px) 209px, (min-width: 580px) 516px, calc(100vw - 24px)' ] // phpcs:ignore Generic.Files.LineLength.MaxExceeded
+                    [ 'sizes' => '(min-width: 1600px) 389px, (min-width: 1200px) 335px, (min-width: 1000px) 281px, (min-width: 780px) 209px, (min-width: 580px) 516px, calc(100vw - 24px)' ]
                 );
 
                 return "<a href='$post_link'>$featured_image</a>";
@@ -272,9 +273,66 @@ function register_more_blocks(): void
             'uses_context' => [ 'postId' ],
         ]
     );
+    // Block displays related posts using the Query Loop block
+    register_block_type(
+        'p4/related-posts',
+        [
+            'attributes' => [
+                'query_attributes' => [
+                    'type' => 'object',
+                    'default' => [],
+                ],
+            ],
+            'render_callback' => 'render_related_posts_block',
+        ]
+    );
 }
 
 add_action('init', 'register_more_blocks');
+
+/**
+ * Custom block render function for Related posts
+ *
+ * @param array  $attributes Array of dynamic attributes to render section.
+ *
+ * @return string HTML markup for front end.
+ */
+function render_related_posts_block(array $attributes): string
+{
+    // Encode the query attributes to JSON for the block template
+    $query_json = wp_json_encode($attributes['query_attributes'], JSON_UNESCAPED_SLASHES);
+
+    // Define the HTML output for the block
+    $output = '<!-- wp:query ' . $query_json . ' -->
+            <div class="wp-block-query posts-list p4-query-loop is-custom-layout-list"><!-- wp:group {"layout":{"type":"flex","justifyContent":"space-between"}} -->
+            <div class="wp-block-group related-posts-block"><!-- wp:heading {"lock":{"move":true}} -->
+            <h2 class="wp-block-heading">' . __('Related Posts', 'planet4-blocks') . '</h2>
+            <!-- /wp:heading -->
+            <!-- wp:navigation-link {"label":"' . __('See all posts', 'planet4-blocks') . '","url":"http://www.planet4.test/news-stories/","className":"see-all-link"} /-->
+            </div>
+            <!-- /wp:group -->
+            <!-- wp:post-template {"lock":{"move":true,"remove":true}} -->
+                <!-- wp:columns -->
+                <div class="wp-block-columns"><!-- wp:post-featured-image {"isLink":true} /-->
+                <!-- wp:group -->
+                <div class="wp-block-group"><!-- wp:group {"layout":{"type":"flex"}} -->
+                <div class="wp-block-group"><!-- wp:post-terms {"term":"category","separator":" | "} /-->
+                <!-- wp:post-terms {"term":"post_tag","separator":" "} /--></div>
+                <!-- /wp:group -->
+                <!-- wp:post-title {"isLink":true} /-->
+                <!-- wp:post-excerpt /-->
+                <!-- wp:group {"className":"posts-list-meta"} -->
+                <div class="wp-block-group posts-list-meta"><!-- wp:post-author-name {"isLink":true} /-->
+                <!-- wp:post-date /--></div>
+                <!-- /wp:group --></div>
+                <!-- /wp:group --></div>
+                <!-- /wp:columns -->
+            <!-- /wp:post-template -->
+            <!-- wp:navigation-link {"label":"' . __('See all posts', 'planet4-blocks') . '","url":"http://www.planet4.test/news-stories/","className":"see-all-link"} /--></div>
+        <!-- /wp:query -->';
+
+    return do_blocks($output);
+}
 
 add_filter(
     'cloudflare_purge_by_url',
@@ -437,8 +495,8 @@ add_action(
         wp_add_inline_script(
             'wp-notices',
             sprintf(
-                'wp.data.dispatch( "core/notices" ).createNotice("warning", "%s" , { isDismissible: false, actions: [ { label: "%s", url: "/wp-admin/options-reading.php"} ] } )', // phpcs:ignore Generic.Files.LineLength.MaxExceeded
-                __('The content on this page is hidden because this page is being used as your \"All Posts\" listing page. You can disable this by un-setting the \"Posts page\"', 'planet4-master-theme'), // phpcs:ignore Generic.Files.LineLength.MaxExceeded
+                'wp.data.dispatch( "core/notices" ).createNotice("warning", "%s" , { isDismissible: false, actions: [ { label: "%s", url: "/wp-admin/options-reading.php"} ] } )',
+                __('The content on this page is hidden because this page is being used as your \"All Posts\" listing page. You can disable this by un-setting the \"Posts page\"', 'planet4-master-theme'),
                 __('here', 'planet4-master-theme')
             )
         );
@@ -517,3 +575,4 @@ add_action(
     10,
     3
 );
+// phpcs:enable Generic.Files.LineLength.MaxExceeded

--- a/single.php
+++ b/single.php
@@ -63,7 +63,7 @@ $context['filter_url'] = add_query_arg(
     get_home_url()
 );
 
-// Build the shortcode for articles block.
+// Build the shortcode for related-posts block.
 if ('yes' === $post->include_articles) {
     $tag_id_array = [];
     foreach ($post->tags() as $post_tag) {
@@ -75,16 +75,25 @@ if ('yes' === $post->include_articles) {
     }
 
     $block_attributes = [
-        'exclude_post_id' => $post->ID,
-        'tags' => $tag_id_array,
-        'categories' => $category_id_array,
-        'article_heading' => __('Related Articles', 'planet4-blocks'),
-        'read_more_text' => __('Load more', 'planet4-blocks'),
+        'query' => [
+            'perPage' => 3,
+            'post_type' => 'post',
+            'taxQuery' => [
+                'post_tag' => $tag_id_array,
+                'category' => $category_id_array,
+            ],
+            'exclude' => [$post->ID],
+        ],
+        'className' => 'posts-list p4-query-loop is-custom-layout-list',
+        'hasPassword' => false,
+        'layout' => [
+            'type' => 'default',
+            'columnCount' => 3,
+        ],
+        'namespace' => 'planet4-blocks/posts-list',
     ];
 
-    $post->articles = '<!-- wp:planet4-blocks/articles '
-        . wp_json_encode($block_attributes, JSON_UNESCAPED_SLASHES)
-        . ' /-->';
+    $post->articles = '<!-- wp:p4/related-posts {"query_attributes" : ' . wp_json_encode($block_attributes) . '} /-->';
 }
 
 if (! empty($take_action_page) && ! has_block('planet4-blocks/take-action-boxout')) {

--- a/tests/e2e/blocks/related-articles.spec.js
+++ b/tests/e2e/blocks/related-articles.spec.js
@@ -7,8 +7,8 @@ import {
 
 test.useAdminLoggedIn();
 
-test('Test Related Articles block', async ({page, admin, editor}) => {
-  await createPostWithFeaturedImage({admin, editor}, {title: 'Test post for Related articles'});
+test('Test Related Posts block', async ({page, admin, editor}) => {
+  await createPostWithFeaturedImage({admin, editor}, {title: 'Test post for Related posts'});
 
   await editor.canvas.getByRole('button', {name: 'Add default block'}).click();
   await page.keyboard.type('Test paragraph.');
@@ -32,10 +32,10 @@ test('Test Related Articles block', async ({page, admin, editor}) => {
   await page.waitForTimeout(1000); // letting metabox post query finish
 
   await page.goto(postUrl);
-  const relatedSection = await page.locator('[data-render="planet4-blocks/articles"]');
+  const relatedSection = await page.locator('.p4-query-loop');
   await relatedSection.scrollIntoViewIfNeeded();
-  await relatedSection.locator('.article-list-item');
-  await expect(relatedSection.locator('.article-list-item')).not.toHaveCount(0);
+  await relatedSection.locator('.wp-block-post-template');
+  await expect(relatedSection.locator('.wp-block-post-template')).not.toHaveCount(0);
 
   //
   // Related articles disabled
@@ -46,5 +46,5 @@ test('Test Related Articles block', async ({page, admin, editor}) => {
   await page.waitForTimeout(1000); // letting metabox post query finish
 
   await page.goto(postUrl);
-  await expect(page.locator('[data-render="planet4-blocks/articles"]')).toHaveCount(0);
+  await expect(page.locator('.p4-query-loop')).toHaveCount(0);
 });


### PR DESCRIPTION
**Ref: https://jira.greenpeace.org/browse/PLANET-7592**

**Testing:**

On local or test instance, the "_Related Articles_" section is now rendered using the Query loop block.

UI wise, it still should be similar.

<!-- Ref: Please add a url to the ticket this change is addressing.

---

Please provide a brief summary of the change introduced to make review process easier.

Ideally this should also be part of the commit summary.
-->
