### PR TITLE
Replace special characters in the content of the posts

### DIFF
--- a/src/Migrations/M040ReplaceSpecialCharactersInPostsContent.php
+++ b/src/Migrations/M040ReplaceSpecialCharactersInPostsContent.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace P4\MasterTheme\Migrations;
+
+use P4\MasterTheme\MigrationRecord;
+use P4\MasterTheme\MigrationScript;
+
+/**
+ * Replace special characters ("u003c", "u003e", "u0022") in the posts content.
+ */
+class M040ReplaceSpecialCharactersInPostsContent extends MigrationScript
+{
+    /**
+     * Perform the actual migration.
+     *
+     * @param MigrationRecord $record Information on the execution, can be used to add logs.
+     * phpcs:disable SlevomatCodingStandard.Functions.UnusedParameter -- interface implementation
+     */
+    public static function execute(MigrationRecord $record): void
+    {
+        echo 'Replacing special characters in posts content...', "\n"; // phpcs:ignore
+
+        $args = [
+            'post_type' => get_post_types(['public' => true], 'names'),
+            'post_status' => 'any',
+            'posts_per_page' => -1,
+        ];
+
+        $results = get_posts($args) ?? [];
+
+        foreach ((array) $results as $post) {
+            if (empty($post->post_content)) {
+                continue;
+            }
+
+            $current_post_id = $post->ID;
+
+            echo 'Parsing post ', $current_post_id, "\n"; // phpcs:ignore
+
+            $post_content = $post->post_content;
+
+            // Only replace standalone "u003c", "u003e", "u0022" (not inside quotes or escape sequences)
+            $post_content = preg_replace('/(?<!\\\\)u003c/', '<', $post_content);
+            $post_content = preg_replace('/(?<!\\\\)u003e/', '>', $post_content);
+            $post_content = preg_replace('/(?<!\\\\)u0022/', '"', $post_content);
+
+            $post_args = [
+                'ID' => $current_post_id,
+                'post_content' => $post_content,
+            ];
+
+            wp_update_post(wp_slash($post_args));
+        }
+    }
+    // phpcs:enable SlevomatCodingStandard.Functions.UnusedParameter
+}

--- a/src/Migrations/M040ReplaceSpecialCharactersInPostsContent.php
+++ b/src/Migrations/M040ReplaceSpecialCharactersInPostsContent.php
@@ -45,8 +45,6 @@ class M040ReplaceSpecialCharactersInPostsContent extends MigrationScript
                     continue;
                 }
 
-                echo 'Parsing post ', $post_id, "\n"; // phpcs:ignore
-
                 $updated_content = preg_replace('/(?<!\\\\)u003c/', '<', $content);
                 $updated_content = preg_replace('/(?<!\\\\)u003e/', '>', $updated_content);
                 $updated_content = preg_replace('/(?<!\\\\)u0022/', '"', $updated_content);
@@ -55,10 +53,16 @@ class M040ReplaceSpecialCharactersInPostsContent extends MigrationScript
                     continue;
                 }
 
-                wp_update_post([
+                $result = wp_update_post([
                     'ID' => $post_id,
                     'post_content' => wp_slash($updated_content),
                 ]);
+
+                if (!is_wp_error($result) && $result > 0) {
+                    echo "Post updated successfully: ID ", $post_id, "\n"; // phpcs:ignore
+                } else {
+                    echo "Failed to update post: ID ", $post_id, "\n"; // phpcs:ignore
+                }
             }
 
             $paged++;

--- a/src/Migrations/M040ReplaceSpecialCharactersInPostsContent.php
+++ b/src/Migrations/M040ReplaceSpecialCharactersInPostsContent.php
@@ -47,7 +47,7 @@ class M040ReplaceSpecialCharactersInPostsContent extends MigrationScript
 
                 $updated_content = preg_replace('/(?<!\\\\)u003c/', '<', $content);
                 $updated_content = preg_replace('/(?<!\\\\)u003e/', '>', $updated_content);
-                $updated_content = preg_replace('/(?<!\\\\)u0022/', '"', $updated_content);
+                $updated_content = preg_replace('/(?<!\\\\)u0022/', '\u0022', $updated_content);
 
                 if ($updated_content === $content) {
                     continue;

--- a/src/Migrations/M040ReplaceSpecialCharactersInPostsContent.php
+++ b/src/Migrations/M040ReplaceSpecialCharactersInPostsContent.php
@@ -45,9 +45,9 @@ class M040ReplaceSpecialCharactersInPostsContent extends MigrationScript
                     continue;
                 }
 
-                $updated_content = preg_replace('/(?<!\\\\)u003c/', '<', $content);
-                $updated_content = preg_replace('/(?<!\\\\)u003e/', '>', $updated_content);
-                $updated_content = preg_replace('/(?<!\\\\)u0022/', '"', $updated_content);
+                $updated_content = preg_replace('/(?<!\\\\)u003c/', '\u003c', $content);
+                $updated_content = preg_replace('/(?<!\\\\)u003e/', '\u003e', $updated_content);
+                $updated_content = preg_replace('/(?<!\\\\)u0022/', '\u0022', $updated_content);
 
                 if ($updated_content === $content) {
                     continue;

--- a/src/Migrations/M040ReplaceSpecialCharactersInPostsContent.php
+++ b/src/Migrations/M040ReplaceSpecialCharactersInPostsContent.php
@@ -47,7 +47,7 @@ class M040ReplaceSpecialCharactersInPostsContent extends MigrationScript
 
                 $updated_content = preg_replace('/(?<!\\\\)u003c/', '<', $content);
                 $updated_content = preg_replace('/(?<!\\\\)u003e/', '>', $updated_content);
-                $updated_content = preg_replace('/(?<!\\\\)u0022/', '\u0022', $updated_content);
+                $updated_content = preg_replace('/(?<!\\\\)u0022/', '"', $updated_content);
 
                 if ($updated_content === $content) {
                     continue;

--- a/src/Migrator.php
+++ b/src/Migrator.php
@@ -41,6 +41,7 @@ use P4\MasterTheme\Migrations\M036RemoveEnFormOptions;
 use P4\MasterTheme\Migrations\M037MigrateCoversContentBlockToPostsListBlock;
 use P4\MasterTheme\Migrations\M038RemoveCustomSiteIcon;
 use P4\MasterTheme\Migrations\M039EnableNewSocialSharePlatforms;
+use P4\MasterTheme\Migrations\M040ReplaceSpecialCharactersInPostsContent;
 
 /**
  * Run any new migration scripts and record results in the log.
@@ -99,6 +100,7 @@ class Migrator
             M037MigrateCoversContentBlockToPostsListBlock::class,
             M038RemoveCustomSiteIcon::class,
             M039EnableNewSocialSharePlatforms::class,
+            M040ReplaceSpecialCharactersInPostsContent::class,
         ];
 
         // Loop migrations and run those that haven't run yet.


### PR DESCRIPTION
### Summary

This PR replaces the special characters `u003c`, `u003e`,  and `u0022` in the content of the posts that were affected by previous migrations, for example [here](https://www.greenpeace.org/sweden/klimat/#vad-du-kan-gora).

---

### Testing

1. Run this PR in your local environment.
2. Add the following text (it contains wrong markups) to a new post or page (or edit an existing one): `This should be replaced: u003cau003eu0022testu0022u003c/au003e, but this should NOT: \u003ca\u003e\u0022test\u0022\u003c/a\u003e` 
4. Run the migrator command: `npx wp-env run cli wp p4-run-activator`
5. Check whether the migration worked as expected and the special characters were fixed.
6. To reset the environment database back to the latest default content and repeat the tests, run: `npm run db:reset`