### PR TITLE
PLANET-7677: Consolidate parent act page injected to window p4_vars

### DIFF
--- a/assets/src/block-editor/PostSelector/index.js
+++ b/assets/src/block-editor/PostSelector/index.js
@@ -32,7 +32,7 @@ export const PostSelector = attributes => {
   /**
    * Fetch relevant posts for autosuggestions
    */
-  const act_parent = window?.p4ge_vars?.planet4_options.act_page || null;
+  const act_parent = window.p4_vars.options.take_action_page || null;
   const args = {per_page: -1, orderby: 'title', post_status: 'publish'};
   const posts = useSelect(select => {
     if ('post' === postType || 'p4_action' === postType || 'page' === postType) {

--- a/assets/src/blocks/ActionsList/index.js
+++ b/assets/src/blocks/ActionsList/index.js
@@ -9,8 +9,7 @@ export const registerActionsListBlock = () => {
   const {registerBlockVariation} = wp.blocks;
   const {__} = wp.i18n;
 
-  const IS_NEW_IA = window.p4_vars.options.new_ia === 'on' ||
-    window.p4_vars.options.new_ia === true;
+  const IS_NEW_IA = window.p4_vars.options.new_ia;
   const ACT_PAGE = window.p4_vars.options.take_action_page || -1;
 
   const queryPostType = IS_NEW_IA ? 'p4_action' : 'page';

--- a/src/MasterBlocks.php
+++ b/src/MasterBlocks.php
@@ -173,6 +173,7 @@ class MasterBlocks
     private function get_p4_options(): array
     {
         $option_values = get_option('planet4_options');
+        $is_new_ia = $option_values['new_ia'] === 'on' ;
 
         $cookies_default_copy = [
             'necessary_cookies_name' => $option_values['necessary_cookies_name'] ?? '',
@@ -188,8 +189,8 @@ class MasterBlocks
             'enable_google_consent_mode' => $option_values['enable_google_consent_mode'] ?? '',
             'cookies_default_copy' => $cookies_default_copy,
             'take_action_covers_button_text' => $option_values['take_action_covers_button_text'] ?? '',
-            'take_action_page' => $option_values['take_action_page'] ?? '',
-            'new_ia' => $option_values['new_ia'] ?? '',
+            'take_action_page' => $is_new_ia ? $option_values['take_action_page'] : $option_values['act_page'],
+            'new_ia' => $is_new_ia,
         ];
     }
 

--- a/src/MasterBlocks.php
+++ b/src/MasterBlocks.php
@@ -173,7 +173,7 @@ class MasterBlocks
     private function get_p4_options(): array
     {
         $option_values = get_option('planet4_options');
-        $is_new_ia = $option_values['new_ia'] === 'on' ;
+        $is_new_ia = !empty(planet4_get_option('new_ia'));
 
         $cookies_default_copy = [
             'necessary_cookies_name' => $option_values['necessary_cookies_name'] ?? '',


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-7677

In preparation of https://jira.greenpeace.org/browse/PLANET-7657

# Description
Remove appearences of p4ge_vars to avoid conflicts whenever the plugin is disabled.

<!-- Ref: Please add a url to the ticket this change is addressing.

---

Please provide a brief summary of the change introduced to make review process easier.

Ideally this should also be part of the commit summary.
-->
