### PR TITLE
PLANET-7647 Enforce consistency on default favicon

### DIFF
--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -249,6 +249,9 @@ class MasterSite extends TimberSite
         add_action(
             'customize_register',
             function ($wp_customize): void {
+                // Remove site icon customization.
+                $wp_customize->remove_control('site_icon');
+
                 if (!defined('WP_APP_ENV') || ( 'production' !== WP_APP_ENV && 'staging' !== WP_APP_ENV )) {
                     return;
                 }

--- a/src/Migrations/M038RemoveCustomSiteIcon.php
+++ b/src/Migrations/M038RemoveCustomSiteIcon.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace P4\MasterTheme\Migrations;
+
+use P4\MasterTheme\MigrationRecord;
+use P4\MasterTheme\MigrationScript;
+
+/**
+ * Remove custom site icon, since we disabled the option to customize it.
+ */
+class M038RemoveCustomSiteIcon extends MigrationScript
+{
+    /**
+     * Perform the actual migration.
+     *
+     * @param MigrationRecord $record Information on the execution, can be used to add logs.
+     * phpcs:disable SlevomatCodingStandard.Functions.UnusedParameter -- interface implementation
+     */
+    protected static function execute(MigrationRecord $record): void
+    {
+        if (!has_site_icon()) {
+            return;
+        }
+        update_option('site_icon', '');
+    }
+    // phpcs:enable SlevomatCodingStandard.Functions.UnusedParameter
+}

--- a/src/Migrator.php
+++ b/src/Migrator.php
@@ -39,6 +39,7 @@ use P4\MasterTheme\Migrations\M034PrePopulateOldPostsArchiveNotice;
 use P4\MasterTheme\Migrations\M035MigrateCampaignCoversToP4ColumnsBlock;
 use P4\MasterTheme\Migrations\M036RemoveEnFormOptions;
 use P4\MasterTheme\Migrations\M037MigrateCoversContentBlockToPostsListBlock;
+use P4\MasterTheme\Migrations\M038RemoveCustomSiteIcon;
 
 /**
  * Run any new migration scripts and record results in the log.
@@ -95,6 +96,7 @@ class Migrator
             M035MigrateCampaignCoversToP4ColumnsBlock::class,
             M036RemoveEnFormOptions::class,
             M037MigrateCoversContentBlockToPostsListBlock::class,
+            M038RemoveCustomSiteIcon::class,
         ];
 
         // Loop migrations and run those that haven't run yet.


### PR DESCRIPTION
### Description

See [PLANET-7647](https://jira.greenpeace.org/browse/PLANET-7647)

We remove the option to customize it in the site identity settings, and we need to run a migration to remove existing values

### Testing

**1. Setting removal**

If you go to `Appearance > Customize > Site Identity` you should no longer be able to change the site icon.

Before the removal you would see this:

<img width="299" alt="Screenshot 2025-01-21 at 10 37 33" src="https://github.com/user-attachments/assets/dff5279e-bac3-499f-8e05-d44435c8033e" />


**2. Migration script**

You can run it on local with `npx wp-env run cli wp p4-run-activator`

Before the migration, we had a custom site icon:

![Screenshot 2025-01-21 at 11 09 24](https://github.com/user-attachments/assets/a912fc7c-9a72-49fa-8f80-a3c4b52da6ed)

After the migration, you should now see the default site icon:

![Screenshot 2025-01-21 at 11 09 33](https://github.com/user-attachments/assets/ed88190b-326a-4f9a-97e5-1ff39ec5c9cf)
