### PR TITLE
PLANET-7647 Hide site icon setting

### DIFF
--- a/admin/css/options.css
+++ b/admin/css/options.css
@@ -28,6 +28,10 @@
   vertical-align: text-bottom;
 }
 
+.site-icon-section {
+  display: none;
+}
+
 @media (min-width: 768px) {
   .planet4_options .cmb-row:not(.hidden) {
     display: grid;

--- a/templates/blocks/favicon.twig
+++ b/templates/blocks/favicon.twig
@@ -1,0 +1,1 @@
+<link rel="shortcut icon" type="image/ico" href="{{ theme.uri }}/favicon.ico">

--- a/templates/html-header.twig
+++ b/templates/html-header.twig
@@ -15,7 +15,7 @@
     <link rel="pingback" href="{{ site.pingback_url }}">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
     <meta name="robots" content="max-snippet:-1, max-image-preview:large, max-video-preview:-1">
-    <link rel="shortcut icon" type="image/ico" href="{{ theme.uri }}/favicon.ico"/>
+    {% include 'blocks/favicon.twig' %}
     {% include 'head/google_fonts.twig' %}
 
     {% if hreflang %}


### PR DESCRIPTION
### Summary

Ref: https://jira.greenpeace.org/browse/PLANET-7647

---

Follow up from https://github.com/greenpeace/planet4-master-theme/pull/2507, there is one more additional option besides the one we disabled.

I couldn't find a hook for this one, so at least we can hide it in css for now to avoid confusion.

Also split up the favicon code in a new partial template, in case some NROs want to override it in their child theme.

### Testing

1. Swithing to this branch should hide the site icon option in _Settings > General_