### PR TITLE
PLANET-7706 Keep News & Stories page layout when reloading/filtering

### DIFF
--- a/assets/src/js/listing_pages.js
+++ b/assets/src/js/listing_pages.js
@@ -1,25 +1,34 @@
 const {__} = wp.i18n;
 
 export const setupListingPages = () => {
+  const listingPageContent = document.getElementById('listing-page-content');
+  // If the current page is not a listing page, we do nothing.
+  if (!listingPageContent) {
+    return;
+  }
+
   // Setup behaviour for list/grid toggle.
   const listViewToggle = document.querySelector('.list-view-toggle');
   const gridViewToggle = document.querySelector('.grid-view-toggle');
 
-  const listingPageContent = document.getElementById('listing-page-content');
-
-  if (!listingPageContent || !listViewToggle || !gridViewToggle) {
+  if (!listViewToggle && !gridViewToggle) {
     return;
   }
 
-  const switchViews = () => {
-    listingPageContent.classList.toggle('wp-block-query--list');
-    listingPageContent.classList.toggle('wp-block-query--grid');
-    gridViewToggle.classList.toggle('d-none');
-    listViewToggle.classList.toggle('d-none');
+  listingPageContent.classList.toggle('wp-block-query--list', gridViewToggle);
+  listingPageContent.classList.toggle('wp-block-query--grid', listViewToggle);
+
+  const switchViews = layout => {
+    const newUrl = new URL(window.location.href);
+    newUrl.searchParams.set('layout', layout);
+    window.location.href = newUrl.href;
   };
 
-  listViewToggle.onclick = switchViews;
-  gridViewToggle.onclick = switchViews;
+  if (listViewToggle) {
+    listViewToggle.onclick = () => switchViews('list');
+  } else {
+    gridViewToggle.onclick = () => switchViews('grid');
+  }
 
   // Setup filters for the News & Stories page.
   const filters = document.querySelector('.listing-page-filters');
@@ -30,7 +39,7 @@ export const setupListingPages = () => {
   const AVAILABLE_FILTERS = ['category', 'post-type'];
 
   const updateFilters = () => {
-    const newUrl = new URL(window.location.href.split('/page/')[0]);
+    const newUrl = new URL(window.location.href.replace(/\/page\/\d/, '/'));
 
     AVAILABLE_FILTERS.forEach(filter => {
       const {value} = document.getElementById(filter);

--- a/src/ListingPage.php
+++ b/src/ListingPage.php
@@ -47,6 +47,9 @@ class ListingPage
         $this->context['page_category'] = is_home() ? 'News' : 'Listing Page';
         $this->context['og_type'] = isset($this->context['author']) ? 'profile' : 'website';
 
+        // Set layout (grid or list)
+        $this->set_layout();
+
         // Filters (News & Stories page only)
         $this->set_filters();
 
@@ -131,6 +134,14 @@ class ListingPage
 
         $this->context['current_category'] = $_GET['category'] ?? '';
         $this->context['current_post_type'] = $_GET['post-type'] ?? '';
+    }
+
+    /**
+     * Set the layout (grid or list). The default is list.
+     */
+    private function set_layout(): void
+    {
+        $this->context['layout'] = $_GET['layout'] ?? 'list';
     }
 
     /**

--- a/src/ListingPage.php
+++ b/src/ListingPage.php
@@ -48,7 +48,7 @@ class ListingPage
         $this->context['og_type'] = isset($this->context['author']) ? 'profile' : 'website';
 
         // Set layout (grid or list)
-        $this->set_layout();
+        $this->context['layout'] = $_GET['layout'] ?? 'list';
 
         // Filters (News & Stories page only)
         $this->set_filters();
@@ -134,14 +134,6 @@ class ListingPage
 
         $this->context['current_category'] = $_GET['category'] ?? '';
         $this->context['current_post_type'] = $_GET['post-type'] ?? '';
-    }
-
-    /**
-     * Set the layout (grid or list). The default is list.
-     */
-    private function set_layout(): void
-    {
-        $this->context['layout'] = $_GET['layout'] ?? 'list';
     }
 
     /**

--- a/templates/listing-page.twig
+++ b/templates/listing-page.twig
@@ -6,12 +6,15 @@
         {% else %}
             <h2>{{ listing_page_title ?? __( 'All articles', 'planet4-master-theme' ) }}</h2>
         {% endif %}
-        <span class="grid-view-toggle" title="{{__( 'Grid layout', 'planet4-master-theme' ) }}">
-            {{ 'grid-view'|svgicon }}
-        </span>
-        <span class="list-view-toggle d-none" title="{{__( 'List layout', 'planet4-master-theme' ) }}">
-            {{ 'list-view'|svgicon }}
-        </span>
+        {% if layout == 'list' %}
+            <span class="grid-view-toggle" title="{{__( 'Grid layout', 'planet4-master-theme' ) }}">
+                {{ 'grid-view'|svgicon }}
+            </span>
+        {% else %}
+            <span class="list-view-toggle" title="{{__( 'List layout', 'planet4-master-theme' ) }}">
+                {{ 'list-view'|svgicon }}
+            </span>
+        {% endif %}
     </div>
     <div>{{ listing_page_content|raw }}</div>
 </div>


### PR DESCRIPTION
### Description

See [PLANET-7706](https://jira.greenpeace.org/browse/PLANET-7706)

### Testing

You can check this new behaviour (with pagination) on the titan instance:
- in a normal listing page ([example](https://www-dev.greenpeace.org/test-titan/press/))
- in the [News & Stories page](https://www-dev.greenpeace.org/test-titan/news-stories/) (for this one make sure the filtering also still works as expected)