### PR TITLE
Fix tag page when redirection is not set

### DIFF
--- a/tag.php
+++ b/tag.php
@@ -21,10 +21,10 @@ if (!is_tag()) {
 
 $tag = get_queried_object();
 $redirect_id = get_term_meta($tag->term_id, 'redirect_page', true);
-$redirect_page = get_post($redirect_id);
 
-if ($redirect_page) {
+if ($redirect_id) {
     global $wp_query;
+    $redirect_page = get_post($redirect_id);
     $wp_query->queried_object = $redirect_page;
     $wp_query->queried_object_id = $redirect_page->ID;
 


### PR DESCRIPTION
This is a revert of fc35da662402012b2d67ae0266ac5aac1321a49b

It seems that `get_post` returns a specific post even the argument passed as id is an empty string.

### Testing
- While on `main` branch:
  - Go to a tag and make sure it doesn't have a "Redirect Page" value (see screenshot)
  - Visit that tag page on the frontend, and instead of the tag listing page you should see a specific post
- Switch to this branch:
  - Refresh the above tag and you should see the regular tag listing page

![image](https://github.com/user-attachments/assets/e9bf65bc-04a1-4d72-bddf-9e2315941fd2)
