### PR TITLE
Fix e2e tests without plugin

### DIFF
--- a/assets/src/js/cookies.js
+++ b/assets/src/js/cookies.js
@@ -1,8 +1,8 @@
 /* global dataLayer */
 export const setupCookies = () => {
   window.dataLayer = window.dataLayer || [];
-  const ENABLE_ANALYTICAL_COOKIES = window.p4bk_vars.enable_analytical_cookies;
-  const ENABLE_GOOGLE_CONSENT_MODE = window.p4bk_vars.enable_google_consent_mode;
+  const ENABLE_ANALYTICAL_COOKIES = window.p4_vars.options.enable_analytical_cookies;
+  const ENABLE_GOOGLE_CONSENT_MODE = window.p4_vars.options.enable_google_consent_mode;
 
   // Possible cookie values
   const ONLY_NECESSARY = '1';

--- a/src/MasterBlocks.php
+++ b/src/MasterBlocks.php
@@ -192,6 +192,7 @@ class MasterBlocks
             'new_ia' => $is_new_ia,
             'page_text_404' => planet4_get_option('404_page_text', ''),
             'page_bg_image_404' => planet4_get_option('404_page_bg_image', ''),
+            'cookies_field' => planet4_get_option('cookies_field', ''),
         ];
     }
 

--- a/tests/e2e/cookies-banner.spec.js
+++ b/tests/e2e/cookies-banner.spec.js
@@ -3,7 +3,7 @@ import {test, expect} from './tools/lib/test-utils.js';
 test('check cookies banner', async ({page}) => {
   await page.goto('./');
 
-  const cookiesText = await page.evaluate('window.p4bk_vars.cookies_field');
+  const cookiesText = await page.evaluate('window.p4_vars.options.cookies_field');
   expect(cookiesText).toBeDefined();
   const cookiesBanner = page.locator('#set-cookie');
   if (!cookiesText) {


### PR DESCRIPTION
### Description

See [PLANET-7635](https://jira.greenpeace.org/browse/PLANET-7635)

Some of them fail when the plugin is disabled, but we need to fix that since we will retire the plugin soon.

**Note:** the Related Posts test should be fixed once we merge https://github.com/greenpeace/planet4-master-theme/pull/2483
