### PR TITLE
Add Social Media block API endpoint

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -104,6 +104,7 @@ add_action(
         Api\ENForm::register_endpoint();
         Api\Covers::register_endpoint();
         Api\Articles::register_endpoint();
+        Api\SocialMedia::register_endpoint();
     }
 );
 

--- a/src/Api/SocialMedia.php
+++ b/src/Api/SocialMedia.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace P4\MasterTheme\Api;
+
+use P4\MasterTheme\Blocks\SocialMedia as SocialMediaBlock;
+use WP_REST_Server;
+
+/**
+ * SocialMedia block API
+ */
+class SocialMedia
+{
+    /**
+     * Endpoint to get the code for Instagram embeds in the Social Media block.
+     *
+     * @example GET /wp-json/planet4/v1/get-instagram-embed
+     */
+    public static function register_endpoint(): void
+    {
+        /**
+         * Endpoint to get the code for Instagram embeds in the Social Media block.
+         */
+        register_rest_route(
+            'planet4/v1',
+            '/get-instagram-embed',
+            [
+                [
+                    'permission_callback' => static function () {
+                        return true;
+                    },
+                    'methods' => WP_REST_Server::READABLE,
+                    'callback' => static function ($fields) {
+                        $url = $fields['url'] ?? '';
+                        $embed_code = SocialMediaBlock::get_fb_oembed_html($url, 'instagram');
+                        return rest_ensure_response($embed_code);
+                    },
+                ],
+            ]
+        );
+    }
+}


### PR DESCRIPTION
### Description

We forgot it when moving this block to the theme. The oEmbed is still not working (see [PLANET-7654](https://jira.greenpeace.org/browse/PLANET-7654)) but at least now everything related to this block will be in the theme. 
Although the Instagram one now shows an error message 😅 [example](https://www-dev.greenpeace.org/test-phobos/oembeds/)

**Related PR:** https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/1264