### PR TITLE
PLANET-7694 Fix design issues in Posts List with carousel style

### DIFF
--- a/assets/src/scss/layout/_query-loop-overrides.scss
+++ b/assets/src/scss/layout/_query-loop-overrides.scss
@@ -1,12 +1,13 @@
 .p4-query-loop {
   & > .wp-block-group {
-    position: relative;
     padding: 0 !important;
+    width: 100%;
   }
 
   &.is-custom-layout-carousel {
     display: flex;
     flex-direction: column;
+    position: relative;
 
     & > p {
       margin: 0 0 48px 0 !important;


### PR DESCRIPTION
### Description

See [PLANET-7694](https://jira.greenpeace.org/browse/PLANET-7694)

These were an issue only in Posts. I know that the ticket also mentions the arrows and indicators showing even when there are not enough items to scroll, but I think I'll handle that in a different PR. These CSS-only changes are quick fixes and more urgent. 

### Testing

- [Broken version](https://www-dev.greenpeace.org/test-rhea/press/1113/duis-posuere-6/)
- [Fixed version](https://www-dev.greenpeace.org/test-telesto/press/1113/duis-posuere-6/)