### PR TITLE
Set server_name tag for Sentry logging

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -530,8 +530,18 @@ add_filter(
 
 if (class_exists('\\Sentry\\Options')) {
     add_filter('wp_sentry_options', function (\Sentry\Options $options) {
-        // Only sample 25% of the events
-        $options->setSampleRate(0.25);
+        // Only sample 50% of the events
+        $options->setSampleRate(0.50);
+
+        // Set server_name tag
+        $podname = gethostname();
+        $parts = explode('-', $podname);
+        $server_name = isset($parts[1]) ? $parts[1] : $podname;
+        if (count($parts) > 6) {
+            $server_name = $parts[1] . '-' . $parts[2];
+        }
+        $options->setServerName($server_name);
+
         return $options;
     });
 }


### PR DESCRIPTION
### Summary

As it currently gets the pod hostname it's harder to filter and merge pods from the same deployment. So tried to get the useful part of the hostname. Which is just one word for most instances, but may be two for some (eg. test instances).

Also increases a bit the events sample rate.

---

### Testing

_This is based on [wp-sentry filter](https://github.com/stayallive/wp-sentry/blob/master/README.md#wp_sentry_options) to set options for Sentry_

1. You should already be able to filter issues on Sentry using the filter `server_name is test-venus` in the Custom Search bar

![image](https://github.com/user-attachments/assets/720e5bcc-5c99-4851-913f-4db96f98b975)

