### PR TITLE
PLANET-7672 Update TAB custom image width in the editor

### DIFF
--- a/assets/src/scss/blocks/TakeActionBoxout/TakeActionBoxoutEditorStyle.scss
+++ b/assets/src/scss/blocks/TakeActionBoxout/TakeActionBoxoutEditorStyle.scss
@@ -9,25 +9,25 @@
     min-width: auto !important;
   }
 
+  // I had to put these styles on the container to get the image controls to work, and remove some from the image itself.
+  .boxout-image-container {
+    position: relative;
+    background: var(--grey-500);
+    width: 50%;
+    padding: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    img {
+      width: 100%;
+    }
+  }
+
   // Prevent line clamp on editable stuff, because it's very buggy.
   [contenteditable] {
     line-clamp: unset !important;
     -webkit-line-clamp: unset !important;
-  }
-}
-
-// I had to put these styles on the container to get the image controls to work, and remove some from the image itself.
-.boxout-image-container {
-  position: relative;
-  background: var(--grey-500);
-  width: 50%;
-  padding: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-
-  img {
-    width: 100%;
   }
 }
 


### PR DESCRIPTION
### Description

See [PLANET-7672](https://jira.greenpeace.org/browse/PLANET-7672)

This editor style was overridden by the frontend styles for the block. 

### Testing

Before these changes this is what a custom boxout looks like in the editor: 

<img width="746" alt="GITS00250719" src="https://github.com/user-attachments/assets/71001658-e062-45a9-b971-12679388184a">

After these changes it should look as expected.