### PR TITLE
Remove carousel autoplay

### DIFF
--- a/assets/src/blocks/Covers/CoversCarouselLayout.js
+++ b/assets/src/blocks/Covers/CoversCarouselLayout.js
@@ -5,7 +5,7 @@ const {__} = wp.i18n;
 export const CoversCarouselLayout = ({covers, amountOfCoversPerRow, ...props}) => {
   const uniqueId = `covers-${uuid()}`;
   return (
-    <div id={uniqueId} className="carousel slide" data-bs-ride="carousel">
+    <div id={uniqueId} className="carousel slide">
       {covers.length > amountOfCoversPerRow &&
         <ol className="carousel-indicators">
           {covers.map((cover, index) => {

--- a/assets/src/js/query_loop_carousel.js
+++ b/assets/src/js/query_loop_carousel.js
@@ -56,7 +56,6 @@ export const setupQueryLoopCarousel = () => {
       const carousel = document.createElement('div');
       carousel.setAttribute('id', uniqueId);
       carousel.classList.add(LAYOUTS.carousel, 'slide');
-      carousel.dataset.bsRide = LAYOUTS.carousel;
 
       list.classList.add(`${LAYOUTS.carousel}-inner`);
       list.after(carousel);

--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -935,7 +935,6 @@ class MasterSite extends TimberSite
         ];
 
         // Allow below tags for carousel slider.
-        $allowedposttags['div']['data-bs-ride'] = true;
         $allowedposttags['li']['data-bs-target'] = true;
         $allowedposttags['li']['data-bs-slide-to'] = true;
         $allowedposttags['a']['data-bs-slide'] = true;


### PR DESCRIPTION
### Description

This is for the Actions List and Covers blocks. This behaviour has been updated in Bootstrap 5.2 ([docs](https://getbootstrap.com/docs/5.2/components/carousel/)). It's been confirmed with the design team that we want to deactivate the autoplay!

<img width="826" alt="Screenshot 2025-02-28 at 11 31 47" src="https://github.com/user-attachments/assets/3c94e531-0054-40d3-a6ac-4f3890aa892a" />

### Testing

On any page with a carousel layout, on `main` branch ([example](https://www-dev.greenpeace.org/test-rhea/actions-list/)) it has autoplay but on this branch it shouldn't ([example](https://www-dev.greenpeace.org/test-janus/actions-list/)).