### PR TITLE
PLANET-7656 Prepare for WordPress 6.7 upgrade

### DIFF
--- a/assets/src/blocks/ActionsList/index.js
+++ b/assets/src/blocks/ActionsList/index.js
@@ -20,7 +20,7 @@ export const registerActionsListBlock = () => {
     description: __('Integrate images and text cards to automatically display tags, take action pages, or Posts in a three or four column layout displayed in a grid or carousel.', 'planet4-blocks-backend'),
     icon: 'list-view',
     scope: ['inserter'],
-    allowedControls: ['taxQuery'],
+    allowedControls: ['taxQuery', 'pages', 'offset'],
     category: 'planet4-blocks-beta',
     isActive: ({namespace, query}) => namespace === ACTIONS_LIST_BLOCK_NAME && query.postType === queryPostType,
     attributes: {

--- a/assets/src/blocks/PostsList/index.js
+++ b/assets/src/blocks/PostsList/index.js
@@ -24,7 +24,7 @@ export const registerPostsListBlock = () => {
     description: __('Insert a list or grid of the latest articles, press releases, and/or publications, organized by publication date. ', 'planet4-blocks-backend'),
     category: 'planet4-blocks-beta',
     scope: ['inserter'],
-    allowedControls: ['taxQuery'],
+    allowedControls: ['taxQuery', 'pages', 'offset'],
     isActive: ({namespace, query}) => namespace === POSTS_LIST_BLOCK_NAME && query.postType === 'post',
     attributes: {
       namespace: POSTS_LIST_BLOCK_NAME,

--- a/assets/src/editorIndex.js
+++ b/assets/src/editorIndex.js
@@ -14,9 +14,6 @@ import {registerBlockVariations} from './block-variations';
 import {registerActionButtonTextBlock} from './blocks/ActionCustomButtonText';
 
 wp.domReady(() => {
-  // Make sure to unregister the posts-list native variation before registering planet4-blocks/posts-list
-  wp.blocks.unregisterBlockVariation('core/query', 'posts-list');
-
   // Blocks
   registerTableOfContentsBlock();
   registerColumnsBlock();

--- a/tests/e2e/navigation-bar.spec.js
+++ b/tests/e2e/navigation-bar.spec.js
@@ -7,7 +7,7 @@ test('Test navigation bar menu', async ({page, admin, requestUtils}) => {
   const testPageTitle = `Navbar test ${testId}`;
 
   // Create a new page with a dummy paragraph
-  await requestUtils.rest({
+  const newPage = await requestUtils.rest({
     path: '/wp/v2/pages',
     method: 'POST',
     data: {
@@ -30,14 +30,12 @@ test('Test navigation bar menu', async ({page, admin, requestUtils}) => {
   const pageOptions = page.locator('#add-post-type-page');
   await pageOptions.getByRole('checkbox', {name: testPageTitle}).first().check();
   await pageOptions.getByRole('button', {name: 'Add to Menu'}).click();
-  const newMenuItem = page.locator('.menu-item-depth-0', {hasText: testPageTitle});
-  await expect(newMenuItem).toBeVisible();
-  const newMenuItemLink = await newMenuItem.locator('.link-to-original a').getAttribute('href');
+  await page.locator('#menu-to-edit .menu-item-title').filter({hasText: testPageTitle}).waitFor();
   await page.getByRole('button', {name: 'Save Menu'}).click();
   await expect(page.locator('.updated.notice')).toBeVisible();
 
   // Check in the frontend that the new menu item is correctly added
   await page.goto('./');
   await expect(page.getByRole('link', {name: testPageTitle})).toBeVisible();
-  await expect(page.getByRole('link', {name: testPageTitle})).toHaveAttribute('href', newMenuItemLink);
+  await expect(page.getByRole('link', {name: testPageTitle})).toHaveAttribute('href', newPage.link);
 });

--- a/tests/e2e/tools/lib/post.js
+++ b/tests/e2e/tools/lib/post.js
@@ -9,6 +9,11 @@ import {expect} from './test-utils';
  * @return {Promise<string>} The URL of the published post.
  */
 async function publishPost({page, editor}) {
+  // We should be able to remove this check once we update Playwright to the latest version.
+  const closeSettingsSidebar = await page.getByRole('button', {name: 'Close Settings'});
+  if (await closeSettingsSidebar.isVisible()) {
+    await closeSettingsSidebar.click();
+  }
   await editor.publishPost();
 
   const urlString = await page


### PR DESCRIPTION
### Description

See [PLANET-7656](https://jira.greenpeace.org/browse/PLANET-7656)

**Related PRs:**
- https://github.com/greenpeace/planet4-base/pull/320
- https://github.com/greenpeace/planet4-develop/pull/47

**Changes made for the upgrade:**
- The core Posts List variation of the Query Loop block [has been removed](https://github.com/WordPress/gutenberg/pull/63404) so we don't need to unregister it anymore
- Some e2e tests were failing
- The Posts List and Actions List block no longer had the controls to set how many items to display, the offset and max number of pages... These [have been moved to the sidebar](https://github.com/WordPress/gutenberg/pull/58207) and we need to add them to the `allowedControls`.

**Things I noticed but don't need changes or I'm not sure they are problematic:**
- WordPress 6.7 adds `sizes=”auto”` for lazy-loaded images (see [here](https://make.wordpress.org/core/2024/10/18/auto-sizes-for-lazy-loaded-images-in-wordpress-6-7/)), I haven't seen it happen for our blocks though, maybe because we add our own `sizes` attribute?
- There is a [new setting](https://make.wordpress.org/core/2024/10/20/miscellaneous-block-editor-changes-in-wordpress-6-7/#new-preference-to-disable-the-choose-a-pattern-modal-when-adding-pages) in the editor preferences to hide the starter modal with our patterns, maybe some NROs don't use them and would be interested in this?
- We should be able to close [this bug ticket](https://jira.greenpeace.org/browse/PLANET-7040) after the upgrade (see comments there)

### Testing

You can update your local to the latest WordPress version (6.7.1) by running `npx wp-env run cli wp core update`. The [janus test instance](https://www-dev.greenpeace.org/test-janus/) used for this PR has already been updated.