### PR TITLE
PLANET-7643: Media Library - Show restrictions on imported media

### DIFF
--- a/admin/css/archive-picker.css
+++ b/admin/css/archive-picker.css
@@ -667,3 +667,9 @@
     grid-template-columns: repeat(6, 1fr);
   }
 }
+
+.compat-field-restrictions_text .field,
+.restrictions-warning dd {
+  color: #D43B57; /* var(--red-500); */
+  font-weight: bold;
+}

--- a/assets/src/js/Components/ArchivePicker/SingleSidebar.js
+++ b/assets/src/js/Components/ArchivePicker/SingleSidebar.js
@@ -4,8 +4,8 @@ import {ACTIONS, ADMIN_VIEW, EDITOR_VIEW, useArchivePickerContext} from './Archi
 const {__, sprintf} = wp.i18n;
 const {useMemo, useEffect, useState} = wp.element;
 
-const renderDefinition = (key, value) => (
-  <div>
+const renderDefinition = (key, value, className) => (
+  <div className={className}>
     <dt>{key}</dt>
     <dd>{value}</dd>
   </div>
@@ -186,14 +186,19 @@ export default function SingleSidebar({image}) {
               __('Credit', 'planet4-master-theme-backend'),
               image.credit
             )}
-            {renderDefinition(
+            {image.original_language_title && (renderDefinition(
               __('Original language title', 'planet4-master-theme-backend'),
               image.original_language_title
-            )}
-            {renderDefinition(
+            ))}
+            {image.original_language_description && (renderDefinition(
               __('Original language description', 'planet4-master-theme-backend'),
               image.original_language_description
-            )}
+            ))}
+            {image.restrictions && (renderDefinition(
+              __('Restrictions', 'planet4-master-theme-backend'),
+              image.restrictions,
+              'restrictions-warning'
+            ))}
           </dl>
           {image.wordpress_id && (
             <a

--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -39,6 +39,12 @@ class MasterSite extends TimberSite
     public const CREDIT_META_FIELD = '_credit_text';
 
     /**
+     * Restrictions meta field key
+     *
+     */
+    public const RESTRICTIONS_META_FIELD = '_media_restriction';
+
+    /**
      * Theme directory
      *
      */
@@ -1457,13 +1463,19 @@ class MasterSite extends TimberSite
      */
     public function add_image_attachment_fields_to_edit(array $form_fields, \WP_Post $post): array
     {
-
         // Add a Credit field.
         $form_fields['credit_text'] = [
             'label' => __('Credit', 'planet4-master-theme-backend'),
             'input' => 'text', // this is default if "input" is omitted.
             'value' => get_post_meta($post->ID, self::CREDIT_META_FIELD, true),
             'helps' => __('The owner of the image.', 'planet4-master-theme-backend'),
+        ];
+
+        // Add a Restrictions field.
+        $form_fields['restrictions_text'] = [
+            'label' => __('Restrictions', 'planet4-master-theme-backend'),
+            'input' => 'html',
+            'html' => get_post_meta($post->ID, self::RESTRICTIONS_META_FIELD, true),
         ];
 
         return $form_fields;


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-7643

<hr>

**DESCRIPTION:**
This PR fetches restrictions from GP Media API and shows them on the import sidebar before importing the file and also on the Media Library while browsing the media file.

![Greenpeace-Media-‹-Greenpeace-—-WordPress(1)](https://github.com/user-attachments/assets/ec6e1451-1d70-46aa-bac1-2dc4006e519b)
