### PR TITLE
Fix <ol> selector issue

### DIFF
--- a/assets/src/scss/blocks/Covers/layouts/CoversCarouselLayout.scss
+++ b/assets/src/scss/blocks/Covers/layouts/CoversCarouselLayout.scss
@@ -55,6 +55,7 @@
 
     .carousel-indicators {
       top: calc(100% + #{$sp-2});
+      list-style: none;
 
       li {
         width: 24px;


### PR DESCRIPTION
### Summary

The carousel indicator numbers are visible and might be hidde and it is happening only in Chrome.

![Screen Shot 2025-01-16 at 09 49 18](https://github.com/user-attachments/assets/fe1b2243-ef03-4e0b-b44f-0e77a4811fa0)


---

<!-- Please add a reference link to the ticket, if one exists. -->
Ref: 

### Testing

<!-- Please add the steps required to test the changes in this Pull Request. -->
1. Go to the assigned [demo page](https://www-dev.greenpeace.org/test-phoebe/fix-covers-block-layout-issue/)
3. Check if the carousel indicator numbers are hidden
4. Ideally confirm on Chrome but could be great if there is another browser to test. Besides Chrome, I've also tested on FF and Safari.
