### PR TITLE
Align the Read More button in the Actions List block

### DIFF
--- a/assets/src/scss/blocks/ActionsList/ActionsListStyle.scss
+++ b/assets/src/scss/blocks/ActionsList/ActionsListStyle.scss
@@ -80,8 +80,14 @@
 
     .read-more-nav {
       display: flex;
-      justify-content: flex-end;
-      margin-top: 25%;
+      position: absolute;
+      bottom: 0;
+      right: 0;
+
+      html[dir="rtl"] & {
+        right: inherit;
+        left: 0;
+      }
 
       a {
         margin-bottom: 0;
@@ -96,12 +102,15 @@
 
   .wp-block-post-title {
     font-size: 20px;
-    margin-bottom: 0;
-    display: -webkit-box;
-    line-clamp: 2;
-    -webkit-line-clamp: 2;
-    -webkit-box-orient: vertical;
-    overflow: hidden;
+    margin-bottom: $sp-1;
+
+    a {
+      display: -webkit-box;
+      line-clamp: 2;
+      -webkit-line-clamp: 2;
+      -webkit-box-orient: vertical;
+      overflow: hidden;
+    }
   }
 
   .wp-block-post-excerpt p {


### PR DESCRIPTION
Ref: https://greenpeace-gpi.slack.com/archives/C0160MX64AG/p1726049842778739

<hr>

**DESCRIPTION:**
- This PR limits the number of lines of the Actions List's titles to 2.
- This PR aligns the position of the Read More button of the Actions List block according to this mockup:
![Frame 574](https://github.com/user-attachments/assets/953b3caa-6ecd-4ecd-b0f7-ec38667edefc)

<hr>

**COMPARISON:**

Main branch:
![Greenpeace](https://github.com/user-attachments/assets/3e2baae5-3f2f-41d3-9db1-b80243d1bfde)

This branch:
![Greenpeace(1)](https://github.com/user-attachments/assets/a728cada-8d13-41ad-b8af-2cbed3230357)