### PR TITLE
Test new interactive API with Query Loop block

### DIFF
--- a/assets/src/js/external_links.js
+++ b/assets/src/js/external_links.js
@@ -3,7 +3,7 @@ const {__} = wp.i18n;
 export const setupExternalLinks = () => {
   const siteURL = window.location.host;
 
-  const linkSelector = ['.page-content', 'article', '.author-details'].map(sel => `${sel} a:not(.btn):not(.cover-card-heading):not(.wp-block-button__link):not(.share-btn):not([href*="${siteURL}"]):not([href*=".pdf"]):not([href^="/"]):not([href^="#"]):not([href^="javascript:"])`).join(', ');
+  const linkSelector = ['.page-content', 'article', '.author-details'].map(sel => `${sel} a:not(.btn):not(.cover-card-heading):not(.wp-block-button__link):not(.share-btn):not([href*="${siteURL}"]):not([href*=".pdf"]):not([href^="/"]):not([href^="#"]):not([href^="javascript:"]):not(.page-numbers)`).join(', ');
   const links = [...document.querySelectorAll(linkSelector)];
 
   links.forEach(link => {

--- a/parts/query-listing-page.html
+++ b/parts/query-listing-page.html
@@ -1,4 +1,4 @@
-<!-- wp:query { "query":{ "inherit": true } } -->
+<!-- wp:query {"queryId":0,"query":{"inherit":true},"enhancedPagination":true} -->
 <div id="listing-page-content" class="wp-block-query wp-block-query--list">
 	<!-- wp:post-template -->
 		<div class="query-list-item-image query-list-item-image-max-width">


### PR DESCRIPTION
### Description

This block has it natively, it would be nice to use in our listing pages

### Testing

- [Test page](https://www-dev.greenpeace.org/test-rhea/test-query-loop-enhanced-pagination/) with a regular Query Loop block
- [Listing page](https://www-dev.greenpeace.org/test-rhea/tag/renewables/) (doesn't work, it seems because we use `inherit:true` in the query 😕)