### PR TITLE
Fix page header title font-weight

### DIFF
--- a/assets/src/scss/layout/_page-header.scss
+++ b/assets/src/scss/layout/_page-header.scss
@@ -141,7 +141,7 @@
 
 .page-header-title _-- {
   font-family: var(--font-family-heading);
-  font-weight: bold;
+  font-weight: var(--font-weight-regular);
   line-height: 1.5em;
   text-transform: none;
   max-width: 80%;


### PR DESCRIPTION
### Summary
Follow up with Houssam, we need to set the page header title `font-weight` to `regular` by default.

---

<!-- Please add a reference link to the ticket, if one exists. -->
Ref:  #2432 

### Testing
Go to the assigned instance https://www-dev.greenpeace.org/test-jupiter/get-informed/

![Screen Shot 2024-12-16 at 16 04 28](https://github.com/user-attachments/assets/e7b1c4f7-a8b5-41e8-86ea-08b3a8757f2d)
