### PR TITLE
Fix new Sentry warning

### DIFF
--- a/src/GravityFormsExtensions.php
+++ b/src/GravityFormsExtensions.php
@@ -131,7 +131,7 @@ class GravityFormsExtensions
      */
     public function p4_send_gp_pixel_counter(array $entry, array $form): void
     {
-        if (!$form['p4_gf_counter']) {
+        if (!isset($form['p4_gf_counter'])) {
             return;
         }
 


### PR DESCRIPTION
Ref: https://sentry.greenpeace.org/organizations/greenpeace-org/issues/1964/?project=2

<hr>

**DESCRIPTION:** 
This PR fixes the following Sentry warning: `Warning: Undefined array key "p4_gf_counter"` 

![image](https://github.com/user-attachments/assets/e386509c-1da8-4f7f-8d2e-6e369c0a0409)