### PR TITLE
Make SoundCloud embed full width

### DIFF
--- a/assets/src/scss/blocks/core-overrides/Embed.scss
+++ b/assets/src/scss/blocks/core-overrides/Embed.scss
@@ -93,9 +93,22 @@ lite-youtube,
     @include media-group-one;
   }
 
-  &-instagram,
-  &-soundcloud {
+  &-instagram {
     @include media-group-two;
+  }
+
+  &-soundcloud {
+    margin-top: $sp-1;
+    margin-bottom: $sp-2;
+
+    .wp-block-embed__wrapper {
+      height: 100%;
+      padding: inherit;
+    }
+
+    iframe {
+      width: 100% !important;
+    }
   }
 
   &-flickr {


### PR DESCRIPTION
Ref: 
- https://github.com/greenpeace/planet4-master-theme/pull/2399#pullrequestreview-2354346162
- https://greenpeace-gpi.slack.com/archives/G015K63081W/p1729519727583989

<hr>

**DESCRIPTION:**
This PR makes the SoundCloud embed elements full-width in order to match them with the rest of the embed elements (Youtube, mp3 files, etc.)

<hr>

**TESTING:**
- Fixed page: https://www-dev.greenpeace.org/test-jupiter/soundcloud-test-page/
- Page with issues: https://www-dev.greenpeace.org/gutenberg/soundcloud-test-page/