### PR TITLE
PLANET-7729: Fix Carousel interval issue

### DIFF
--- a/assets/src/blocks/Covers/CoversCarouselLayout.js
+++ b/assets/src/blocks/Covers/CoversCarouselLayout.js
@@ -5,7 +5,7 @@ const {__} = wp.i18n;
 export const CoversCarouselLayout = ({covers, amountOfCoversPerRow, ...props}) => {
   const uniqueId = `covers-${uuid()}`;
   return (
-    <div id={uniqueId} className="carousel slide" data-bs-ride="carousel" data-bs-interval="false">
+    <div id={uniqueId} className="carousel slide" data-bs-ride="carousel">
       {covers.length > amountOfCoversPerRow &&
         <ol className="carousel-indicators">
           {covers.map((cover, index) => {


### PR DESCRIPTION
By removing this attr the Carousel stops sliding crazily

### Summary

<!-- Please provide a brief summary of the change introduced in this Pull Request. -->

---

<!-- Please add a reference link to the ticket, if one exists. -->
Ref: https://jira.greenpeace.org/browse/PLANET-7729?

### Testing

<!-- Please add the steps required to test the changes in this Pull Request. -->
1. Create a new page
2. Add the Covers block into that
3. Preview the page and then the Covers Block might work normally
