### PR TITLE
PLANET-7523 Remove Twitter from Social Media block and rename it Meta

### DIFF
--- a/assets/src/blocks/SocialMedia/SocialMediaBlock.js
+++ b/assets/src/blocks/SocialMedia/SocialMediaBlock.js
@@ -16,7 +16,7 @@ export const registerSocialMediaBlock = () => {
   }
 
   registerBlockType(BLOCK_NAME, {
-    title: 'Social Media',
+    title: 'Meta',
     description: __('An embed-style block, customized to display and align content from Facebook and Instagram by inputting the URL.', 'planet4-blocks-backend'),
     icon: 'share',
     category: 'planet4-blocks',

--- a/assets/src/blocks/SocialMedia/SocialMediaConstants.js
+++ b/assets/src/blocks/SocialMedia/SocialMediaConstants.js
@@ -6,7 +6,6 @@ export const FACEBOOK_PAGE_TAB_EVENTS = 'events';
 export const FACEBOOK_PAGE_TAB_MESSAGES = 'messages';
 
 export const ALLOWED_OEMBED_PROVIDERS = [
-  'twitter',
   'facebook',
   'instagram',
 ];

--- a/assets/src/blocks/SocialMedia/SocialMediaEditorScript.js
+++ b/assets/src/blocks/SocialMedia/SocialMediaEditorScript.js
@@ -31,14 +31,6 @@ const loadScriptAsync = uri => {
   });
 };
 
-const initializeTwitterEmbeds = () => {
-  setTimeout(() => {
-    if ('undefined' !== window.twttr) {
-      window.twttr.widgets.load();
-    }
-  }, 2000);
-};
-
 const initializeInstagramEmbeds = () => {
   setTimeout(() => {
     if ('undefined' !== window.instgrm) {
@@ -56,10 +48,6 @@ const initializeFacebookEmbeds = () => {
 };
 
 const PROVIDER_SCRIPT_DATA = {
-  twitter: {
-    script: 'https://platform.twitter.com/widgets.js',
-    initFunction: initializeTwitterEmbeds,
-  },
   facebook: {
     script: 'https://connect.facebook.net/en_US/sdk.js#xfbml=1&version=v9.0',
     initFunction: initializeFacebookEmbeds,
@@ -92,7 +80,7 @@ export const SocialMediaEditor = ({
 
   /**
    * Check if social media corresponding embeds script is loaded and initiliaze it.
-   * Can be used for Facebook, Twitter and Instagram depending on the parameter.
+   * Can be used for Facebook and Instagram depending on the parameter.
    *
    * @param {Object} provider
    */
@@ -149,7 +137,7 @@ export const SocialMediaEditor = ({
     })();
   }, [social_media_url]);
 
-  const embed_type_help = __('Select oEmbed for the following types of social media<br>- Twitter: tweet, profile, list, collection, likes, moment<br>- Facebook: post, activity, photo, video, media, question, note<br>- Instagram: image', 'planet4-blocks-backend');
+  const embed_type_help = __('Select oEmbed for the following types of social media<br>- Facebook: post, activity, photo, video, media, question, note<br>- Instagram: image', 'planet4-blocks-backend');
 
   const renderEditInPlace = () => (
     <>

--- a/assets/src/blocks/SocialMedia/SocialMediaEditorScript.js
+++ b/assets/src/blocks/SocialMedia/SocialMediaEditorScript.js
@@ -101,10 +101,7 @@ export const SocialMediaEditor = ({
 
     let embedCode;
     try {
-      if (provider === 'twitter') {
-        const twitterEmbedData = await apiFetch({path: addQueryArgs('/oembed/1.0/proxy', {url})});
-        embedCode = twitterEmbedData ? twitterEmbedData.html : '';
-      } else if (provider === 'instagram') {
+      if (provider === 'instagram') {
         const instagramEmbedData = await apiFetch({path: addQueryArgs('planet4/v1/get-instagram-embed', {url})});
 
         if (instagramEmbedData) {

--- a/src/Blocks/SocialMedia.php
+++ b/src/Blocks/SocialMedia.php
@@ -23,7 +23,6 @@ class SocialMedia extends BaseBlock
     public const BLOCK_NAME = 'social-media';
 
     private const ALLOWED_OEMBED_PROVIDERS = [
-        'twitter',
         'facebook',
         'instagram',
     ];
@@ -126,17 +125,8 @@ class SocialMedia extends BaseBlock
             if ('oembed' === $embed_type) {
                 // need to remove . so instagr.am becomes instagram.
                 $provider = preg_replace('#(^www\.)|(\.com$)|(\.)#', '', strtolower(wp_parse_url($url, PHP_URL_HOST)));
-
-                // Fix for backend preview, do not include embed script in response.
-                if ($this->is_rest_request() && 'twitter' === $provider) {
-                    $url = add_query_arg([ 'omit_script' => true ], $url);
-                }
                 if (in_array($provider, self::ALLOWED_OEMBED_PROVIDERS, true)) {
-                    if ('twitter' === $provider) {
-                        $data['embed_code'] = wp_oembed_get($url);
-                    } else {
-                        $data['embed_code'] = $this->get_fb_oembed_html(rawurlencode($url), $provider);
-                    }
+                    $data['embed_code'] = $this->get_fb_oembed_html(rawurlencode($url), $provider);
                 }
             } elseif ('facebook_page' === $embed_type) {
                 $data['facebook_page_url'] = $url;

--- a/src/Migrations/M033MigrateSocialMediaTwitterBlockToEmbedBlock.php
+++ b/src/Migrations/M033MigrateSocialMediaTwitterBlockToEmbedBlock.php
@@ -59,6 +59,7 @@ class M033MigrateSocialMediaTwitterBlockToEmbedBlock extends MigrationScript
      * we want to migrate.
      *
      * @param array $block - A parsed Social Media block.
+     *
      * @return bool - Whether or not the block should be migrated.
      */
     private static function check_is_valid_block(array $block): bool
@@ -105,6 +106,7 @@ class M033MigrateSocialMediaTwitterBlockToEmbedBlock extends MigrationScript
      * and a final block (Embed) for the Twitter/X embed.
      *
      * @param array $block_attrs - The initial Social Media block attributes.
+     *
      * @return array - The transformed block.
      */
     private static function transform_block(array $block_attrs): array
@@ -134,47 +136,18 @@ class M033MigrateSocialMediaTwitterBlockToEmbedBlock extends MigrationScript
             $block_description,
         ) : null;
 
-        $block = [];
-        $block['blockName'] = Utils\Constants::BLOCK_GROUP;
-        $block['attrs']['metadata']['name'] = 'Twitter/X Group';
+        $attrs = [];
+        $attrs['metadata']['name'] = 'Twitter/X Group';
 
-        $block['innerBlocks'] = [];
-        $block['innerBlocks'][0] = $title;
-        $block['innerBlocks'][1] = $description;
-        $block['innerBlocks'][3] = Utils\Functions::create_embed_block(
+        $inner_blocks = [];
+        $inner_blocks[0] = $title;
+        $inner_blocks[1] = $description;
+        $inner_blocks[3] = Utils\Functions::create_embed_block(
             $social_media_url,
             'rich',
             Utils\Constants::TWITTER,
         );
 
-        // IMPORTANT: DO NOT MODIFY THIS FORMAT!
-        $block['innerHTML'] =
-        '<div class="wp-block-group">
-
-
-
-
-
-        </div>';
-
-        // IMPORTANT: DO NOT MODIFY THIS FORMAT!
-        $block['innerContent'] = array (
-            0 => '
-        <div class="wp-block-group">',
-            1 => null,
-            2 => '
-        ',
-            3 => null,
-            4 => '
-        ',
-            5 => null,
-            6 => '
-        ',
-            7 => null,
-            8 => '</div>
-        ',
-        );
-
-        return $block;
+        return Utils\Functions::create_group_block($inner_blocks, $attrs);
     }
 }

--- a/src/Migrations/M033MigrateSocialMediaTwitterBlockToEmbedBlock.php
+++ b/src/Migrations/M033MigrateSocialMediaTwitterBlockToEmbedBlock.php
@@ -34,7 +34,7 @@ class M033MigrateSocialMediaTwitterBlockToEmbedBlock extends MigrationScript
     protected static function execute(MigrationRecord $record): void
     {
         try {
-            // Get the list of posts using Media blocks.
+            // Get the list of posts using Social Media blocks.
             $posts = Utils\Functions::get_posts_using_specific_block(
                 Utils\Constants::BLOCK_SOCIAL_MEDIA,
                 Utils\Constants::ALL_POST_TYPES
@@ -60,12 +60,12 @@ class M033MigrateSocialMediaTwitterBlockToEmbedBlock extends MigrationScript
 
                 $current_post_id = $post->ID; // Store the current post ID
 
-                echo 'Parsing post ', $post->ID, "\n"; // phpcs:ignore
+                echo 'Parsing post ', $current_post_id, "\n"; // phpcs:ignore
 
                 $blocks = $parser->parse($post->post_content);
 
                 if (!is_array($blocks)) {
-                    throw new \Exception("Invalid block structure for post #" . $post->ID);
+                    throw new \Exception("Invalid block structure for post #" . $current_post_id);
                 }
 
                 foreach ($blocks as &$block) {
@@ -90,7 +90,7 @@ class M033MigrateSocialMediaTwitterBlockToEmbedBlock extends MigrationScript
                     }
 
                     // If not, we get the social media URL.
-                    $social_media_url = self::get_social_media_url($block);
+                    $social_media_url = $block['attrs']['social_media_url'] ?? null;
 
                     // If there's no social media url, we do nothing.
                     if (!$social_media_url) {
@@ -132,7 +132,7 @@ class M033MigrateSocialMediaTwitterBlockToEmbedBlock extends MigrationScript
                 }
 
                 $post_update = array(
-                    'ID' => $post->ID,
+                    'ID' => $current_post_id,
                     'post_content' => $new_content,
                 );
 
@@ -140,7 +140,7 @@ class M033MigrateSocialMediaTwitterBlockToEmbedBlock extends MigrationScript
                 $result = wp_update_post($post_update);
 
                 if ($result === 0) {
-                    throw new \Exception("There was an error trying to update the post #" . $post->ID);
+                    throw new \Exception("There was an error trying to update the post #" . $current_post_id);
                 }
 
                 echo "Migration successful\n";
@@ -151,21 +151,7 @@ class M033MigrateSocialMediaTwitterBlockToEmbedBlock extends MigrationScript
             echo $e->getMessage(), "\n";
         }
     }
-
     // phpcs:enable SlevomatCodingStandard.Functions.UnusedParameter
-
-    /**
-     * Get the social media URL from a Social Media block.
-     *
-     * @param array $block - A parsed Media block.
-     * @return string - The social media URL.
-     */
-    private static function get_social_media_url(array $block): mixed
-    {
-        $social_media_url = $block['attrs']['social_media_url'] ?? null;
-
-        return $social_media_url;
-    }
 
     /**
      * Get the source of a Social Media block.
@@ -202,7 +188,7 @@ class M033MigrateSocialMediaTwitterBlockToEmbedBlock extends MigrationScript
 
         $block = [];
         $block['blockName'] = Utils\Constants::BLOCK_GROUP;
-        $block['attrs']['metadata']['name'] = 'Social Media Group';
+        $block['attrs']['metadata']['name'] = 'Twitter/X Group';
 
         $block['innerBlocks'] = [];
         $block['innerBlocks'][0] = $block_title ? self::get_heading_block($block_title) : null;
@@ -241,7 +227,7 @@ class M033MigrateSocialMediaTwitterBlockToEmbedBlock extends MigrationScript
     }
 
     /**
-     * Transform a Media block into an embed block.
+     * Transform a Social Media block into an embed block.
      *
      * @param array $block - A parsed Social Media block.
      * @param string $social_media_url - The Social Media URL.

--- a/src/Migrations/M033MigrateSocialMediaTwitterBlockToEmbedBlock.php
+++ b/src/Migrations/M033MigrateSocialMediaTwitterBlockToEmbedBlock.php
@@ -107,10 +107,14 @@ class M033MigrateSocialMediaTwitterBlockToEmbedBlock extends MigrationScript
                         continue;
                     }
 
-                    // If the source is Twitter, we want to change it to X.
-                    // This avoids an extra redirection.
-                    if ($source === self::SOURCE_TWITTER) {
-                        $social_media_url = str_replace(self::SOURCE_TWITTER, self::SOURCE_X, $social_media_url);
+                    // If the source is X, we want to change it to Twitter.
+                    // Links from x.com don't work in the Embed block at the moment.
+                    if ($source === self::SOURCE_X) {
+                        $social_media_url = str_replace(
+                            self::SOURCE_X . '.com',
+                            self::SOURCE_TWITTER . '.com',
+                            $social_media_url,
+                        );
                     }
 
                     // Transform the Social Media block into an Embed block.

--- a/src/Migrations/M033MigrateSocialMediaTwitterBlockToEmbedBlock.php
+++ b/src/Migrations/M033MigrateSocialMediaTwitterBlockToEmbedBlock.php
@@ -1,0 +1,356 @@
+<?php
+
+// phpcs:disable Generic.Files.LineLength.MaxExceeded
+
+namespace P4\MasterTheme\Migrations;
+
+use P4\MasterTheme\MigrationRecord;
+use P4\MasterTheme\MigrationScript;
+use WP_Block_Parser;
+
+/**
+ * Migrate Social Media blocks with Twitter/X urls to Embed blocks.
+ */
+class M033MigrateSocialMediaTwitterBlockToEmbedBlock extends MigrationScript
+{
+    private const SOURCE_INSTAGRAM = 'instagram';
+    private const SOURCE_FACEBOOK = 'facebook';
+    private const SOURCE_TWITTER = 'twitter';
+    private const SOURCE_X = 'x';
+
+    private const SOURCE_PATTERNS = [
+        self::SOURCE_INSTAGRAM => '/^(https?\:\/\/)?(www\.)?instagram\.com\/.+$/i',
+        self::SOURCE_FACEBOOK => '/^(https?\:\/\/)?(www\.)?facebook\.com\/.+$/i',
+        self::SOURCE_TWITTER => '/^(https?\:\/\/)?(www\.)?(twitter\.com)\/.+$/i',
+        self::SOURCE_X => '/^(https?\:\/\/)?(www\.)?x\.com\/.+$/i',
+    ];
+
+    /**
+     * Perform the actual migration.
+     *
+     * @param MigrationRecord $record Information on the execution, can be used to add logs.
+     * phpcs:disable SlevomatCodingStandard.Functions.UnusedParameter -- interface implementation
+     */
+    protected static function execute(MigrationRecord $record): void
+    {
+        try {
+            // Get the list of posts using Media blocks.
+            $posts = Utils\Functions::get_posts_using_specific_block(
+                Utils\Constants::BLOCK_SOCIAL_MEDIA,
+                Utils\Constants::ALL_POST_TYPES
+            );
+
+            // If there are no posts, abort.
+            if (!$posts) {
+                return;
+            }
+
+            echo "Social Media block migration in progress...\n"; // phpcs:ignore
+
+            $parser = new WP_Block_Parser();
+
+            // Variable to store the current post ID
+            $current_post_id = null;
+
+            // Get all the blocks of each post.
+            foreach ($posts as $post) {
+                if (empty($post->post_content)) {
+                    continue;
+                }
+
+                $current_post_id = $post->ID; // Store the current post ID
+
+                echo 'Parsing post ', $post->ID, "\n"; // phpcs:ignore
+
+                $blocks = $parser->parse($post->post_content);
+
+                if (!is_array($blocks)) {
+                    throw new \Exception("Invalid block structure for post #" . $post->ID);
+                }
+
+                foreach ($blocks as &$block) {
+                    // Check if the block is valid.
+                    if (!is_array($block)) {
+                        continue;
+                    }
+
+                    // Check if the block has a 'blockName' key.
+                    if (!isset($block['blockName'])) {
+                        continue;
+                    }
+
+                    // Check if the block is a Social Media block.
+                    if ($block['blockName'] !== Utils\Constants::BLOCK_SOCIAL_MEDIA) {
+                        continue;
+                    }
+
+                    // Check if the embed is a Facebook page, in which case we do nothing.
+                    if (isset($block['attrs']['embed_type']) && $block['attrs']['embed_type'] === 'facebook_page') {
+                        continue;
+                    }
+
+                    // If not, we get the social media URL.
+                    $social_media_url = self::get_social_media_url($block);
+
+                    // Identify the source of the media (Facebook, Instagram, Twitter, X)
+                    $source = self::identify_source($social_media_url);
+
+                    // If there is no source or social media url, the block is transformed into an empty Embed block.
+                    if (!$source || !$social_media_url) {
+                        $block = self::transform_block_to_empty_embed($block);
+                        continue;
+                    }
+
+                    // If the source is Facebook or Instagram we do nothing.
+                    // We only want to migrate Twitter/X embeds.
+                    if ($source === self::SOURCE_FACEBOOK || $source === self::SOURCE_INSTAGRAM) {
+                        continue;
+                    }
+
+                    // If the source is Twitter, we want to change it to X.
+                    // This avoids an extra redirection.
+                    if ($source === self::SOURCE_TWITTER) {
+                        $social_media_url = str_replace(self::SOURCE_TWITTER, self::SOURCE_X, $social_media_url);
+                    }
+
+                    // Transform the Social Media block into an Embed block.
+                    $block = self::transform_blocks($block, $social_media_url);
+                }
+
+                // Unset the reference to prevent potential issues.
+                unset($block);
+
+                // Serialize the blocks content.
+                $new_content = serialize_blocks($blocks);
+
+                $post_update = array(
+                    'ID' => $post->ID,
+                    'post_content' => $new_content,
+                );
+
+                // Update the post with the replaced blocks.
+                $result = wp_update_post($post_update);
+
+                if ($result === 0) {
+                    throw new \Exception("There was an error trying to update the post #" . $post->ID);
+                }
+
+                echo "Migration successful\n";
+            }
+        } catch (\Exception $e) {
+            // Catch any exceptions and display the post ID if available
+            echo "Migration wasn't executed for post ID: ", $current_post_id ?? 'unknown', "\n";
+            echo $e->getMessage(), "\n";
+        }
+    }
+
+    // phpcs:enable SlevomatCodingStandard.Functions.UnusedParameter
+
+    /**
+     * Get the social media URL from a Social Media block.
+     *
+     * @param array $block - A parsed Media block.
+     * @return string - The social media URL.
+     */
+    private static function get_social_media_url(array $block): mixed
+    {
+        $social_media_url = $block['attrs']['social_media_url'] ?? null;
+
+        return $social_media_url;
+    }
+
+    /**
+     * Get the source of a Social Media block.
+     * It can be Instagram, Facebook, or Twitter/X.
+     *
+     * @param string $url - The social media URL used to identify the source.
+     * @return string - The source of the Social Media block or an empty string if no source was found.
+     */
+    private static function identify_source(string $url): string
+    {
+        foreach (self::SOURCE_PATTERNS as $value => $key) {
+            if (preg_match($key, $url)) {
+                return $value;
+            }
+        }
+        return '';
+    }
+
+    /**
+     * Transform a Social Media block into a group of blocks.
+     * This group contains a header for the Social Media block title,
+     * a paragraph for the Social Media block description,
+     * and a final block (Embed) for the Twitter/X embed.
+     *
+     * @param array $block - A parsed Social Media block.
+     * @param string $source - The source of the Social Media block (Twitter or X).
+     * @param string $social_media_url - The Social Media URL.
+     * @return array - The transformed block.
+     */
+    private static function transform_blocks(array $block, string $social_media_url): array
+    {
+        $block_title = array_key_exists("title", $block['attrs']) ? $block['attrs']['title'] : null;
+        $block_description = array_key_exists("description", $block['attrs']) ? $block['attrs']['description'] : null;
+
+        $block = [];
+        $block['blockName'] = Utils\Constants::BLOCK_GROUP;
+        $block['attrs']['metadata']['name'] = 'Social Media Group';
+
+        $block['innerBlocks'] = [];
+        $block['innerBlocks'][0] = $block_title ? self::get_heading_block($block_title) : null;
+        $block['innerBlocks'][1] = $block_description ? self::get_paragraph_block($block_description) : null;
+        $block['innerBlocks'][3] = self::get_social_media_block($block, $social_media_url);
+
+        // IMPORTANT: DO NOT MODIFY THIS FORMAT!
+        $block['innerHTML'] =
+        '<div class="wp-block-group">
+
+
+
+
+
+        </div>';
+
+        // IMPORTANT: DO NOT MODIFY THIS FORMAT!
+        $block['innerContent'] = array (
+            0 => '
+        <div class="wp-block-group">',
+            1 => null,
+            2 => '
+        ',
+            3 => null,
+            4 => '
+        ',
+            5 => null,
+            6 => '
+        ',
+            7 => null,
+            8 => '</div>
+        ',
+        );
+
+        return $block;
+    }
+
+    /**
+     * Transform a Social Media block into an Embed,
+     * if the URL is from Twitter or X.
+     *
+     * @param array $block - A parsed Social Media block.
+     * @param string $social_media_url - The Social Media URL.
+     * @return array - The transformed block.
+     */
+    private static function get_social_media_block(array $block, string $social_media_url): array
+    {
+        return self::transform_block_to_embed($block, $social_media_url);
+    }
+
+    /**
+     * Transform a Media block into an empty embed block.
+     * This is useful when the Media block has no media URL
+     * or its source cannot be identified.
+     *
+     * @param array $block - A parsed Media block.
+     * @return array - The transformed block.
+     */
+    private static function transform_block_to_empty_embed(array $block): array
+    {
+        $block['blockName'] = Utils\Constants::BLOCK_EMBED;
+        $block['attrs']['metadata']['name'] = 'Embed';
+        $block = self::set_shared_attrs($block, "", "");
+        return $block;
+    }
+
+    /**
+     * Transform a Media block into an embed block.
+     *
+     * @param array $block - A parsed Social Media block.
+     * @param string $social_media_url - The Social Media URL.
+     * @return array - The transformed block.
+     */
+    private static function transform_block_to_embed(array $block, string $social_media_url): array
+    {
+        $type = 'rich';
+        $provider = self::SOURCE_TWITTER;
+
+        // IMPORTANT: DO NOT MODIFY THIS FORMAT!
+        $html_content = '<figure class="wp-block-embed is-type-' . $type . ' is-provider-' . $provider . ' wp-block-embed-' . $provider . ' wp-embed-aspect-16-9 wp-has-aspect-ratio"><div class="wp-block-embed__wrapper">
+        ' . $social_media_url . '
+        </div></figure>';
+
+        $block['blockName'] = Utils\Constants::BLOCK_EMBED;
+        $block['attrs']['type'] = $type;
+        $block['attrs']['providerNameSlug'] = $provider;
+        $block['attrs']['metadata']['name'] = $provider;
+
+        $block = self::set_shared_attrs($block, $social_media_url, $html_content);
+        return $block;
+    }
+
+    /**
+     * Set attributes that are common to all the blocks.
+     *
+     * @param array $block - A parsed Social Media block.
+     * @param string $social_media_url - The Social Media URL.
+     * @param string $html_content - The HTML content for the new block.
+     * @return array - The updated block.
+     */
+    private static function set_shared_attrs(array $block, string $social_media_url, string $html_content): array
+    {
+        $block['attrs']['url'] = $social_media_url;
+        $block['innerHTML'] = $html_content;
+        $block['innerContent'][0] = $html_content;
+        $block['innerBlocks'] = [];
+
+        unset($block['attrs']['title']);
+        unset($block['attrs']['description']);
+
+        return $block;
+    }
+
+    /**
+     * Get a heading block.
+     *
+     * @param string $text - The text for the heading.
+     * @return array - The block.
+     */
+    private static function get_heading_block(string $text): array
+    {
+        // IMPORTANT: DO NOT MODIFY THIS FORMAT!
+        $html = '
+  <h2 class="wp-block-heading">' . $text . '</h2>
+  ';
+
+        $heading = [];
+        $heading['blockName'] = Utils\Constants::BLOCK_HEADING;
+        $heading['attrs'] = [];
+        $heading['innerBlocks'] = [];
+        $heading['innerHTML'] = $html;
+        $heading['innerContent'][0] = $html;
+
+        return $heading;
+    }
+
+    /**
+     * Get a paragraph block.
+     *
+     * @param string $text - The text for the paragraph.
+     * @return array - The block.
+     */
+    private static function get_paragraph_block(string $text): array
+    {
+        // IMPORTANT: DO NOT MODIFY THIS FORMAT!
+        $html = '
+    <p>' . $text . '</p>
+    ';
+
+        $paragraph = [];
+        $paragraph['blockName'] = Utils\Constants::BLOCK_PARAGRAPH;
+        $paragraph['attrs'] = [];
+        $paragraph['innerBlocks'] = [];
+        $paragraph['innerHTML'] = $html;
+        $paragraph['innerContent'][0] = $html;
+
+        return $paragraph;
+    }
+}

--- a/src/Migrations/M033MigrateSocialMediaTwitterBlockToEmbedBlock.php
+++ b/src/Migrations/M033MigrateSocialMediaTwitterBlockToEmbedBlock.php
@@ -37,7 +37,8 @@ class M033MigrateSocialMediaTwitterBlockToEmbedBlock extends MigrationScript
             // Get the list of posts using Social Media blocks.
             $posts = Utils\Functions::get_posts_using_specific_block(
                 Utils\Constants::BLOCK_SOCIAL_MEDIA,
-                Utils\Constants::ALL_POST_TYPES
+                Utils\Constants::ALL_POST_TYPES,
+                Utils\Constants::POST_STATUS_LIST,
             );
 
             // If there are no posts, abort.

--- a/src/Migrations/M033MigrateSocialMediaTwitterBlockToEmbedBlock.php
+++ b/src/Migrations/M033MigrateSocialMediaTwitterBlockToEmbedBlock.php
@@ -141,7 +141,7 @@ class M033MigrateSocialMediaTwitterBlockToEmbedBlock extends MigrationScript
         $block['innerBlocks'] = [];
         $block['innerBlocks'][0] = $title;
         $block['innerBlocks'][1] = $description;
-        $block['innerBlocks'][3] = self::transform_block_to_embed(
+        $block['innerBlocks'][3] = Utils\Functions::create_embed_block(
             $social_media_url,
             'rich',
             Utils\Constants::TWITTER,
@@ -174,35 +174,6 @@ class M033MigrateSocialMediaTwitterBlockToEmbedBlock extends MigrationScript
             8 => '</div>
         ',
         );
-
-        return $block;
-    }
-
-    /**
-     * Create an Embed block based on a social media url.
-     *
-     * @param string $social_media_url - The Social Media URL.
-     * @param string $type - The embed type.
-     * @param $provider - The embed provider.
-     *
-     * @return array - The new Embed block.
-     */
-    private static function transform_block_to_embed(string $social_media_url, string $type, string $provider): array
-    {
-        // IMPORTANT: DO NOT MODIFY THIS FORMAT!
-        $html_content = '<figure class="wp-block-embed is-type-' . $type . ' is-provider-' . $provider . ' wp-block-embed-' . $provider . '"><div class="wp-block-embed__wrapper">
-        ' . $social_media_url . '
-        </div></figure>';
-
-        $block = [];
-        $block['blockName'] = Utils\Constants::BLOCK_EMBED;
-        $block['attrs']['type'] = $type;
-        $block['attrs']['providerNameSlug'] = $provider;
-        $block['attrs']['metadata']['name'] = $provider;
-        $block['attrs']['url'] = $social_media_url;
-        $block['innerHTML'] = $html_content;
-        $block['innerContent'][0] = $html_content;
-        $block['innerBlocks'] = [];
 
         return $block;
     }

--- a/src/Migrations/M033MigrateSocialMediaTwitterBlockToEmbedBlock.php
+++ b/src/Migrations/M033MigrateSocialMediaTwitterBlockToEmbedBlock.php
@@ -19,8 +19,8 @@ class M033MigrateSocialMediaTwitterBlockToEmbedBlock extends MigrationScript
     private const SOURCE_X = 'x';
 
     private const SOURCE_PATTERNS = [
-        self::SOURCE_INSTAGRAM => '/^(https?\:\/\/)?(www\.)?instagram\.com\/.+$/i',
-        self::SOURCE_FACEBOOK => '/^(https?\:\/\/)?(www\.)?facebook\.com\/.+$/i',
+        self::SOURCE_INSTAGRAM => '/^(?:(?:http|https):\/\/)?(?:www.)?(?:instagram.com|instagr.am|instagr.com)\/.+$/i',
+        self::SOURCE_FACEBOOK => '/^(?:(?:http|https)?:\/\/)?(?:www\.)?(mbasic.facebook|m\.facebook|facebook|fb)\.(com|me)\/.+$/i',
         self::SOURCE_TWITTER => '/^(https?\:\/\/)?(www\.)?(twitter\.com)\/.+$/i',
         self::SOURCE_X => '/^(https?\:\/\/)?(www\.)?x\.com\/.+$/i',
     ];

--- a/src/Migrations/Utils/Constants.php
+++ b/src/Migrations/Utils/Constants.php
@@ -44,4 +44,18 @@ class Constants
         'future',
         'private',
     ];
+
+    public const INSTAGRAM = 'instagram';
+    public const FACEBOOK = 'facebook';
+    public const TWITTER = 'twitter';
+    public const X = 'x';
+
+    // phpcs:disable Generic.Files.LineLength.MaxExceeded
+    public const SOCIAL_MEDIA_PATTERNS = [
+        self::INSTAGRAM => '/^(?:(?:http|https):\/\/)?(?:www.)?(?:instagram.com|instagr.am|instagr.com)\/.+$/i',
+        self::FACEBOOK => '/^(?:(?:http|https)?:\/\/)?(?:www\.)?(mbasic.facebook|m\.facebook|facebook|fb)\.(com|me)\/.+$/i',
+        self::TWITTER => '/^(https?\:\/\/)?(www\.)?(twitter\.com)\/.+$/i',
+        self::X => '/^(https?\:\/\/)?(www\.)?x\.com\/.+$/i',
+    ];
+    // phpcs:enable Generic.Files.LineLength.MaxExceeded
 }

--- a/src/Migrations/Utils/Constants.php
+++ b/src/Migrations/Utils/Constants.php
@@ -12,6 +12,7 @@ class Constants
 
     public const BLOCK_MEDIA_VIDEO = self::PREFIX_P4_BLOCKS . '/media-video';
     public const BLOCK_SPLIT_TWO_COLUMNS = self::PREFIX_P4_BLOCKS . '/split-two-columns';
+    public const BLOCK_SOCIAL_MEDIA = self::PREFIX_P4_BLOCKS . '/social-media';
 
     public const BLOCK_EMBED = self::PREFIX_CORE_BLOCKS . '/embed';
     public const BLOCK_AUDIO = self::PREFIX_CORE_BLOCKS . '/audio';
@@ -34,7 +35,6 @@ class Constants
         self::POST_TYPES_PAGE,
         self::POST_TYPES_POST,
         self::POST_TYPES_ACTION,
-        self::POST_TYPES_CAMPAIGN,
     ];
 
     public const POST_STATUS_LIST = [

--- a/src/Migrations/Utils/Constants.php
+++ b/src/Migrations/Utils/Constants.php
@@ -44,4 +44,12 @@ class Constants
         'future',
         'private',
     ];
+
+    public const POST_STATUS_LIST = [
+        'publish',
+        'pending',
+        'draft',
+        'future',
+        'private',
+    ];
 }

--- a/src/Migrations/Utils/Constants.php
+++ b/src/Migrations/Utils/Constants.php
@@ -44,12 +44,4 @@ class Constants
         'future',
         'private',
     ];
-
-    public const POST_STATUS_LIST = [
-        'publish',
-        'pending',
-        'draft',
-        'future',
-        'private',
-    ];
 }

--- a/src/Migrations/Utils/Constants.php
+++ b/src/Migrations/Utils/Constants.php
@@ -35,6 +35,7 @@ class Constants
         self::POST_TYPES_PAGE,
         self::POST_TYPES_POST,
         self::POST_TYPES_ACTION,
+        self::POST_TYPES_CAMPAIGN,
     ];
 
     public const POST_STATUS_LIST = [

--- a/src/Migrations/Utils/Functions.php
+++ b/src/Migrations/Utils/Functions.php
@@ -355,7 +355,6 @@ class Functions
         string $img_url,
         int $img_id
     ): array {
-
         // phpcs:disable Generic.Files.LineLength.MaxExceeded
         $html = array (
            0 => '
@@ -380,6 +379,44 @@ class Functions
             $inner_blocks,
             $html[0] . $html[6],
             $html
+        );
+    }
+
+    /**
+     * Create a new Embed block.
+     *
+     * @param string $social_media_url - The Social Media URL.
+     * @param string $type - The embed type.
+     * @param $provider - The embed provider.
+     *
+     * @return array - The new Embed block.
+     */
+
+    public static function create_embed_block(
+        string $social_media_url,
+        string $type,
+        string $provider,
+    ): array {
+        // phpcs:disable Generic.Files.LineLength.MaxExceeded
+        $html_content = '<figure class="wp-block-embed is-type-' . $type . ' is-provider-' . $provider . ' wp-block-embed-' . $provider . '"><div class="wp-block-embed__wrapper">
+        ' . $social_media_url . '
+        </div></figure>';
+        // phpcs:enable Generic.Files.LineLength.MaxExceeded
+
+        $attrs = [];
+        $attrs['type'] = $type;
+        $attrs['providerNameSlug'] = $provider;
+        $attrs['metadata']['name'] = $provider;
+        $attrs['url'] = $social_media_url;
+        $block['innerHTML'] = $html_content;
+        $block['innerContent'][0] = $html_content;
+
+        return self::create_new_block(
+            Constants::BLOCK_EMBED,
+            $attrs,
+            [],
+            $html_content,
+            [$html_content],
         );
     }
 }

--- a/src/Migrations/Utils/Functions.php
+++ b/src/Migrations/Utils/Functions.php
@@ -419,4 +419,52 @@ class Functions
             [$html_content],
         );
     }
+
+    /**
+     * Create a new Group block.
+     *
+     * @param array $inner_blocks - The block's inner blocks.
+     * @param array $attrs - The block's attributes.
+     *
+     * @return array - The new Group block.
+     */
+
+    public static function create_group_block(array $inner_blocks, array $attrs): array
+    {
+        // IMPORTANT: DO NOT MODIFY THIS FORMAT!
+        $inner_html =
+        '<div class="wp-block-group">
+
+
+
+
+
+        </div>';
+
+        // IMPORTANT: DO NOT MODIFY THIS FORMAT!
+        $inner_content = array (
+            0 => '
+        <div class="wp-block-group">',
+            1 => null,
+            2 => '
+        ',
+            3 => null,
+            4 => '
+        ',
+            5 => null,
+            6 => '
+        ',
+            7 => null,
+            8 => '</div>
+        ',
+        );
+
+        return self::create_new_block(
+            Constants::BLOCK_GROUP,
+            $attrs,
+            $inner_blocks,
+            $inner_html,
+            $inner_content,
+        );
+    }
 }

--- a/src/Migrator.php
+++ b/src/Migrator.php
@@ -34,6 +34,7 @@ use P4\MasterTheme\Migrations\M029RemoveTemplateEditorOption;
 use P4\MasterTheme\Migrations\M030RemovePurgeOnFeatureChangeOption;
 use P4\MasterTheme\Migrations\M031MigrateMediaBlockToAudioVideoBlock;
 use P4\MasterTheme\Migrations\M032MigrateSplit2ColumnBlock;
+use P4\MasterTheme\Migrations\M033MigrateSocialMediaTwitterBlockToEmbedBlock;
 
 /**
  * Run any new migration scripts and record results in the log.
@@ -85,6 +86,7 @@ class Migrator
             M030RemovePurgeOnFeatureChangeOption::class,
             M031MigrateMediaBlockToAudioVideoBlock::class,
             M032MigrateSplit2ColumnBlock::class,
+            M033MigrateSocialMediaTwitterBlockToEmbedBlock::class,
         ];
 
         // Loop migrations and run those that haven't run yet.

--- a/templates/blocks/social-media.twig
+++ b/templates/blocks/social-media.twig
@@ -1,0 +1,31 @@
+{% block social_media %}
+	<section class="block social-media-block">
+		{% if ( title ) %}
+			<header>
+				<h2 class="page-section-header">{{ title }}</h2>
+			</header>
+		{% endif %}
+		{% if ( description ) %}
+			<div class="page-section-description">{{ description|e('wp_kses_post')|wpautop|raw }}</div>
+		{% endif %}
+
+		<div class="social-media-embed {{ alignment_class }}">
+			{% if ( embed_code ) %}
+				{{ embed_code|raw }}
+			{% elseif ( facebook_page_url ) %}
+				<iframe class="social-media-embed-facebook social-media-embed-facebook--small" src="https://www.facebook.com/plugins/page.php?href={{ facebook_page_url|url_encode }}&tabs={{ facebook_page_tab }}&width=240&height=500&small_header=false&adapt_container_width=true&hide_cover=false&show_facepile=true"
+					scrolling="no"
+					frameborder="0"
+					allowTransparency="true"
+					allow="encrypted-media"
+				></iframe>
+				<iframe class="social-media-embed-facebook social-media-embed-facebook--large" src="https://www.facebook.com/plugins/page.php?href={{ facebook_page_url|url_encode }}&tabs={{ facebook_page_tab }}&width=500&height=500&small_header=false&adapt_container_width=true&hide_cover=false&show_facepile=true"
+					scrolling="no"
+					frameborder="0"
+					allowTransparency="true"
+					allow="encrypted-media"
+				></iframe>
+			{% endif %}
+		</div>
+	</section>
+{% endblock %}

--- a/templates/blocks/social-media.twig
+++ b/templates/blocks/social-media.twig
@@ -13,17 +13,23 @@
 			{% if ( embed_code ) %}
 				{{ embed_code|raw }}
 			{% elseif ( facebook_page_url ) %}
-				<iframe class="social-media-embed-facebook social-media-embed-facebook--small" src="https://www.facebook.com/plugins/page.php?href={{ facebook_page_url|url_encode }}&tabs={{ facebook_page_tab }}&width=240&height=500&small_header=false&adapt_container_width=true&hide_cover=false&show_facepile=true"
+				<iframe
+                    class="social-media-embed-facebook social-media-embed-facebook--small"
+                    src="https://www.facebook.com/plugins/page.php?href={{ facebook_page_url|url_encode }}&tabs={{ facebook_page_tab }}&width=240&height=500&small_header=false&adapt_container_width=true&hide_cover=false&show_facepile=true"
 					scrolling="no"
 					frameborder="0"
 					allowTransparency="true"
 					allow="encrypted-media"
+                    title="Small Facebook embed"
 				></iframe>
-				<iframe class="social-media-embed-facebook social-media-embed-facebook--large" src="https://www.facebook.com/plugins/page.php?href={{ facebook_page_url|url_encode }}&tabs={{ facebook_page_tab }}&width=500&height=500&small_header=false&adapt_container_width=true&hide_cover=false&show_facepile=true"
+				<iframe
+                    class="social-media-embed-facebook social-media-embed-facebook--large"
+                    src="https://www.facebook.com/plugins/page.php?href={{ facebook_page_url|url_encode }}&tabs={{ facebook_page_tab }}&width=500&height=500&small_header=false&adapt_container_width=true&hide_cover=false&show_facepile=true"
 					scrolling="no"
 					frameborder="0"
 					allowTransparency="true"
 					allow="encrypted-media"
+                    title="Large Facebook embed"
 				></iframe>
 			{% endif %}
 		</div>


### PR DESCRIPTION
### Description

See [PLANET-7523](https://jira.greenpeace.org/browse/PLANET-7523)

This also includes cleaning up the code of all previous Twitter/X customisations since we will now use the Embed block for these instead. The corresponding migration is included in this PR too.

**Note:** it seems X urls were not working anyways 😬 see [here](https://www-dev.greenpeace.org/gutenberg/twitter-x-embeds/) for example

### Testing

**For the block changes:**

Make sure the block is now called `Meta` and it has no more mentions of Twitter/X in its options.

**For the migration:**

1. Run this PR in your local environment.
2. Add a Meta block to a page using a Twitter/X post url ([example](https://x.com/Greenpeace/status/1842512562383913248)), it won't embed the block anymore because of this PR's changes but it's good enough to test the migration script.

You can also directly copy/paste this in the code editor:

```
<!-- wp:planet4-blocks/social-media {"title":"Twitter","description":"A Twitter feed","social_media_url":"https://twitter.com/Greenpeace"} -->
<section class="block social-media-block wp-block-planet4-blocks-social-media"><header><h2 class="page-section-header">Twitter</h2></header><p class="page-section-description">A Twitter feed</p></section>
<!-- /wp:planet4-blocks/social-media -->

<!-- wp:planet4-blocks/social-media {"title":"X","description":"A X post","social_media_url":"https://x.com/Greenpeace/status/1842512562383913248"} -->
<section class="block social-media-block wp-block-planet4-blocks-social-media"><header><h2 class="page-section-header">X</h2></header><p class="page-section-description">A X post</p></section>
<!-- /wp:planet4-blocks/social-media -->
```

4. Run the migrator command: `npx wp-env run cli wp p4-run-activator`
5. Check whether the migration worked as expected. You might need to run `npx wp-env run cli wp embed cache clear <post-id>` to make sure that the new Embeds render in the frontend.
6. To reset the environment database back to the latest default content and repeat the tests, run: `npm run db:reset`.