### PR TITLE
PLANET-7482 Use proper function for displaying author bio

### DIFF
--- a/assets/src/scss/pages/_author.scss
+++ b/assets/src/scss/pages/_author.scss
@@ -49,6 +49,10 @@
   display: flex;
   flex-direction: column;
   justify-content: center;
+
+  a {
+    @include shared-link-styles;
+  }
 }
 
 .author-image {

--- a/assets/src/scss/pages/post/_author-block.scss
+++ b/assets/src/scss/pages/post/_author-block.scss
@@ -63,18 +63,19 @@
   }
 }
 
-.author-block-info {
-  font-size: $font-size-sm;
-  line-height: 1.5;
-  margin: 0;
+.author-bio {
+  p {
+    font-size: $font-size-sm;
+    line-height: 1.5;
+    margin: 0;
 
-  .collapsing {
-    display: none;
-    transition: none;
+    .collapsing {
+      display: none;
+      transition: none;
+    }
   }
 
-  & > div a,
-  .author-details a {
+  a {
     @include shared-link-styles;
   }
 }

--- a/templates/author.twig
+++ b/templates/author.twig
@@ -12,7 +12,9 @@
         <div class="author-details">
             <h1 class="page-header-title">{{ author.name }}</h1>
             {% if ( author.description ) %}
-                <p class="d-md-block author-bio" aria-label="{{ __( 'Author bio', 'planet4-master-theme' ) }}">{{ fn('wpautop', fn('the_author_meta', 'description', author.id))|e('wp_kses_post')|raw }}</p>
+                <div class="d-md-block author-bio" aria-label="{{ __( 'Author bio', 'planet4-master-theme' ) }}">
+                    {{ fn('wpautop', fn('get_the_author_meta', 'description', author.id))|e('wp_kses_post')|raw }}
+                </div>
             {% endif %}
         </div>
     </header>

--- a/templates/blocks/author_profile.twig
+++ b/templates/blocks/author_profile.twig
@@ -27,10 +27,10 @@
 
                 {% set author_bio_char_limit = 180 %}
 
-                <div itemprop="description">
+                <div itemprop="description" class="author-bio" aria-label="{{ __( 'Author bio', 'planet4-master-theme' ) }}">
                     {# If needed, we first show a truncated version of the description, with an ellipsis and a "Show more" button #}
                     {% if ( post.author.description|length <= author_bio_char_limit ) %}
-                        {{ post.author.description|raw }}
+                        {{ fn('wpautop', post.author.description)|e('wp_kses_post')|raw }}
                     {% else %}
                         {% set post_author_description_teaser = post.author.description|slice(0, author_bio_char_limit) ~ '<span class="collapse show multi-collapse">&hellip;</span>' %}
                         {% set post_author_description_remainder = post.author.description|slice(author_bio_char_limit) %}


### PR DESCRIPTION
We are currently using [the_author_meta](https://developer.wordpress.org/reference/functions/the_author_meta/).
But the function doesn't return a string, which is what [wpautop](https://developer.wordpress.org/reference/functions/wpautop/) expects. This also triggers the following warning locally:

```
Deprecated: trim(): Passing null to parameter #1 ($string) of type string is deprecated in /var/www/html/wp-includes/formatting.php on line 449
```

Instead, we should use [get_the_author_meta](https://developer.wordpress.org/reference/functions/get_the_author_meta/) as it's also mentioned in the documentation of `the_author_meta`:

>NOTE: Use `get_the_author_meta()` if you need to return (and do something with) the field, rather than just display it.

This also fixes bug [PLANET-7482](https://jira.greenpeace.org/browse/PLANET-7482).
So it includes some css changes to make the links also follow the correct design.

On the Authors block (Post view), when the bio is bigger than our character limit, the `wpautop` is not used
as it's hard to keep the formatting while breaking up the description text.

### Testing
- Use these two bio examples (short and long):
  ```
  This is test short bio.

  With a few lines and a <b>bold</b> markup.

  <a href="https://twitter.com/Greenpeace">Follow on Twitter</a>.
  ```

  ```
  This is longer bio, to test collapse/expand functionality.

  It still has a few lines and a <b>bold</b> markup, but it should appear as one paragraph on the Author block.

  Follow on <a href="https://twitter.com/Greenpeace">Twitter</a>.
  ```

- Check both the author block on Post (that requires the user is assigned a post) and the Author page

- Elements to check:
  -- Author page and Author block: links should follow the default design
  -- Author page and Author block short version: New lines should be converted to paragraphs