### PR TITLE
PLANET-7563 Apply New Link Style to lists in Posts

### DIFF
--- a/assets/src/scss/pages/post/_article-content.scss
+++ b/assets/src/scss/pages/post/_article-content.scss
@@ -101,7 +101,8 @@
 
   p:not(.article-list-item-meta) a,
   > article > ul li a,
-  > article > ol li a {
+  > article > ol li a,
+  > article > li a {
     @include shared-link-styles;
   }
 

--- a/assets/src/scss/pages/post/_article-content.scss
+++ b/assets/src/scss/pages/post/_article-content.scss
@@ -100,8 +100,8 @@
   }
 
   p:not(.article-list-item-meta) a,
-  > ul li a,
-  > ol li a {
+  > article > ul li a,
+  > article > ol li a {
     @include shared-link-styles;
   }
 


### PR DESCRIPTION
### Description

See latest comments on [PLANET-7563](https://jira.greenpeace.org/browse/PLANET-7563)

This was only working for other post types

### Testing

On [this post](https://www-dev.greenpeace.org/test-deimos/press/1109/duis-posuere-4/) for example, the list link should now have the same styles as our other links.