### PR TITLE
PLANET-7605 Implement page_date dataLayer variable for Posts

### DIFF
--- a/single.php
+++ b/single.php
@@ -46,6 +46,8 @@ $context['social_accounts'] = $post->get_social_accounts($context['footer_social
 $context['page_category'] = 'Post Page';
 $context['post_tags'] = implode(', ', $post->tags());
 $context['post_categories'] = implode(', ', $post->categories());
+// We need the explode because we want to remove "+00:00" at the end of the string.
+$context['page_date'] = explode('+', get_the_date('c', $post->ID))[0];
 
 Context::set_og_meta_fields($context, $post);
 Context::set_campaign_datalayer($context, $page_meta_data);

--- a/templates/blocks/google_tag_manager.twig
+++ b/templates/blocks/google_tag_manager.twig
@@ -59,6 +59,7 @@
       'p4_blocks': '{{ p4_blocks }}',
       'post_categories': '{{ post_categories }}',
       {{ reading_time ? "'reading_time': #{reading_time},"|raw : '' }}
+      {{ page_date ? "'page_date': '#{page_date}',"|raw : '' }}
     });
 
     {% if not post.password_required %}


### PR DESCRIPTION
### Description

See [PLANET-7605](https://jira.greenpeace.org/browse/PLANET-7605)

This needs to be standardised for better reporting.

**Requirements:**
- Implement a `page_date` dataLayer variable in page load with the value standardised in the ISO format "YYYY-MM-DDTHH:MM:SS" in UTC.
- Add this new variable on Posts post type existing dataLayer array.


### Testing

You can make sure that the new dataLayer variable is present for any Post from the phobos test instance, such as [this one](https://www-dev.greenpeace.org/test-phobos/press/1113/duis-posuere-6/).