### PR TITLE
PLANET-7761 Add new Portugal website to NRO footer selector

### DIFF
--- a/templates/countries.json
+++ b/templates/countries.json
@@ -469,6 +469,17 @@
           "locale": ["pl-PL"]
         }
       ]
+    },
+    {
+      "name": "Portugal",
+      "codes": ["PT"],
+      "lang": [
+        {
+          "name": "Portugal",
+          "url": "https://www.greenpeace.pt/",
+          "locale": ["pt-PT"]
+        }
+      ]
     }
   ],
   "R": [


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-7761

### Testing

1. There should be a new link for Portugal in the footer country selector