### PR TITLE
PLANET-7637 Planet 4 Bug Report: Gallery Block - Upload image issue

### DIFF
--- a/assets/src/blocks/CarouselHeader/StaticCaption.js
+++ b/assets/src/blocks/CarouselHeader/StaticCaption.js
@@ -21,7 +21,7 @@ export const StaticCaption = ({slide}) => (
             data-ga-category="Carousel Header"
             data-ga-action="Call to Action"
             data-ga-label={slide.index}
-            {...slide.link_url_new_tab && {rel: 'noreferrer', target: '_blank'}}
+            {...slide.link_url_new_tab && {rel: 'noreferrer noopener', target: '_blank'}}
           >
             <span>
               {slide.link_text}


### PR DESCRIPTION
**Ref: https://jira.greenpeace.org/browse/PLANET-7637**

**Testing:**

When uploading images through the _Upload Tab_ in the pop up, there is no validation for images so non-supported images get uploaded but don't show up. With this fix there is an error messages that prompts the user of the image type being uploaded. Also the block validation error no longer exists for the _Carousel Header_ block.

_To test the Image Validation_
- In the editor add the image block.
- Choose the media library
- Go to the upload tab and click to upload an image.
- Only supported images(png, jpg, gif and ico) are allowed to be uploaded, other image types throw and error.

To test the Carousel Block Validation, try editing a page like the Homepage that already has the Carousel block. The validation error should no longer be present in the console.

<!-- Ref: Please add a url to the ticket this change is addressing.

---

Please provide a brief summary of the change introduced to make review process easier.

Ideally this should also be part of the commit summary.
-->
