### PR TITLE
PLANET-7674: Fix tags list

### DIFF
--- a/assets/src/block-editor/TagSelector/index.js
+++ b/assets/src/block-editor/TagSelector/index.js
@@ -6,6 +6,6 @@ const TagSelector = props => <TaxonomySelector label="Select Tags" {...props} />
 
 export default compose(
   withSelect(select => ({
-    suggestions: select('core').getEntityRecords('taxonomy', 'post_tag', {hide_empty: false, per_page: -1}) || [],
+    suggestions: select('core').getEntityRecords('taxonomy', 'post_tag', {hide_empty: false}) || [],
   }))
 )(TagSelector);


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-7674

The issue has been reported by [GPUS](https://greenpeace-gpi.slack.com/archives/C07J7BB7NL9/p1732215809593329).

# Description
Remove per_page parameter

# Testing
- Create a new page
- Insert a Covers block into the page
- Set any Tag from settings panel

## External resources
- https://developer.wordpress.org/block-editor/reference-guides/data/data-core/#getentityrecords
- https://developer.wordpress.org/block-editor/reference-guides/data/data-core/
- https://developer.wordpress.org/rest-api/reference/

<!-- Ref: Please add a url to the ticket this change is addressing.

---

Please provide a brief summary of the change introduced to make review process easier.

Ideally this should also be part of the commit summary.
-->
