### PR TITLE
PLANET-7618 Make sure nav links don't exceed 2 lines

### DIFF
--- a/assets/src/scss/layout/_navbar.scss
+++ b/assets/src/scss/layout/_navbar.scss
@@ -208,6 +208,14 @@ a.nav-link {
   width: 100%;
   text-decoration: none !important;
 
+  span {
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    line-clamp: 2;
+    -webkit-line-clamp: 2;
+    overflow: hidden;
+  }
+
   &:hover {
     color: var(--color-text-nav_link);
   }

--- a/templates/burger-menu-items.twig
+++ b/templates/burger-menu-items.twig
@@ -53,8 +53,9 @@
                         target="{{ item.target }}"
                         data-ga-category="Submenu Navigation"
                         data-ga-action="{{ link_ga_action }}"
-                        data-ga-label="{{ page_category }}">
-                            {{ item.title|e('wp_kses_post')|raw }}
+                        data-ga-label="{{ page_category }}"
+                    >
+                        <span>{{ item.title|e('wp_kses_post')|raw }}</span>
                     </a>
                 </li>
             {% endfor %}

--- a/templates/navigation-submenu.twig
+++ b/templates/navigation-submenu.twig
@@ -15,8 +15,9 @@
                 target="{{ item.target }}"
                 data-ga-category="Submenu Navigation"
                 data-ga-action="{{ item.title }}"
-                data-ga-label="{{ page_category }}">
-                    {{ item.title|e('wp_kses_post')|raw }}
+                data-ga-label="{{ page_category }}"
+            >
+                <span>{{ item.title|e('wp_kses_post')|raw }}</span>
             </a>
         </li>
     {% endfor %}


### PR DESCRIPTION
### Description

See [PLANET-7618](https://jira.greenpeace.org/browse/PLANET-7618)

This can happen in edge cases where a page used in the navigation is renamed with a longer title

### Testing

On the [titan instance](https://www-dev.greenpeace.org/test-titan/) in the navigation under `The issues we work on` I've added a page with a really long title. It should be cut off after 2 lines for both mobile and desktop.