### PR TITLE
Fix special characters in submenu navigation and in footer

### DIFF
--- a/templates/burger-menu-items.twig
+++ b/templates/burger-menu-items.twig
@@ -54,7 +54,7 @@
                         data-ga-category="Submenu Navigation"
                         data-ga-action="{{ link_ga_action }}"
                         data-ga-label="{{ page_category }}">
-                            {{ item.title }}
+                            {{ item.title|e('wp_kses_post')|raw }}
                     </a>
                 </li>
             {% endfor %}

--- a/templates/footer.twig
+++ b/templates/footer.twig
@@ -24,7 +24,7 @@
                                     rel="noopener noreferrer"
                                 {% endif %}
                             >
-                                {{ primary.title }}
+                                {{ primary.title|e('wp_kses_post')|raw }}
                             </a>
                         </li>
                     {% endfor %}
@@ -42,7 +42,7 @@
                                     rel="noopener noreferrer"
                                 {% endif %}
                             >
-                                {{ secondary.title }}
+                                {{ secondary.title|e('wp_kses_post')|raw }}
                             </a>
                         </li>
                     {% endfor %}

--- a/templates/navigation-submenu.twig
+++ b/templates/navigation-submenu.twig
@@ -16,7 +16,7 @@
                 data-ga-category="Submenu Navigation"
                 data-ga-action="{{ item.title }}"
                 data-ga-label="{{ page_category }}">
-                    {{ item.title }}
+                    {{ item.title|e('wp_kses_post')|raw }}
             </a>
         </li>
     {% endfor %}


### PR DESCRIPTION
### Description

This can happen if some pages used in the navigation have special characters in their title

### Testing

You can check the first submenu item under `Take Action` on the following test instances:

- [Broken](https://www-dev.greenpeace.org/test-rhea)
- [Fixed](https://www-dev.greenpeace.org/test-venus)