### PR TITLE
Show media import button only on Media Library

### DIFF
--- a/src/Exporter.php
+++ b/src/Exporter.php
@@ -115,7 +115,7 @@ class Exporter
         ?>
         <script>
             jQuery(function(){
-                jQuery(".wrap .page-title-action")
+                jQuery(".upload-php .wrap .page-title-action")
                     .after('<a href="upload.php?page=media-picker" class="add-new-h2"><?php esc_html_e('Import Greenpeace Media', 'planet4-master-theme-backend'); ?></a>');
             });
 


### PR DESCRIPTION
We are injecting an Import button, in order to guide people on import media files while on Media Library. But currently that button show up everywhere, on all post types.

This small change makes the button visible only in the Media Library.

### Testing
- Ensure the "Import Greenpeace Media" button works the same as before
- It should no longer appear on Posts and Pages
