### PR TITLE
Fix special characters in sitemap links

### DIFF
--- a/templates/sitemap.twig
+++ b/templates/sitemap.twig
@@ -52,11 +52,11 @@
                     {% if posts[cat.term_id] is not empty %}
                     <div class="col-md-5 order-md-2 order-lg-3 col-lg-3">
                             <h5 class="mb-3 mt-5 mt-lg-0">
-                                <a href="{{ function('get_category_link', cat.term_id) }}">{{ cat.name }}</a>
+                                <a href="{{ function('get_category_link', cat.term_id) }}">{{ cat.name|e('wp_kses_post')|raw }}</a>
                             </h5>
                             <ul>
                                 {% for post in posts[cat.term_id] %}
-                                <li><a href="{{ function('get_permalink', post.ID) }}">{{ post.post_title }}</a></li>
+                                <li><a href="{{ function('get_permalink', post.ID) }}">{{ post.post_title|e('wp_kses_post')|raw }}</a></li>
                                 {% endfor %}
                             </ul>
                     </div>


### PR DESCRIPTION
### Description

This can happen if some pages or categories have special characters in their title

### Testing

[Broken version](https://www-dev.greenpeace.org/test-rhea/sitemap/):

<img width="204" alt="Screenshot 2024-10-03 at 14 49 32" src="https://github.com/user-attachments/assets/69491dee-19df-441a-be27-834f1c11cf35">

[Fixed version](https://www-dev.greenpeace.org/test-iocaste/sitemap/):

<img width="178" alt="Screenshot 2024-10-03 at 14 50 58" src="https://github.com/user-attachments/assets/04a7e99a-3a17-4181-9b27-3e4e2728b252">