### PR TITLE
Add styles to embed elements

### DIFF
--- a/assets/src/scss/base/_mixins.scss
+++ b/assets/src/scss/base/_mixins.scss
@@ -99,6 +99,15 @@
   left: 0;
 }
 
+// Move an element at the top-left corner of its nearest ancestor and set its width and height to 100%.
+@mixin absolute-position {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
 // Build a linear gradient with a direction and any number of color stops.
 @mixin linear-gradient($direction, $color-stops...) {
   background: nth(nth($color-stops, 1), 1); /* Old browsers */

--- a/assets/src/scss/core-overrides/embed.scss
+++ b/assets/src/scss/core-overrides/embed.scss
@@ -1,0 +1,131 @@
+// This combination of height: 0, and padding-bottom: 56.25%
+// is to force the aspect ratio of the video to 16:9, based
+// on the width. See: https://css-tricks.com/fluid-width-video/
+@mixin embed-wrapper {
+    position: relative;
+    overflow: hidden;
+    max-width: 100%;
+    max-height: 100%;
+    padding-bottom: 56.25%;
+    height: 0;
+}
+
+@mixin absolute-position {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+}
+
+@mixin media-group-one {
+    margin-top: $sp-1;
+    margin-bottom: $sp-2;
+
+    @include large-and-up {
+        margin-top: $sp-2;
+        margin-bottom: $sp-4;
+    }
+    iframe {
+        @include absolute-position;
+    }
+    .wp-block-embed__wrapper {
+        @include embed-wrapper;
+    }
+}
+
+@mixin media-group-two {
+    margin-top: $sp-1;
+    margin-bottom: $sp-2;
+
+    @include medium-and-up {
+        width: 510px;
+    }
+
+    @include large-and-up {
+        margin-top: $sp-2;
+        margin-bottom: $sp-4;
+        width: 610px;
+    }
+
+    @include x-large-and-up {
+        width: 630px;
+    }
+
+    iframe {
+        width: 100% !important;
+    }
+}
+
+.edit-post-visual-editor .wp-block {
+    
+    .video-embed {
+        max-height: 100%;
+    }
+
+    .wp-block-embed {
+        &-youtube,
+        &-vimeo,
+        &-dailymotion,
+        &-kickstarter {
+            max-height: 100%;
+        }
+    }
+}
+
+lite-youtube,
+.video-embed-container,
+.instagram-media {
+    width: 100% !important;
+    max-width: 100% !important;
+}
+
+.embed-container {
+    @include embed-wrapper;
+
+    iframe {
+        @include absolute-position;
+    }
+}
+
+.wp-block-embed {
+    .wp-block-embed__wrapper {
+        @include embed-wrapper;
+    }
+
+    &-youtube,
+    &-vimeo,
+    &-dailymotion,
+    &-kickstarter {
+        @include media-group-one;   
+    }
+
+    &-instagram,
+    &-soundcloud {
+        @include media-group-two;
+    }
+
+    &-flickr {
+        @include media-group-two;
+
+        img {
+            width: 100%;
+        }
+    }
+
+    &-twitter, 
+    &-reddit {
+        @include media-group-two;
+
+        .wp-block-embed__wrapper {
+            padding-bottom: unset;
+        }
+    }
+
+    &-reddit {
+        .embedly-card-hug {
+            max-width: 100% !important;
+            margin: unset !important;
+        }
+    }
+}

--- a/assets/src/scss/core-overrides/embed.scss
+++ b/assets/src/scss/core-overrides/embed.scss
@@ -2,130 +2,131 @@
 // is to force the aspect ratio of the video to 16:9, based
 // on the width. See: https://css-tricks.com/fluid-width-video/
 @mixin embed-wrapper {
-    position: relative;
-    overflow: hidden;
-    max-width: 100%;
-    max-height: 100%;
-    padding-bottom: 56.25%;
-    height: 0;
+  position: relative;
+  overflow: hidden;
+  max-width: 100%;
+  max-height: 100%;
+  padding-bottom: 56.25%;
+  height: 0;
 }
 
 @mixin absolute-position {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
 }
 
 @mixin media-group-one {
-    margin-top: $sp-1;
-    margin-bottom: $sp-2;
+  margin-top: $sp-1;
+  margin-bottom: $sp-2;
 
-    @include large-and-up {
-        margin-top: $sp-2;
-        margin-bottom: $sp-4;
-    }
-    iframe {
-        @include absolute-position;
-    }
-    .wp-block-embed__wrapper {
-        @include embed-wrapper;
-    }
+  @include large-and-up {
+    margin-top: $sp-2;
+    margin-bottom: $sp-4;
+  }
+
+  iframe {
+    @include absolute-position;
+  }
+
+  .wp-block-embed__wrapper {
+    @include embed-wrapper;
+  }
 }
 
 @mixin media-group-two {
-    margin-top: $sp-1;
-    margin-bottom: $sp-2;
+  margin-top: $sp-1;
+  margin-bottom: $sp-2;
 
-    @include medium-and-up {
-        width: 510px;
-    }
+  @include medium-and-up {
+    width: 510px;
+  }
 
-    @include large-and-up {
-        margin-top: $sp-2;
-        margin-bottom: $sp-4;
-        width: 610px;
-    }
+  @include large-and-up {
+    margin-top: $sp-2;
+    margin-bottom: $sp-4;
+    width: 610px;
+  }
 
-    @include x-large-and-up {
-        width: 630px;
-    }
+  @include x-large-and-up {
+    width: 630px;
+  }
 
-    iframe {
-        width: 100% !important;
-    }
+  iframe {
+    width: 100% !important;
+  }
 }
 
 .edit-post-visual-editor .wp-block {
-    
-    .video-embed {
-        max-height: 100%;
-    }
+  .video-embed {
+    max-height: 100%;
+  }
 
-    .wp-block-embed {
-        &-youtube,
-        &-vimeo,
-        &-dailymotion,
-        &-kickstarter {
-            max-height: 100%;
-        }
+  .wp-block-embed {
+    &-youtube,
+    &-vimeo,
+    &-dailymotion,
+    &-kickstarter {
+      max-height: 100%;
     }
+  }
 }
 
 lite-youtube,
 .video-embed-container,
 .instagram-media {
-    width: 100% !important;
-    max-width: 100% !important;
+  width: 100% !important;
+  max-width: 100% !important;
 }
 
 .embed-container {
-    @include embed-wrapper;
+  @include embed-wrapper;
 
-    iframe {
-        @include absolute-position;
-    }
+  iframe {
+    @include absolute-position;
+  }
 }
 
 .wp-block-embed {
+  .wp-block-embed__wrapper {
+    @include embed-wrapper;
+  }
+
+  &-youtube,
+  &-vimeo,
+  &-dailymotion,
+  &-kickstarter {
+    @include media-group-one;
+  }
+
+  &-instagram,
+  &-soundcloud {
+    @include media-group-two;
+  }
+
+  &-flickr {
+    @include media-group-two;
+
+    img {
+      width: 100%;
+    }
+  }
+
+  &-twitter,
+  &-reddit {
+    @include media-group-two;
+
     .wp-block-embed__wrapper {
-        @include embed-wrapper;
+      padding-bottom: unset;
     }
+  }
 
-    &-youtube,
-    &-vimeo,
-    &-dailymotion,
-    &-kickstarter {
-        @include media-group-one;   
+  &-reddit {
+    .embedly-card-hug {
+      max-width: 100% !important;
+      margin: unset !important;
     }
-
-    &-instagram,
-    &-soundcloud {
-        @include media-group-two;
-    }
-
-    &-flickr {
-        @include media-group-two;
-
-        img {
-            width: 100%;
-        }
-    }
-
-    &-twitter, 
-    &-reddit {
-        @include media-group-two;
-
-        .wp-block-embed__wrapper {
-            padding-bottom: unset;
-        }
-    }
-
-    &-reddit {
-        .embedly-card-hug {
-            max-width: 100% !important;
-            margin: unset !important;
-        }
-    }
+  }
 }

--- a/assets/src/scss/core-overrides/embed.scss
+++ b/assets/src/scss/core-overrides/embed.scss
@@ -10,14 +10,6 @@
   height: 0;
 }
 
-@mixin absolute-position {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-}
-
 @mixin media-group-one {
   margin-top: $sp-1;
   margin-bottom: $sp-2;

--- a/assets/src/scss/style.scss
+++ b/assets/src/scss/style.scss
@@ -86,6 +86,7 @@ Text Domain: planet4-master-theme
 // Overrides
 @import "core-overrides/image";
 @import "core-overrides/heading";
+@import "core-overrides/embed";
 @import "layout/query-loop-overrides";
 
 // Variations


### PR DESCRIPTION
**DESCRIPTION:**

This PR re-adds the styles removed [here](https://github.com/greenpeace/planet4-master-theme/pull/2357/files) from the `Media.scss` file.
By removing the `Media.scss` file many embed elements (such as Youtube or Vimeo iframes) lost their styles, especially the full-width property.
Additionally, the scss code was refactored to avoid as much duplicate code as possible.

- Example without styles: https://www-dev.greenpeace.org/gutenberg/media-block-test-page/
- Example with styles: https://www-dev.greenpeace.org/test-iocaste/media-block-test-page/