### PR TITLE
PLANET-7607 Fix Cookies block frontend bug

### DIFF
--- a/admin/js/options.js
+++ b/admin/js/options.js
@@ -7,24 +7,42 @@ spamButtons.forEach(box => {
 // Show/hide old special pages when enabling or disabling the new IA.
 document.addEventListener('DOMContentLoaded', () => {
   const newIASetting = document.querySelector('#new_ia');
+  const analyticalCookiesCheckbox = document.querySelector('#enable_analytical_cookies');
 
-  if (!newIASetting) {
+  if (!newIASetting && !analyticalCookiesCheckbox) {
     return;
   }
 
-  const actPageDropdown = document.querySelector('[data-fieldtype="act_page_dropdown"]');
-  const explorePageDropdown = document.querySelector('[data-fieldtype="explore_page_dropdown"]');
-  const issuesParentCategoryDropdown = document.querySelector('[data-fieldtype="category_select_taxonomy"]');
+  if (newIASetting) {
+    const actPageDropdown = document.querySelector('[data-fieldtype="act_page_dropdown"]');
+    const explorePageDropdown = document.querySelector('[data-fieldtype="explore_page_dropdown"]');
+    const issuesParentCategoryDropdown = document.querySelector('[data-fieldtype="category_select_taxonomy"]');
 
-  // Needed for page reload when saving settings.
-  actPageDropdown.classList.toggle('hidden', newIASetting.checked);
-  explorePageDropdown.classList.toggle('hidden', newIASetting.checked);
-  issuesParentCategoryDropdown.classList.toggle('hidden', newIASetting.checked);
+    // Needed for page reload when saving settings.
+    actPageDropdown.classList.toggle('hidden', newIASetting.checked);
+    explorePageDropdown.classList.toggle('hidden', newIASetting.checked);
+    issuesParentCategoryDropdown.classList.toggle('hidden', newIASetting.checked);
 
-  newIASetting.addEventListener('change', event => {
-    const {checked} = event.currentTarget;
-    actPageDropdown.classList.toggle('hidden', checked);
-    explorePageDropdown.classList.toggle('hidden', checked);
-    issuesParentCategoryDropdown.classList.toggle('hidden', checked);
-  });
+    newIASetting.addEventListener('change', event => {
+      const {checked} = event.currentTarget;
+      actPageDropdown.classList.toggle('hidden', checked);
+      explorePageDropdown.classList.toggle('hidden', checked);
+      issuesParentCategoryDropdown.classList.toggle('hidden', checked);
+    });
+  }
+
+  if (analyticalCookiesCheckbox) {
+    const nameTextField = document.querySelector('.cmb2-id-analytical-cookies-name');
+    const descriptionTextField = document.querySelector('.cmb2-id-analytical-cookies-description');
+
+    // Needed for page reload when saving settings.
+    nameTextField.classList.toggle('hidden', !analyticalCookiesCheckbox.checked);
+    descriptionTextField.classList.toggle('hidden', !analyticalCookiesCheckbox.checked);
+
+    analyticalCookiesCheckbox.addEventListener('change', event => {
+      const {checked} = event.currentTarget;
+      nameTextField.classList.toggle('hidden', !checked);
+      descriptionTextField.classList.toggle('hidden', !checked);
+    });
+  }
 });

--- a/assets/src/blocks/Cookies/CookiesFrontend.js
+++ b/assets/src/blocks/Cookies/CookiesFrontend.js
@@ -62,8 +62,12 @@ export const CookiesFrontend = props => {
       [key]: granted ? 'granted' : 'denied',
     });
 
-    // eslint-disable-next-line no-undef
-    const updatedCapabilities = {...capabilities, [key]: granted ? 'granted' : 'denied'};
+    let updatedCapabilities = {[key]: granted ? 'granted' : 'denied'};
+    if (typeof capabilities !== 'undefined') {
+      // eslint-disable-next-line no-undef
+      updatedCapabilities = {...capabilities, [key]: granted ? 'granted' : 'denied'};
+    }
+
     dataLayer.push({
       event: 'updateConsent',
       ...updatedCapabilities,
@@ -72,7 +76,7 @@ export const CookiesFrontend = props => {
     let ad_storage = true;
     if (key === 'ad_storage' && granted) {
       ad_storage = false;
-    } else if (key !== 'ad_storage') {
+    } else if (key !== 'ad_storage' && typeof capabilities !== 'undefined') {
       // eslint-disable-next-line no-undef
       ad_storage = capabilities.ad_storage === 'denied';
     }

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -203,6 +203,17 @@ class Settings
                             ],
                         ],
                     ],
+
+                    [
+                        'name' => __('Enable Analytical Cookies', 'planet4-master-theme-backend'),
+                        'desc' => __(
+                            'Enable the Analytical cookies option in Cookies block and box',
+                            'planet4-master-theme-backend'
+                        ),
+                        'id' => 'enable_analytical_cookies',
+                        'type' => 'checkbox',
+                    ],
+
                     [
                         'name' => __('Analytical Cookies label', 'planet4-master-theme-backend'),
                         'id' => 'analytical_cookies_name',
@@ -247,16 +258,6 @@ class Settings
                             'planet4-master-theme-backend'
                         ),
                         'id' => 'enforce_cookies_policy',
-                        'type' => 'checkbox',
-                    ],
-
-                    [
-                        'name' => __('Enable Analytical Cookies', 'planet4-master-theme-backend'),
-                        'desc' => __(
-                            'Enable the Analytical cookies option in Cookies block and box',
-                            'planet4-master-theme-backend'
-                        ),
-                        'id' => 'enable_analytical_cookies',
                         'type' => 'checkbox',
                     ],
 

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -60,6 +60,7 @@ class Settings
         // Each subpage has a title and a path and the fields.
         // phpcs:disable Generic.Files.LineLength.MaxExceeded
         $is_new_ia = !empty(planet4_get_option('new_ia'));
+        $anaylical_cookies_enabled = !empty(planet4_get_option('enable_analytical_cookies'));
         $this->subpages = [
             'planet4_settings_navigation' => [
                 'title' => 'Navigation',
@@ -205,33 +206,6 @@ class Settings
                     ],
 
                     [
-                        'name' => __('Enable Analytical Cookies', 'planet4-master-theme-backend'),
-                        'desc' => __(
-                            'Enable the Analytical cookies option in Cookies block and box',
-                            'planet4-master-theme-backend'
-                        ),
-                        'id' => 'enable_analytical_cookies',
-                        'type' => 'checkbox',
-                    ],
-
-                    [
-                        'name' => __('Analytical Cookies label', 'planet4-master-theme-backend'),
-                        'id' => 'analytical_cookies_name',
-                        'type' => 'text',
-                    ],
-                    [
-                        'name' => __('Analytical Cookies description', 'planet4-master-theme-backend'),
-                        'id' => 'analytical_cookies_description',
-                        'type' => 'wysiwyg',
-                        'options' => [
-                            'textarea_rows' => 2,
-                            'media_buttons' => false,
-                            'quicktags' => [
-                                'buttons' => 'strong,em',
-                            ],
-                        ],
-                    ],
-                    [
                         'name' => __('Marketing Cookies label', 'planet4-master-theme-backend'),
                         'id' => 'all_cookies_name',
                         'type' => 'text',
@@ -247,6 +221,36 @@ class Settings
                                 'buttons' => 'strong,em',
                             ],
                         ],
+                    ],
+
+                    [
+                        'name' => __('Enable Analytical Cookies', 'planet4-master-theme-backend'),
+                        'desc' => __(
+                            'Enable the Analytical cookies option in Cookies block and box',
+                            'planet4-master-theme-backend'
+                        ),
+                        'id' => 'enable_analytical_cookies',
+                        'type' => 'checkbox',
+                    ],
+
+                    [
+                        'name' => __('Analytical Cookies label', 'planet4-master-theme-backend'),
+                        'id' => 'analytical_cookies_name',
+                        'type' => 'text',
+                        'classes' => $anaylical_cookies_enabled ? '' : 'hidden',
+                    ],
+                    [
+                        'name' => __('Analytical Cookies description', 'planet4-master-theme-backend'),
+                        'id' => 'analytical_cookies_description',
+                        'type' => 'wysiwyg',
+                        'options' => [
+                            'textarea_rows' => 2,
+                            'media_buttons' => false,
+                            'quicktags' => [
+                                'buttons' => 'strong,em',
+                            ],
+                        ],
+                        'classes' => $anaylical_cookies_enabled ? '' : 'hidden',
                     ],
 
                     [


### PR DESCRIPTION
### Description

See [PLANET-7607](https://jira.greenpeace.org/browse/PLANET-7607)

It doesn't always work depending on analytical cookies settings, because the capabilities object is not defined

### Testing

Before this fix, when enabling the analytical cookies but not filling the corresponding text fields, the block would not work properly in the frontend. You can check the following instances to test:

- [Broken version](https://www-dev.greenpeace.org/test-pluto/privacy-and-cookies/)
- [Fixed version](https://www-dev.greenpeace.org/test-nix/privacy-and-cookies/)
