### PR TITLE
PLANET-7662: Fix action pages dropdown

### DIFF
--- a/assets/src/blocks/TakeActionBoxout/TakeActionBoxoutEditor.js
+++ b/assets/src/blocks/TakeActionBoxout/TakeActionBoxoutEditor.js
@@ -37,7 +37,7 @@ export const TakeActionBoxoutEditor = ({
   } = attributes;
 
   const {options: p4_options} = window.p4_vars;
-  const isNewIA = p4_options.new_ia === 'on';
+  const isNewIA = p4_options.new_ia;
 
   const {
     loading,

--- a/assets/src/blocks/TakeActionBoxout/TakeActionBoxoutEditor.js
+++ b/assets/src/blocks/TakeActionBoxout/TakeActionBoxoutEditor.js
@@ -36,6 +36,9 @@ export const TakeActionBoxoutEditor = ({
     stickyOnMobile,
   } = attributes;
 
+  const urlParams = new URLSearchParams(window.location.search);
+  const postId = urlParams.get('post');
+
   const {
     loading,
     actPageList,
@@ -63,7 +66,7 @@ export const TakeActionBoxoutEditor = ({
         (select('core').getEntityRecords('postType', 'p4_action', args) || []) :
         []
       )
-    ).sort((a, b) => {
+    ).filter(a => `${a.id}` !== postId).sort((a, b) => {
       if (a.title.raw === b.title.raw) {
         return 0;
       }

--- a/assets/src/blocks/TakeActionBoxout/TakeActionBoxoutEditor.js
+++ b/assets/src/blocks/TakeActionBoxout/TakeActionBoxoutEditor.js
@@ -51,21 +51,18 @@ export const TakeActionBoxoutEditor = ({
       per_page: -1,
       sort_order: 'asc',
       sort_column: 'post_title',
-      parent: window.p4_vars.take_action_page,
-      post_status: 'publish',
-    };
-
-    const actionsArgs = {
-      per_page: -1,
-      sort_order: 'asc',
-      sort_column: 'post_title',
       post_status: 'publish',
     };
 
     // eslint-disable-next-line no-shadow
     const actPageList = [].concat(
-      select('core').getEntityRecords('postType', 'page', args) || [],
-      select('core').getEntityRecords('postType', 'p4_action', actionsArgs) || []
+      select('core').getEntityRecords('postType', 'page', {
+        ...args, parent: window.p4_vars.options.take_action_page,
+      }) || [],
+      ...(window.p4_vars.options.new_ia === 'on' ?
+        (select('core').getEntityRecords('postType', 'p4_action', args) || []) :
+        []
+      )
     ).sort((a, b) => {
       if (a.title.raw === b.title.raw) {
         return 0;

--- a/assets/src/blocks/TakeActionBoxout/TakeActionBoxoutEditor.js
+++ b/assets/src/blocks/TakeActionBoxout/TakeActionBoxoutEditor.js
@@ -36,8 +36,8 @@ export const TakeActionBoxoutEditor = ({
     stickyOnMobile,
   } = attributes;
 
-  const urlParams = new URLSearchParams(window.location.search);
-  const postId = urlParams.get('post');
+  const {options: p4_options} = window.p4_vars;
+  const isNewIA = p4_options.new_ia === 'on';
 
   const {
     loading,
@@ -50,6 +50,7 @@ export const TakeActionBoxoutEditor = ({
     imageUrl,
     imageAlt,
   } = useSelect(select => {
+    const postId = select('core/editor').getCurrentPostId();
     const args = {
       per_page: -1,
       sort_order: 'asc',
@@ -60,13 +61,11 @@ export const TakeActionBoxoutEditor = ({
     // eslint-disable-next-line no-shadow
     const actPageList = [].concat(
       select('core').getEntityRecords('postType', 'page', {
-        ...args, parent: window.p4_vars.options.take_action_page,
+        ...args,
+        parent: isNewIA ? p4_options.take_action_page : p4_options.act_page,
       }) || [],
-      ...(window.p4_vars.options.new_ia === 'on' ?
-        (select('core').getEntityRecords('postType', 'p4_action', args) || []) :
-        []
-      )
-    ).filter(a => `${a.id}` !== postId).sort((a, b) => {
+      ...(isNewIA ? (select('core').getEntityRecords('postType', 'p4_action', args) || []) : [])
+    ).filter(a => parseInt(a.id) !== postId).sort((a, b) => {
       if (a.title.raw === b.title.raw) {
         return 0;
       }


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-7662

The `Select Take Action Page` is now rendered based on IA.

[Demo page](https://www-dev.greenpeace.org/test-tavros/act/test-tab-demo-page/) 

## Testing
- Go to Planet 4 > Navigation and see if new IA feature is enabled
- Create a new page and include a Take Action Boxout block
- If the new IA feature is disabled the list should render only pages that its parents are the same as the one defined trough `/wp-admin/admin.php?page=planet4_settings_navigation`.
- If the new IA feature is enabled the list should include not  only the previous ones but also `p4_action` pages

<!-- Ref: Please add a url to the ticket this change is addressing.