### PR TITLE
PLANET-7732 Add an e2e test for the Posts List block (list layout)

### DIFF
--- a/tests/e2e/blocks/posts-list.spec.js
+++ b/tests/e2e/blocks/posts-list.spec.js
@@ -1,0 +1,48 @@
+import {test, expect} from '../tools/lib/test-utils.js';
+import {publishPostAndVisit, createPostWithFeaturedImage} from '../tools/lib/post.js';
+import {searchAndInsertBlock} from '../tools/lib/editor';
+
+const TEST_TITLE = 'Related Stories';
+const TEST_CATEGORY = 'Energy';
+
+test.useAdminLoggedIn();
+
+test.describe('Test Posts List block', () => {
+  // This is the default layout, so we don't need to select it manually.
+  test('Test the List layout', async ({page, admin, editor}) => {
+    await createPostWithFeaturedImage({page, admin, editor}, {title: 'Test Posts List', postType: 'page'});
+
+    // Add Posts List block.
+    await searchAndInsertBlock({page}, 'Posts List');
+
+    // Change amount of posts from 3 to 4.
+    await page.getByRole('spinbutton', {name: 'Posts per page'}).fill('4');
+
+    // Filter by "Energy" category.
+    const editorSettings = page.getByRole('region', {name: 'Editor settings'});
+    await editorSettings.getByRole('button', {name: 'Filters options'}).click();
+    await page.getByLabel('Show Taxonomies').click();
+    await editorSettings.getByLabel('Categories').fill(TEST_CATEGORY);
+    await editorSettings.locator(
+      '.components-form-token-field__suggestion', {hasText: TEST_CATEGORY}
+    ).click();
+    await expect(editorSettings.locator(
+      '.components-form-token-field__token-text', {hasText: TEST_CATEGORY})
+    ).toBeVisible();
+
+    // Change the title.
+    await page.getByRole('document', {name: 'Block: Heading'}).fill(TEST_TITLE);
+
+    // Publish page.
+    await publishPostAndVisit({page, editor});
+
+    // Test that the block is displayed as expected in the frontend.
+    const block = page.locator('.p4-query-loop');
+    await expect(block).toHaveClass(/is-custom-layout-list/);
+    await expect(block.locator('h2.wp-block-heading')).toHaveText(TEST_TITLE);
+    await expect(block.locator('.wp-block-post')).toHaveCount(4);
+    for (const category of await block.locator('.taxonomy-category').all()) {
+      await expect(category).toHaveText(TEST_CATEGORY);
+    }
+  });
+});


### PR DESCRIPTION
### Description

See [PLANET-7732](https://jira.greenpeace.org/browse/PLANET-7732)

**Test Steps**

1. Login to the Admin Panel.
2. Create a new Page.
3. Add a Posts List block:
    - Pick the List layout _-> not necessary since it's the default_
    - Increase the Posts per page value to 4
    - Filter posts by category "Energy"
    - Change block title to "Related Stories"
4. Publish the page.
5. Navigate to the frontend view of that Page and verify that all of the above properties are working as expected:
    - Block title
    - All posts are from the "Energy" category
    - Assess list layout
    - There are 4 posts displayed