### PR TITLE
PLANET-7568 Fix styles for the Gravity Forms multiple file upload

### DIFF
--- a/assets/src/scss/layout/_gravity-forms.scss
+++ b/assets/src/scss/layout/_gravity-forms.scss
@@ -152,3 +152,16 @@
 .gform_description {
   font-family: var(--font-family-paragraph-secondary);
 }
+
+.gform_delete_file {
+  margin-inline-start: $sp-2;
+
+  .dashicons-trash {
+    vertical-align: text-top;
+  }
+}
+
+.gfield_fileupload_cancel {
+  margin-inline-start: $sp-2;
+  text-decoration: underline;
+}


### PR DESCRIPTION
### Description

See [PLANET-7568](https://jira.greenpeace.org/browse/PLANET-7568)

These are really small changes in buttons alignment and margins

### Testing

You can test the fix with any form using a multi-file upload field, such as [this one](https://www-dev.greenpeace.org/test-venus/gf-multi-file-upload/)

- **Broken version:**

<img width="316" alt="Screenshot 2024-07-26 at 11 35 47" src="https://github.com/user-attachments/assets/8bfebb5a-6344-4668-8b7c-89c6bdf4f86f">
<img width="346" alt="Screenshot 2024-07-26 at 11 36 19" src="https://github.com/user-attachments/assets/bd6c5aa1-8b00-4592-a88e-a9956b4f1d2b">

- **Fixed version:**

<img width="308" alt="Screenshot 2024-10-01 at 17 01 58" src="https://github.com/user-attachments/assets/4c23c450-acdd-43b3-a7e3-62d019cd3c1c">
<img width="297" alt="Screenshot 2024-10-01 at 17 03 14" src="https://github.com/user-attachments/assets/444d2957-17b1-4b7e-99b8-b6a4c6769a55">
