### PR TITLE
Fix icons not showing up in footer social menu

### DIFF
--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -740,7 +740,7 @@ class MasterSite extends TimberSite
             $footer_social_menu = new TimberMenu('footer-social-menu');
             $context['footer_social_menu'] = $footer_social_menu->get_items();
         } else {
-            $context['footer_primary_menu'] = wp_get_nav_menu_items('Footer Social');
+            $context['footer_social_menu'] = wp_get_nav_menu_items('Footer Social');
         }
 
         if (has_nav_menu('footer-primary-menu')) {
@@ -749,8 +749,7 @@ class MasterSite extends TimberSite
         } else {
             $context['footer_primary_menu'] = wp_get_nav_menu_items('Footer Primary');
         }
-
-
+        
         if (has_nav_menu('footer-secondary-menu')) {
             $footer_secondary_menu = new TimberMenu('footer-secondary-menu');
             $context['footer_secondary_menu'] = $footer_secondary_menu->get_items();

--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -739,16 +739,14 @@ class MasterSite extends TimberSite
         if (has_nav_menu('footer-social-menu')) {
             $footer_social_menu = new TimberMenu('footer-social-menu');
             $context['footer_social_menu'] = $footer_social_menu->get_items();
-        }
-        else {
+        } else {
             $context['footer_primary_menu'] = wp_get_nav_menu_items('Footer Social');
         }
 
         if (has_nav_menu('footer-primary-menu')) {
             $footer_primary_menu = new TimberMenu('footer-primary-menu');
             $context['footer_primary_menu'] = $footer_primary_menu->get_items();
-        }
-        else {
+        } else {
             $context['footer_primary_menu'] = wp_get_nav_menu_items('Footer Primary');
         }
 
@@ -756,8 +754,7 @@ class MasterSite extends TimberSite
         if (has_nav_menu('footer-secondary-menu')) {
             $footer_secondary_menu = new TimberMenu('footer-secondary-menu');
             $context['footer_secondary_menu'] = $footer_secondary_menu->get_items();
-        }
-        else {
+        } else {
             $context['footer_secondary_menu'] = wp_get_nav_menu_items('Footer Secondary');
         }
 

--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -738,21 +738,21 @@ class MasterSite extends TimberSite
 
         if (has_nav_menu('footer-social-menu')) {
             $footer_social_menu = new TimberMenu('footer-social-menu');
-            $context['footer_social_menu'] = $footer_social_menu->get_items();
+            $context['footer_social_menu'] = wp_get_nav_menu_items($footer_social_menu->id);
         } else {
             $context['footer_social_menu'] = wp_get_nav_menu_items('Footer Social');
         }
 
         if (has_nav_menu('footer-primary-menu')) {
             $footer_primary_menu = new TimberMenu('footer-primary-menu');
-            $context['footer_primary_menu'] = $footer_primary_menu->get_items();
+            $context['footer_primary_menu'] = wp_get_nav_menu_items($footer_primary_menu->id);
         } else {
             $context['footer_primary_menu'] = wp_get_nav_menu_items('Footer Primary');
         }
         
         if (has_nav_menu('footer-secondary-menu')) {
             $footer_secondary_menu = new TimberMenu('footer-secondary-menu');
-            $context['footer_secondary_menu'] = $footer_secondary_menu->get_items();
+            $context['footer_secondary_menu'] = wp_get_nav_menu_items($footer_secondary_menu->id);
         } else {
             $context['footer_secondary_menu'] = wp_get_nav_menu_items('Footer Secondary');
         }


### PR DESCRIPTION
### Summary

Fixes the empty social media menu after assigning the menu to the theme position.

The recent change that allows the footer menus to be assigned to theme positions creates an issue with the social media menu: Once the menu is assigned to the menu positions, the icons for the social channels are not displayed anymore in the frontend (the menu appears empty). 
It doesn't happen when the menu isn't assigned and just loaded by naming convention.

### Testing

1. Go to Design > Menus in WP Admin
2. Select the Footer Social menu from the dropdown and click the "Select" button next to it$
![grafik](https://github.com/user-attachments/assets/183913f9-adb5-4f99-a2cc-2ac6e97e6fa4)
3. Scroll down to the Menu Settings section (below the menu items) and set "Position in Theme" to "Footer Social Menu" (if that's set already, leave it as is)
![grafik](https://github.com/user-attachments/assets/2699c24d-77e3-4173-b4d4-ea00fd7a1366)
4. Save the menu
5. Reload the frontend and check the social media menu in the footer

**Expected Result:** You can see the social media menu on the right hand side of the footer. There should be a text "Follow us" and a list of the social media icons as defined in the menu.

Example (but will show different icons depending on the menu):
![grafik](https://github.com/user-attachments/assets/80db9d08-3a2f-4f4e-800d-f38fe5fc1381)


**Without this fix:** The menu only shows a text "Follow us", but no icons.

![grafik](https://github.com/user-attachments/assets/72a27a7f-f19c-4531-bc4a-1677c61588f8)


