### PR TITLE
PLANET-7636 Remove editor sidebar labels uppercase

### DIFF
--- a/assets/src/scss/editorOverrides.scss
+++ b/assets/src/scss/editorOverrides.scss
@@ -28,7 +28,8 @@
 }
 
 .components-panel__body label {
-  font-size: 13px;
+  font-size: 13px !important;
+  text-transform: none !important;
 }
 
 .components-radio-control__option {


### PR DESCRIPTION
### Description

See [PLANET-7636](https://jira.greenpeace.org/browse/PLANET-7636)

### Testing

Make sure all labels in the editor sidebar are no longer in uppercase, and all look the same. Please test all post types since they have different sidebar fields.