### PR TITLE
PLANET-7766: Purge Cloudflare on file replacement

### DIFF
--- a/admin/js/media_replacer.js
+++ b/admin/js/media_replacer.js
@@ -49,7 +49,7 @@ document.addEventListener('DOMContentLoaded', () => {
             return;
           }
 
-          window.location.href = window.location.href + '&nocache=' + new Date().getTime();
+          location.reload(true);
         })
         .catch(error => {
           if (replaceMediaButton) {

--- a/src/CloudflarePurger.php
+++ b/src/CloudflarePurger.php
@@ -55,10 +55,13 @@ class CloudflarePurger
         $chunks = array_chunk(array_unique($urls), 30);
 
         foreach ($chunks as $chunk) {
-            yield [
-                $this->api->zonePurgeFiles($this->zone_id, $chunk),
-                $chunk,
-            ];
+            $result = $this->api->zonePurgeFiles($this->zone_id, $chunk);
+
+            if (function_exists('\Sentry\captureMessage')) {
+                \Sentry\captureMessage(print_r($result, true));
+            }
+
+            yield [$result, $chunk];
         }
     }
 

--- a/src/MediaReplacer.php
+++ b/src/MediaReplacer.php
@@ -13,6 +13,7 @@ class MediaReplacer
 {
     private array $replacement_status;
     private array $user_messages;
+    private CloudflarePurger $cf;
 
     private const IMAGE_MIME_TYPES = [
         IMAGETYPE_JPEG => [
@@ -53,6 +54,8 @@ class MediaReplacer
         if (function_exists('ud_get_stateless_media') && ud_get_stateless_media('sm.mode') === 'disabled') {
             return;
         }
+
+        $this->cf = new CloudflarePurger();
 
         $this->replacement_status = [
             'success' => [],
@@ -498,7 +501,8 @@ class MediaReplacer
             $status = ud_get_stateless_media()->get_client()->add_media($image_args);
 
             if ($status) {
-                $this->success_handler($this->user_messages['success'], $name);
+                $stateless_url = "https://www.greenpeace.org/static/" . $status['bucket'] . "/" . $status['name'];
+                $this->success_handler($this->user_messages['success'], $stateless_url);
                 return true;
             }
             throw new \LogicException($this->user_messages['error']);
@@ -529,8 +533,19 @@ class MediaReplacer
      *
      * @param string $message The success message.
      */
-    private function success_handler(string $message): void
+    private function success_handler(string $message, string $stateless_url): void
     {
+        $this->cf->purge([$stateless_url]);
+
+        // foreach ($aa as [$response, $purgedUrls]) {
+        //     error_log ("Purged URLs:");
+        //     error_log(print_r($purgedUrls, true));
+        //     // print_r($purgedUrls);
+        //     // echo "Response:\n";
+        //     error_log('aaaa $response');
+        //     error_log(print_r($response, true));
+        // }
+
         array_push($this->replacement_status['success'], $message);
         $this->transient_handler(self::TRANSIENT['file'], $this->replacement_status);
     }

--- a/src/MediaReplacer.php
+++ b/src/MediaReplacer.php
@@ -535,16 +535,14 @@ class MediaReplacer
      */
     private function success_handler(string $message, string $stateless_url): void
     {
-        $this->cf->purge([$stateless_url]);
+        $result = $this->cf->purge([$stateless_url]);
 
-        // foreach ($aa as [$response, $purgedUrls]) {
-        //     error_log ("Purged URLs:");
-        //     error_log(print_r($purgedUrls, true));
-        //     // print_r($purgedUrls);
-        //     // echo "Response:\n";
-        //     error_log('aaaa $response');
-        //     error_log(print_r($response, true));
-        // }
+        foreach ($result as [$response, $purgedUrls]) {
+            if (function_exists('\Sentry\captureException')) {
+                \Sentry\captureException(print_r($response, true));
+                \Sentry\captureException(print_r($purgedUrls, true));
+            }
+        }
 
         array_push($this->replacement_status['success'], $message);
         $this->transient_handler(self::TRANSIENT['file'], $this->replacement_status);

--- a/src/MediaReplacer.php
+++ b/src/MediaReplacer.php
@@ -538,9 +538,9 @@ class MediaReplacer
         $result = $this->cf->purge([$stateless_url]);
 
         foreach ($result as [$response, $purgedUrls]) {
-            if (function_exists('\Sentry\captureException')) {
-                \Sentry\captureException(print_r($response, true));
-                \Sentry\captureException(print_r($purgedUrls, true));
+            if (function_exists('\Sentry\captureMessage')) {
+                \Sentry\captureMessage(print_r($response, true));
+                \Sentry\captureMessage(print_r($purgedUrls, true));
             }
         }
         $this->cf->purge([$stateless_url]);

--- a/src/MediaReplacer.php
+++ b/src/MediaReplacer.php
@@ -543,6 +543,16 @@ class MediaReplacer
                 \Sentry\captureException(print_r($purgedUrls, true));
             }
         }
+        $this->cf->purge([$stateless_url]);
+
+        // foreach ($aa as [$response, $purgedUrls]) {
+        //     error_log ("Purged URLs:");
+        //     error_log(print_r($purgedUrls, true));
+        //     // print_r($purgedUrls);
+        //     // echo "Response:\n";
+        //     error_log('aaaa $response');
+        //     error_log(print_r($response, true));
+        // }
 
         array_push($this->replacement_status['success'], $message);
         $this->transient_handler(self::TRANSIENT['file'], $this->replacement_status);

--- a/src/MediaReplacer.php
+++ b/src/MediaReplacer.php
@@ -502,7 +502,8 @@ class MediaReplacer
                 'absolutePath' => $absolute_path,
                 'mimeType' => $mime,
                 'metadata' => $metadata,
-                'cacheControl' => 'public, max-age=36000, must-revalidate',
+                // 'cacheControl' => 'public, max-age=36000, must-revalidate',
+                'cacheControl' => 'no-store, no-cache, must-revalidate, max-age=0, private',
                 'contentDisposition' => null,
                 'force' => true,
             ];


### PR DESCRIPTION
### Summary

This PR:
- Purges the Cloudflare cache after file replacements.
- Reduces the calls to the `ud_get_stateless_media` function.

---

Ref: https://jira.greenpeace.org/browse/PLANET-7766

### Testing

1. Go to the [Media Library](https://www-dev.greenpeace.org/test-nix/wp-admin/upload.php).
2. Upload a new file, preferably an image.
3. Replace it by clicking the Replace Media button.
4. Check that the file was replaced and the user can see and interact with the new file (for instance, if an image was replaced, the new one has to be visible in the back and the front).
