### PR TITLE
PLANET-7755 Add option for applying social share settings to Posts an…

### DIFF
--- a/src/GravityFormsExtensions.php
+++ b/src/GravityFormsExtensions.php
@@ -54,6 +54,34 @@ class GravityFormsExtensions
         ],
     ];
 
+    public const P4_SHARE_BUTTONS = [
+        [
+            'label' => 'WhatsApp',
+            'name' => 'whatsapp',
+            'default_value' => 1,
+        ],
+        [
+            'label' => 'Facebook',
+            'name' => 'facebook',
+            'default_value' => 1,
+        ],
+        [
+            'label' => 'Twitter',
+            'name' => 'twitter',
+            'default_value' => 1,
+        ],
+        [
+            'label' => 'Email',
+            'name' => 'email',
+            'default_value' => 1,
+        ],
+        [
+            'label' => 'Native share (mobile only)',
+            'name' => 'native',
+            'default_value' => 1,
+        ],
+    ];
+
     public array $current_entry = [];
 
     public string $is_payment_successful = '';
@@ -341,6 +369,17 @@ class GravityFormsExtensions
             $fields = array_merge($fields, $share_buttons);
         }
 
+        $apply_social_sharing_options = planet4_get_option('apply_social_sharing_options', 'posts_and_forms');
+
+        if ($apply_social_sharing_options === "posts") {
+            $fields['p4_share_buttons']['fields'][] = [
+                'type' => 'checkbox',
+                'name' => 'p4_gf_share_platforms',
+                'label' => __('Show share buttons below message', 'planet4-master-theme-backend'),
+                'choices' => self::P4_SHARE_BUTTONS,
+            ];
+        }
+
         $fields['p4_share_buttons']['fields'][] = [
             'type' => 'text',
             'name' => 'p4_gf_share_text_override',
@@ -464,18 +503,31 @@ class GravityFormsExtensions
             </script>";
         }
 
-        $social_share_options = planet4_get_option('social_share_options', []);
+        $share_platforms = [
+            'facebook' => $current_confirmation['facebook'] ?? true,
+            'twitter' => $current_confirmation['twitter'] ?? true,
+            'whatsapp' => $current_confirmation['whatsapp'] ?? true,
+            'native' => $current_confirmation['native'] ?? true,
+            'email' => $current_confirmation['email'] ?? true,
+        ];
 
-        $confirmation_fields = [
-            'confirmation' => $confirmation,
-            'share_platforms' => [
+        $apply_social_sharing_options = planet4_get_option('apply_social_sharing_options', 'posts_and_forms');
+
+        if ($apply_social_sharing_options === "posts_and_forms") {
+            $social_share_options = planet4_get_option('social_share_options', []);
+            $share_platforms = [
                 'facebook' => in_array('facebook', $social_share_options),
                 'twitter' => in_array('twitter', $social_share_options),
                 'whatsapp' => in_array('whatsapp', $social_share_options),
                 'email' => in_array('email', $social_share_options),
                 // We might add a setting for this one in the future, but for now we always enable it in GF.
                 'native' => true,
-            ],
+            ];
+        }
+
+        $confirmation_fields = [
+            'confirmation' => $confirmation,
+            'share_platforms' => $share_platforms,
             'post' => $post,
             'social_accounts' => $post->get_social_accounts($context['footer_social_menu'] ?: []),
             'utm_medium' => 'gf-share',

--- a/src/Migrations/M041SetDefaultSocialSharingOption.php
+++ b/src/Migrations/M041SetDefaultSocialSharingOption.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace P4\MasterTheme\Migrations;
+
+use P4\MasterTheme\MigrationRecord;
+use P4\MasterTheme\MigrationScript;
+
+/**
+ * Set default social sharing option via the new P4 setting.
+ */
+class M041SetDefaultSocialSharingOption extends MigrationScript
+{
+    /**
+     * Perform the actual migration.
+     *
+     * @param MigrationRecord $record Information on the execution, can be used to add logs.
+     * phpcs:disable SlevomatCodingStandard.Functions.UnusedParameter -- interface implementation
+     */
+    protected static function execute(MigrationRecord $record): void
+    {
+        $options = get_option('planet4_options');
+        $options['apply_social_sharing_options'] = 'posts_and_forms';
+        update_option('planet4_options', $options);
+    }
+    // phpcs:enable SlevomatCodingStandard.Functions.UnusedParameter
+}

--- a/src/Migrator.php
+++ b/src/Migrator.php
@@ -42,6 +42,7 @@ use P4\MasterTheme\Migrations\M037MigrateCoversContentBlockToPostsListBlock;
 use P4\MasterTheme\Migrations\M038RemoveCustomSiteIcon;
 use P4\MasterTheme\Migrations\M039EnableNewSocialSharePlatforms;
 use P4\MasterTheme\Migrations\M040ReplaceSpecialCharactersInPostsContent;
+use P4\MasterTheme\Migrations\M041SetDefaultSocialSharingOption;
 
 /**
  * Run any new migration scripts and record results in the log.
@@ -101,6 +102,7 @@ class Migrator
             M038RemoveCustomSiteIcon::class,
             M039EnableNewSocialSharePlatforms::class,
             M040ReplaceSpecialCharactersInPostsContent::class,
+            M041SetDefaultSocialSharingOption::class,
         ];
 
         // Loop migrations and run those that haven't run yet.

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -412,6 +412,16 @@ class Settings
                         'type' => 'social_share_checkboxes',
                         'default' => [],
                     ],
+                    [
+                        'name' => __('Apply social sharing options', 'planet4-master-theme-backend'),
+                        'id' => 'apply_social_sharing_options',
+                        'type' => 'radio',
+                        'options' => [
+                            'posts' => __('Posts', 'planet4-master-theme-backend'),
+                            'posts_and_forms' => __('Posts & Forms', 'planet4-master-theme-backend'),
+                        ],
+                        'default' => 'posts_and_forms',
+                    ],
                 ],
             ],
             'planet4_settings_404_page' => [

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -421,6 +421,8 @@ class Settings
                             'posts_and_forms' => __('Posts & Forms', 'planet4-master-theme-backend'),
                         ],
                         'default' => 'posts_and_forms',
+                        'desc' => __('This is determining where the options above will be applied<br>
+                        If only Posts is selected, you can still customize sharing options for each form on its Confirmation settings.', 'planet4-master-theme-backend'),
                     ],
                 ],
             ],


### PR DESCRIPTION
### Summary
- Add option for applying social share settings to Posts and Forms
- Create a migration to set "Posts & Forms" as the default option
- Ensure that when only "Posts" is selected, Gravity Form Settings social share options work as before

---
Ref: [PLANET-7755](https://jira.greenpeace.org/browse/PLANET-7755)

### Testing Instructions

1. Testing Migration on Local:

    - Run `npx wp-env run cli wp p4-run-activator` to apply the migration.
    - The new settings default option (i.e "Posts & Forms") should be selected by default.
    - If needed, run `npm run db:reset` beforehand.

2. Testing the New Settings:
    
    -  On local or a test instance, go to `Planet 4 > Social` and select "Apply social sharing options" as either "Posts" or "Posts & Forms".
    - Verify that social sharing options works as expected in:
          - Any post
          - Gravity Forms confirmation page share buttons

3. Verifying "Posts" Only Behavior:

      - If "Posts" option is selected, the Gravity Forms Settings social share options should work as before.