### PR TITLE
PLANET-7597 Fix Block Usage Report 'group by post id' links'

### DIFF
--- a/src/BlockReportSearch/Block/BlockUsageTable.php
+++ b/src/BlockReportSearch/Block/BlockUsageTable.php
@@ -518,7 +518,8 @@ class BlockUsageTable extends WP_List_Table
         $link_tpl = '<a href="%s" title="%s">%s</a>';
         // The post id may be empty if we removed it when creating the rows (see single_row function).
         $post_id = empty($item['post_id']) ? $this->latest_row : $item['post_id'];
-        $page_uri = get_page_uri($post_id);
+        // If the post is still a draft we don't want to show a link in the title column.
+        $page_uri = $item['post_status'] === 'draft' ? '' : get_permalink($post_id);
 
         return sprintf(
             empty($page_uri) ? $title_tpl : $link_tpl,

--- a/src/BlockReportSearch/Block/BlockUsageTable.php
+++ b/src/BlockReportSearch/Block/BlockUsageTable.php
@@ -516,7 +516,9 @@ class BlockUsageTable extends WP_List_Table
 
         $title_tpl = '%2$s';
         $link_tpl = '<a href="%s" title="%s">%s</a>';
-        $page_uri = get_page_uri($item['post_id']);
+        // The post id may be empty if we removed it when creating the rows (see single_row function).
+        $post_id = empty($item['post_id']) ? $this->latest_row : $item['post_id'];
+        $page_uri = get_page_uri($post_id);
 
         return sprintf(
             empty($page_uri) ? $title_tpl : $link_tpl,
@@ -580,7 +582,7 @@ class BlockUsageTable extends WP_List_Table
     protected function handle_row_actions($item, $column_name, $primary)
     {
         return $this->row_actions(
-            ( new RowActions() )->get_post_actions($item, $column_name, $primary)
+            ( new RowActions() )->get_post_actions($item, $column_name, $primary, $this->latest_row)
         );
     }
     // phpcs:enable SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingAnyTypeHint

--- a/src/BlockReportSearch/Pattern/PatternUsageTable.php
+++ b/src/BlockReportSearch/Pattern/PatternUsageTable.php
@@ -242,7 +242,7 @@ class PatternUsageTable extends WP_List_Table
     protected function handle_row_actions($item, $column_name, $primary)
     {
         return $this->row_actions(
-            ( new RowActions() )->get_post_actions($item, $column_name, $primary)
+            ( new RowActions() )->get_post_actions($item, $column_name, $primary, $this->latest_row)
         );
     }
     // phpcs:enable SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingAnyTypeHint, SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
@@ -328,13 +328,31 @@ class PatternUsageTable extends WP_List_Table
 
         $title_tpl = '%2$s';
         $link_tpl = '<a href="%s" title="%s">%s</a>';
-        $page_uri = get_page_uri($item['post_id']);
+        // The post id may be empty if we removed it when creating the rows (see single_row function).
+        $post_id = empty($item['post_id']) ? $this->latest_row : $item['post_id'];
+        // If the post is still a draft we don't want to show a link in the title column.
+        $page_uri = $item['post_status'] === 'draft' ? '' : get_permalink($post_id);
 
         return sprintf(
             empty($page_uri) ? $title_tpl : $link_tpl,
             $page_uri,
             esc_attr($content),
             ( strlen($content) > 45 ? substr($content, 0, 45) . '...' : $content )
+        );
+    }
+
+    /**
+     * Post ID display.
+     *
+     * @param array $item Item.
+     * @phpcs:disable SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
+     */
+    public function column_post_id($item): string
+    {
+        return sprintf(
+            '<a href="%s">%s</a>',
+            get_edit_post_link($item['post_id']),
+            $item['post_id']
         );
     }
 

--- a/src/BlockReportSearch/RowActions.php
+++ b/src/BlockReportSearch/RowActions.php
@@ -17,7 +17,7 @@ class RowActions
      * @param array  $item              Item.
      * @param string $column_name       Current column name.
      * @param string $primary           Primary column name.
-     * @param string $potential_post_id Primary column name.
+     * @param string $potential_post_id Post id if the rows are grouped by id.
      *
 	 * phpcs:disable WordPress.WP.I18n.TextDomainMismatch
      */

--- a/src/BlockReportSearch/RowActions.php
+++ b/src/BlockReportSearch/RowActions.php
@@ -14,25 +14,30 @@ class RowActions
     /**
      * Add action links to a row
      *
-     * @param array  $item        Item.
-     * @param string $column_name Current column name.
-     * @param string $primary     Primary column name.
+     * @param array  $item              Item.
+     * @param string $column_name       Current column name.
+     * @param string $primary           Primary column name.
+     * @param string $potential_post_id Primary column name.
      *
 	 * phpcs:disable WordPress.WP.I18n.TextDomainMismatch
      */
-    public function get_post_actions(array $item, string $column_name, string $primary): array
-    {
+    public function get_post_actions(
+        array $item,
+        string $column_name,
+        string $primary,
+        string $potential_post_id
+    ): array {
         if ($column_name !== $primary) {
             return [];
         }
 
-        $id = (int) $item['post_id'];
+        $id = empty($item['post_id']) ? (int) $potential_post_id : (int) $item['post_id'];
         $title = $item['post_title'];
         $actions = [];
 
         $actions['edit'] = sprintf(
             '<a href="%s" aria-label="%s">%s</a>',
-            get_edit_post_link($item['post_id']),
+            get_edit_post_link($id),
             /* translators: %s: Post title. */
             esc_attr(sprintf(__('Edit &#8220;%s&#8221;', 'default'), $title)),
             __('Edit', 'default')
@@ -50,7 +55,7 @@ class RowActions
         } elseif ('trash' !== $item['post_status']) {
             $actions['view'] = sprintf(
                 '<a href="%s" rel="bookmark" aria-label="%s">%s</a>',
-                get_permalink($item['post_id']),
+                get_permalink($id),
                 /* translators: %s: Post title. */
                 esc_attr(sprintf(__('View &#8220;%s&#8221;', 'default'), $title)),
                 __('View', 'default')


### PR DESCRIPTION
### Description

See [PLANET-7597](https://jira.greenpeace.org/browse/PLANET-7597)

If this implementation was working in the plugin, it's weird that it no longer works in the theme. Maybe WordPress changed something in `WP_List_Table`.

**Note:** this is a bit of a messy fix, so any feedback is welcome!

### Testing

- In the [broken version](https://www-dev.greenpeace.org/test-pluto/wp-admin/admin.php?page=plugin_blocks_report&group=post_id), there is no link in the "title" column and the row actions links are not the page edit url, they just reload the page:

<img width="408" alt="Screenshot 2024-10-01 at 16 09 28" src="https://github.com/user-attachments/assets/ecb5dd8e-4bf2-4e0b-8cd2-edcf43f0c1fd">

- In the [fixed version](https://www-dev.greenpeace.org/test-nix/wp-admin/admin.php?page=plugin_blocks_report&group=post_id), both of these issues are no longer present:

<img width="429" alt="Screenshot 2024-10-01 at 16 09 41" src="https://github.com/user-attachments/assets/8aa2aa93-40ef-4fd4-8bc8-8320ce626346">
