### PR TITLE
Refresh images after replacing them using the Media Replacer

### DIFF
--- a/admin/js/media_replacer_cache_cleaner.js
+++ b/admin/js/media_replacer_cache_cleaner.js
@@ -1,0 +1,36 @@
+/* global cacheCleaner */
+
+/**
+ * JavaScript implementation for forcing images to update after replacing,
+ * by introducing an extra parameter to the URL.
+ */
+document.addEventListener('DOMContentLoaded', () => {
+  const cleaner = '?cache_cleaner=' + Date.now();
+
+  // Check if we are on the media library page
+  if (window.location.href.indexOf('upload.php') > -1) {
+    const selectors = '.attachments-wrapper img, .edit-attachment-frame img, #the-list img';
+    const images = document.querySelectorAll(selectors);
+
+    images.forEach(img => {
+      if (cacheCleaner.some(substring => img.getAttribute('src').includes(substring))) {
+        img.setAttribute('src', img.getAttribute('src') + cleaner);
+      }
+    });
+  }
+
+  // Check if we are on the media edit page
+  if (window.location.href.indexOf('post.php') > -1) {
+    const images = document.querySelectorAll('.wp_attachment_holder img');
+    const thumbLinks = document.querySelectorAll('#sm-attachment-metabox .sm-view-link');
+
+    images.forEach(img => {
+      if (cacheCleaner.some(substring => img.getAttribute('src').includes(substring))) {
+        img.setAttribute('src', img.getAttribute('src') + cleaner);
+      }
+    });
+    thumbLinks.forEach(thumb => {
+      thumb.setAttribute('href', thumb.getAttribute('href') + cleaner);
+    });
+  }
+});


### PR DESCRIPTION
### Summary

This PR introduces a mechanism to refresh the images after replacing them using the Media Replacer feature.

---

<!-- Please add a reference link to the ticket, if one exists. -->
Ref: https://jira.greenpeace.org/browse/PLANET-7766

### Notes
@comzeradd: I am not quite happy with this solution but it works.
Purging Cloudflare using the methods of the `CloudflarePurger` class showed not to be effective to reflect the changes of the replaced image. Instead of that, this PR adds a query parameter to the image URLs using JavaScript to force the browser to show the updated version of the image. If you're okay with this implementation, I'll ask the reviewers to check the code in depth.

### Testing

1. Replace an image using the Media Replacer feature.
2. Check the image was replaced in Google Cloud Storage.
3. Check that the Media Library shows the newly replaced image.
4. Check that the links of the Stateless metabox in the image editor open the newly replaced image.