### PR TITLE
PLANET-7436 Added search_results to DLV

### DIFF
--- a/assets/src/js/google_tag_manager.js
+++ b/assets/src/js/google_tag_manager.js
@@ -60,6 +60,9 @@ if (googleTagManagerData?.google_tag_value) {
     'post_categories': googleTagManagerData.post_categories,
     'reading_time': googleTagManagerData.reading_time ? `#${googleTagManagerData.reading_time}` : '',
     'page_date': googleTagManagerData.page_date ? `#${googleTagManagerData.page_date}` : '',
+    ...(googleTagManagerData.page_category === 'Search Page' && {
+      'search_results': googleTagManagerData.search_results,
+    }),
   });
 
   if (!googleTagManagerData?.post_password_required) {

--- a/src/EnqueueController.php
+++ b/src/EnqueueController.php
@@ -254,6 +254,7 @@ class EnqueueController
             'enforce_cookies_policy' => $context['enforce_cookies_policy'] ?? null,
             'cookies_enable_google_consent_mode' => $context['cookies']->enable_google_consent_mode ?? null,
             'post_password_required' => $context['post']->password_required ?? null,
+            'search_results' => $context['found_posts'] ?? '',
         ];
 
         wp_localize_script($script['name'], $script['id'], $gtm_data);


### PR DESCRIPTION
### Summary

<!-- Please provide a brief summary of the change introduced in this Pull Request. -->

---

<!-- Please add a reference link to the ticket, if one exists. -->
Ref: https://jira.greenpeace.org/browse/PLANET-7436

### Testing

<!-- Please add the steps required to test the changes in this Pull Request. -->
1. Locally use an NRO with GTM
2. On the search page when you search a term, the number of search results from the query is added to the DLV
3. You can also test on the Belgium dev [instance](https://www-dev.greenpeace.org/belgium/fr/).
