### PR TITLE
Update apiVersion for our blocks to 3

### DIFF
--- a/assets/src/block-templates/action/block.json
+++ b/assets/src/block-templates/action/block.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schemas.wp.org/trunk/block.json",
-  "apiVersion": 2,
+  "apiVersion": 3,
   "name": "planet4-block-templates/action",
   "title": "Action",
   "category": "planet4-block-templates",

--- a/assets/src/block-templates/campaign/block.json
+++ b/assets/src/block-templates/campaign/block.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schemas.wp.org/trunk/block.json",
-  "apiVersion": 2,
+  "apiVersion": 3,
   "name": "planet4-block-templates/campaign",
   "title": "Campaign",
   "category": "planet4-block-templates",

--- a/assets/src/block-templates/deep-dive-topic/block.json
+++ b/assets/src/block-templates/deep-dive-topic/block.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schemas.wp.org/trunk/block.json",
-  "apiVersion": 2,
+  "apiVersion": 3,
   "name": "planet4-block-templates/deep-dive-topic",
   "title": "Deep Dive Topic",
   "category": "planet4-block-templates",

--- a/assets/src/block-templates/deep-dive/block.json
+++ b/assets/src/block-templates/deep-dive/block.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schemas.wp.org/trunk/block.json",
-  "apiVersion": 2,
+  "apiVersion": 3,
   "name": "planet4-block-templates/deep-dive",
   "title": "Deep Dive",
   "category": "planet4-block-templates",

--- a/assets/src/block-templates/get-informed/block.json
+++ b/assets/src/block-templates/get-informed/block.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schemas.wp.org/trunk/block.json",
-  "apiVersion": 2,
+  "apiVersion": 3,
   "name": "planet4-block-templates/get-informed",
   "title": "Get Informed",
   "category": "planet4-block-templates",

--- a/assets/src/block-templates/high-level-topic/block.json
+++ b/assets/src/block-templates/high-level-topic/block.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schemas.wp.org/trunk/block.json",
-  "apiVersion": 2,
+  "apiVersion": 3,
   "name": "planet4-block-templates/high-level-topic",
   "title": "High-Level Topic",
   "category": "planet4-block-templates",

--- a/assets/src/block-templates/highlighted-cta/block.json
+++ b/assets/src/block-templates/highlighted-cta/block.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schemas.wp.org/trunk/block.json",
-  "apiVersion": 2,
+  "apiVersion": 3,
   "name": "planet4-block-templates/highlighted-cta",
   "title": "Highlighted CTA",
   "category": "planet4-block-templates",

--- a/assets/src/block-templates/homepage/block.json
+++ b/assets/src/block-templates/homepage/block.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schemas.wp.org/trunk/block.json",
-  "apiVersion": 2,
+  "apiVersion": 3,
   "name": "planet4-block-templates/homepage",
   "title": "Homepage",
   "category": "planet4-block-templates",

--- a/assets/src/block-templates/issues/block.json
+++ b/assets/src/block-templates/issues/block.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schemas.wp.org/trunk/block.json",
-  "apiVersion": 2,
+  "apiVersion": 3,
   "name": "planet4-block-templates/issues",
   "title": "Issues",
   "category": "planet4-block-templates",

--- a/assets/src/block-templates/page-header/block.json
+++ b/assets/src/block-templates/page-header/block.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schemas.wp.org/trunk/block.json",
-  "apiVersion": 2,
+  "apiVersion": 3,
   "name": "planet4-block-templates/page-header",
   "title": "Page Header",
   "category": "planet4-block-templates",

--- a/assets/src/block-templates/quick-links/block.json
+++ b/assets/src/block-templates/quick-links/block.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schemas.wp.org/trunk/block.json",
-  "apiVersion": 2,
+  "apiVersion": 3,
   "name": "planet4-block-templates/quick-links",
   "title": "Quick Links",
   "category": "planet4-block-templates",

--- a/assets/src/block-templates/reality-check/block.json
+++ b/assets/src/block-templates/reality-check/block.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schemas.wp.org/trunk/block.json",
-  "apiVersion": 2,
+  "apiVersion": 3,
   "name": "planet4-block-templates/reality-check",
   "title": "Reality Check",
   "category": "planet4-block-templates",

--- a/assets/src/block-templates/side-image-with-text-and-cta/block.json
+++ b/assets/src/block-templates/side-image-with-text-and-cta/block.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schemas.wp.org/trunk/block.json",
-  "apiVersion": 2,
+  "apiVersion": 3,
   "name": "planet4-block-templates/side-image-with-text-and-cta",
   "title": "Side image with text and CTA",
   "category": "planet4-block-templates",

--- a/assets/src/block-templates/take-action/block.json
+++ b/assets/src/block-templates/take-action/block.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schemas.wp.org/trunk/block.json",
-  "apiVersion": 2,
+  "apiVersion": 3,
   "name": "planet4-block-templates/take-action",
   "title": "Take Action",
   "category": "planet4-block-templates",


### PR DESCRIPTION
### Description

See [PLANET-7201](https://jira.greenpeace.org/browse/PLANET-7201). This has been available since WP 6.3, see [docs](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-api-versions/). I don't see any difference 🤷‍♀️ 