### PR TITLE
PLANET-7598: Add a petition counter id field (iframe)

### DIFF
--- a/src/GravityFormsExtensions.php
+++ b/src/GravityFormsExtensions.php
@@ -113,9 +113,32 @@ class GravityFormsExtensions
         add_filter('gform_pre_render', [ $this, 'p4_client_side_gravityforms_prefill' ], 10, 1);
         add_filter('gform_form_post_get_meta', [$this, 'p4_gf_enable_default_meta_settings'], 10, 1);
         add_filter('gform_hubspot_form_object_pre_save_feed', [$this, 'p4_gf_hb_form_object_pre_save_feed'], 10, 1);
+        add_action('gform_after_submission', [$this, 'p4_send_gp_pixel_counter'], 10, 2);
 
         add_action('gform_stripe_fulfillment', [ $this, 'record_fulfillment_entry' ], 10, 2);
         add_action('gform_post_payment_action', [ $this, 'check_stripe_payment_status' ], 10, 2);
+    }
+
+    /**
+     * Increase in one unit the total number of submissions for a counter.
+     * @link https://counter.greenpeace.org/documentation
+     *
+     * @param array $form The form setting.
+     * @param array $entry A form entry.
+     *
+     */
+    public function p4_send_gp_pixel_counter(array $entry, array $form): void
+    {
+        if (!$form['p4_gf_counter']) {
+            return;
+        }
+
+        $iframe_url = 'https://counter.greenpeace.org/count';
+        $iframe_url .= '?id=' . $form['p4_gf_counter'];
+        $iframe_url .= '&email_hash=' . $this->p4_gf_get_email_hash($form, $entry);
+
+        $iframe = '<iframe src="' . $iframe_url . '" width="1" height="1" frameborder=0 style="overflow:hidden;" scrolling="no"></iframe>'; // phpcs:ignore Generic.Files.LineLength.MaxExceeded
+        echo $iframe;
     }
 
     /**
@@ -174,6 +197,17 @@ class GravityFormsExtensions
             'required' => true,
             'default_value ' => self::DEFAULT_GF_TYPE,
             'choices' => self::P4_GF_TYPES,
+        ];
+
+        $fields['p4_options']['fields'][] = [
+            'type' => 'text',
+            'name' => 'p4_gf_counter',
+            'label' => __('Global Counter ID', 'planet4-master-theme-backend'),
+            'tooltip' => __(
+                'Add the Counter Name from counter.greenpeace.org',
+                'planet4-master-theme-backend'
+            ),
+            'required' => false,
         ];
 
         return $fields;


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-7598

<hr>

**DESCRIPTION:**
This PR fires an automatic GET request to the GP Pixel Counter API when submitting a Gravity Form with the `p4_gf_counter` field.

<hr>

**TESTING:**
- Login to the Pixel Counter website: https://counter.greenpeace.org/login  
- Go to the list of counters: https://counter.greenpeace.org/list 
- Locate the counter named `alt-futures`
- Take note of the current count number in the Counter column.
- Visit this page: https://www-dev.greenpeace.org/test-iocaste/form-test-page/
- Fill out and submit the form.
- Go back to the list of counters.
- Check the counter number of `alt-futures` again. It should be increased by one unit.