### PR TITLE
PLANET-7666 Add template include for extra footer block

### DIFF
--- a/templates/footer.twig
+++ b/templates/footer.twig
@@ -1,3 +1,5 @@
+{% include 'footer_block.twig' ignore missing %}
+
 <footer id="footer" class="site-footer site-footer--{{ nav_type }}">
     {% if nav_type != 'minimal' %}
     <div id="country-selector" class="footer-country-selector">


### PR DESCRIPTION
This will some NROs to add a custom block on top of the footer on all pages without the need to override the entire footer template.

---

Ref: https://jira.greenpeace.org/browse/PLANET-7666