### PR TITLE
Remove beta blocks that we won't migrate

### DIFF
--- a/exporter-helper.php
+++ b/exporter-helper.php
@@ -55,14 +55,6 @@ function get_attachments_used_in_content(string $content): array
                 }
                 break;
 
-            case 'planet4-blocks/social-media-cards':
-                if (isset($block['attrs']['cards'])) {
-                    foreach ($block['attrs']['cards'] as $card) {
-                        $attachment_ids[] = $card['image_id'];
-                    }
-                }
-                break;
-
             case 'planet4-blocks/take-action-boxout':
                 $attachment_ids[] = $block['attrs']['background_image'] ?? '';
                 break;

--- a/src/BlockSettings.php
+++ b/src/BlockSettings.php
@@ -11,8 +11,6 @@ use P4\MasterTheme\Settings\Features;
  */
 class BlockSettings
 {
-    private const BETA_BLOCKS_FEATURE = 'beta_blocks';
-
     private const ALL_BLOCKS_FEATURE = 'allow_all_blocks';
 
     private const CORE_BLOCKS_PREFIX = "core";
@@ -60,10 +58,6 @@ class BlockSettings
         self::GRAVITY_FORMS_BLOCK,
     ];
 
-    private const BETA_PAGE_BLOCK_TYPES = [
-        self::P4_BLOCKS_PREFIX . '/share-buttons',
-    ];
-
     private const CAMPAIGN_BLOCK_TYPES = [
         self::P4_BLOCKS_PREFIX . '/accordion',
         self::P4_BLOCKS_PREFIX . '/articles',
@@ -76,16 +70,10 @@ class BlockSettings
         self::P4_BLOCKS_PREFIX . '/happypoint',
         self::P4_BLOCKS_PREFIX . '/social-media',
         self::P4_BLOCKS_PREFIX . '/spreadsheet',
-        self::P4_BLOCKS_PREFIX . '/sub-pages',
         self::P4_BLOCKS_PREFIX . '/timeline',
         self::P4_BLOCKS_PREFIX . '/guestbook',
         self::HUBSPOT_FORMS_BLOCK,
         self::GRAVITY_FORMS_BLOCK,
-    ];
-
-    private const BETA_CAMPAIGN_BLOCK_TYPES = [
-        self::P4_BLOCKS_PREFIX . '/social-media-cards',
-        self::P4_BLOCKS_PREFIX . '/share-buttons',
     ];
 
     private const ACTION_BLOCK_TYPES = [
@@ -104,14 +92,8 @@ class BlockSettings
         self::P4_BLOCKS_PREFIX . '/take-action-boxout',
         self::P4_BLOCKS_PREFIX . '/timeline',
         self::P4_BLOCKS_PREFIX . '/guestbook',
-        self::P4_BLOCKS_PREFIX . '/sub-pages',
         self::HUBSPOT_FORMS_BLOCK,
         self::GRAVITY_FORMS_BLOCK,
-    ];
-
-    private const BETA_ACTION_BLOCK_TYPES = [
-        self::P4_BLOCKS_PREFIX . '/social-media-cards',
-        self::P4_BLOCKS_PREFIX . '/share-buttons',
     ];
 
     private const BLOCK_TEMPLATES = [
@@ -209,19 +191,16 @@ class BlockSettings
 
         $page_block_types = array_merge(
             self::PAGE_BLOCK_TYPES,
-            ! Features::is_active(self::BETA_BLOCKS_FEATURE) ? [] : self::BETA_PAGE_BLOCK_TYPES,
             self::BLOCK_TEMPLATES,
         );
 
         $campaign_block_types = array_merge(
             self::CAMPAIGN_BLOCK_TYPES,
-            ! Features::is_active(self::BETA_BLOCKS_FEATURE) ? [] : self::BETA_CAMPAIGN_BLOCK_TYPES,
             self::BLOCK_TEMPLATES,
         );
 
         $action_block_types = array_merge(
             self::ACTION_BLOCK_TYPES,
-            ! Features::is_active(self::BETA_BLOCKS_FEATURE) ? [] : self::BETA_ACTION_BLOCK_TYPES,
             self::BLOCK_TEMPLATES,
         );
 

--- a/src/Importer.php
+++ b/src/Importer.php
@@ -78,14 +78,6 @@ class Importer
                     }
                     break;
 
-                case 'planet4-blocks/social-media-cards':
-                    if (isset($block['attrs']['cards'])) {
-                        foreach ($block['attrs']['cards'] as $card) {
-                            $filter_data[] = 'image_id":' . $card['image_id'];
-                        }
-                    }
-                    break;
-
                 case 'planet4-blocks/take-action-boxout':
                     $filter_data[] = isset($block['attrs']['background_image'])
                         ? 'background_image":' . $block['attrs']['background_image'] : '';


### PR DESCRIPTION
### Description

See [PLANET-7635](https://jira.greenpeace.org/browse/PLANET-7635)

These blocks are `SubPages`, `ShareButtons`, and `SocialMediaCards`. We won't move them from the plugin to the theme.