### PR TITLE
Fix zoom on hover in the home template

### DIFF
--- a/assets/src/scss/variations/stretched-link/index.scss
+++ b/assets/src/scss/variations/stretched-link/index.scss
@@ -11,8 +11,8 @@
     }
   }
 
-  &:hover {
-    [class*="is-style-rounded-"] img {
+  &:hover > {
+    figure[class*="is-style-rounded-"] img {
       transform: scale(1.3);
     }
   }


### PR DESCRIPTION
**DESCRIPTION:**
This PR fixes an error in the Homepage template when a user hovers over one of the images.
When that happens, the hover effect instead of zooming in on the hovered image, zooms in all of them.

![image](https://github.com/user-attachments/assets/c7225c57-ce97-47d6-b06f-c55803df8483)

<hr>

**LINKS:**
- Page with error: https://www.greenpeace.org/nl/
- Page without the error: https://www-dev.greenpeace.org/test-pluto/test-page/

<hr>

**RELATED PR:**
- https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/1252