### PR TITLE
Test new Posts List implementation

### DIFF
--- a/assets/src/blocks/PostsListTest/block.json
+++ b/assets/src/blocks/PostsListTest/block.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://schemas.wp.org/trunk/block.json",
+  "apiVersion": 2,
+  "name": "planet4-blocks/posts-list-test",
+  "title": "Posts List Test",
+  "category": "planet4-blocks-beta",
+  "icon": "list-view",
+  "textdomain": "planet4-blocks-backend"
+}

--- a/assets/src/blocks/PostsListTest/index.js
+++ b/assets/src/blocks/PostsListTest/index.js
@@ -1,0 +1,14 @@
+import metadata from './block.json';
+import template from './template';
+
+const {registerBlockType} = wp.blocks;
+const {useBlockProps, InnerBlocks} = wp.blockEditor;
+
+export const registerPostsListTest = () => registerBlockType(metadata, {
+  edit: props => (
+    <div {...useBlockProps()}>
+      {wp.element.createElement(InnerBlocks, {template: template(props.attributes ?? {})})}
+    </div>
+  ),
+  save: () => wp.element.createElement(wp.blockEditor.InnerBlocks.Content, {}),
+});

--- a/assets/src/blocks/PostsListTest/template.js
+++ b/assets/src/blocks/PostsListTest/template.js
@@ -1,0 +1,95 @@
+export const POSTS_LIST_BLOCK_NAME = 'planet4-blocks/posts-list';
+export const POSTS_LISTS_LAYOUT_TYPES = [
+  {label: 'List', value: 'default', columnCount: 3},
+  {label: 'Grid', value: 'grid', columnCount: 4},
+  {label: 'Carousel', value: 'flex', columnCount: 8},
+];
+
+const {__} = wp.i18n;
+
+const newsPageLink = window.p4_vars.news_page_link;
+
+const seeAllLink = ['core/navigation-link', {...!newsPageLink ? {className: 'd-none'} : {
+  url: newsPageLink,
+  label: __('See all stories', 'planet4-blocks-backend'),
+  className: 'see-all-link',
+}}];
+
+const template = () => ([
+  ['core/query', {
+    className: 'posts-list p4-query-loop is-custom-layout-list',
+    query: {
+      perPage: 3,
+      pages: 0,
+      offset: 0,
+      postType: 'post',
+      order: 'desc',
+      orderBy: 'date',
+      author: '',
+      search: '',
+      exclude: [],
+      sticky: '',
+      inherit: false,
+      postIn: [],
+      hasPassword: false,
+    },
+    layout: {
+      type: 'default',
+      columnCount: 3,
+    },
+  }, [
+    ['core/group', {layout: {type: 'flex', justifyContent: 'space-between'}}, [
+      ['core/heading', {lock: {move: true}, content: __('Related Posts', 'planet4-blocks-backend')}],
+      seeAllLink,
+    ]],
+    ['core/paragraph', {
+      lock: {move: true},
+      placeholder: __('Enter description', 'planet4-blocks-backend'),
+      style: {
+        spacing: {
+          margin: {
+            top: '24px',
+            bottom: '36px',
+          },
+        },
+      },
+    }],
+    ['core/query-no-results', {}, [
+      ['core/paragraph', {content: __('No posts found. (This default text can be edited)', 'planet4-blocks-backend')}],
+    ]],
+    ['core/post-template', {lock: {move: true, remove: true}}, [
+      ['core/columns', {}, [
+        ['core/post-featured-image', {isLink: true}],
+        ['core/group', {}, [
+          ['core/group', {layout: {type: 'flex'}}, [
+            ['core/post-terms', {
+              term: 'category',
+              separator: ' | ',
+            }],
+            ['core/post-terms', {
+              term: 'post_tag',
+              separator: ' ',
+            }],
+          ]],
+          ['core/post-title', {isLink: true}],
+          ['core/post-excerpt'],
+          ['core/group', {className: 'posts-list-meta'}, [
+            ['core/post-author-name', {isLink: true}],
+            ['core/post-date'],
+          ]],
+        ]],
+      ]],
+    ]],
+    ['core/buttons', {
+      className: 'carousel-controls',
+      lock: {move: true},
+      layout: {type: 'flex', justifyContent: 'space-between', orientation: 'horizontal', flexWrap: 'nowrap'},
+    }, [
+      ['core/button', {className: 'carousel-control-prev', text: __('Prev', 'planet4-blocks-backend')}],
+      ['core/button', {className: 'carousel-control-next', text: __('Next', 'planet4-blocks-backend')}],
+    ]],
+    seeAllLink,
+  ]],
+]);
+
+export default template;

--- a/assets/src/editorIndex.js
+++ b/assets/src/editorIndex.js
@@ -12,6 +12,7 @@ import {registerColumnsBlock} from './blocks/Columns/ColumnsBlock';
 import {registerBlockStyles} from './block-styles';
 import {registerBlockVariations} from './block-variations';
 import {registerActionButtonTextBlock} from './blocks/ActionCustomButtonText';
+import {registerPostsListTest} from './blocks/PostsListTest';
 
 wp.domReady(() => {
   // Make sure to unregister the posts-list native variation before registering planet4-blocks/posts-list
@@ -24,6 +25,7 @@ wp.domReady(() => {
   registerHappyPointBlock();
   registerSocialMediaBlock();
   registerTimelineBlock();
+  registerPostsListTest();
 
   // Block Templates
   registerBlockTemplates();

--- a/single.php
+++ b/single.php
@@ -63,26 +63,7 @@ $context['filter_url'] = add_query_arg(
 
 // Build the shortcode for articles block.
 if ('yes' === $post->include_articles) {
-    $tag_id_array = [];
-    foreach ($post->tags() as $post_tag) {
-        $tag_id_array[] = $post_tag->id;
-    }
-    $category_id_array = [];
-    foreach ($post->terms('category') as $category) {
-        $category_id_array[] = $category->id;
-    }
-
-    $block_attributes = [
-        'exclude_post_id' => $post->ID,
-        'tags' => $tag_id_array,
-        'categories' => $category_id_array,
-        'article_heading' => __('Related Articles', 'planet4-blocks'),
-        'read_more_text' => __('Load more', 'planet4-blocks'),
-    ];
-
-    $post->articles = '<!-- wp:planet4-blocks/articles '
-        . wp_json_encode($block_attributes, JSON_UNESCAPED_SLASHES)
-        . ' /-->';
+    $post->articles = '<!-- wp:planet4-blocks/posts-list-test /-->';
 }
 
 if (! empty($take_action_page) && ! has_block('planet4-blocks/take-action-boxout')) {


### PR DESCRIPTION
### Description

To replace the "Related Articles" post setting we would like to use our new Posts List block, but currently in order to achieve this the code is quite long ([see PR](https://github.com/greenpeace/planet4-master-theme/pull/2370)). It would be nice to find a shorter way to write it.

Instead of a block variation, we could create it as a separate block. This would allow us to easily use it in our code, for example we should be able to write `<!-- wp:planet4-blocks/posts-list-test /-->` (this can be tested in the backend via the code editor). It seems there is no way to do this with block variations.

For now I haven't looked into the Query Loop extensions (sidebar options) that we have and how to make them work with this new version, but I guess it should be rather straightforward.

We should also be able to add attributes to this block if needed via the `block.json` file.