### PR TITLE
Remove native share button background

### DIFF
--- a/assets/src/scss/components/_share-buttons.scss
+++ b/assets/src/scss/components/_share-buttons.scss
@@ -11,6 +11,7 @@
     height: 3rem;
     border-radius: 50%;
     margin-bottom: 0;
+    cursor: pointer;
     background: var(--color-background-button_share--secondary-passive);
 
     &:not(:last-child) {

--- a/assets/src/scss/components/_share-buttons.scss
+++ b/assets/src/scss/components/_share-buttons.scss
@@ -58,11 +58,6 @@
   }
 
   .native {
-    background: var(--p4-action-yellow-500);
     display: none;
-
-    &:active {
-      background: var(--p4-action-yellow-600);
-    }
   }
 }


### PR DESCRIPTION
### Description

We removed the background color for other share buttons already but forgot this one

### Testing

You need to test this on mobile/tablet since the native share button doesn't show otherwise.

**Before the fix:**

<img width="469" alt="Screenshot 2024-09-18 at 16 41 42" src="https://github.com/user-attachments/assets/6c80f923-1e18-4c3d-b1e4-013c82af8a29">

**After the fix:**

<img width="452" alt="Screenshot 2024-09-18 at 16 41 32" src="https://github.com/user-attachments/assets/200f7494-a572-49c8-b94c-5c463b1fba67">
