### PR TITLE
PLANET-7489: Check number of columns in the P4 columns block

### DIFF
--- a/src/BlockReportSearch/Block/BlockUsageTable.php
+++ b/src/BlockReportSearch/Block/BlockUsageTable.php
@@ -473,9 +473,9 @@ class BlockUsageTable extends WP_List_Table
      */
     public function column_block_attrs($item): string
     {
-        $content = $item['block_attrs'] ?? "";
+        $content = $item['block_attrs'] ?? null;
         if (empty($content)) {
-            return $content;
+            return '';
         }
 
 		//phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r , Squiz.PHP.DiscouragedFunctions.Discouraged

--- a/src/BlockReportSearch/Block/BlockUsageTable.php
+++ b/src/BlockReportSearch/Block/BlockUsageTable.php
@@ -473,9 +473,9 @@ class BlockUsageTable extends WP_List_Table
      */
     public function column_block_attrs($item): string
     {
-        $content = $item['block_attrs'] ?? null;
+        $content = $item['block_attrs'] ?? "";
         if (empty($content)) {
-            return '';
+            return $content;
         }
 
 		//phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r , Squiz.PHP.DiscouragedFunctions.Discouraged

--- a/src/BlockReportSearch/Block/BlockUsageTable.php
+++ b/src/BlockReportSearch/Block/BlockUsageTable.php
@@ -272,6 +272,12 @@ class BlockUsageTable extends WP_List_Table
             'post_status' => 'Status',
         ];
 
+        // This is a temporary fix to identify problems with the columns migrated here:
+        // https://jira.greenpeace.org/browse/PLANET-7489
+        if (isset($_GET['name']) && $_GET['name'] === 'planet4-blocks/columns') {
+            $default_columns['block_cols'] = 'Columns';
+        }
+
         $this->columns = array_merge(
             [ $this->group_by => $default_columns[ $this->group_by ] ],
             $default_columns
@@ -485,6 +491,33 @@ class BlockUsageTable extends WP_List_Table
                 : $content
             )
         );
+    }
+
+    /**
+     * Add the number of columns to the table.
+     *
+     * This is a temporary fix to identify problems with the columns migrated here:
+     * https://jira.greenpeace.org/browse/PLANET-7489
+     * We need this function to identify P4 columns blocks using more than 4 columns.
+     *
+     * @param array $item Item.
+     * @phpcs:disable SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
+     */
+    public function column_block_cols($item): string
+    {
+        $content = $item['block_attrs'] ?? null;
+
+        if (empty($content)) {
+            return '';
+        }
+
+        $cols = $content['columns'] ? count($content['columns']) : '0';
+
+        if ($cols > 4) {
+            return "<span style='color: red;'>$cols - Fix needed!</span>";
+        }
+
+        return (string)$cols;
     }
 
     /**


### PR DESCRIPTION
### Summary

This is a temporary fix to solve the issue mentioned by Kelli in the ticket [PLANET-7489](https://jira.greenpeace.org/browse/PLANET-7489).
This PR adds an additional column to the Blocks Report page only once the P4 Columns block is selected, to show the number of columns for each block. If more than 4 columns were added to the block (the maximum allowed) a warning message is shown.

![Report-‹-Greenpeace-—-WordPress](https://github.com/user-attachments/assets/4fce4c7a-891a-4245-81e7-54eb16a3d330)
---

<!-- Please add a reference link to the ticket, if one exists. -->
Ref: https://jira.greenpeace.org/browse/PLANET-7489 

### Testing

1. Go to the Blocks Report page (`/wp-admin/admin.php?page=plugin_blocks_report`)
2. Filter only P4 Columns block.
3. Check the Columns table's column.
4. Check if there are blocks using more than 4 columns. If so, a warning should be shown. If not, create a new page, add the following block code and check the report again:

``` 
<!-- wp:planet4-blocks/columns {"columns_title":"Test Column","columns":[{"title":"Column A","description":"This is a test description","cta_text":"A test button!"},{"title":"Column B","cta_text":"A test button!","description":"This is a test description"},{"title":"Column C","cta_text":"A test button!","description":"This is a test description"},{"title":"Column D","cta_text":"A test button!","description":"This is a test description"},{"title":"Column E","description":"This is a test description","attachment":0,"cta_link":"","cta_text":"A test button!","link_new_tab":false}],"className":"is-style-no_image"} /-->
``` 