### PR TITLE
PLANET-7539: Add button to convert the ToC block into a List block

### DIFF
--- a/assets/src/blocks/TableOfContents/TableOfContentsEditor.js
+++ b/assets/src/blocks/TableOfContents/TableOfContentsEditor.js
@@ -6,8 +6,8 @@ import {getHeadingsFromBlocks} from './getHeadingsFromBlocks';
 import {deepClone} from '../../functions/deepClone';
 
 const {useSelect} = wp.data;
-const {InspectorControls, RichText} = wp.blockEditor;
-const {Button, PanelBody} = wp.components;
+const {InspectorControls, RichText, BlockControls} = wp.blockEditor;
+const {Button, PanelBody, ToolbarItem} = wp.components;
 const {__} = wp.i18n;
 
 const renderEdit = (attributes, setAttributes) => {
@@ -110,22 +110,32 @@ const renderView = (attributes, setAttributes, className) => {
   const style = getTableOfContentsStyle(className, submenu_style);
 
   return (
-    <section className={`block table-of-contents-block table-of-contents-${style} ${className ?? ''}`}>
-      <RichText
-        tagName="h2"
-        placeholder={__('Enter title', 'planet4-blocks-backend')}
-        value={title}
-        onChange={titl => setAttributes({title: titl})}
-        withoutInteractiveFormatting
-        allowedFormats={[]}
-      />
-      {menuItems.length > 0 ?
-        <TableOfContentsItems menuItems={menuItems} /> :
-        <div className="EmptyMessage">
-          {__('There are not any pre-established headings that this block can display in the form of a table of content. Please add headings to your page or choose another heading size.', 'planet4-blocks-backend')}
-        </div>
-      }
-    </section>
+    <>
+      <BlockControls>
+        <ToolbarItem
+          as={Button}
+          onClick={() => alert('Converting...')}
+        >
+            Convert to static list
+        </ToolbarItem>
+      </BlockControls>
+      <section className={`block table-of-contents-block table-of-contents-${style} ${className ?? ''}`}>
+        <RichText
+          tagName="h2"
+          placeholder={__('Enter title', 'planet4-blocks-backend')}
+          value={title}
+          onChange={titl => setAttributes({title: titl})}
+          withoutInteractiveFormatting
+          allowedFormats={[]}
+        />
+        {menuItems.length > 0 ?
+          <TableOfContentsItems menuItems={menuItems} /> :
+          <div className="EmptyMessage">
+            {__('There are not any pre-established headings that this block can display in the form of a table of content. Please add headings to your page or choose another heading size.', 'planet4-blocks-backend')}
+          </div>
+        }
+      </section>
+    </>
   );
 };
 

--- a/assets/src/blocks/TableOfContents/TableOfContentsEditor.js
+++ b/assets/src/blocks/TableOfContents/TableOfContentsEditor.js
@@ -10,6 +10,10 @@ const {InspectorControls, RichText, BlockControls} = wp.blockEditor;
 const {Button, PanelBody, ToolbarItem} = wp.components;
 const {__} = wp.i18n;
 
+import {useBlockProps} from '@wordpress/block-editor';
+import {select, dispatch} from '@wordpress/data';
+import {createBlock} from '@wordpress/blocks';
+
 const renderEdit = (attributes, setAttributes) => {
   function addLevel() {
     const [previousLastLevel] = attributes.levels.slice(-1);
@@ -92,6 +96,25 @@ const renderEdit = (attributes, setAttributes) => {
   );
 };
 
+const convertIntoListBlock = menuItems => {
+  const blockList = select('core/block-editor').getBlocks(); // Get the current blocks
+  const blockIndex = blockList.findIndex(block => block.name === 'planet4-blocks/submenu'); // Find the index of the block to transform
+
+  if (blockIndex !== -1) {
+    const oldBlock = blockList[blockIndex];
+    const newBlockAttributes = {...oldBlock.attributes}; // Preserve existing attributes
+
+    // Create a new block with the new type and attributes
+    const newBlock = createBlock('core/list', newBlockAttributes);
+
+    // Replace the old block with the new block
+    dispatch('core/block-editor').insertBlock(newBlock, blockIndex); // Insert the new block at the old block's position
+    dispatch('core/block-editor').removeBlock(oldBlock.clientId); // Remove the old block
+
+    // console.log(menuItems);
+  }
+};
+
 const renderView = (attributes, setAttributes, className) => {
   const {
     title,
@@ -114,7 +137,7 @@ const renderView = (attributes, setAttributes, className) => {
       <BlockControls>
         <ToolbarItem
           as={Button}
-          onClick={() => alert('Converting...')}
+          onClick={() => convertIntoListBlock(menuItems)}
         >
             Convert to static list
         </ToolbarItem>


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-7539

<hr>

**DESCRIPTION:**
This PR adds a "Convert to static list" button to the Table of Content block (formerly the Submenu block).
Editors can click on it to convert the Table of Content block into a native List block and edit the block content.
This is the first step in investigating how to add WYSIWYG features to the Table of Content block.

Additionally, some JSDocs were added to make our future selves' work lighter.