### PR TITLE
PLANET-7636 Remove editor sidebar labels uppercase

### DIFF
--- a/assets/src/block-editor/Sidebar/AnalyticsTrackingSidebar.js
+++ b/assets/src/block-editor/Sidebar/AnalyticsTrackingSidebar.js
@@ -33,14 +33,17 @@ export const AnalyticsTrackingSidebar = {
       >
         <SelectSidebarField
           label={__('Global Project', 'planet4-master-theme-backend')}
+          id="global-project-select"
           options={options.global_projects || []}
           {...getParams('p4_campaign_name')} />
         <SelectSidebarField
           label={__('Local Projects', 'planet4-master-theme-backend')}
+          id="local-projects-select"
           options={options.local_projects || []}
           {...getParams('p4_local_project')} />
         <SelectSidebarField
           label={__('Basket Name', 'planet4-master-theme-backend')}
+          id="basket-name-select"
           options={options.baskets || []}
           {...getParams('p4_basket_name')} />
         <TextSidebarField

--- a/assets/src/block-editor/SidebarFields/SelectSidebarField.js
+++ b/assets/src/block-editor/SidebarFields/SelectSidebarField.js
@@ -1,10 +1,13 @@
 const {SelectControl} = wp.components;
 
-export const SelectSidebarField = ({options, value, setValue, label}) => (
-  <SelectControl
-    label={label}
-    options={options}
-    value={value}
-    onChange={setValue}
-  />
+export const SelectSidebarField = ({options, value, setValue, label, id}) => (
+  <>
+    <label htmlFor={id}>{label}</label>
+    <SelectControl
+      id={id}
+      options={options}
+      value={value}
+      onChange={setValue}
+    />
+  </>
 );

--- a/assets/src/blocks/Covers/CoversEditor.js
+++ b/assets/src/blocks/Covers/CoversEditor.js
@@ -47,12 +47,15 @@ const renderEdit = (attributes, toAttribute, setAttributes) => {
       </PanelBody>
       <PanelBody title={__('Settings', 'planet4-blocks-backend')}>
         {layout !== COVERS_LAYOUTS.carousel &&
-          <SelectControl
-            label="Rows to display"
-            value={initialRowsLimit}
-            options={rowLimitOptions}
-            onChange={value => toAttribute('initialRowsLimit')(Number(value))}
-          />
+          <>
+            <label htmlFor="row-amount-select">{__('Rows to display', 'planet4-blocks-backend')}</label>
+            <SelectControl
+              id="row-amount-select"
+              value={initialRowsLimit}
+              options={rowLimitOptions}
+              onChange={value => toAttribute('initialRowsLimit')(Number(value))}
+            />
+          </>
         }
 
         {!posts.length &&

--- a/assets/src/scss/editorOverrides.scss
+++ b/assets/src/scss/editorOverrides.scss
@@ -29,6 +29,10 @@
 
 .components-panel__body label {
   font-size: 13px;
+  text-transform: none;
+  font-weight: 500;
+  line-height: 1.4;
+  margin-bottom: $sp-1;
 }
 
 .components-radio-control__option {


### PR DESCRIPTION
### Description

See [PLANET-7636](https://jira.greenpeace.org/browse/PLANET-7636)

### Testing

Make sure all labels in the editor sidebar are no longer in uppercase, and all look the same. Please test all post types since they have different sidebar fields.