### PR TITLE
PLANET-7685 Update tag selector limit

### DIFF
--- a/assets/src/block-editor/TagSelector/index.js
+++ b/assets/src/block-editor/TagSelector/index.js
@@ -6,6 +6,10 @@ const TagSelector = props => <TaxonomySelector label="Select Tags" {...props} />
 
 export default compose(
   withSelect(select => ({
-    suggestions: select('core').getEntityRecords('taxonomy', 'post_tag', {hide_empty: false}) || [],
+    suggestions: select('core').getEntityRecords(
+      'taxonomy',
+      'post_tag',
+      {hide_empty: false, per_page: 100}
+    ) || [],
   }))
 )(TagSelector);


### PR DESCRIPTION
### Description

See [PLANET-7685](https://jira.greenpeace.org/browse/PLANET-7685)

We thought this number was applied by default but maybe it isn't after all, it doesn't work in the Articles block

### Testing

Before this fix, only the first 10 tags were available in the TagSelector for the Articles block.