### PR TITLE
PLANET-7617 Apply caption styles to all figcaption elements

### DIFF
--- a/assets/src/scss/base/_typography.scss
+++ b/assets/src/scss/base/_typography.scss
@@ -141,6 +141,18 @@ mark {
   padding: 0;
 }
 
-figcaption a {
-  @include shared-link-styles;
+figcaption {
+  --block-figcaption-- {
+    font-family: var(--font-family-tertiary);
+    font-size: var(--font-size-s--font-family-tertiary);
+    line-height: var(--line-height-s--font-family-tertiary);
+  }
+  margin-bottom: 0;
+  color: var(--color-text-image_caption);
+  text-align: center;
+  min-height: 24px; // This is needed in case there's a link in the caption, for our styles
+
+  a {
+    @include shared-link-styles;
+  }
 }

--- a/assets/src/scss/blocks/core-overrides/Image.scss
+++ b/assets/src/scss/blocks/core-overrides/Image.scss
@@ -93,17 +93,6 @@
     height: auto;
   }
 
-  figcaption {
-    --image-figcaption-- {
-      font-family: var(--font-family-paragraph-secondary);
-      font-size: var(--font-size-s--font-family-tertiary);
-      line-height: var(--line-height-s--font-family-tertiary);
-    }
-    margin-bottom: 0;
-    color: var(--color-text-image_caption);
-    text-align: center;
-  }
-
   &.caption-alignment-left figcaption {
     text-align: left;
   }

--- a/assets/src/scss/blocks/core-overrides/Table.scss
+++ b/assets/src/scss/blocks/core-overrides/Table.scss
@@ -51,16 +51,6 @@
     }
   }
 
-  // Table caption
-  figcaption {
-    min-height: 24px; // This is needed in case there's a link in the caption, for our styles
-    text-align: center;
-    font-size: var(--font-size-s--font-family-tertiary);
-    font-family: var(--font-family-tertiary);
-    color: var(--color-text-image_caption);
-    line-height: var(--line-height-s--font-family-tertiary);
-  }
-
   &.is-style-stripes table {
     // Grey background (defaut)
     tr:nth-child(odd) {

--- a/assets/src/scss/core-overrides/_image.scss
+++ b/assets/src/scss/core-overrides/_image.scss
@@ -83,17 +83,6 @@
     height: auto;
   }
 
-  figcaption {
-    --image-figcaption-- {
-      font-family: var(--font-family-paragraph-secondary);
-      font-size: var(--font-size-s--font-family-tertiary);
-      line-height: var(--line-height-s--font-family-tertiary);
-    }
-    margin-bottom: 0;
-    color: var(--color-text-image_caption);
-    text-align: center;
-  }
-
   &.caption-alignment-left figcaption {
     text-align: left;
   }

--- a/assets/src/scss/pages/post/_article-content.scss
+++ b/assets/src/scss/pages/post/_article-content.scss
@@ -310,10 +310,6 @@
     display: block;
   }
 
-  figcaption {
-    margin-top: 10px;
-  }
-
   .wp-caption-text {
     font-size: $font-size-xxs;
     font-family: var(--font-family-primary);


### PR DESCRIPTION
### Description

See [PLANET-7617](https://jira.greenpeace.org/browse/PLANET-7617)

**Related PR:** https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/1245

### Testing

I've added multiple blocks with captions on [this page](https://www-dev.greenpeace.org/test-venus/so-many-captions/), all should now look the same!