### PR TITLE
PLANET-7756: Navigation Menu: fix accessibility issues on mobile

### DIFF
--- a/assets/src/js/accessible_nav_menu.js
+++ b/assets/src/js/accessible_nav_menu.js
@@ -17,6 +17,10 @@ class AccessibleNavMenu {
       this.handleAccessibleNavLink(mainNav);
       this.handleNavMenuSub(mainNav);
       this.handleNavMenuSubItems(mainNav);
+
+      this.addKeyboardTrap();
+      this.focusLogoOnMenuOpen();
+      this.focusLogoOnMenuClose();
     });
   }
 
@@ -125,6 +129,58 @@ class AccessibleNavMenu {
           submenu.querySelector('.accessible-nav-link')?.focus();
         }
       });
+    });
+  }
+
+  /**
+   * Adds event listeners to create a keyboard trap between the donate button and the close button.
+   */
+  addKeyboardTrap() {
+    const donateBtn = document.querySelector('#nav-main .btn-donate');
+    const closeBtn = document.querySelector('#nav-main .nav-menu-close');
+
+    if (!donateBtn || !closeBtn) {
+      return;
+    }
+
+    donateBtn.addEventListener('focusout', () => {
+      closeBtn.focus();
+    });
+  }
+
+  /**
+   * Adds event listeners to focus the logo when the menu is opened.
+   */
+  focusLogoOnMenuOpen() {
+    const hamburgerBtn = document.querySelector('.nav-menu-toggle');
+    const logo = document.querySelector('#nav-main .site-logo');
+
+    if (!hamburgerBtn || !logo) {
+      return;
+    }
+
+    hamburgerBtn.addEventListener('keydown', event => {
+      if (event.key === 'Enter') {
+        setTimeout(() => logo.focus(), 0); // Give time for focus to apply
+      }
+    });
+  }
+
+  /**
+   * Adds event listeners to focus the logo when the menu is closed.
+   */
+  focusLogoOnMenuClose() {
+    const closeBtn = document.querySelector('#nav-main .nav-menu-close');
+    const logo = document.querySelector('#header .site-logo');
+
+    if (!logo || !closeBtn) {
+      return;
+    }
+
+    closeBtn.addEventListener('keydown', event => {
+      if (event.key === 'Enter') {
+        setTimeout(() => logo.focus(), 0); // Give time for focus to apply
+      }
     });
   }
 }

--- a/assets/src/js/accessible_nav_menu.js
+++ b/assets/src/js/accessible_nav_menu.js
@@ -8,19 +8,19 @@ class AccessibleNavMenu {
   constructor() {
     document.addEventListener('DOMContentLoaded', () => {
       const mainNav = document.querySelector('#nav-main-desktop');
+      const mobileNav = document.querySelector('#nav-main');
 
-      if (!mainNav) {
-        return;
+      if (mainNav) {
+        this.handleNavMenuItem(mainNav);
+        this.handleAccessibleNavLink(mainNav);
+        this.handleNavMenuSub(mainNav);
+        this.handleNavMenuSubItems(mainNav);
       }
-
-      this.handleNavMenuItem(mainNav);
-      this.handleAccessibleNavLink(mainNav);
-      this.handleNavMenuSub(mainNav);
-      this.handleNavMenuSubItems(mainNav);
-
-      this.addKeyboardTrap();
-      this.focusLogoOnMenuOpen();
-      this.focusLogoOnMenuClose();
+      if (mobileNav) {
+        this.addKeyboardTrap(mobileNav);
+        this.focusLogoOnMenuOpen(mobileNav);
+        this.focusLogoOnMenuClose(mobileNav);
+      }
     });
   }
 
@@ -134,10 +134,11 @@ class AccessibleNavMenu {
 
   /**
    * Adds event listeners to create a keyboard trap between the donate button and the close button.
+   * @param {HTMLElement} mobileNav The mobile nav selector.
    */
-  addKeyboardTrap() {
-    const donateBtn = document.querySelector('#nav-main .btn-donate');
-    const closeBtn = document.querySelector('#nav-main .nav-menu-close');
+  addKeyboardTrap(mobileNav) {
+    const donateBtn = mobileNav.querySelector('.btn-donate');
+    const closeBtn = mobileNav.querySelector('.nav-menu-close');
 
     if (!donateBtn || !closeBtn) {
       return;
@@ -150,10 +151,11 @@ class AccessibleNavMenu {
 
   /**
    * Adds event listeners to focus the logo when the menu is opened.
+   * @param {HTMLElement} mobileNav The mobile nav selector.
    */
-  focusLogoOnMenuOpen() {
+  focusLogoOnMenuOpen(mobileNav) {
     const hamburgerBtn = document.querySelector('.nav-menu-toggle');
-    const logo = document.querySelector('#nav-main .site-logo');
+    const logo = mobileNav.querySelector('.site-logo');
 
     if (!hamburgerBtn || !logo) {
       return;
@@ -168,18 +170,23 @@ class AccessibleNavMenu {
 
   /**
    * Adds event listeners to focus the logo when the menu is closed.
+   * @param {HTMLElement} mobileNav The mobile nav selector.
    */
-  focusLogoOnMenuClose() {
-    const closeBtn = document.querySelector('#nav-main .nav-menu-close');
-    const logo = document.querySelector('#header .site-logo');
+  focusLogoOnMenuClose(mobileNav) {
+    const closeBtn = mobileNav.querySelector('.nav-menu-close');
+    const hamburgerLogo = mobileNav.querySelector('.site-logo');
+    const mainLogo = document.querySelector('#header .site-logo');
 
-    if (!logo || !closeBtn) {
+    if (!mainLogo || !hamburgerLogo || !closeBtn) {
       return;
     }
 
     closeBtn.addEventListener('keydown', event => {
       if (event.key === 'Enter') {
-        setTimeout(() => logo.focus(), 0); // Give time for focus to apply
+        setTimeout(() => mainLogo.focus(), 0); // Give time for focus to apply
+      }
+      if (event.key === 'Tab' && event.shiftKey) {
+        setTimeout(() => hamburgerLogo.focus(), 0); // Give time for focus to apply
       }
     });
   }

--- a/assets/src/js/accessible_nav_menu.js
+++ b/assets/src/js/accessible_nav_menu.js
@@ -133,19 +133,27 @@ class AccessibleNavMenu {
   }
 
   /**
-   * Adds event listeners to create a keyboard trap between the donate button and the close button.
+   * Adds event listeners to create a keyboard trap between the buttons.
    * @param {HTMLElement} mobileNav The mobile nav selector.
    */
   addKeyboardTrap(mobileNav) {
     const donateBtn = mobileNav.querySelector('.btn-donate');
     const closeBtn = mobileNav.querySelector('.nav-menu-close');
+    const logo = mobileNav.querySelector('.site-logo');
 
-    if (!donateBtn || !closeBtn) {
-      return;
-    }
-
-    donateBtn.addEventListener('focusout', () => {
-      closeBtn.focus();
+    closeBtn.addEventListener('keydown', event => {
+      if (event.key === 'Tab' && event.shiftKey) {
+        event.preventDefault();
+        setTimeout(() => donateBtn.focus(), 5);
+      }
+      if (event.key === 'Tab') {
+        setTimeout(() => logo.focus(), 0);
+      }
+    });
+    logo.addEventListener('keydown', event => {
+      if (event.key === 'Tab' && event.shiftKey) {
+        setTimeout(() => closeBtn.focus(), 0);
+      }
     });
   }
 
@@ -163,7 +171,7 @@ class AccessibleNavMenu {
 
     hamburgerBtn.addEventListener('keydown', event => {
       if (event.key === 'Enter') {
-        setTimeout(() => logo.focus(), 0); // Give time for focus to apply
+        setTimeout(() => logo.focus(), 0);
       }
     });
   }
@@ -183,10 +191,10 @@ class AccessibleNavMenu {
 
     closeBtn.addEventListener('keydown', event => {
       if (event.key === 'Enter') {
-        setTimeout(() => mainLogo.focus(), 0); // Give time for focus to apply
+        setTimeout(() => mainLogo.focus(), 0);
       }
       if (event.key === 'Tab' && event.shiftKey) {
-        setTimeout(() => hamburgerLogo.focus(), 0); // Give time for focus to apply
+        setTimeout(() => hamburgerLogo.focus(), 0);
       }
     });
   }

--- a/assets/src/scss/layout/_navbar.scss
+++ b/assets/src/scss/layout/_navbar.scss
@@ -363,6 +363,12 @@ a.nav-link:hover:before,
   @include large-and-up {
     display: none;
   }
+
+  &:focus,
+  &:focus-within,
+  &:focus-visible {
+    @include focus-styles;
+  }
 }
 
 .navigation-bar_min {

--- a/assets/src/scss/layout/navbar/_burger-menu.scss
+++ b/assets/src/scss/layout/navbar/_burger-menu.scss
@@ -208,6 +208,12 @@ $transition-duration: .2s;
       transform: rotate(90deg);
     }
   }
+
+  &:focus,
+  &:focus-within,
+  &:focus-visible {
+    @include focus-styles;
+  }
 }
 
 .nav-menu-close {

--- a/assets/src/scss/layout/navbar/_burger-menu.scss
+++ b/assets/src/scss/layout/navbar/_burger-menu.scss
@@ -106,7 +106,7 @@ $transition-duration: .2s;
 
   .nav-items {
     width: 100%;
-    padding: $sp-1x 0 0;
+    padding: $sp-1x $sp-x 0;
   }
 
   @include scrollbar-layout;
@@ -213,14 +213,25 @@ $transition-duration: .2s;
 .nav-menu-close {
   display: block;
   position: absolute;
-  top: 16px;
   inset-inline-end: $sp-3;
   border: none;
-  height: 16px;
-  width: 16px;
-  mask: url("../../images/cross.svg") 50% 50%/16px 16px no-repeat;
-  background-color: var(--grey-900);
+  height: 20px;
+  width: 20px;
+  top: 18px;
   z-index: 5;
+  background-color: transparent;
+  background-image: url("../../images/black-cross.svg");
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: contain;
+  background-size: 12px;
+  border-radius: 100%;
+
+  &:focus,
+  &:focus-visible {
+    outline: 2px solid #99c3ff;
+    outline-offset: 2px;
+  }
 
   @supports not (inset-inline-end: $sp-3) {
     right: $sp-3;

--- a/assets/src/scss/layout/navbar/_burger-menu.scss
+++ b/assets/src/scss/layout/navbar/_burger-menu.scss
@@ -229,8 +229,7 @@ $transition-duration: .2s;
 
   &:focus,
   &:focus-visible {
-    outline: 2px solid #99c3ff;
-    outline-offset: 2px;
+    @include focus-styles;
   }
 
   @supports not (inset-inline-end: $sp-3) {

--- a/assets/src/scss/layout/navbar/mobile.scss
+++ b/assets/src/scss/layout/navbar/mobile.scss
@@ -1,8 +1,4 @@
 #nav-mobile {
-  _-- {
-    height: 50px;
-  }
-
   display: flex;
   flex: 1 1 100%;
   flex-grow: 1;
@@ -42,7 +38,7 @@
   .nav-item {
     line-height: 50px;
     font-weight: var(--font-weight-regular);
-    margin: 0 20px;
+    margin: 5px 20px;
   }
 
   .nav-link {

--- a/templates/burger-menu.twig
+++ b/templates/burger-menu.twig
@@ -1,16 +1,4 @@
 <div id="nav-main" class="burger-menu d-lg-none">
-    <button
-            class="nav-menu-close"
-            type="button"
-            aria-label="{{ __( 'Close navigation mobile menu', 'planet4-master-theme' ) }}"
-            aria-expanded="false"
-            data-bs-toggle="open"
-            data-bs-target="#nav-main">
-    <span class="visually-hidden">
-      {{ __( 'Close navigation mobile menu', 'planet4-master-theme' ) }}
-    </span>
-    </button>
-
     <div class="burger-menu-header">
         <a class="site-logo" href="{{ data_nav_bar.home_url }}">
             {% include "blocks/site_logo.twig" %}
@@ -58,5 +46,17 @@
             {{ donate_menu_items[0].title }}
         </a>
     </div>
+
+    <button
+        class="nav-menu-close"
+        type="button"
+        aria-label="{{ __( 'Close navigation mobile menu', 'planet4-master-theme' ) }}"
+        aria-expanded="false"
+        data-bs-toggle="open"
+        data-bs-target="#nav-main">
+            <span class="visually-hidden">
+            {{ __( 'Close navigation mobile menu', 'planet4-master-theme' ) }}
+            </span>
+    </button>
 </div>
 <div class="burger-menu-overlay d-lg-none"></div>


### PR DESCRIPTION
### Summary

This PR improves the accessibility of the mobile navigation menu by introducing these changes:
- When the hamburger menu is open, tabbing makes the close button reachable.
- A keyboard trap is added to the navigation menu when the hamburger menu is open.
- A focus ring is added to the reset button of the search field.
- The focus rings are no longer cut off.

---

Ref: https://jira.greenpeace.org/browse/PLANET-7756 

### Testing

1. Run this PR locally or in the dev instance.
2. Check the mobile version.
3. Check that the mobile navigation menu accomplishes the requirements of the Jira ticket.
