### PR TITLE
PLANET-7681 Make existing social share buttons configurable

### DIFF
--- a/admin/css/options.css
+++ b/admin/css/options.css
@@ -20,6 +20,14 @@
   display: none;
 }
 
+.social-share-checkbox {
+  margin-inline-end: 16px;
+}
+
+.social-share-checkbox input {
+  vertical-align: text-bottom;
+}
+
 @media (min-width: 768px) {
   .planet4_options .cmb-row:not(.hidden) {
     display: grid;

--- a/src/GravityFormsExtensions.php
+++ b/src/GravityFormsExtensions.php
@@ -54,34 +54,6 @@ class GravityFormsExtensions
         ],
     ];
 
-    public const P4_SHARE_BUTTONS = [
-        [
-            'label' => 'WhatsApp',
-            'name' => 'whatsapp',
-            'default_value' => 1,
-        ],
-        [
-            'label' => 'Facebook',
-            'name' => 'facebook',
-            'default_value' => 1,
-        ],
-        [
-            'label' => 'Twitter',
-            'name' => 'twitter',
-            'default_value' => 1,
-        ],
-        [
-            'label' => 'Email',
-            'name' => 'email',
-            'default_value' => 1,
-        ],
-        [
-            'label' => 'Native share (mobile only)',
-            'name' => 'native',
-            'default_value' => 1,
-        ],
-    ];
-
     public array $current_entry = [];
 
     public string $is_payment_successful = '';
@@ -370,13 +342,6 @@ class GravityFormsExtensions
         }
 
         $fields['p4_share_buttons']['fields'][] = [
-            'type' => 'checkbox',
-            'name' => 'p4_gf_share_platforms',
-            'label' => __('Show share buttons below message', 'planet4-master-theme-backend'),
-            'choices' => self::P4_SHARE_BUTTONS,
-        ];
-
-        $fields['p4_share_buttons']['fields'][] = [
             'type' => 'text',
             'name' => 'p4_gf_share_text_override',
             'label' => __('Share text', 'planet4-master-theme-backend'),
@@ -499,14 +464,17 @@ class GravityFormsExtensions
             </script>";
         }
 
+        $social_share_options = planet4_get_option('social_share_options', []);
+
         $confirmation_fields = [
             'confirmation' => $confirmation,
             'share_platforms' => [
-                'facebook' => $current_confirmation['facebook'] ?? true,
-                'twitter' => $current_confirmation['twitter'] ?? true,
-                'whatsapp' => $current_confirmation['whatsapp'] ?? true,
-                'native' => $current_confirmation['native'] ?? true,
-                'email' => $current_confirmation['email'] ?? true,
+                'facebook' => $social_share_options['facebook'] ?? false,
+                'twitter' => $social_share_options['twitter'] ?? false,
+                'whatsapp' => $social_share_options['whatsapp'] ?? false,
+                'email' => $social_share_options['email'] ?? false,
+                // We might add a setting for this one in the future, but for now we always enable it in GF.
+                'native' => true,
             ],
             'post' => $post,
             'social_accounts' => $post->get_social_accounts($context['footer_social_menu'] ?: []),

--- a/src/GravityFormsExtensions.php
+++ b/src/GravityFormsExtensions.php
@@ -469,10 +469,10 @@ class GravityFormsExtensions
         $confirmation_fields = [
             'confirmation' => $confirmation,
             'share_platforms' => [
-                'facebook' => $social_share_options['facebook'] ?? false,
-                'twitter' => $social_share_options['twitter'] ?? false,
-                'whatsapp' => $social_share_options['whatsapp'] ?? false,
-                'email' => $social_share_options['email'] ?? false,
+                'facebook' => in_array('facebook', $social_share_options),
+                'twitter' => in_array('twitter', $social_share_options),
+                'whatsapp' => in_array('whatsapp', $social_share_options),
+                'email' => in_array('email', $social_share_options),
                 // We might add a setting for this one in the future, but for now we always enable it in GF.
                 'native' => true,
             ],

--- a/src/Migrations/M039EnableNewSocialSharePlatforms.php
+++ b/src/Migrations/M039EnableNewSocialSharePlatforms.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace P4\MasterTheme\Migrations;
+
+use P4\MasterTheme\MigrationRecord;
+use P4\MasterTheme\MigrationScript;
+use P4\MasterTheme\Settings;
+
+/**
+ * Enable all social share options via the new P4 setting.
+ */
+class M039EnableNewSocialSharePlatforms extends MigrationScript
+{
+    /**
+     * Perform the actual migration.
+     *
+     * @param MigrationRecord $record Information on the execution, can be used to add logs.
+     * phpcs:disable SlevomatCodingStandard.Functions.UnusedParameter -- interface implementation
+     */
+    protected static function execute(MigrationRecord $record): void
+    {
+        $options = get_option('planet4_options');
+        $options['social_share_options'] = array_keys(Settings::SOCIAL_SHARE_OPTIONS);
+        update_option('planet4_options', $options);
+    }
+    // phpcs:enable SlevomatCodingStandard.Functions.UnusedParameter
+}

--- a/src/Migrator.php
+++ b/src/Migrator.php
@@ -40,6 +40,7 @@ use P4\MasterTheme\Migrations\M035MigrateCampaignCoversToP4ColumnsBlock;
 use P4\MasterTheme\Migrations\M036RemoveEnFormOptions;
 use P4\MasterTheme\Migrations\M037MigrateCoversContentBlockToPostsListBlock;
 use P4\MasterTheme\Migrations\M038RemoveCustomSiteIcon;
+use P4\MasterTheme\Migrations\M039EnableNewSocialSharePlatforms;
 
 /**
  * Run any new migration scripts and record results in the log.
@@ -97,6 +98,7 @@ class Migrator
             M036RemoveEnFormOptions::class,
             M037MigrateCoversContentBlockToPostsListBlock::class,
             M038RemoveCustomSiteIcon::class,
+            M039EnableNewSocialSharePlatforms::class,
         ];
 
         // Loop migrations and run those that haven't run yet.

--- a/src/Post.php
+++ b/src/Post.php
@@ -335,18 +335,16 @@ class Post extends TimberPost
 
     /**
      * Get values for share buttons content.
-     *
-     * @return string[]
      */
     public function social_share_platforms(): array
     {
         $social_share_options = planet4_get_option('social_share_options', []);
 
         return [
-            'facebook' => $social_share_options['facebook'] ?? false,
-            'twitter' => $social_share_options['twitter'] ?? false,
-            'whatsapp' => $social_share_options['whatsapp'] ?? false,
-            'email' => $social_share_options['email'] ?? false,
+            'facebook' => in_array('facebook', $social_share_options),
+            'twitter' => in_array('twitter', $social_share_options),
+            'whatsapp' => in_array('whatsapp', $social_share_options),
+            'email' => in_array('email', $social_share_options),
             // We might add a setting for this one in the future, but for now we always disable it in Posts.
             'native' => false,
         ];

--- a/src/Post.php
+++ b/src/Post.php
@@ -334,6 +334,25 @@ class Post extends TimberPost
     }
 
     /**
+     * Get values for share buttons content.
+     *
+     * @return string[]
+     */
+    public function social_share_platforms(): array
+    {
+        $social_share_options = planet4_get_option('social_share_options', []);
+
+        return [
+            'facebook' => $social_share_options['facebook'] ?? false,
+            'twitter' => $social_share_options['twitter'] ?? false,
+            'whatsapp' => $social_share_options['whatsapp'] ?? false,
+            'email' => $social_share_options['email'] ?? false,
+            // We might add a setting for this one in the future, but for now we always disable it in Posts.
+            'native' => false,
+        ];
+    }
+
+    /**
      * Get post's author override status.
      *
      */

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -48,11 +48,20 @@ class Settings
     protected array $subpages = [];
 
     /**
+     * Social share options
+     */
+    public const SOCIAL_SHARE_OPTIONS = [
+        'facebook' => 'Facebook',
+        'whatsapp' => 'WhatsApp',
+        'twitter' => 'X',
+        'email' => 'Email',
+    ];
+
+    /**
      * Constructor
      */
     public function __construct()
     {
-
         // Set our title.
         $this->title = __('Planet 4', 'planet4-master-theme-backend');
 
@@ -397,6 +406,12 @@ class Settings
                             'type' => 'text',
                         ],
                     ],
+                    [
+                        'name' => __('Choose social sharing options', 'planet4-master-theme-backend'),
+                        'id' => 'social_share_options',
+                        'type' => 'social_share_checkboxes',
+                        'default' => [],
+                    ],
                 ],
             ],
             'planet4_settings_404_page' => [
@@ -577,6 +592,7 @@ class Settings
         add_filter('cmb2_render_get_informed_page_dropdown', [$this, 'p4_render_page_dropdown'], 10, 2);
         add_filter('cmb2_render_take_action_page_dropdown', [$this, 'p4_render_page_dropdown'], 10, 2);
         add_filter('cmb2_render_about_us_page_dropdown', [$this, 'p4_render_page_dropdown'], 10, 2);
+        add_filter('cmb2_render_social_share_checkboxes', [$this, 'p4_render_social_share_checkboxes'], 10, 2);
         add_action('admin_enqueue_scripts', [$this, 'enqueue_admin_assets']);
 
         // Make settings multilingual if wpml plugin is installed and activated.
@@ -681,6 +697,31 @@ class Settings
         );
     }
     // phpcs:enable SlevomatCodingStandard.Functions.UnusedParameter
+
+    /**
+     * Render category dropdown.
+     *
+     * @param CMB2_Field $field_args Field arguments.
+     * @param array $value Value.
+     */
+    public function p4_render_social_share_checkboxes(CMB2_Field $field_args, array $value): void
+    {
+        echo '<fieldset>';
+        foreach (self::SOCIAL_SHARE_OPTIONS as $key => $label) {
+            $selected = in_array($key, $value);
+
+            printf(
+                '<label><input type="checkbox" id="%1$s" name="%2$s" value="%3$s" %4$s />%5$s</label>',
+                $field_args->id(),
+                $field_args->id() . '[' . $key . ']',
+                $key,
+                $selected ? 'checked' : '',
+                $label,
+            );
+            echo '<br/><br/>';
+        }
+        echo '</fieldset>';
+    }
 
     /**
      * Admin page markup. Mostly handled by CMB2.

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -699,7 +699,7 @@ class Settings
     // phpcs:enable SlevomatCodingStandard.Functions.UnusedParameter
 
     /**
-     * Render category dropdown.
+     * Render social share checkboxes.
      *
      * @param CMB2_Field $field_args Field arguments.
      * @param array $value Value.
@@ -711,14 +711,15 @@ class Settings
             $selected = in_array($key, $value);
 
             printf(
-                '<label><input type="checkbox" id="%1$s" name="%2$s" value="%3$s" %4$s />%5$s</label>',
+                '<label class="social-share-checkbox">
+                    <input type="checkbox" id="%1$s" name="%2$s" value="%3$s" %4$s />%5$s
+                </label>',
                 $field_args->id(),
                 $field_args->id() . '[' . $key . ']',
                 $key,
                 $selected ? 'checked' : '',
                 $label,
             );
-            echo '<br/><br/>';
         }
         echo '</fieldset>';
     }

--- a/templates/blocks/header.twig
+++ b/templates/blocks/header.twig
@@ -52,7 +52,10 @@
                 <h1 class="page-header-title">{{ header_title|e('wp_kses_post')|raw }}</h1>
             {% endif %}
             {% if not hide_page_title and ( post.is_take_action_page ) %}
-                {% include "blocks/share_buttons.twig" with {social:post.share_meta} %}
+                {% include "blocks/share_buttons.twig" with {
+                    social: post.share_meta,
+                    share_platforms: post.social_share_platforms,
+                } %}
             {% endif %}
             {% if ( header_subtitle ) %}
                 <h3 class="page-header-subtitle">{{ header_subtitle }}</h3>

--- a/templates/blocks/share_buttons.twig
+++ b/templates/blocks/share_buttons.twig
@@ -1,9 +1,8 @@
 {% do action('enqueue_share_buttons_script', social) %}
 {% set socialLink = (share_url ?? social.link) ~ '?utm_medium=' ~ utm_medium ~ utm_content_param ~ utm_campaign_param %}
-{% set all_platforms = share_platforms is not defined %}
 <div class="share-buttons">
     <!-- Whatsapp -->
-    {% if all_platforms or share_platforms.whatsapp %}
+    {% if share_platforms.whatsapp %}
         <a href="https://wa.me/?text={% if share_text or social.description %}{{ (share_text ?? social.description)|striptags|url_encode }} {% endif %}{{ (socialLink ~ '&utm_source=whatsapp')|url_encode }}"
             onclick="window.dataLayerPush('Whatsapp');"
             target="_blank" class="share-btn whatsapp">
@@ -12,7 +11,7 @@
         </a>
     {% endif %}
     <!-- Facebook -->
-    {% if all_platforms or share_platforms.facebook %}
+    {% if share_platforms.facebook %}
         <a href="https://www.facebook.com/sharer/sharer.php?u={{ (socialLink ~ '&utm_source=facebook')|url_encode }}"
             onclick="window.dataLayerPush('Facebook');"
             target="_blank" class="share-btn facebook">
@@ -21,7 +20,7 @@
         </a>
     {% endif %}
     <!-- Twitter -->
-    {% if all_platforms or share_platforms.twitter %}
+    {% if share_platforms.twitter %}
         <a href="https://x.com/intent/post?related={{ social_accounts.twitter }}&text={{ social.title|url_encode }}{% if share_text or social.description %} - {{ (share_text ?? social.description)|striptags|url_encode }}{% endif %}, via @{{ social_accounts.twitter }}&url={{ (socialLink ~ '&utm_source=twitter')|url_encode }}"
             onclick="window.dataLayerPush('Twitter');"
             target="_blank" class="share-btn twitter">
@@ -30,7 +29,7 @@
         </a>
     {% endif %}
     <!-- Email -->
-    {% if all_platforms or share_platforms.email %}
+    {% if share_platforms.email %}
         <a href="mailto:?subject={{ social.title|url_encode }}&body={% if share_text or social.description %}{{ (share_text ?? social.description)|striptags|url_encode }} {% endif %}{{ (socialLink ~ '&utm_source=email')|url_encode }}"
             onclick="window.dataLayerPush('Email');"
             target="_blank" class="share-btn email">
@@ -39,7 +38,7 @@
         </a>
     {% endif %}
     <!-- Native (Gravity Forms only, for devices that support it) -->
-    {% if not all_platforms and share_platforms.native %}
+    {% if share_platforms.native %}
         <a
             onclick="window.nativeShare();"
             target="_blank"

--- a/templates/single-attachment.twig
+++ b/templates/single-attachment.twig
@@ -18,7 +18,10 @@
                     <span class="single-post-meta-bullet" aria-hidden="true">&#8226;</span>
                     <time class="single-post-time" pubdate>{{ post.post_date|date }}</time>
                 </div>
-                {% include "blocks/share_buttons.twig" with {social:post.share_meta} %}
+                {% include "blocks/share_buttons.twig" with {
+                    social:post.share_meta,
+                    share_platforms: post.social_share_platforms,
+                } %}
             </header>
         </div>
 

--- a/templates/single.twig
+++ b/templates/single.twig
@@ -78,7 +78,11 @@
                         {% endif %}
                     </div>
                 </div>
-                {% include "blocks/share_buttons.twig" with {social:post.share_meta, utm_medium: 'share'} %}
+                {% include "blocks/share_buttons.twig" with {
+                    social: post.share_meta,
+                    utm_medium: 'share',
+                    share_platforms: post.social_share_platforms,
+                } %}
 
                 {% if old_posts_archive_notice.show_notice %}
                     <div class="single-post-old-posts-archive-notice">


### PR DESCRIPTION
### Description

See [PLANET-7681](https://jira.greenpeace.org/browse/PLANET-7681)

**Requirements**

- [x] A new setting under Planet 4 > Social
  - Label: "Choose social sharing options"
  - This should be a multiple selection option field (checkboxes), showing the 4 sharing options we already have (WhatsApp, Facebook, X, Email).
- [x] We should create a migration to have those options enabled by default
- [x] Settings should also apply on the Gravity Forms Share button settings
  - Remove the current customization menu
  - Native share should still be displayed in mobile
  - We can keep the text fields for custom share url/text
- [x] Adjust the social sharing template to dynamically include the selected options

### Testing

- To test the migration on local, you can run `npx wp-env run cli wp p4-run-activator` and the new settings should all be checked by default. You can run `npm run db:reset` beforehand if necessary.
- To test the new settings, either on local or on the test instance in `Planet 4 > Social` you can try (un)checking the various social media sharing options. Then you can make sure that they work as expected in any post, or Gravity Forms confirmation that has share buttons. 
- Please also make sure that the social share platforms checkboxes have been removed from the Gravity Forms confirmation settings.