### PR TITLE
PLANET-7598: Form Builder - Add a petition counter id field

### DIFF
--- a/src/GravityFormsExtensions.php
+++ b/src/GravityFormsExtensions.php
@@ -114,16 +114,17 @@ class GravityFormsExtensions
         add_filter('gform_form_post_get_meta', [$this, 'p4_gf_enable_default_meta_settings'], 10, 1);
         add_filter('gform_hubspot_form_object_pre_save_feed', [$this, 'p4_gf_hb_form_object_pre_save_feed'], 10, 1);
         add_action('gform_after_submission', [$this, 'p4_send_gp_pixel_counter'], 10, 2);
-        add_action('gform_after_submission', [$this, 'p4_send_gp_pixel_counter_iframe'], 10, 2);
 
         add_action('gform_stripe_fulfillment', [ $this, 'record_fulfillment_entry' ], 10, 2);
         add_action('gform_post_payment_action', [ $this, 'check_stripe_payment_status' ], 10, 2);
     }
 
     /**
-     * Make an API call to the Greenpeace Pixel Counter.
-     * Increase in one unit the total number of submissions for a counter.
+     * Increase in one unit the total number of submissions for a counter by
+     * making an API call to the Greenpeace Pixel Counter, or
+     * adding an iframe.
      *
+     * @link https://counter.greenpeace.org/documentation
      * @param array $form The form setting.
      * @param array $entry A form entry.
      *
@@ -138,37 +139,19 @@ class GravityFormsExtensions
         $endpoint_url .= '?id=' . $form['p4_gf_counter'];
         $endpoint_url .= '&email_hash=' . $this->p4_gf_get_email_hash($form, $entry);
 
-        $response = wp_remote_get($endpoint_url);
-        GFCommon::log_debug('gform_after_submission: response => ' . $response);
+        // Pass the referer explicitily.
+        $wp_remote_get_args = array(
+            'headers' => array(
+                'Referer' => home_url(),
+            ),
+        );
 
-        $endpoint_url_2 = 'https://counter.greenpeace.org/count_pixel';
-        $endpoint_url_2 .= '?id=' . $form['p4_gf_counter'];
-        $endpoint_url_2 .= '&email_hash=' . $this->p4_gf_get_email_hash($form, $entry);
+        $response = wp_remote_get($endpoint_url, $wp_remote_get_args);
 
-        $response_2 = wp_remote_get($endpoint_url_2);
-        GFCommon::log_debug('gform_after_submission: response => ' . $response_2);
-    }
-
-        /**
-     * Increase in one unit the total number of submissions for a counter.
-     * @link https://counter.greenpeace.org/documentation
-     *
-     * @param array $form The form setting.
-     * @param array $entry A form entry.
-     *
-     */
-    public function p4_send_gp_pixel_counter_iframe(array $entry, array $form): void
-    {
-        if (!$form['p4_gf_counter']) {
-            return;
-        }
-
-        $iframe_url = 'https://counter.greenpeace.org/count';
-        $iframe_url .= '?id=' . $form['p4_gf_counter'];
-        $iframe_url .= '&email_hash=' . $this->p4_gf_get_email_hash($form, $entry);
-
-        $iframe = '<iframe src="' . $iframe_url . '" width="1" height="1" frameborder=0 style="overflow:hidden;" scrolling="no"></iframe>'; // phpcs:ignore Generic.Files.LineLength.MaxExceeded
-        echo $iframe;
+        GFCommon::log_debug('Pixel Counter Response Message: ' . $response['body']);
+        GFCommon::log_debug('Pixel Counter Response Status Code: ' . $response['response']['code']);
+        GFCommon::log_debug('Pixel Counter Response Status Message: ' . $response['response']['message']);
+        return;
     }
 
     /**

--- a/src/GravityFormsExtensions.php
+++ b/src/GravityFormsExtensions.php
@@ -176,6 +176,17 @@ class GravityFormsExtensions
             'choices' => self::P4_GF_TYPES,
         ];
 
+        $fields['p4_options']['fields'][] = [
+            'type' => 'text',
+            'name' => 'p4_gf_counter',
+            'label' => __('Global Counter ID', 'planet4-master-theme-backend'),
+            'tooltip' => __(
+                'Add the Counter Name from counter.greenpeace.org',
+                'planet4-master-theme-backend'
+            ),
+            'required' => false,
+        ];
+
         return $fields;
     }
 


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-7598

<hr>

**DESCRIPTION:**
This PR attempts to increment Pixel Counter's counters when submitting a Gravity Form that includes the `p4_gf_counter` field.

<hr>

**TESTING:**
- Login to the Pixel Counter website: https://counter.greenpeace.org/login  
- Go to the list of counters: https://counter.greenpeace.org/list 
- Locate the counter named `testcounter`
- Take note of the current count number in the Counter column.
- Go to the [form settings page](https://www-dev.greenpeace.org/test-iocaste/wp-admin/admin.php?page=gf_edit_forms&view=settings&subview=settings&id=1) and check that the field Global Counter ID is `testcounter`
- Visit this page: https://www-dev.greenpeace.org/test-iocaste/form-test-page/
- Fill out and submit the form.
- Go back to the list of counters.
- Refresh the page and check the counter number of `testcounter` again. It should be increased.
- Repeat the previous steps using the same email. The counter should not be incremented on form submit.
- Repeat the previous steps using a different email. The counter should be incremented.
- Go to the [Confirmations page](https://www-dev.greenpeace.org/test-iocaste/wp-admin/admin.php?subview=confirmation&page=gf_edit_forms&id=1&view=settings&cid=5179518e5e160) and change the "Confirmation Type" to "Redirect". Repeat the previous steps using a different email. The counter should be incremented.
- Optionally, check the logs here (it takes a few minutes to update): https://storage.googleapis.com/planet4-test-iocaste-stateless-develop/2024/09/gravity_forms/logs/gravityforms_c8a71a0b4f41ec223996ba2d0eceab95a886e529.txt

<hr>

~~**NOTES:**~~
~~According to the [Pixel Counter documentation](https://counter.greenpeace.org/documentation), there are 2 ways of incrementing the counters: via iframe or a GET request. So far, only the iframe method seems to be working. The GET requests always return a "400 Bad Request" error with the message "Not in allowed list", which contradicts the domain `www-dev.greenpeace.org` which is part of the [allowed domains list](https://counter.greenpeace.org/allowedlist).~~

~~Because of that error, and only for testing purposes, I decided to implement a selector (called "Global Counter Mode") in the [P4 forms settings](https://www-dev.greenpeace.org/test-iocaste/wp-admin/admin.php?page=gf_edit_forms&view=settings&subview=settings&id=1) that allow users to choose between the iframe or the GET method. Furthermore, as the [Jira ticket](https://jira.greenpeace.org/browse/PLANET-7598) and the [official documentation](https://counter.greenpeace.org/documentation) mention two different endpoints (`/count` and `/count_pixel`) another selector ("Global Counter Get URL") lets users decide which one to use:~~