### PR TITLE
PLANET-7773: Fix error in the `toggleCommentSubmit` script

### DIFF
--- a/assets/src/js/toggle_comment_submit.js
+++ b/assets/src/js/toggle_comment_submit.js
@@ -1,16 +1,13 @@
-function toggleCommentSubmit() {
-  const checkbox = document.getElementById('gdpr-comments-checkbox');
+document.addEventListener('DOMContentLoaded', () => {
+  const checkbox = document.querySelector('#gdpr-comments-checkbox');
   const submit = document.querySelector('#commentform button[type="submit"]');
 
-  if (checkbox.checked) {
-    submit.removeAttribute('disabled');
-  } else {
-    submit.setAttribute('disabled', '');
+  if (!checkbox || !submit) {
+    return;
   }
-}
 
-document.addEventListener('DOMContentLoaded', () => {
-  document.getElementById('gdpr-comments-checkbox')
-    .addEventListener('change', () => toggleCommentSubmit());
-  toggleCommentSubmit();
+  const toggleSubmit = () => { submit.disabled = !checkbox.checked; };
+
+  checkbox.addEventListener('change', toggleSubmit);
+  toggleSubmit();
 });


### PR DESCRIPTION
### Summary
This PR fixes the error in the `assets/src/js/toggle_comment_submit.js` script when the element `gdpr-comments-checkbox` is not part of the DOM. It also refactors the script for better readability and performance.

---

Ref: https://jira.greenpeace.org/browse/PLANET-7773

### Testing

1. Visit any post with comments and check that the "Post comment" toggles enable or disable when clicking on the "I agree on providing my name, email and content so that my comment can be stored and displayed in the website." checkbox.
3. Check there is no error in the browser console when comments are not enabled on a post.