### PR TITLE
PLANET-7220: Add definitions to blocks settings 

### DIFF
--- a/assets/src/block-editor/QueryLoopBlockExtension/index.js
+++ b/assets/src/block-editor/QueryLoopBlockExtension/index.js
@@ -142,7 +142,7 @@ export const setupQueryLoopBlockExtension = () => {
               {
                 <PanelBody title={__('Learn more about this block ', 'planet4-blocks-backend')} initialOpen={false}>
                   <p className="components-base-control__help">
-                    { isActionsList && (
+                    {isActionsList && (
                       <>
                         <a target="_blank" href="https://planet4.greenpeace.org/content/blocks/covers/" rel="noreferrer">
                         P4 Handbook Actions Lists
@@ -150,7 +150,7 @@ export const setupQueryLoopBlockExtension = () => {
                         {' '} &#127745;
                       </>
                     )}
-                    { isPostsList && (
+                    {isPostsList && (
                       <>
                         <a target="_blank" href="https://planet4.greenpeace.org/content/blocks/articles/" rel="noreferrer">
                       P4 Handbook Posts List

--- a/assets/src/block-editor/QueryLoopBlockExtension/index.js
+++ b/assets/src/block-editor/QueryLoopBlockExtension/index.js
@@ -142,10 +142,22 @@ export const setupQueryLoopBlockExtension = () => {
               {
                 <PanelBody title={__('Learn more about this block ', 'planet4-blocks-backend')} initialOpen={false}>
                   <p className="components-base-control__help">
-                    <a target="_blank" href="https://planet4.greenpeace.org/content/blocks/articles/" rel="noreferrer">
-                    P4 Handbook Posts List
-                    </a>
-                    {' '} &#128478;&#65039;
+                    { isActionsList && (
+                      <>
+                        <a target="_blank" href="https://planet4.greenpeace.org/content/blocks/covers/" rel="noreferrer">
+                        P4 Handbook Actions Lists
+                        </a>
+                        {' '} &#127745;
+                      </>
+                    )}
+                    { isPostsList && (
+                      <>
+                        <a target="_blank" href="https://planet4.greenpeace.org/content/blocks/articles/" rel="noreferrer">
+                      P4 Handbook Posts List
+                        </a>
+                        {' '} &#128478;&#65039;
+                      </>
+                    )}
                   </p>
                 </PanelBody>
               }

--- a/assets/src/block-editor/QueryLoopBlockExtension/index.js
+++ b/assets/src/block-editor/QueryLoopBlockExtension/index.js
@@ -139,6 +139,16 @@ export const setupQueryLoopBlockExtension = () => {
                   />
                 </PanelBody>
               }
+              {
+                <PanelBody title={__('Learn more about this block ', 'planet4-blocks-backend')} initialOpen={false}>
+                  <p className="components-base-control__help">
+                    <a target="_blank" href="https://planet4.greenpeace.org/content/blocks/articles/" rel="noreferrer">
+                    P4 Handbook Posts List
+                    </a>
+                    {' '} &#128478;&#65039;
+                  </p>
+                </PanelBody>
+              }
             </InspectorControls>
             <BlockEdit {...props} />
           </>

--- a/assets/src/blocks/Accordion/AccordionEditor.js
+++ b/assets/src/blocks/Accordion/AccordionEditor.js
@@ -155,6 +155,14 @@ const renderEdit = ({tabs}, setAttributes, updateTabAttribute) => {
           {__('Remove item', 'planet4-blocks-backend')}
         </Button>
       </PanelBody>
+      <PanelBody title={__('Learn more about this block ', 'planet4-blocks-backend')} initialOpen={false}>
+        <p className="components-base-control__help">
+          <a target="_blank" href="https://planet4.greenpeace.org/content/blocks/accordion/" rel="noreferrer">
+            P4 Handbook Accordion
+          </a>
+          {' '} &#11015;&#65039;
+        </p>
+      </PanelBody>
     </InspectorControls>
   );
 };

--- a/assets/src/blocks/Accordion/AccordionEditorScript.js
+++ b/assets/src/blocks/Accordion/AccordionEditorScript.js
@@ -1,6 +1,7 @@
 import {AccordionEditor} from './AccordionEditor';
 import {AccordionFrontend} from './AccordionFrontend';
 const {registerBlockType, registerBlockStyle} = wp.blocks;
+const {__} = wp.i18n;
 
 const BLOCK_NAME = 'planet4-blocks/accordion';
 
@@ -37,7 +38,7 @@ const styles = [
 
 registerBlockType(BLOCK_NAME, {
   title: 'Accordion',
-  description: 'Offers collapsible sections with a title, a description, a link or a call to action button.',
+  description: __('Offers collapsible sections with a title, a description, a link or a call to action button.', 'planet4-blocks-backend'),
   icon: 'menu',
   category: 'planet4-blocks',
   keywords: [

--- a/assets/src/blocks/Accordion/AccordionEditorScript.js
+++ b/assets/src/blocks/Accordion/AccordionEditorScript.js
@@ -37,6 +37,7 @@ const styles = [
 
 registerBlockType(BLOCK_NAME, {
   title: 'Accordion',
+  description: 'Offers collapsible sections with a title, a description, a link or a call to action button.',
   icon: 'menu',
   category: 'planet4-blocks',
   keywords: [

--- a/assets/src/blocks/ActionsList/index.js
+++ b/assets/src/blocks/ActionsList/index.js
@@ -18,7 +18,7 @@ export const registerActionsListBlock = () => {
   registerBlockVariation('core/query', {
     name: ACTIONS_LIST_BLOCK_NAME,
     title: 'Actions List',
-    description: __('A list of possible actions', 'planet4-blocks-backend'),
+    description: __('Integrate images and text cards to automatically display tags, take action pages, or Posts in a three or four column layout displayed in a grid or carousel.', 'planet4-blocks-backend'),
     icon: 'list-view',
     scope: ['inserter'],
     allowedControls: ['taxQuery'],

--- a/assets/src/blocks/CarouselHeader/CarouselHeaderBlock.js
+++ b/assets/src/blocks/CarouselHeader/CarouselHeaderBlock.js
@@ -44,6 +44,7 @@ const attributes = {
 export const registerCarouselHeaderBlock = () =>
   registerBlockType(BLOCK_NAME, {
     title: 'Carousel Header',
+    description: 'A gallery block that features a scrolling collection of images and media content, typically found at the top of the Homepage.',
     icon: 'welcome-widgets-menus',
     category: 'planet4-blocks',
     supports: {

--- a/assets/src/blocks/CarouselHeader/CarouselHeaderBlock.js
+++ b/assets/src/blocks/CarouselHeader/CarouselHeaderBlock.js
@@ -5,6 +5,7 @@ import {renderToString} from 'react-dom/server';
 
 const {registerBlockType} = wp.blocks;
 const {RawHTML} = wp.element;
+const {__} = wp.i18n;
 
 const BLOCK_NAME = 'planet4-blocks/carousel-header';
 
@@ -44,7 +45,7 @@ const attributes = {
 export const registerCarouselHeaderBlock = () =>
   registerBlockType(BLOCK_NAME, {
     title: 'Carousel Header',
-    description: 'A gallery block that features a scrolling collection of images and media content, typically found at the top of the Homepage.',
+    description: __('A gallery block that features a scrolling collection of images and media content, typically found at the top of the Homepage.', 'planet4-blocks-backend'),
     icon: 'welcome-widgets-menus',
     category: 'planet4-blocks',
     supports: {

--- a/assets/src/blocks/CarouselHeader/Sidebar.js
+++ b/assets/src/blocks/CarouselHeader/Sidebar.js
@@ -171,5 +171,13 @@ export const Sidebar = ({
         upOrDownHandler={upOrDownHandler}
       />) }
     </div>
+    <PanelBody title={__('Learn more about this block ', 'planet4-blocks-backend')} initialOpen={false}>
+      <p className="components-base-control__help">
+        <a target="_blank" href="https://planet4.greenpeace.org/content/blocks/carousel-header/" rel="noreferrer">
+          P4 Handbook Carousel Header
+        </a>
+        {' '} &#127904;
+      </p>
+    </PanelBody>
   </InspectorControls>;
 };

--- a/assets/src/blocks/Columns/ColumnsBlock.js
+++ b/assets/src/blocks/Columns/ColumnsBlock.js
@@ -17,7 +17,7 @@ export const registerColumnsBlock = () => {
 
   registerBlockType(BLOCK_NAME, {
     title: 'Planet 4 Columns',
-    description: 'The columns block comes in four styles and groups static content in an aligned, responsive and styled column.',
+    description: __('The columns block comes in four styles and groups static content in an aligned, responsive and styled column.', 'planet4-blocks-backend'),
     icon: 'grid-view',
     category: 'planet4-blocks',
     attributes: {

--- a/assets/src/blocks/Columns/ColumnsBlock.js
+++ b/assets/src/blocks/Columns/ColumnsBlock.js
@@ -17,6 +17,7 @@ export const registerColumnsBlock = () => {
 
   registerBlockType(BLOCK_NAME, {
     title: 'Planet 4 Columns',
+    description: 'The columns block comes in four styles and groups static content in an aligned, responsive and styled column.',
     icon: 'grid-view',
     category: 'planet4-blocks',
     attributes: {

--- a/assets/src/blocks/Columns/ColumnsEditor.js
+++ b/assets/src/blocks/Columns/ColumnsEditor.js
@@ -71,6 +71,14 @@ const renderEdit = (attributes, toAttribute, setAttributes, isSelected) => {
             );
           })}
         </PanelBody>
+        <PanelBody title={__('Learn more about this block ', 'planet4-blocks-backend')} initialOpen={false}>
+          <p className="components-base-control__help">
+            <a target="_blank" href="https://planet4.greenpeace.org/content/blocks/columns/" rel="noreferrer">
+              P4 Handbook Columns
+            </a>
+            {' '} &#127963;&#65039;
+          </p>
+        </PanelBody>
       </InspectorControls>
     </>
   );

--- a/assets/src/blocks/Cookies/CookiesBlock.js
+++ b/assets/src/blocks/Cookies/CookiesBlock.js
@@ -2,10 +2,11 @@ import {CookiesEditor} from './CookiesEditor.js';
 
 export const registerCookiesBlock = () => {
   const {registerBlockType} = wp.blocks;
+  const {__} = wp.i18n;
 
   registerBlockType('planet4-blocks/cookies', {
     title: 'Cookies',
-    description: 'Displays the cookies settings and control panel within P4 for editors to control their level of compliance regarding data collection.',
+    description: __('Display real time signatures being collected worldwide on petitions.', 'planet4-blocks-backend'),
     icon: 'welcome-view-site',
     category: 'planet4-blocks',
     supports: {

--- a/assets/src/blocks/Cookies/CookiesBlock.js
+++ b/assets/src/blocks/Cookies/CookiesBlock.js
@@ -5,6 +5,7 @@ export const registerCookiesBlock = () => {
 
   registerBlockType('planet4-blocks/cookies', {
     title: 'Cookies',
+    description: 'Displays the cookies settings and control panel within P4 for editors to control their level of compliance regarding data collection.',
     icon: 'welcome-view-site',
     category: 'planet4-blocks',
     supports: {

--- a/assets/src/blocks/Cookies/CookiesBlock.js
+++ b/assets/src/blocks/Cookies/CookiesBlock.js
@@ -6,7 +6,7 @@ export const registerCookiesBlock = () => {
 
   registerBlockType('planet4-blocks/cookies', {
     title: 'Cookies',
-    description: __('Display real time signatures being collected worldwide on petitions.', 'planet4-blocks-backend'),
+    description: __('Displays the cookies settings and control panel within P4 for editors to control their level of compliance regarding data collection.', 'planet4-blocks-backend'),
     icon: 'welcome-view-site',
     category: 'planet4-blocks',
     supports: {

--- a/assets/src/blocks/Cookies/CookiesEditor.js
+++ b/assets/src/blocks/Cookies/CookiesEditor.js
@@ -1,5 +1,7 @@
 import {FrontendRichText} from '../components/FrontendRichText/FrontendRichText';
 import {CookiesFieldResetButton} from './CookiesFieldResetButton';
+const {InspectorControls} = wp.blockEditor;
+const {PanelBody} = wp.components;
 
 const {__} = wp.i18n;
 
@@ -8,7 +10,7 @@ const COOKIES_DEFAULT_COPY = window.p4_vars.options.cookies_default_copy || {};
 // Planet4 settings(Planet 4 > Cookies > Enable Analytical Cookies).
 const ENABLE_ANALYTICAL_COOKIES = window.p4_vars.options.enable_analytical_cookies;
 
-export const CookiesEditor = ({setAttributes, attributes}) => {
+export const CookiesEditor = ({setAttributes, attributes, isSelected}) => {
   const {
     title,
     description,
@@ -32,7 +34,7 @@ export const CookiesEditor = ({setAttributes, attributes}) => {
     [attributeName]: value,
   });
 
-  return (
+  const renderView = () => (
     <section className={`block cookies-block ${className ?? ''}`}>
       <header>
         <FrontendRichText
@@ -183,5 +185,27 @@ export const CookiesEditor = ({setAttributes, attributes}) => {
         </div>
       </>
     </section>
+  );
+
+  const renderEdit = () => (
+    <>
+      <InspectorControls>
+        <PanelBody title={__('Learn more about this block ', 'planet4-blocks-backend')} initialOpen={false}>
+          <p className="components-base-control__help">
+            <a target="_blank" href="https://planet4.greenpeace.org/content/blocks/cookies/" rel="noreferrer">
+            P4 Handbook Cookies
+            </a>
+            {' '} &#127850;
+          </p>
+        </PanelBody>
+      </InspectorControls>
+    </>
+  );
+
+  return (
+    <>
+      {isSelected ? renderEdit() : null}
+      {renderView()}
+    </>
   );
 };

--- a/assets/src/blocks/Counter/CounterBlock.js
+++ b/assets/src/blocks/Counter/CounterBlock.js
@@ -42,6 +42,7 @@ export const registerCounterBlock = () => {
 
   registerBlockType(BLOCK_NAME, {
     title: 'Counter',
+    description: 'Display real time signatures being collected worldwide on petitions.',
     icon: 'dashboard',
     category: 'planet4-blocks',
     attributes,

--- a/assets/src/blocks/Counter/CounterBlock.js
+++ b/assets/src/blocks/Counter/CounterBlock.js
@@ -39,10 +39,11 @@ const attributes = {
 export const registerCounterBlock = () => {
   const {registerBlockType, unregisterBlockStyle, registerBlockStyle} = wp.blocks;
   const {RawHTML} = wp.element;
+  const {__} = wp.i18n;
 
   registerBlockType(BLOCK_NAME, {
     title: 'Counter',
-    description: 'Display real time signatures being collected worldwide on petitions.',
+    description: __('Display real time signatures being collected worldwide on petitions.', 'planet4-blocks-backend'),
     icon: 'dashboard',
     category: 'planet4-blocks',
     attributes,

--- a/assets/src/blocks/Counter/CounterEditor.js
+++ b/assets/src/blocks/Counter/CounterEditor.js
@@ -56,6 +56,14 @@ export const CounterEditor = ({setAttributes, attributes, isSelected}) => {
             <code>%completed%</code>, <code>%target%</code>, <code>%remaining%</code>
           </div>
         </PanelBody>
+        <PanelBody title={__('Learn more about this block ', 'planet4-blocks-backend')} initialOpen={false}>
+          <p className="components-base-control__help">
+            <a target="_blank" href="https://planet4.greenpeace.org/content/blocks/counter/" rel="noreferrer">
+            P4 Handbook Counter
+            </a>
+            {' '} &#129518;
+          </p>
+        </PanelBody>
       </InspectorControls>
     </>
   );

--- a/assets/src/blocks/ENForm/ENFormBlock.js
+++ b/assets/src/blocks/ENForm/ENFormBlock.js
@@ -45,7 +45,7 @@ export const registerENForm = () => {
 
   registerBlockType(BLOCK_NAME, {
     title: 'EN Form',
-    description: 'Allows for adding in-page call to actions with data collected and sent to the relevant engaging network account. ',
+    description: __('Allows for adding in-page call to actions with data collected and sent to the relevant engaging network account.', 'planet4-blocks-backend'),
     icon: 'feedback',
     category: 'planet4-blocks',
     supports: {

--- a/assets/src/blocks/ENForm/ENFormBlock.js
+++ b/assets/src/blocks/ENForm/ENFormBlock.js
@@ -45,6 +45,7 @@ export const registerENForm = () => {
 
   registerBlockType(BLOCK_NAME, {
     title: 'EN Form',
+    description: 'Allows for adding in-page call to actions with data collected and sent to the relevant engaging network account. ',
     icon: 'feedback',
     category: 'planet4-blocks',
     supports: {

--- a/assets/src/blocks/ENForm/ENFormSettings.js
+++ b/assets/src/blocks/ENForm/ENFormSettings.js
@@ -158,6 +158,14 @@ export const ENFormSettings = ({attributes, setAttributes}) => {
           help={__('Title, Subtitle, Social media message / icons and DONATE will not be shown', 'planet4-engagingnetworks-backend')}
         />
       </PanelBody>
+      <PanelBody title={__('Learn more about this block ', 'planet4-blocks-backend')} initialOpen={false}>
+        <p className="components-base-control__help">
+          <a target="_blank" href="https://planet4.greenpeace.org/content/blocks/form-engaging-networks/" rel="noreferrer">
+            P4 Handbook EN Form
+          </a>
+          {' '} &#9997;&#65039;
+        </p>
+      </PanelBody>
     </InspectorControls>
   );
 };

--- a/assets/src/blocks/Happypoint/HappypointBlock.js
+++ b/assets/src/blocks/Happypoint/HappypointBlock.js
@@ -7,6 +7,7 @@ export const registerHappypointBlock = () => {
   if (!getBlockType('planet4-blocks/happypoint')) {
     registerBlockType('planet4-blocks/happypoint', {
       title: 'Happypoint',
+      description: 'The happy point block embeds (via iFrame) a “Subscribe” or engagement form on top of a full-width background image.',
       icon: 'format-image',
       category: 'planet4-blocks',
       supports: {

--- a/assets/src/blocks/Happypoint/HappypointBlock.js
+++ b/assets/src/blocks/Happypoint/HappypointBlock.js
@@ -2,12 +2,13 @@ import {HappypointEditor} from './HappypointEditor';
 import {HappypointBlock as HappypointBlockV1} from './deprecated/HappypointBlocklV1.js';
 
 const {registerBlockType, getBlockType} = wp.blocks;
+const {__} = wp.i18n;
 
 export const registerHappypointBlock = () => {
   if (!getBlockType('planet4-blocks/happypoint')) {
     registerBlockType('planet4-blocks/happypoint', {
       title: 'Happypoint',
-      description: 'The happy point block embeds (via iFrame) a “Subscribe” or engagement form on top of a full-width background image.',
+      description: __('The happy point block embeds (via iFrame) a “Subscribe” or engagement form on top of a full-width background image.', 'planet4-blocks-backend'),
       icon: 'format-image',
       category: 'planet4-blocks',
       supports: {

--- a/assets/src/blocks/Happypoint/HappypointEditor.js
+++ b/assets/src/blocks/Happypoint/HappypointEditor.js
@@ -195,6 +195,14 @@ export const HappypointEditor = ({attributes, setAttributes, isSelected}) => {
                 </div>
               }
             </PanelBody>
+            <PanelBody title={__('Learn more about this block ', 'planet4-blocks-backend')} initialOpen={false}>
+              <p className="components-base-control__help">
+                <a target="_blank" href="https://planet4.greenpeace.org/content/blocks/happy-point/" rel="noreferrer">
+            P4 Handbook Happy Point
+                </a>
+                {' '} &#128588;
+              </p>
+            </PanelBody>
           </InspectorControls>
           <BlockControls>
             {id && 0 < id && (

--- a/assets/src/blocks/PostsList/index.js
+++ b/assets/src/blocks/PostsList/index.js
@@ -21,7 +21,7 @@ export const registerPostsListBlock = () => {
     name: POSTS_LIST_BLOCK_NAME,
     title: 'Posts List',
     icon: 'list-view',
-    description: __('Posts List is the place in Planet 4 that the latest articles, press releases and publications can be found.', 'planet4-blocks-backend'),
+    description: __('Insert a list or grid of the latest articles, press releases, and/or publications, organized by publication date. ', 'planet4-blocks-backend'),
     category: 'planet4-blocks-beta',
     scope: ['inserter'],
     allowedControls: ['taxQuery'],

--- a/assets/src/blocks/SocialMedia/SocialMediaBlock.js
+++ b/assets/src/blocks/SocialMedia/SocialMediaBlock.js
@@ -4,6 +4,7 @@ import {OEMBED_EMBED_TYPE, FACEBOOK_PAGE_TAB_TIMELINE} from './SocialMediaConsta
 import {SocialMediaFrontend} from './SocialMediaFrontend.js';
 
 const {registerBlockType, getBlockTypes} = wp.blocks;
+const {__} = wp.i18n;
 
 const BLOCK_NAME = 'planet4-blocks/social-media';
 
@@ -16,7 +17,7 @@ export const registerSocialMediaBlock = () => {
 
   registerBlockType(BLOCK_NAME, {
     title: 'Social Media',
-    description: 'An embed-style block, customized to display and align content from Facebook and Instagram by inputting the URL.',
+    description: __('An embed-style block, customized to display and align content from Facebook and Instagram by inputting the URL.', 'planet4-blocks-backend'),
     icon: 'share',
     category: 'planet4-blocks',
     attributes: {

--- a/assets/src/blocks/SocialMedia/SocialMediaBlock.js
+++ b/assets/src/blocks/SocialMedia/SocialMediaBlock.js
@@ -16,6 +16,7 @@ export const registerSocialMediaBlock = () => {
 
   registerBlockType(BLOCK_NAME, {
     title: 'Social Media',
+    description: 'An embed-style block, customized to display and align content from Facebook and Instagram by inputting the URL.',
     icon: 'share',
     category: 'planet4-blocks',
     attributes: {

--- a/assets/src/blocks/SocialMedia/SocialMediaEditorScript.js
+++ b/assets/src/blocks/SocialMedia/SocialMediaEditorScript.js
@@ -224,6 +224,14 @@ export const SocialMediaEditor = ({
           onChange={toAttribute('alignment_class')}
         />
       </PanelBody>
+      <PanelBody title={__('Learn more about this block', 'planet4-blocks-backend')} initialOpen={false}>
+        <p className="components-base-control__help">
+          <a target="_blank" href="https://planet4.greenpeace.org/content/blocks/socials/" rel="noreferrer">
+          P4 Handbook Meta Block
+          </a>
+          {' '} &#129331;
+        </p>
+      </PanelBody>
     </InspectorControls>
   );
 

--- a/assets/src/blocks/Spreadsheet/SpreadsheetBlock.js
+++ b/assets/src/blocks/Spreadsheet/SpreadsheetBlock.js
@@ -24,10 +24,11 @@ const CSS_VARIABLES_ATTRIBUTE = {
 export const registerSpreadsheetBlock = () => {
   const {registerBlockType} = wp.blocks;
   const {RawHTML} = wp.element;
+  const {__} = wp.i18n;
 
   registerBlockType(BLOCK_NAME, {
     title: 'Spreadsheet',
-    description: 'Embed a Google Spreadsheet directly into your website by copying the spreadsheet URL and customize the table appearance by choosing from a selection of four predefined colors.',
+    description: __('Embed a Google Spreadsheet directly into your website by copying the spreadsheet URL and customize the table appearance by choosing from a selection of four predefined colors.', 'planet4-blocks-backend'),
     icon: 'editor-table',
     category: 'planet4-blocks',
     attributes,

--- a/assets/src/blocks/Spreadsheet/SpreadsheetBlock.js
+++ b/assets/src/blocks/Spreadsheet/SpreadsheetBlock.js
@@ -27,6 +27,7 @@ export const registerSpreadsheetBlock = () => {
 
   registerBlockType(BLOCK_NAME, {
     title: 'Spreadsheet',
+    description: 'Embed a Google Spreadsheet directly into your website by copying the spreadsheet URL and customize the table appearance by choosing from a selection of four predefined colors.',
     icon: 'editor-table',
     category: 'planet4-blocks',
     attributes,

--- a/assets/src/blocks/Spreadsheet/SpreadsheetEditor.js
+++ b/assets/src/blocks/Spreadsheet/SpreadsheetEditor.js
@@ -74,6 +74,14 @@ export const SpreadsheetEditor = ({
             </ul>
           </div>
         </PanelBody>
+        <PanelBody title={__('Learn more about this block ', 'planet4-blocks-backend')} initialOpen={false}>
+          <p className="components-base-control__help">
+            <a target="_blank" href="https://planet4.greenpeace.org/content/blocks/spreadsheet-table/" rel="noreferrer">
+            P4 Handbook Spreadsheet
+            </a>
+            {' '} &#128202;
+          </p>
+        </PanelBody>
       </InspectorControls>
     </>
   );

--- a/assets/src/blocks/Submenu/SubmenuBlock.js
+++ b/assets/src/blocks/Submenu/SubmenuBlock.js
@@ -17,6 +17,7 @@ export const registerSubmenuBlock = () => {
 
   registerBlockType(BLOCK_NAME, {
     title: 'Submenu',
+    description: 'Insert text, media, and other content in an ordered list of clickable headings corresponding to the content sections on the page.',
     icon: 'welcome-widgets-menus',
     category: 'planet4-blocks',
     attributes: {

--- a/assets/src/blocks/Submenu/SubmenuBlock.js
+++ b/assets/src/blocks/Submenu/SubmenuBlock.js
@@ -17,7 +17,7 @@ export const registerSubmenuBlock = () => {
 
   registerBlockType(BLOCK_NAME, {
     title: 'Submenu',
-    description: 'Insert text, media, and other content in an ordered list of clickable headings corresponding to the content sections on the page.',
+    description: __('Insert text, media, and other content in an ordered list of clickable headings corresponding to the content sections on the page.', 'planet4-blocks-backend'),
     icon: 'welcome-widgets-menus',
     category: 'planet4-blocks',
     attributes: {

--- a/assets/src/blocks/Submenu/SubmenuEditor.js
+++ b/assets/src/blocks/Submenu/SubmenuEditor.js
@@ -80,6 +80,14 @@ const renderEdit = (attributes, setAttributes) => {
           {__('Remove level', 'planet4-blocks-backend')}
         </Button>
       </PanelBody>
+      <PanelBody title={__('Learn more about this block', 'planet4-blocks-backend')} initialOpen={false}>
+        <p className="components-base-control__help">
+          <a target="_blank" href="https://planet4.greenpeace.org/content/blocks/table-of-contents/" rel="noreferrer">
+            P4 Handbook P4 Table of Contents
+          </a>
+          {' '} &#128203;
+        </p>
+      </PanelBody>
     </InspectorControls>
   );
 };

--- a/assets/src/blocks/TakeActionBoxout/TakeActionBoxoutBlock.js
+++ b/assets/src/blocks/TakeActionBoxout/TakeActionBoxoutBlock.js
@@ -2,6 +2,7 @@ import {TakeActionBoxoutEditor} from './TakeActionBoxoutEditor.js';
 import {takeActionBoxoutV1} from './deprecated/takeActionBoxoutV1';
 
 const {registerBlockType, getBlockTypes} = wp.blocks;
+const {__} = wp.i18n;
 
 const BLOCK_NAME = 'planet4-blocks/take-action-boxout';
 
@@ -14,7 +15,7 @@ export const registerTakeActionBoxoutBlock = () => {
 
   registerBlockType(BLOCK_NAME, {
     title: 'Take Action Boxout',
-    description: 'A versatile horizontal card featuring an image, description, and Call to Action, designed to link to Take Action pages or any custom link such as external petitions or donation pages.',
+    description: __('A versatile horizontal card featuring an image, description, and Call to Action, designed to link to Take Action pages or any custom link such as external petitions or donation pages.', 'planet4-blocks-backend'),
     icon: 'welcome-widgets-menus',
     category: 'planet4-blocks',
     supports: {

--- a/assets/src/blocks/TakeActionBoxout/TakeActionBoxoutBlock.js
+++ b/assets/src/blocks/TakeActionBoxout/TakeActionBoxoutBlock.js
@@ -14,6 +14,7 @@ export const registerTakeActionBoxoutBlock = () => {
 
   registerBlockType(BLOCK_NAME, {
     title: 'Take Action Boxout',
+    description: 'A versatile horizontal card featuring an image, description, and Call to Action, designed to link to Take Action pages or any custom link such as external petitions or donation pages.',
     icon: 'welcome-widgets-menus',
     category: 'planet4-blocks',
     supports: {

--- a/assets/src/blocks/TakeActionBoxout/TakeActionBoxoutEditor.js
+++ b/assets/src/blocks/TakeActionBoxout/TakeActionBoxoutEditor.js
@@ -244,6 +244,14 @@ export const TakeActionBoxoutEditor = ({
             </MediaUploadCheck>
           }
         </PanelBody>
+        <PanelBody title={__('Learn more about this block', 'planet4-blocks-backend')} initialOpen={false}>
+          <p className="components-base-control__help">
+            <a target="_blank" href="https://planet4.greenpeace.org/content/blocks/take-action-boxout/" rel="noreferrer">
+            P4 Handbook Take Action Boxout
+            </a>
+            {' '} &#128499;&#65039;;
+          </p>
+        </PanelBody>
       </InspectorControls>
       {!takeActionPageSelected && imageId &&
         <BlockControls>

--- a/assets/src/blocks/Timeline/TimelineBlock.js
+++ b/assets/src/blocks/Timeline/TimelineBlock.js
@@ -34,6 +34,7 @@ const attributes = {
 
 export const registerTimelineBlock = () => {
   const {registerBlockType, getBlockTypes} = wp.blocks;
+  const {__} = wp.i18n;
   const {RawHTML} = wp.element;
 
   const blockAlreadyExists = getBlockTypes().find(block => block.name === BLOCK_NAME);
@@ -44,7 +45,7 @@ export const registerTimelineBlock = () => {
 
   registerBlockType(BLOCK_NAME, {
     title: 'Timeline',
-    description: 'A type of graphic that arranges a chain of events, activities, and milestones in chronological order.',
+    description: __('A type of graphic that arranges a chain of events, activities, and milestones in chronological order.', 'planet4-blocks-backend'),
     icon: 'clock',
     category: 'planet4-blocks',
     supports: {

--- a/assets/src/blocks/Timeline/TimelineBlock.js
+++ b/assets/src/blocks/Timeline/TimelineBlock.js
@@ -44,6 +44,7 @@ export const registerTimelineBlock = () => {
 
   registerBlockType(BLOCK_NAME, {
     title: 'Timeline',
+    description: 'A type of graphic that arranges a chain of events, activities, and milestones in chronological order.',
     icon: 'clock',
     category: 'planet4-blocks',
     supports: {

--- a/assets/src/blocks/Timeline/TimelineEditorScript.js
+++ b/assets/src/blocks/Timeline/TimelineEditorScript.js
@@ -86,6 +86,14 @@ const renderEdit = (
         />
 
       </PanelBody>
+      <PanelBody title={__('Learn more about this block', 'planet4-blocks-backend')} initialOpen={false}>
+        <p className="components-base-control__help">
+          <a target="_blank" href="https://planet4.greenpeace.org/content/blocks/timeline/" rel="noreferrer">
+            P4 Handbook Timeline
+          </a>
+          {' '} &#8987;
+        </p>
+      </PanelBody>
     </InspectorControls>
   );
 };


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-7220

<hr>

**DESCRIPTION:**
Based on [this mockup](https://www.figma.com/design/87AqKGnduB2Uq5fVkIcdcg/Handbook-Links-in-Backend?node-id=1-437&node-type=FRAME&t=bzJp6zu3cilsg1wU-0), this PR adds a description to some of the blocks in the P4 master theme and an additional collapsible panel body in the editor with a link to the P4 Handbook.

<hr>

**RELATED PR:**
https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/1237

<hr>

**TESTING LINK:**
https://www-dev.greenpeace.org/test-pandora/wp-admin/post.php?post=1437&action=edit