### PR TITLE
PLANET-7578: Fix special characters in the Post List block description

### DIFF
--- a/src/Migrations/M040FixSpecialCharactersInPostsListBlock.php
+++ b/src/Migrations/M040FixSpecialCharactersInPostsListBlock.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace P4\MasterTheme\Migrations;
+
+use P4\MasterTheme\MigrationRecord;
+use P4\MasterTheme\MigrationScript;
+
+/**
+ * Replace the special characters in the Post List block description that were not correctly migrated.
+ */
+class M040FixSpecialCharactersInPostsListBlock extends MigrationScript
+{
+    /**
+     * Perform the actual migration.
+     *
+     * @param MigrationRecord $record Information on the execution, can be used to add logs.
+     * phpcs:disable SlevomatCodingStandard.Functions.UnusedParameter -- interface implementation
+     */
+    public static function execute(MigrationRecord $record): void
+    {
+        $check_is_valid_block = function ($block) {
+            return self::check_is_valid_block($block);
+        };
+
+        $transform_block = function ($block) {
+            return self::transform_block($block);
+        };
+
+        Utils\Functions::execute_block_migration(
+            Utils\Constants::BLOCK_QUERY,
+            $check_is_valid_block,
+            $transform_block,
+        );
+    }
+    // phpcs:enable SlevomatCodingStandard.Functions.UnusedParameter
+
+    /**
+     * Check whether a block is a Query/Post List block.
+     *
+     * @param array $block - A block data array.
+     */
+    private static function check_is_valid_block(array $block): bool
+    {
+        // Check if the block is valid.
+        if (!is_array($block)) {
+            return false;
+        }
+
+        // Check if the block has a 'blockName' key.
+        if (!isset($block['blockName'])) {
+            return false;
+        }
+
+        // Check if the block is a Query block. If not, abort.
+        if ($block['blockName'] !== Utils\Constants::BLOCK_QUERY) {
+            return false;
+        }
+
+        // Check if the block contains a namespace. If not, abort.
+        if (!isset($block['attrs']['namespace'])) {
+            return false;
+        }
+
+        // Check if the block is a Post List block.
+        return $block['attrs']['namespace'] === Utils\Constants::BLOCK_POSTS_LIST;
+    }
+
+    /**
+     * Replace the special characters in the block description.
+     *
+     * @param array $block - The current Query block.
+     * @return array - The block with the fixes.
+     */
+    private static function transform_block(array $block): array
+    {
+        foreach ($block['innerBlocks'] as &$inner_block) {
+            if (!isset($inner_block['blockName'])) {
+                continue;
+            }
+
+            if ($inner_block['blockName'] !== Utils\Constants::BLOCK_PARAGRAPH) {
+                continue;
+            }
+
+            $content = $inner_block['innerHTML'];
+
+            // Only replace standalone "u003c", "u003e", "u0022" (not inside quotes or escape sequences)
+            $content = preg_replace('/(?<!\\\\)u003c/', '<', $content);
+            $content = preg_replace('/(?<!\\\\)u003e/', '>', $content);
+            $content = preg_replace('/(?<!\\\\)u0022/', '"', $content);
+
+            $inner_block['innerHTML'] = $content;
+            $inner_block['innerContent'][0] = $content;
+        }
+        unset($inner_block);
+        return $block;
+    }
+}

--- a/src/Migrator.php
+++ b/src/Migrator.php
@@ -41,6 +41,7 @@ use P4\MasterTheme\Migrations\M036RemoveEnFormOptions;
 use P4\MasterTheme\Migrations\M037MigrateCoversContentBlockToPostsListBlock;
 use P4\MasterTheme\Migrations\M038RemoveCustomSiteIcon;
 use P4\MasterTheme\Migrations\M039EnableNewSocialSharePlatforms;
+use P4\MasterTheme\Migrations\M040FixSpecialCharactersInPostsListBlock;
 
 /**
  * Run any new migration scripts and record results in the log.
@@ -99,6 +100,7 @@ class Migrator
             M037MigrateCoversContentBlockToPostsListBlock::class,
             M038RemoveCustomSiteIcon::class,
             M039EnableNewSocialSharePlatforms::class,
+            M040FixSpecialCharactersInPostsListBlock::class,
         ];
 
         // Loop migrations and run those that haven't run yet.


### PR DESCRIPTION
### Summary

This PR replaces the special characters in the Post List block description that were not correctly migrated in PR #2461, for example [here](https://www.greenpeace.org/sweden/klimat/#vad-du-kan-gora):

![image](https://github.com/user-attachments/assets/c3e3ca0d-f448-4f0b-a810-d514add34f51)

---

Ref: https://jira.greenpeace.org/browse/PLANET-7578

### Testing

1. Run this PR in your local environment.
2. Add a Post List block to a post or page (or edit an existing one) with the following description (it's a text containing wrong markups): `This should be replaced: u003cau003eu0022testu0022u003c/au003e, but this should NOT: \u003ca\u003e\u0022test\u0022\u003c/a\u003e` 
4. Run the migrator command: `npx wp-env run cli wp p4-run-activator`
5. Check whether the migration worked as expected and the special characters were fixed.
6. To reset the environment database back to the latest default content and repeat the tests, run: `npm run db:reset`.