### PR TITLE
Simplify CF zone code to only remove www. from hostname

### DIFF
--- a/src/Commands/SaveCloudflareKey.php
+++ b/src/Commands/SaveCloudflareKey.php
@@ -49,10 +49,8 @@ class SaveCloudflareKey extends Command
             WP_CLI::error('CLOUDFLARE_API_KEY constant is not set.');
         }
 
-        // Keep last two parts of the hostname, or three in special cases like .org.au.
-        $domain_parts = explode('.', $hostname);
-        $slice = count($domain_parts) - 1;
-        $root_domain = implode('.', array_slice($domain_parts, - $slice));
+        // Remove www from the hostname, since Cloudflare needs the apex domain.
+        $root_domain = str_replace('www.', '', $hostname);
 
         update_option('cloudflare_api_key', CLOUDFLARE_API_KEY);
         update_option('automatic_platform_optimization', [ 'value' => 1 ]);


### PR DESCRIPTION
We made a change to accommodate for domains with more parts (like `.org.au`), but that broke `ummah4earth.org` because they don't have `www` in their hostname.

Since we practically only want to remove `www`, this simplifies that part of the code to avoid complicated conditional logic for all use cases.

### Testing 

It's hard to test directly with Cloudflare, but I moved the code to a different file and use php cli to test out the logic with the different use cases.
