### PR TITLE
PLANET-7703 Fix country selector close button focus ring

### DIFF
--- a/assets/src/scss/layout/_country-selector.scss
+++ b/assets/src/scss/layout/_country-selector.scss
@@ -19,7 +19,7 @@
   button:focus {
     border-radius: var(--link--focus--border-radius, 4px);
     outline: var(--link--focus--border, 2px solid #99c3ff);
-    outline-offset: 0;
+    outline-offset: 1px;
   }
 
   button:focus:not(:focus-visible) {
@@ -178,15 +178,13 @@
 }
 
 .country-control-close {
-  color: var(--white);
   border: none;
-  background: transparent;
+  background-image: url("../../images/cross.svg");
+  background-color: transparent;
+  background-size: cover;
   float: right;
   height: 16px;
   width: 16px;
-  padding: 0;
-  font-size: 16px;
-  font-weight: bold;
 
   html[dir="rtl"] & {
     float: left;

--- a/assets/src/scss/layout/_country-selector.scss
+++ b/assets/src/scss/layout/_country-selector.scss
@@ -12,13 +12,13 @@
     color: inherit;
   }
 
-  button:hover {
+  button:not(.country-control-close):hover {
     text-decoration: var(--link--hover--text-decoration);
   }
 
   button:focus {
     border-radius: var(--link--focus--border-radius, 4px);
-    outline: var(--link--focus--border, 2px solid rgba($white, 0.6));
+    outline: var(--link--focus--border, 2px solid #99c3ff);
     outline-offset: 0;
   }
 
@@ -178,14 +178,15 @@
 }
 
 .country-control-close {
-  background-color: var(--white);
-  background-repeat: no-repeat;
+  color: var(--white);
   border: none;
-  display: block;
+  background: transparent;
   float: right;
   height: 16px;
-  mask: url("../../images/cross.svg") 50% 50%/16px 16px no-repeat;
   width: 16px;
+  padding: 0;
+  font-size: 16px;
+  font-weight: bold;
 
   html[dir="rtl"] & {
     float: left;

--- a/templates/footer_country_selector.twig
+++ b/templates/footer_country_selector.twig
@@ -20,9 +20,7 @@
         data-bs-target="#country-selector"
         aria-expanded="false"
         aria-label="{{ __( 'Close country selector', 'planet4-master-theme' ) }}"
-    >
-        &#10005;
-    </button>
+    ></button>
     <ul class="countries" aria-label="{{ __('Worldwide site list', 'planet4-master-theme') }}">
         <li class="international"><a href="{{ international.url }}">{{ international.name }}</a></li>
         {% for initial, countries in countries_by_initials[1:] %}

--- a/templates/footer_country_selector.twig
+++ b/templates/footer_country_selector.twig
@@ -19,7 +19,9 @@
         data-bs-toggle="open"
         data-bs-target="#country-selector"
         aria-expanded="false"
-        aria-label="{{ __( 'Close country selector', 'planet4-master-theme' ) }}">
+        aria-label="{{ __( 'Close country selector', 'planet4-master-theme' ) }}"
+    >
+        &#10005;
     </button>
     <ul class="countries" aria-label="{{ __('Worldwide site list', 'planet4-master-theme') }}">
         <li class="international"><a href="{{ international.url }}">{{ international.name }}</a></li>


### PR DESCRIPTION
### Description

See [PLANET-7703](https://jira.greenpeace.org/browse/PLANET-7703)

This commit also adds a visually hidden span for better accessibility.

### Testing

Either on local or on the [titan instance](https://www-dev.greenpeace.org/test-titan/), make sure that the close button now has a visible focus state when navigating with tabs. Note that on local you will need to clear the Timber cache (`npx wp-env run cli wp timber clear_cache`) to test this.