### PR TITLE
Fix formSubmission event for GravityForms redirect confirmations

### DIFF
--- a/src/GravityFormsExtensions.php
+++ b/src/GravityFormsExtensions.php
@@ -840,7 +840,7 @@ class GravityFormsExtensions
 
 
             $script = '<script type="text/javascript">
-                if (window["google_tag_value"]) {
+                if (typeof googleTagManagerData !== "undefined" && googleTagManagerData?.google_tag_value) {
                     window.dataLayer = window.dataLayer || [];
 
                     let push_data = {


### PR DESCRIPTION
### Summary
Fixes sending formSubmission events when using redirect confirmations in GravityForms. 

The new [JS file that contains Tag Manager code](https://github.com/greenpeace/planet4-master-theme/blob/695451aee431d4058de99e48ae006f4c0a9d0245/assets/src/js/google_tag_manager.js#L5)  for Tag Manager since [PLANET-7625](https://jira.greenpeace.org/browse/PLANET-7625) initialized `google_tag_value` inside a conditional. It was a global variable in the Twig template that was used before that change.

The [script that sends formSubmission events before redirecting](https://github.com/greenpeace/planet4-master-theme/blob/695451aee431d4058de99e48ae006f4c0a9d0245/src/GravityFormsExtensions.php#L875-L911) was still referencing `google_tag_value` as a global variable and stopped working. 

The new version now uses `googleTagManagerData`, the constant that contains the tag manager settings of Planet4.

### Testing

1. Create a GravityForm that uses a redirect as a confirmation
2. Fill in the form and test if the `formSubmission` event is pushed to dataLayer (using either Google Tag Manager preview mode or the Chrome plugin "Adswerve - dataLayer Inspector+" both works


