### PR TITLE
PLANET-7688 Fixed huge space between Spotify embed and captions

### DIFF
--- a/assets/src/scss/blocks/core-overrides/Embed.scss
+++ b/assets/src/scss/blocks/core-overrides/Embed.scss
@@ -128,9 +128,16 @@ lite-youtube,
     }
   }
 
-  &-twitter {
+  &-twitter,
+  &-spotify {
     .wp-block-embed__wrapper {
       height: auto;
+    }
+  }
+
+  &-spotify {
+    .wp-block-embed__wrapper {
+      padding-bottom: unset;
     }
   }
 


### PR DESCRIPTION
### Summary

<!-- Please provide a brief summary of the change introduced in this Pull Request. -->

---

<!-- Please add a reference link to the ticket, if one exists. -->
Ref:  Ref: https://jira.greenpeace.org/browse/PLANET-7688

### Testing

<!-- Please add the steps required to test the changes in this Pull Request. -->
1.  Create a new page and add the Embed block with a Spotify URL
2.  The shouldn't be any huge space anymore between the block and the captions
3.  Compare this [page](https://www-dev.greenpeace.org/test-umbriel/testing-spotify-fix/) with fix, to this [page](https://www.greenpeace.org/international/audio-series/) with bug.
