### PR TITLE
PLANET-7754 Fix P4 sidebar panel disappear issue

### DIFF
--- a/assets/src/editorIndex.js
+++ b/assets/src/editorIndex.js
@@ -44,13 +44,13 @@ wp.domReady(() => {
 
   // Block variations
   registerBlockVariations();
-
-  // Editor behaviour.
-  setupQueryLoopBlockExtension();
-  setupCustomSidebar();
-  addButtonLinkPasteWarning();
-  addBlockFilters();
-  replaceTaxonomyTermSelectors();
-  setupImageBlockExtension();
-  setupBlockEditorValidation();
 });
+
+// Editor behaviour(It should be executed after the DOM is ready).
+setupQueryLoopBlockExtension();
+setupCustomSidebar();
+addButtonLinkPasteWarning();
+addBlockFilters();
+replaceTaxonomyTermSelectors();
+setupImageBlockExtension();
+setupBlockEditorValidation();


### PR DESCRIPTION
### Summary

Move editor behavior-related scripts outside wp.domReady() function

---
Ref: [PLANET-7754](https://jira.greenpeace.org/browse/PLANET-7754)


### Testing

- The issue is reproducible on the latest code from the master theme's main branch.
- To test the fix, check out this branch, build the assets, and verify the changes.
- You can also check the issue on the [test-rhea](https://www-dev.greenpeace.org/test-rhea/wp-admin/post.php?post=1113&action=edit) instance.
- The fix can be tested on the [test-nix](https://www-dev.greenpeace.org/test-nix/wp-admin/post.php?post=260&action=edit) instance.