### PR TITLE
PLANET-7638 Add e2e tests for GF redirect and page confirmation types

### DIFF
--- a/tests/e2e/gravity-forms.spec.js
+++ b/tests/e2e/gravity-forms.spec.js
@@ -92,7 +92,7 @@ test.describe('Gravity Forms tests', () => {
     await fillAndSubmitForm({page}, createdForm.id);
 
     // Make sure the page is redirected as expected.
-    await page.waitForURL(TEST_REDIRECT, {waitUntil: 'domcontentloaded'});
+    await expect(page).toHaveURL(TEST_REDIRECT);
 
     // Check that the entry has been registered as expected.
     await checkEntry({page}, createdForm.id);

--- a/tests/e2e/gravity-forms.spec.js
+++ b/tests/e2e/gravity-forms.spec.js
@@ -1,10 +1,14 @@
 import {test, expect} from './tools/lib/test-utils.js';
-import {toggleRestAPI, createForm} from './tools/lib/gravity-forms.js';
+import {
+  toggleRestAPI,
+  createForm,
+  fillAndSubmitForm,
+  checkEntry,
+  changeConfirmationType,
+} from './tools/lib/gravity-forms.js';
 
 const CONFIRMATION_MESSAGE = 'This is a dummy confirmation message for testing purposes.';
-const TEST_FIRST_NAME = 'Jon';
-const TEST_LAST_NAME = 'Snow';
-const TEST_EMAIL = 'jon.snow@gmail.com';
+const TEST_REDIRECT = 'https://www.greenpeace.org/international/';
 
 test.useAdminLoggedIn();
 
@@ -12,8 +16,9 @@ test.describe('Gravity Forms tests', () => {
   test.describe.configure({mode: 'serial'});
   const testId = Math.floor(Math.random() * 10000); //NOSONAR
   let createdForm;
+  let newPost;
 
-  test.beforeAll(async ({browser}) => {
+  test.beforeAll(async ({browser, requestUtils}) => {
     const page = await browser.newPage();
     // Enable Gravity Forms rest API.
     await toggleRestAPI({page}, true);
@@ -22,6 +27,19 @@ test.describe('Gravity Forms tests', () => {
     createdForm = await createForm({page}, {
       title: `Gravity Forms test form - ${testId}`,
     });
+
+    // Create a new post with the new form.
+    newPost = await requestUtils.rest({
+      path: '/wp/v2/posts',
+      method: 'POST',
+      data: {
+        title: `Gravity Forms test post - ${testId}`,
+        content: `<!-- wp:gravityforms/form {"formId":"${createdForm.id}"} /-->`,
+        status: 'publish',
+        featured_media: 357,
+      },
+    });
+
     await page.close();
   });
 
@@ -34,46 +52,50 @@ test.describe('Gravity Forms tests', () => {
     await toggleRestAPI({page}, false);
   });
 
-  test('check the confirmation message, text type', async ({page, requestUtils}) => {
+  test('check the confirmation message, text type', async ({page}) => {
+    // Make sure the form uses the Text confirmation type.
+    await changeConfirmationType({page}, createdForm.id, 'Text');
+
     // Update the form's default confirmation text.
-    await page.goto(`./wp-admin/admin.php?page=gf_edit_forms&view=settings&subview=confirmation&id=${createdForm.id}`);
-    await page.locator('#the-list > tr:first-child').hover();
-    await page.getByRole('link', {name: 'Edit', exact: true}).click();
     await page.frameLocator('#_gform_setting_message_ifr').locator('#tinymce').fill(CONFIRMATION_MESSAGE);
     await page.getByRole('button', {name: 'Save Confirmation'}).click();
     await expect(page.locator('.gforms_note_success')).toBeVisible();
 
-    // Create a new post with the new form.
-    const newPost = await requestUtils.rest({
-      path: '/wp/v2/posts',
-      method: 'POST',
-      data: {
-        title: `Gravity Forms test post - ${testId}`,
-        content: `<!-- wp:gravityforms/form {"formId":"${createdForm.id}"} /-->`,
-        status: 'publish',
-        featured_media: 357,
-      },
-    });
+    // Go to the post which has the form.
     await page.goto(newPost.link);
 
-    // Fill and submit the form and check the confirmation message text.
-    const form = page.locator(`#gform_${createdForm.id}`);
-    await form.getByLabel('First name').fill(TEST_FIRST_NAME);
-    await form.getByLabel('Last name').fill(TEST_LAST_NAME);
-    await form.getByLabel('Email').fill(TEST_EMAIL);
-    const submitButton = form.getByRole('button', {name: 'Submit'});
-    await submitButton.click();
+    // Fill and submit the form.
+    await fillAndSubmitForm({page}, createdForm.id);
+
+    // Check the confirmation message text.
     const confirmationMessage = page.locator('.gform_confirmation_message');
     await expect(confirmationMessage).toBeVisible();
     await expect(confirmationMessage).toContainText(CONFIRMATION_MESSAGE);
 
     // Check that the entry has been registered as expected.
-    await page.goto(`./wp-admin/admin.php?page=gf_entries&id=${createdForm.id}`);
-    const latestEntry = page.locator('#the-list > tr.entry_row').first();
-    await expect(latestEntry).toBeVisible();
-    await expect(latestEntry.locator('td[data-colname="First name"]')).toContainText(TEST_FIRST_NAME);
-    await expect(latestEntry.locator('td[data-colname="Last name"]')).toContainText(TEST_LAST_NAME);
-    await expect(latestEntry.locator('td[data-colname="Email"]')).toContainText(TEST_EMAIL);
+    await checkEntry({page}, createdForm.id);
+  });
+
+  test('check the confirmation message, redirect type', async ({page}) => {
+    // Make sure the form uses the Redirect confirmation type.
+    await changeConfirmationType({page}, createdForm.id, 'Redirect');
+
+    // Set up the redirection.
+    await page.getByLabel('Redirect URL(Required)').fill(TEST_REDIRECT);
+    await page.getByRole('button', {name: 'Save Confirmation'}).click();
+    await expect(page.locator('.gforms_note_success')).toBeVisible();
+
+    // Go to the post which has the form.
+    await page.goto(newPost.link);
+
+    // Fill and submit the form.
+    await fillAndSubmitForm({page}, createdForm.id);
+
+    // Make sure the page is redirected as expected.
+    await page.waitForURL(TEST_REDIRECT, {waitUntil: 'domcontentloaded'});
+
+    // Check that the entry has been registered as expected.
+    await checkEntry({page}, createdForm.id);
   });
 
   test('check the Hubspot feeds', async ({page}) => {

--- a/tests/e2e/gravity-forms.spec.js
+++ b/tests/e2e/gravity-forms.spec.js
@@ -98,6 +98,37 @@ test.describe('Gravity Forms tests', () => {
     await checkEntry({page}, createdForm.id);
   });
 
+  test('check the confirmation message, page type', async ({page}) => {
+    // Make sure the form uses the Page confirmation type.
+    await changeConfirmationType({page}, createdForm.id, 'Page');
+
+    // Set up the page redirect.
+    const confirmationSettings = page.locator('#gform_setting_page');
+    const pagesList = confirmationSettings.locator('.gform-dropdown__list');
+    const spinner = confirmationSettings.locator('.gform-dropdown__spinner');
+    await confirmationSettings.getByRole('button', {name: 'Select a Page'}).click();
+    await expect(pagesList).toBeVisible();
+    await confirmationSettings.getByPlaceholder('Search all Pages').type('Home');
+    await expect(spinner).toBeVisible();
+    await expect(spinner).toBeHidden();
+    await pagesList.getByRole('button', {name: 'Home'}).click();
+    await expect(pagesList).toBeHidden();
+    await page.getByRole('button', {name: 'Save Confirmation'}).click();
+    await expect(page.locator('.gforms_note_success')).toBeVisible();
+
+    // Go to the post which has the form.
+    await page.goto(newPost.link);
+
+    // Fill and submit the form.
+    await fillAndSubmitForm({page}, createdForm.id);
+
+    // Make sure the page is redirected as expected.
+    await expect(page).toHaveURL('./');
+
+    // Check that the entry has been registered as expected.
+    await checkEntry({page}, createdForm.id);
+  });
+
   test('check the Hubspot feeds', async ({page}) => {
     // Add a Hubspot feed.
     await page.goto(`./wp-admin/admin.php?page=gf_edit_forms&view=settings&subview=gravityformshubspot&id=${createdForm.id}`);

--- a/tests/e2e/tools/lib/gravity-forms.js
+++ b/tests/e2e/tools/lib/gravity-forms.js
@@ -1,5 +1,9 @@
 import {expect} from '@playwright/test';
 
+const TEST_FIRST_NAME = 'Jon';
+const TEST_LAST_NAME = 'Snow';
+const TEST_EMAIL = 'jon.snow@gmail.com';
+
 const toggleRestAPI = async ({page}, enabled) => {
   await page.goto('./wp-admin/admin.php?page=gf_settings&subview=gravityformswebapi');
   await page.getByRole('checkbox', {label: 'Enabled'}).setChecked(enabled);
@@ -45,4 +49,29 @@ const createForm = async ({page}, {title}) => {
   return createdForm;
 };
 
-export {toggleRestAPI, createForm};
+const fillAndSubmitForm = async ({page}, formId) => {
+  const form = page.locator(`#gform_${formId}`);
+  await form.getByLabel('First name').fill(TEST_FIRST_NAME);
+  await form.getByLabel('Last name').fill(TEST_LAST_NAME);
+  await form.getByLabel('Email').fill(TEST_EMAIL);
+  const submitButton = form.getByRole('button', {name: 'Submit'});
+  await submitButton.click();
+};
+
+const checkEntry = async ({page}, formId) => {
+  await page.goto(`./wp-admin/admin.php?page=gf_entries&id=${formId}`);
+  const latestEntry = page.locator('#the-list > tr.entry_row').first();
+  await expect(latestEntry).toBeVisible();
+  await expect(latestEntry.locator('td[data-colname="First name"]')).toContainText(TEST_FIRST_NAME);
+  await expect(latestEntry.locator('td[data-colname="Last name"]')).toContainText(TEST_LAST_NAME);
+  await expect(latestEntry.locator('td[data-colname="Email"]')).toContainText(TEST_EMAIL);
+};
+
+const changeConfirmationType = async ({page}, formId, label) => {
+  await page.goto(`./wp-admin/admin.php?page=gf_edit_forms&view=settings&subview=confirmation&id=${formId}`);
+  await page.locator('#the-list > tr:first-child').hover();
+  await page.getByRole('link', {name: 'Edit', exact: true}).click();
+  await page.getByLabel(label, {exact: true}).check();
+};
+
+export {toggleRestAPI, createForm, fillAndSubmitForm, checkEntry, changeConfirmationType};

--- a/tests/e2e/tools/lib/gravity-forms.js
+++ b/tests/e2e/tools/lib/gravity-forms.js
@@ -4,6 +4,13 @@ const TEST_FIRST_NAME = 'Jon';
 const TEST_LAST_NAME = 'Snow';
 const TEST_EMAIL = 'jon.snow@gmail.com';
 
+/**
+ * Toggle the Gravity Forms rest API to use it for tests.
+ * It is disabled by default.
+ *
+ * @param {Object} page     - The page object for interacting with the browser.
+ * @param {boolean} enabled - Whether it should be enabled or disabled.
+ */
 const toggleRestAPI = async ({page}, enabled) => {
   await page.goto('./wp-admin/admin.php?page=gf_settings&subview=gravityformswebapi');
   await page.getByRole('checkbox', {label: 'Enabled'}).setChecked(enabled);
@@ -17,6 +24,12 @@ const toggleRestAPI = async ({page}, enabled) => {
   await expect(page.locator('.gforms_note_success')).toBeVisible();
 };
 
+/**
+ * Create a new Gravity Forms form.
+ *
+ * @param {Object} page  - The page object for interacting with the browser.
+ * @param {Object} title - The form title.
+ */
 const createForm = async ({page}, {title}) => {
   const response = await page.request.post('./wp-json/gf/v2/forms', {
     data: {
@@ -49,6 +62,12 @@ const createForm = async ({page}, {title}) => {
   return createdForm;
 };
 
+/**
+ * Fill and submit a Gravity Forms form.
+ *
+ * @param {Object} page   - The page object for interacting with the browser.
+ * @param {number} formId - The form id.
+ */
 const fillAndSubmitForm = async ({page}, formId) => {
   const form = page.locator(`#gform_${formId}`);
   await form.getByLabel('First name').fill(TEST_FIRST_NAME);
@@ -58,6 +77,12 @@ const fillAndSubmitForm = async ({page}, formId) => {
   await submitButton.click();
 };
 
+/**
+ * Check the latest entry for a Gravity Forms form.
+ *
+ * @param {Object} page   - The page object for interacting with the browser.
+ * @param {number} formId - The form id.
+ */
 const checkEntry = async ({page}, formId) => {
   await page.goto(`./wp-admin/admin.php?page=gf_entries&id=${formId}`);
   const latestEntry = page.locator('#the-list > tr.entry_row').first();
@@ -67,6 +92,13 @@ const checkEntry = async ({page}, formId) => {
   await expect(latestEntry.locator('td[data-colname="Email"]')).toContainText(TEST_EMAIL);
 };
 
+/**
+ * Change the confirmation type for a Gravity Forms form.
+ *
+ * @param {Object} page   - The page object for interacting with the browser.
+ * @param {number} formId - The form id.
+ * @param {string} label  - The confirmation type label.
+ */
 const changeConfirmationType = async ({page}, formId, label) => {
   await page.goto(`./wp-admin/admin.php?page=gf_edit_forms&view=settings&subview=confirmation&id=${formId}`);
   await page.locator('#the-list > tr:first-child').hover();


### PR DESCRIPTION
### Description

See [PLANET-7638](https://jira.greenpeace.org/browse/PLANET-7638) & [PLANET-7639](https://jira.greenpeace.org/browse/PLANET-7639)

Until now we only had an e2e test for the text confirmation type.