### PR TITLE
PLANET-7657: Add support for Take Action pages

### DIFF
--- a/assets/src/block-editor/setupTaxonomyBreadcrumbBlock.js
+++ b/assets/src/block-editor/setupTaxonomyBreadcrumbBlock.js
@@ -42,13 +42,15 @@ function editFunction({attributes, context}) {
       const taxonomyField = taxonomy === 'category' ? 'categories' : taxonomy;
 
       let postTypeField = post_type;
+
       if(postTypeField === 'p4_multipost') {
         postTypeField = await wp.apiFetch({path: `/wp/v2/p4_multipost/${postId}`});
-      } else {
-        for(const type of [['post', 'posts'], ['page', 'pages']]) {
-          if(postTypeField === type[0]) {
-            postTypeField = type[1];
-          }
+      }
+
+      // Pluralize post types
+      for(const type of [['post', 'posts'], ['page', 'pages']]) {
+        if(postTypeField === type[0]) {
+          postTypeField = type[1];
         }
       }
 

--- a/assets/src/block-editor/setupTaxonomyBreadcrumbBlock.js
+++ b/assets/src/block-editor/setupTaxonomyBreadcrumbBlock.js
@@ -36,19 +36,25 @@ function editFunction({attributes, context}) {
   const [term, setTerm] = wp.element.useState(null);
 
   wp.element.useEffect(() => {
-    if (!postId || !taxonomy || !post_type) {return;}
+    (async () => {
+      if (!postId || !taxonomy || !post_type) {return;}
 
-    const postTypeField = post_type === 'post' ? 'posts' : post_type;
-    const taxonomyField = taxonomy === 'category' ? 'categories' : taxonomy;
+      const taxonomyField = taxonomy === 'category' ? 'categories' : taxonomy;
+      let postTypeField = post_type === 'post' ? 'posts' : post_type;
 
-    wp.apiFetch({path: `/wp/v2/${postTypeField}/${postId}`}).then(post => {
-      const termIds = post[taxonomyField];
-      if (termIds && termIds.length > 0) {
-        wp.apiFetch({path: `/wp/v2/${taxonomyField}/${termIds[0]}`}).then(termData => {
-          setTerm(termData.name);
-        });
+      if(post_type === 'p4_multipost') {
+        postTypeField = await wp.apiFetch({path: `/wp/v2/p4_multipost/${postId}`});
       }
-    });
+
+      wp.apiFetch({path: `/wp/v2/${postTypeField}/${postId}`}).then(post => {
+        const termIds = post[taxonomyField];
+        if (termIds && termIds.length > 0) {
+          wp.apiFetch({path: `/wp/v2/${taxonomyField}/${termIds[0]}`}).then(termData => {
+            setTerm(termData.name);
+          });
+        }
+      });
+    })();
   }, [postId, taxonomy]);
 
   const linkAttrs = {href: '', onClick: e => e.preventDefault()};

--- a/assets/src/block-editor/setupTaxonomyBreadcrumbBlock.js
+++ b/assets/src/block-editor/setupTaxonomyBreadcrumbBlock.js
@@ -68,8 +68,8 @@ function editFunction({attributes, context}) {
   const linkAttrs = {href: '', onClick: e => e.preventDefault()};
   const contentAttrs = {className: 'taxonomy-category wp-block-post-terms'};
 
-  const link = wp.element.createElement('a', linkAttrs, term || 'Loading...');
-  const content = wp.element.createElement('div', contentAttrs, link);
+  const link = term ? wp.element.createElement('a', linkAttrs, term || 'Loading...') : null;
+  const content = link ? wp.element.createElement('div', contentAttrs, link) : null;
 
   return content;
 }

--- a/assets/src/block-editor/setupTaxonomyBreadcrumbBlock.js
+++ b/assets/src/block-editor/setupTaxonomyBreadcrumbBlock.js
@@ -40,10 +40,16 @@ function editFunction({attributes, context}) {
       if (!postId || !taxonomy || !post_type) {return;}
 
       const taxonomyField = taxonomy === 'category' ? 'categories' : taxonomy;
-      let postTypeField = post_type === 'post' ? 'posts' : post_type;
 
-      if(post_type === 'p4_multipost') {
+      let postTypeField = post_type;
+      if(postTypeField === 'p4_multipost') {
         postTypeField = await wp.apiFetch({path: `/wp/v2/p4_multipost/${postId}`});
+      } else {
+        for(const type of [['post', 'posts'], ['page', 'pages']]) {
+          if(postTypeField === type[0]) {
+            postTypeField = type[1];
+          }
+        }
       }
 
       wp.apiFetch({path: `/wp/v2/${postTypeField}/${postId}`}).then(post => {

--- a/assets/src/blocks/ActionsList/index.js
+++ b/assets/src/blocks/ActionsList/index.js
@@ -66,7 +66,7 @@ export const registerActionsListBlock = () => {
         ['core/group', {}, [
           [TAX_BREADCRUMB_BLOCK_NAME, {
             taxonomy: LISTS_BREADCRUMBS[0].value,
-            post_type: queryPostType,
+            post_type: postType,
           }],
           ['core/post-title', {isLink: true}],
           ['core/post-excerpt'],

--- a/assets/src/blocks/ActionsList/index.js
+++ b/assets/src/blocks/ActionsList/index.js
@@ -12,11 +12,7 @@ export const ACTIONS_LIST_LAYOUT_TYPES = [
 export const registerActionsListBlock = () => {
   const {registerBlockVariation} = wp.blocks;
   const {__} = wp.i18n;
-
-  const IS_NEW_IA = window.p4_vars.options.new_ia;
-  const ACT_PAGE = window.p4_vars.options.take_action_page || -1;
-
-  const queryPostType = IS_NEW_IA ? 'p4_action' : 'page';
+  const postType = 'p4_query_loop_interceptor';
 
   registerBlockVariation('core/query', {
     name: ACTIONS_LIST_BLOCK_NAME,
@@ -26,7 +22,7 @@ export const registerActionsListBlock = () => {
     scope: ['inserter'],
     allowedControls: ['taxQuery', 'pages', 'offset'],
     category: 'planet4-blocks-beta',
-    isActive: ({namespace, query}) => namespace === ACTIONS_LIST_BLOCK_NAME && query.postType === queryPostType,
+    isActive: ({namespace, query}) => namespace === ACTIONS_LIST_BLOCK_NAME && query.postType === postType,
     attributes: {
       namespace: ACTIONS_LIST_BLOCK_NAME,
       className: 'actions-list p4-query-loop is-custom-layout-grid',
@@ -34,17 +30,14 @@ export const registerActionsListBlock = () => {
         pages: 0,
         perPage: 3,
         offset: 0,
-        order: 'desc',
-        orderBy: 'date',
         author: '',
         search: '',
         exclude: [],
         sticky: '',
         inherit: false,
-        postType: queryPostType,
+        postType,
         postIn: [],
         hasPassword: false,
-        ...!IS_NEW_IA && {postParent: ACT_PAGE},
       },
       layout: {
         type: 'grid',

--- a/assets/src/blocks/ActionsList/index.js
+++ b/assets/src/blocks/ActionsList/index.js
@@ -12,7 +12,7 @@ export const ACTIONS_LIST_LAYOUT_TYPES = [
 export const registerActionsListBlock = () => {
   const {registerBlockVariation} = wp.blocks;
   const {__} = wp.i18n;
-  const postType = 'p4_query_loop_interceptor';
+  const postType = 'p4_multipost';
 
   registerBlockVariation('core/query', {
     name: ACTIONS_LIST_BLOCK_NAME,

--- a/functions.php
+++ b/functions.php
@@ -102,6 +102,7 @@ add_action(
         Api\Settings::register_endpoint();
         Api\AnalyticsValues::register_endpoint();
         Api\Tracking::register_endpoint();
+        Api\QueryLoopExtension::register_endpoint();
     }
 );
 

--- a/src/Api/QueryLoopExtension.php
+++ b/src/Api/QueryLoopExtension.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace P4\MasterTheme\Api;
 
 use WP_REST_Response;
+use WP_REST_Request;
 
 /**
  * Instance QueryLoopExtension API
@@ -26,8 +27,13 @@ class QueryLoopExtension
             '/p4_multipost/(?P<id>\d+)',
             [
                 'methods' => 'GET',
-                'callback' => function () {
-                    return new WP_REST_Response([], 200);
+                'callback' => function (WP_REST_Request $request) {
+                    global $wpdb;
+                    $post_type = $wpdb->get_col($wpdb->prepare(
+                        "SELECT post_type FROM {$wpdb->posts} WHERE ID = %s",
+                        $request->get_param('id')
+                    ));
+                    return new WP_REST_Response($post_type[0] ?? "", 200);
                 },
                 'permission_callback' => '__return_true',
             ]

--- a/src/Api/QueryLoopExtension.php
+++ b/src/Api/QueryLoopExtension.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace P4\MasterTheme\Api;
+
+use WP_REST_Response;
+
+/**
+ * Instance QueryLoopExtension API
+ */
+class QueryLoopExtension
+{
+    /**
+     * Register endpoint to avoid 404 response when fetching multiples
+     * posts within the Actions List block.
+     * Please check /src/Blocks/QueryLoopExtension.php for more reference.
+     *
+     * @example GET /wp-json/wp/v2/p4_multipost/193
+     */
+
+    public static function register_endpoint(): void
+    {
+        register_rest_route(
+            'wp/v2',
+            '/p4_multipost/(?P<id>\d+)',
+            [
+                'methods' => 'GET',
+                'callback' => function () {
+                    return new WP_REST_Response([], 200);
+                },
+                'permission_callback' => '__return_true',
+            ]
+        );
+    }
+}

--- a/src/Blocks/QueryLoopExtension.php
+++ b/src/Blocks/QueryLoopExtension.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace P4\MasterTheme\Blocks;
 
+use WP_REST_Request;
+
 /**
  * Handle Posts/Actions List block manual override query with custom `postIn` filter.
  * `include` is not used because it generates some issues with getEntityRecords filters.
@@ -19,11 +21,10 @@ class QueryLoopExtension
 
     public static function registerEditorQuery(): void
     {
-
         // This is used to handle Actions List block with multiple Post Types
         register_post_type('p4_multipost', [
-            'label' => 'P4 Query Loop Interceptor',
-            'description' => 'This post type is used to filter filter queries since arrays are not supported natively.',
+            'label' => 'P4 multipost',
+            'description' => 'This post type is used to filter queries since arrays are not supported natively.',
             'public' => false,
             'show_ui' => false,
             'show_in_rest' => true,
@@ -62,12 +63,12 @@ class QueryLoopExtension
     /**
      * Filter the query to include the postIn and hasPassword parameters
      *
-     * @param array $args The query
-     * @param array $request The request
+     * @param array           $args The query
+     * @param WP_REST_Request $request The request
      *
      * @return array The new parsed query
      */
-    public static function postInFilter(array $args, array $request): array
+    public static function postInFilter(array $args, WP_REST_Request $request): array
     {
         $postIn = $request->get_param('postIn');
         if (!empty($postIn)) {

--- a/src/Blocks/QueryLoopExtension.php
+++ b/src/Blocks/QueryLoopExtension.php
@@ -19,22 +19,24 @@ class QueryLoopExtension
 
     public static function registerEditorQuery(): void
     {
-        $postInFilter = function ($args, $request) {
-            $postIn = $request->get_param('postIn');
-            if (!empty($postIn)) {
-                $args['post__in'] = array_map('intval', (array) $postIn);
-                $args['orderby'] = 'post__in';
-            }
-            if ($request->has_param('hasPassword')) {
-                $hasPassword = $request->get_param('hasPassword');
-                $args['has_password'] = $hasPassword !== false && $hasPassword !== 'false';
-            }
-            return $args;
-        };
+        // This is used to handle Actions List block with multiple Post Types
+        register_post_type('p4_query_loop_interceptor', [
+            'label' => 'P4 Query Loop Interceptor',
+            'description' => 'This post type is used to filter filter queries since arrays are not supported natively.',
+            'public' => false,
+            'show_ui' => false,
+            'show_in_rest' => true,
+            'capability_type' => 'post',
+            'supports' => [],
+            'query_var' => false,
+        ]);
 
-        add_filter('rest_post_query', $postInFilter, 10, 2);
-        add_filter('rest_page_query', $postInFilter, 10, 2);
-        add_filter('rest_p4_action_query', $postInFilter, 10, 2);
+        add_filter('rest_post_query', [self::class, 'postInFilter'], 10, 2);
+        add_filter('rest_page_query', [self::class, 'postInFilter'], 10, 2);
+        add_filter('rest_p4_action_query', [self::class, 'postInFilter'], 10, 2);
+        add_filter('rest_p4_query_loop_interceptor_query', function ($query, $request) {
+            return self::sanitizePostTypes($query, $request->get_params());
+        }, 10, 2);
     }
 
     public static function registerFrontendQuery(): void
@@ -42,18 +44,93 @@ class QueryLoopExtension
         add_filter(
             'query_loop_block_query_vars',
             function ($query, $block) {
-                $blockQuery = $block->context['query'] ?? [];
-                if (!empty($blockQuery['postIn'])) {
-                    $query['post__in'] = array_map('intval', (array) $blockQuery['postIn']);
-                    $query['orderby'] = 'post__in';
+                if ($block->context['query']['postType'] === 'p4_query_loop_interceptor') {
+                    return self::sanitizePostTypes(
+                        $query,
+                        $block->context['query'],
+                    );
                 }
-                if (isset($blockQuery['hasPassword'])) {
-                    $query['has_password'] = (bool) $blockQuery['hasPassword'];
-                }
+
                 return $query;
             },
             10,
             2
         );
+    }
+
+    /**
+     * Filter the query to include the postIn and hasPassword parameters
+     *
+     * @param array $args The query
+     * @param array $request The request
+     *
+     * @return array The new parsed query
+     */
+    public static function postInFilter(array $args, array $request): array
+    {
+        $postIn = $request->get_param('postIn');
+        if (!empty($postIn)) {
+            $args['post__in'] = array_map('intval', (array) $postIn);
+            $args['orderby'] = 'post__in';
+        }
+        if ($request->has_param('hasPassword')) {
+            $hasPassword = $request->get_param('hasPassword');
+            $args['has_password'] = $hasPassword !== false && $hasPassword !== 'false';
+        }
+        return $args;
+    }
+
+    /**
+     * Sanitize the query received by the editor and frontend
+     *
+     * @param array $query The query
+     * @param array $params The query or request params
+     *
+     * @return array The new parsed query
+     */
+    public static function sanitizePostTypes(array $query, array $params = []): array
+    {
+        $is_new_ia = !empty(planet4_get_option('new_ia'));
+        $query['post_status'] = 'publish';
+
+        if (!$is_new_ia) {
+            $query['post_type'] = ['page'];
+            $query['post_parent'] = planet4_get_option('act_page');
+
+            if (!empty($params['postIn'])) {
+                $query['post__in'] = array_map('intval', (array) $params['postIn']);
+            }
+        } else {
+            $query['post_type'] = ['page', 'p4_action'];
+
+            global $wpdb;
+            $post_ids = $wpdb->get_col($wpdb->prepare(
+                "
+                (SELECT ID FROM {$wpdb->posts} WHERE post_type = %s)
+                UNION ALL
+                (SELECT ID FROM {$wpdb->posts} WHERE post_type = %s AND post_parent = %d)",
+                'p4_action',
+                'page',
+                planet4_get_option('take_action_page')
+            ));
+
+            if (!empty($post_ids)) {
+                $query['post__in'] = $post_ids;
+            } else {
+                $query['post__in'] = [0];
+            }
+
+            if (!empty($params['hasPassword'])) {
+                $query['has_password'] = $params['hasPassword'] !== false && $params['hasPassword'] !== 'false';
+            }
+
+            $query['orderby'] = [
+                'menu_order' => 'ASC',
+                'post_date' => 'DESC',
+                'post_title' => 'ASC',
+                'post__in' => 'ASC',
+            ];
+        }
+        return $query;
     }
 }

--- a/src/Blocks/QueryLoopExtension.php
+++ b/src/Blocks/QueryLoopExtension.php
@@ -19,8 +19,9 @@ class QueryLoopExtension
 
     public static function registerEditorQuery(): void
     {
+
         // This is used to handle Actions List block with multiple Post Types
-        register_post_type('p4_query_loop_interceptor', [
+        register_post_type('p4_multipost', [
             'label' => 'P4 Query Loop Interceptor',
             'description' => 'This post type is used to filter filter queries since arrays are not supported natively.',
             'public' => false,
@@ -34,7 +35,7 @@ class QueryLoopExtension
         add_filter('rest_post_query', [self::class, 'postInFilter'], 10, 2);
         add_filter('rest_page_query', [self::class, 'postInFilter'], 10, 2);
         add_filter('rest_p4_action_query', [self::class, 'postInFilter'], 10, 2);
-        add_filter('rest_p4_query_loop_interceptor_query', function ($query, $request) {
+        add_filter('rest_p4_multipost_query', function ($query, $request) {
             return self::sanitizePostTypes($query, $request->get_params());
         }, 10, 2);
     }
@@ -44,7 +45,7 @@ class QueryLoopExtension
         add_filter(
             'query_loop_block_query_vars',
             function ($query, $block) {
-                if ($block->context['query']['postType'] === 'p4_query_loop_interceptor') {
+                if ($block->context['query']['postType'] === 'p4_multipost') {
                     return self::sanitizePostTypes(
                         $query,
                         $block->context['query'],

--- a/src/Blocks/QueryLoopExtension.php
+++ b/src/Blocks/QueryLoopExtension.php
@@ -97,24 +97,29 @@ class QueryLoopExtension
 
         if (!$is_new_ia) {
             $query['post_type'] = ['page'];
-            $query['post_parent'] = planet4_get_option('act_page');
+            $query['post_parent'] = !empty(planet4_get_option('act_page'))
+                ? planet4_get_option('act_page')
+                : -1;
 
             if (!empty($params['postIn'])) {
                 $query['post__in'] = array_map('intval', (array) $params['postIn']);
             }
         } else {
             $query['post_type'] = ['page', 'p4_action'];
+            $post_ids = [];
 
-            global $wpdb;
-            $post_ids = $wpdb->get_col($wpdb->prepare(
-                "
-                (SELECT ID FROM {$wpdb->posts} WHERE post_type = %s)
-                UNION ALL
-                (SELECT ID FROM {$wpdb->posts} WHERE post_type = %s AND post_parent = %d)",
-                'p4_action',
-                'page',
-                planet4_get_option('take_action_page')
-            ));
+            if (!empty(planet4_get_option('take_action_page'))) {
+                global $wpdb;
+                $post_ids = $wpdb->get_col($wpdb->prepare(
+                    "
+                    (SELECT ID FROM {$wpdb->posts} WHERE post_type = %s)
+                    UNION ALL
+                    (SELECT ID FROM {$wpdb->posts} WHERE post_type = %s AND post_parent = %d)",
+                    'p4_action',
+                    'page',
+                    planet4_get_option('take_action_page')
+                ));
+            }
 
             if (!empty($post_ids)) {
                 $query['post__in'] = $post_ids;

--- a/src/Blocks/QueryLoopExtension.php
+++ b/src/Blocks/QueryLoopExtension.php
@@ -105,21 +105,24 @@ class QueryLoopExtension
                 $query['post__in'] = array_map('intval', (array) $params['postIn']);
             }
         } else {
-            $query['post_type'] = ['page', 'p4_action'];
-            $post_ids = [];
+            global $wpdb;
 
-            if (!empty(planet4_get_option('take_action_page'))) {
-                global $wpdb;
-                $post_ids = $wpdb->get_col($wpdb->prepare(
-                    "
-                    (SELECT ID FROM {$wpdb->posts} WHERE post_type = %s)
-                    UNION ALL
-                    (SELECT ID FROM {$wpdb->posts} WHERE post_type = %s AND post_parent = %d)",
-                    'p4_action',
-                    'page',
-                    planet4_get_option('take_action_page')
-                ));
-            }
+            $query['post_type'] = ['page', 'p4_action'];
+
+            $post_parent = !empty(planet4_get_option('take_action_page'))
+                ? planet4_get_option('take_action_page')
+                : -1;
+
+            $post_ids = [];
+            $post_ids = $wpdb->get_col($wpdb->prepare(
+                "
+                (SELECT ID FROM {$wpdb->posts} WHERE post_type = %s)
+                UNION ALL
+                (SELECT ID FROM {$wpdb->posts} WHERE post_type = %s AND post_parent = %d)",
+                'p4_action',
+                'page',
+                $post_parent,
+            ));
 
             if (!empty($post_ids)) {
                 $query['post__in'] = $post_ids;

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -202,6 +202,8 @@ final class Loader
             return;
         }
 
+        Blocks\QueryLoopExtension::registerHooks();
+
         new MasterBlocks();//NOSONAR
         new Blocks\Accordion();//NOSONAR
         new Blocks\CarouselHeader();//NOSONAR
@@ -229,7 +231,6 @@ final class Loader
 
         new Blocks\ActionButtonText();//NOSONAR
 
-        Blocks\QueryLoopExtension::registerHooks();
         add_filter(
             'allowed_block_types_all',
             function ($allowed_block_types) {


### PR DESCRIPTION
### Summary

The ActionsList block might render the same content as the Covers block.

[Demo page as a reference](https://www-dev.greenpeace.org/test-pandora/support-to-ta-pages-demo-page/)

Also play around with [this page](https://www-dev.greenpeace.org/test-pandora/take-action/page-with-act-parent/) and change its parent to `Act` or `Take Action`. The block should follows the expected behavior.

---

<!-- Please add a reference link to the ticket, if one exists. -->
Ref: https://jira.greenpeace.org/browse/PLANET-7657

### Testing

<!-- Please add the steps required to test the changes in this Pull Request. -->
1. Create a new page
2. Add two blocks: ActionsList and Cover which will be needed to compare content

Then check:
1. it's disabled, we should only fetch children pages of the page that is assigned as "Act Page" (same as the current Covers block).
2. If it's enabled, we should fetch Actions (we already do that) but also the children pages of the page that is assigned as "Take Action Page"

### Updates
Unfortunately the query loop from editor doesn't accept to pass an array of post types.
- if `IA` is `false` and post type is equal to `"page"`, then endpoint is pointed to `/wp-json/wp/v2/taxonomies`
- if `IA` is `true` and post type is equal to `"p4_action"`, then endpoint is pointed to `/wp-json/wp/v2/p4_action`
- if `IA` is `true|false` and post type is equal to an array of post types (like `["p4_action", "page"]`), then the enpoint is pointed to `/wp-json/wp/v2/types/p4_action,page`

#### Native behavior:
`/wp/v2/types`: returns all public post types
`/wp/v2/types/post`:returns info about the post post type
`/wp/v2/types/post,page`: will return a 404
