### PR TITLE
PLANET-7612: Track user logins

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -101,6 +101,7 @@ add_action(
         Api\Search::register_endpoint();
         Api\Settings::register_endpoint();
         Api\AnalyticsValues::register_endpoint();
+        Api\Tracking::register_endpoint();
     }
 );
 

--- a/src/Api/Tracking.php
+++ b/src/Api/Tracking.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace P4\MasterTheme\Api;
+
+use WP_REST_Server;
+
+/**
+ * Instance Tracking API
+ */
+class Tracking
+{
+    /**
+     * Register endpoint to read general Tracking.
+     *
+     * @example GET /wp-json/planet4/v1/tracking/
+     */
+    public static function register_endpoint(): void
+    {
+        register_rest_route(
+            'planet4/v1',
+            'tracking/login',
+            [
+                'methods' => WP_REST_Server::READABLE,
+                'callback' => function ($request) {
+                    global $wpdb;
+
+                    $last_days = (60 * 60 * 24 * $request->get_param('last_days'));
+                    $now = time();
+
+                    $query = $wpdb->get_results(
+                        "select * from wp_usermeta as m
+                        inner join wp_users as u
+                        on m.user_id = u.ID
+                        and m.meta_key='session_tokens'",
+                        OBJECT
+                    );
+
+                    $data = array();
+                    foreach ($query as $row) {
+                        $unserialized = maybe_unserialize($row->meta_value);
+                        $key = array_keys($unserialized)[0];
+                        $login_date = $unserialized[$key]['login'];
+                        // $obj = ;
+
+                        if (($now - $login_date) >= $last_days) {
+                            continue;
+                        }
+
+                        array_push(
+                            $data,
+                            [
+                                'display_name' => $row->display_name,
+                                // Convert epoch to human-readable date
+                                'login_date' => date("Y-m-d H:i:s", $login_date),
+                            ]
+                        );
+                    }
+
+                    return count($data);
+                },
+                // 'permission_callback' => function ($request) {
+                    // return true;
+                    // if (!defined('PLANET4_API_KEY') || empty(PLANET4_API_KEY)) {
+                    //     return false;
+                    // }
+
+                    // $token = $request->get_header('X-Auth-Token');
+                    // return !empty($token) && $token === PLANET4_API_KEY;
+                // },
+                'args' => array(
+                    'last_days' => array(
+                        'required' => false,
+                        'default' => 30,
+                    ),
+                ),
+            ]
+        );
+    }
+}

--- a/src/Api/Tracking.php
+++ b/src/Api/Tracking.php
@@ -20,62 +20,91 @@ class Tracking
     {
         register_rest_route(
             'planet4/v1',
-            'tracking/login',
+            'tracking',
             [
                 'methods' => WP_REST_Server::READABLE,
                 'callback' => function ($request) {
-                    global $wpdb;
+                    $params = $request->get_params();
 
-                    $last_days = (60 * 60 * 24 * $request->get_param('last_days'));
-                    $now = time();
-
-                    $query = $wpdb->get_results(
-                        "select * from wp_usermeta as m
-                        inner join wp_users as u
-                        on m.user_id = u.ID
-                        and m.meta_key='session_tokens'",
-                        OBJECT
-                    );
-
-                    $data = array();
-                    foreach ($query as $row) {
-                        $unserialized = maybe_unserialize($row->meta_value);
-                        $key = array_keys($unserialized)[0];
-                        $login_date = $unserialized[$key]['login'];
-                        // $obj = ;
-
-                        if (($now - $login_date) >= $last_days) {
-                            continue;
-                        }
-
-                        array_push(
-                            $data,
-                            [
-                                'display_name' => $row->display_name,
-                                // Convert epoch to human-readable date
-                                'login_date' => date("Y-m-d H:i:s", $login_date),
-                            ]
-                        );
+                    return [
+                        'logins' => self::get_logins($params),
+                    ];
+                },
+                'permission_callback' => function ($request) {
+                    if (current_user_can('manage_options')) {
+                        return true;
                     }
 
-                    return count($data);
-                },
-                // 'permission_callback' => function ($request) {
-                    // return true;
-                    // if (!defined('PLANET4_API_KEY') || empty(PLANET4_API_KEY)) {
-                    //     return false;
-                    // }
+                    if (!defined('PLANET4_API_KEY') || empty(PLANET4_API_KEY)) {
+                        return false;
+                    }
 
-                    // $token = $request->get_header('X-Auth-Token');
-                    // return !empty($token) && $token === PLANET4_API_KEY;
-                // },
+                    $token = $request->get_header('X-Auth-Token');
+                    return !empty($token) && $token === PLANET4_API_KEY;
+                },
                 'args' => array(
                     'last_days' => array(
                         'required' => false,
                         'default' => 30,
                     ),
+                    'full' => array(
+                        'required' => false,
+                        'default' => false,
+                    ),
                 ),
             ]
         );
+    }
+
+    /**
+     * Get last logins filtered by days.
+     *
+     * @param array $params refers to request params
+     * @return array Get logins.
+    */
+    private static function get_logins(array $params): array
+    {
+        global $wpdb;
+
+        $response = [];
+        $last_days = (60 * 60 * 24 * $params['last_days']);
+        $now = time();
+
+        $query = $wpdb->get_results(
+            "select * from wp_usermeta as m
+            inner join wp_users as u
+            on m.user_id = u.ID
+            and m.meta_key='session_tokens'",
+            OBJECT
+        );
+
+        $data = array();
+
+        foreach ($query as $row) {
+            $unserialized = maybe_unserialize($row->meta_value);
+            $key = array_keys($unserialized)[0];
+            $login_date = $unserialized[$key]['login'];
+
+            if (($now - $login_date) >= $last_days) {
+                continue;
+            }
+
+            array_push(
+                $data,
+                [
+                    'display_name' => $row->display_name,
+                    // Convert epoch to human-readable date
+                    'login_date' => date("Y-m-d H:i:s", $login_date),
+                ]
+            );
+        }
+
+        if ($params['full']) {
+            $response['data'] = $data;
+        }
+
+        $response['total'] = count($data);
+
+        return $response;
     }
 }

--- a/src/Api/Tracking.php
+++ b/src/Api/Tracking.php
@@ -92,7 +92,7 @@ class Tracking
             OBJECT
         );
 
-        $data = array();
+        $data = [];
 
         foreach ($query as $row) {
             $unserialized = maybe_unserialize($row->meta_value);


### PR DESCRIPTION
### Summary

This endpoint it's going to be implemented within [this spreedsheet](https://docs.google.com/spreadsheets/d/1uAmZLIWYsxrBByqbhoF_vVtSM7WGebYWIc0xftPRPwE/edit?gid=1046330328#gid=1046330328).

#### Additional implementation:
- Added the `last_days` param wich returns the last N days. By default is set to `30`
- Added the `full` param wich returns also metadata for logins. By default is set `false`

Example of response (requires auth)
```shell
curl -X GET -G \
'https://www-dev.greenpeace.org/test-jupiter/wp-json/planet4/v1/tracking' \
-d last_days=365 \
-d full=true
```

```json
{
    "logins": {
        "data": [
            {
                "display_name": "Dan Tovbein - P4 team",
                "login_date": "2025-02-13 09:33:44"
            },
            {
                "display_name": "Nikos",
                "login_date": "2025-02-13 10:14:58"
            },
            {
                "display_name": "Foppe Pieters - P4 team",
                "login_date": "2024-02-26 10:31:49"
            },
            {
                "display_name": "Maud Leray - P4 team",
                "login_date": "2024-02-27 09:22:21"
            },
            {
                "display_name": "Osong Agberndifor - P4 team",
                "login_date": "2024-02-28 10:42:59"
            }
        ],
        "total": 5
    }
}
```

This is the diff comparison between AppScripts


---

<!-- Please add a reference link to the ticket, if one exists. -->
Ref: https://jira.greenpeace.org/browse/PLANET-7612

### Testing
#### Google sheet
Navigate through this [sheet](https://docs.google.com/spreadsheets/d/1uAmZLIWYsxrBByqbhoF_vVtSM7WGebYWIc0xftPRPwE/edit?gid=636537247#gid=636537247) > Tracking and then click on top nav Planet 4 > Tracking. The total column should be updated.

⚠️  Once this PR is merged, we'll need to update this sheet with all NROs and remove the assigned instance.
