### PR TITLE
Register footer menus as theme locations

### DIFF
--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -740,7 +740,7 @@ class MasterSite extends TimberSite
             $footer_social_menu = new TimberMenu('footer-social-menu');
             $context['footer_social_menu'] = $footer_social_menu->get_items();
         } else {
-            $context['footer_primary_menu'] = wp_get_nav_menu_items('Footer Social');
+            $context['footer_social_menu'] = wp_get_nav_menu_items('Footer Social');
         }
 
         if (has_nav_menu('footer-primary-menu')) {
@@ -749,8 +749,7 @@ class MasterSite extends TimberSite
         } else {
             $context['footer_primary_menu'] = wp_get_nav_menu_items('Footer Primary');
         }
-
-
+        
         if (has_nav_menu('footer-secondary-menu')) {
             $footer_secondary_menu = new TimberMenu('footer-secondary-menu');
             $context['footer_secondary_menu'] = $footer_secondary_menu->get_items();

--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -739,16 +739,14 @@ class MasterSite extends TimberSite
         if (has_nav_menu('footer-social-menu')) {
             $footer_social_menu = new TimberMenu('footer-social-menu');
             $context['footer_social_menu'] = $footer_social_menu->get_items();
-        }
-        else {
+        } else {
             $context['footer_primary_menu'] = wp_get_nav_menu_items('Footer Social');
         }
 
         if (has_nav_menu('footer-primary-menu')) {
             $footer_primary_menu = new TimberMenu('footer-primary-menu');
             $context['footer_primary_menu'] = $footer_primary_menu->get_items();
-        }
-        else {
+        } else {
             $context['footer_primary_menu'] = wp_get_nav_menu_items('Footer Primary');
         }
 
@@ -756,8 +754,7 @@ class MasterSite extends TimberSite
         if (has_nav_menu('footer-secondary-menu')) {
             $footer_secondary_menu = new TimberMenu('footer-secondary-menu');
             $context['footer_secondary_menu'] = $footer_secondary_menu->get_items();
-        }
-        else {
+        } else {
             $context['footer_secondary_menu'] = wp_get_nav_menu_items('Footer Secondary');
         }
 

--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -159,6 +159,9 @@ class MasterSite extends TimberSite
             [
                 'navigation-bar-menu' => __('Navigation Bar Menu', 'planet4-master-theme-backend'),
                 'donate-menu' => __('Donate Button', 'planet4-master-theme-backend'),
+                'footer-primary-menu' => __('Footer Primary Menu', 'planet4-master-theme-backend'),
+                'footer-secondary-menu' => __('Footer Secondary Menu', 'planet4-master-theme-backend'),
+                'footer-social-menu' => __('Footer Social Menu', 'planet4-master-theme-backend'),
             ]
         );
 
@@ -732,9 +735,32 @@ class MasterSite extends TimberSite
         // Footer context.
         $context['copyright_text_line1'] = $options['copyright_line1'] ?? '';
         $context['copyright_text_line2'] = $options['copyright_line2'] ?? '';
-        $context['footer_social_menu'] = wp_get_nav_menu_items('Footer Social');
-        $context['footer_primary_menu'] = wp_get_nav_menu_items('Footer Primary');
-        $context['footer_secondary_menu'] = wp_get_nav_menu_items('Footer Secondary');
+
+        if (has_nav_menu('footer-social-menu')) {
+            $footer_social_menu = new TimberMenu('footer-social-menu');
+            $context['footer_social_menu'] = $footer_social_menu->get_items();
+        }
+        else {
+            $context['footer_primary_menu'] = wp_get_nav_menu_items('Footer Social');
+        }
+
+        if (has_nav_menu('footer-primary-menu')) {
+            $footer_primary_menu = new TimberMenu('footer-primary-menu');
+            $context['footer_primary_menu'] = $footer_primary_menu->get_items();
+        }
+        else {
+            $context['footer_primary_menu'] = wp_get_nav_menu_items('Footer Primary');
+        }
+
+
+        if (has_nav_menu('footer-secondary-menu')) {
+            $footer_secondary_menu = new TimberMenu('footer-secondary-menu');
+            $context['footer_secondary_menu'] = $footer_secondary_menu->get_items();
+        }
+        else {
+            $context['footer_secondary_menu'] = wp_get_nav_menu_items('Footer Secondary');
+        }
+
         // Default depth level set to 1 if not selected from admin.
         $context['p4_comments_depth'] = get_option('thread_comments_depth') ?? 1;
 


### PR DESCRIPTION


### Summary

Register footer menus so they are available as positions in WordPress admin. 

Currently, the menus in the footer (Footer Primary, Footer Secondary, Social) are only defined by naming convention. That doesn't work for multilingual setups because menu names are unique and menus that work with the master theme can not be created in more than one language at a time. Registering the menu as theme locations  enabled the use of WordPress admin to select what menus to show in the footer, independent of menu names.

If no menu is set for the location, the old naming convention is still in use to ensure backwards compatibility.

### Testing

1.  Make sure existing menus are still shown in the footer after installing this update (backwards compatibility)
2. Create or edit menus and assign them to the appropriate theme locations
3. Make sure the menus display correctly
