### PR TITLE
PLANET-7749 Add Bluesky share button

### DIFF
--- a/assets/src/scss/base/_colors.scss
+++ b/assets/src/scss/base/_colors.scss
@@ -2,3 +2,4 @@
 $facebook: #4267b2;
 $twitter:  #1c1c1c;
 $whatsapp: #25d366;
+$bluesky: #1185fe;

--- a/assets/src/scss/components/_share-buttons.scss
+++ b/assets/src/scss/components/_share-buttons.scss
@@ -36,6 +36,10 @@
     color: $facebook;
   }
 
+  .bluesky {
+    color: $bluesky;
+  }
+
   .email {
     .icon {
       fill: none;
@@ -52,7 +56,7 @@
     }
   }
 
-  .twitter, .facebook, .email {
+  .twitter, .facebook, .email, .bluesky {
     .icon {
       top: 1px;
     }

--- a/src/GravityFormsExtensions.php
+++ b/src/GravityFormsExtensions.php
@@ -80,6 +80,11 @@ class GravityFormsExtensions
             'name' => 'native',
             'default_value' => 1,
         ],
+        [
+            'label' => 'Bluesky',
+            'name' => 'bluesky',
+            'default_value' => 0,
+        ],
     ];
 
     public array $current_entry = [];
@@ -509,6 +514,7 @@ class GravityFormsExtensions
             'whatsapp' => $current_confirmation['whatsapp'] ?? true,
             'native' => $current_confirmation['native'] ?? true,
             'email' => $current_confirmation['email'] ?? true,
+            'bluesky' => $current_confirmation['bluesky'] ?? true,
         ];
 
         $apply_social_sharing_options = planet4_get_option('apply_social_sharing_options', 'posts_and_forms');
@@ -520,6 +526,7 @@ class GravityFormsExtensions
                 'twitter' => in_array('twitter', $social_share_options),
                 'whatsapp' => in_array('whatsapp', $social_share_options),
                 'email' => in_array('email', $social_share_options),
+                'bluesky' => in_array('bluesky', $social_share_options),
                 // We might add a setting for this one in the future, but for now we always enable it in GF.
                 'native' => true,
             ];

--- a/src/Post.php
+++ b/src/Post.php
@@ -345,6 +345,7 @@ class Post extends TimberPost
             'twitter' => in_array('twitter', $social_share_options),
             'whatsapp' => in_array('whatsapp', $social_share_options),
             'email' => in_array('email', $social_share_options),
+            'bluesky' => in_array('bluesky', $social_share_options),
             // We might add a setting for this one in the future, but for now we always disable it in Posts.
             'native' => false,
         ];
@@ -397,6 +398,7 @@ class Post extends TimberPost
                 'twitter',
                 'youtube',
                 'instagram',
+                'bluesky',
             ];
             foreach ($social_menu as $social_menu_item) {
                 $url_parts = explode('/', rtrim($social_menu_item->url, '/'));

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -55,6 +55,7 @@ class Settings
         'whatsapp' => 'WhatsApp',
         'twitter' => 'X',
         'email' => 'Email',
+        'bluesky' => 'Bluesky',
     ];
 
     /**

--- a/templates/blocks/share_buttons.twig
+++ b/templates/blocks/share_buttons.twig
@@ -39,11 +39,12 @@
     {% endif %}
     <!-- Bluesky -->
     {% if share_platforms.bluesky %}
-        <a href="https://bsky.app/intent/compose?text={{ social.title|url_encode }}{% if share_text or social.description %} - {{ (share_text ?? social.description)|striptags|url_encode }}{% endif %}, via @{{ social_accounts.bluesky ?? 'greenpeace' }} {{ (socialLink ~ '&utm_source=bluesky')|url_encode }}"
+        <a href="https://bsky.app/intent/compose?text={{ social.title|url_encode }}{% if share_text or social.description %} - {{ (share_text ?? social.description)|striptags|url_encode }}{% endif %}, via @{{ social_accounts.bluesky }} {{ (socialLink ~ '&utm_source=bluesky')|url_encode }}"
            onclick="window.dataLayerPush('Bluesky');"
            target="_blank" class="share-btn bluesky">
             {{ 'bluesky'|svgicon }}
-            <span class="visually-hidden">{{ __( 'Share on', 'planet4-master-theme' ) }} Bluesky</span>
+            <!-- translators: %s = social share platform. -->
+            <span class="visually-hidden">{{ __( 'Share on %s', 'planet4-master-theme' )|format('Bluesky') }}</span>
         </a>
     {% endif %}
     <!-- Native (Gravity Forms only, for devices that support it) -->

--- a/templates/blocks/share_buttons.twig
+++ b/templates/blocks/share_buttons.twig
@@ -21,7 +21,7 @@
     {% endif %}
     <!-- Twitter -->
     {% if share_platforms.twitter %}
-        <a href="https://x.com/intent/post?related={{ social_accounts.twitter }}&text={{ social.title|url_encode }}{% if share_text or social.description %} - {{ (share_text ?? social.description)|striptags|url_encode }}{% endif %}, via @{{ social_accounts.twitter }}&url={{ (socialLink ~ '&utm_source=twitter')|url_encode }}"
+        <a href="https://x.com/intent/post?related={{ social_accounts.twitter }}&text={{ social.title|url_encode }}{% if share_text or social.description %} - {{ (share_text ?? social.description)|striptags|url_encode }}{% endif %}{% if social_accounts.twitter %}, via @{{ social_accounts.twitter }}{% endif %}&url={{ (socialLink ~ '&utm_source=twitter')|url_encode }}"
             onclick="window.dataLayerPush('Twitter');"
             target="_blank" class="share-btn twitter">
             {{ 'twitter'|svgicon }}
@@ -39,7 +39,7 @@
     {% endif %}
     <!-- Bluesky -->
     {% if share_platforms.bluesky %}
-        <a href="https://bsky.app/intent/compose?text={{ social.title|url_encode }}{% if share_text or social.description %} - {{ (share_text ?? social.description)|striptags|url_encode }}{% endif %}, via @{{ social_accounts.bluesky }} {{ (socialLink ~ '&utm_source=bluesky')|url_encode }}"
+        <a href="https://bsky.app/intent/compose?text={{ social.title|url_encode }}{% if share_text or social.description %} - {{ (share_text ?? social.description)|striptags|url_encode }}{% endif %}{% if social_accounts.bluesky %}, via @{{ social_accounts.bluesky }}{% endif %} {{ (socialLink ~ '&utm_source=bluesky')|url_encode }}"
            onclick="window.dataLayerPush('Bluesky');"
            target="_blank" class="share-btn bluesky">
             {{ 'bluesky'|svgicon }}

--- a/templates/blocks/share_buttons.twig
+++ b/templates/blocks/share_buttons.twig
@@ -37,6 +37,15 @@
             <span class="visually-hidden">{{ __( 'Share via', 'planet4-master-theme' ) }} Email</span>
         </a>
     {% endif %}
+    <!-- Bluesky -->
+    {% if share_platforms.bluesky %}
+        <a href="https://bsky.app/intent/compose?text={{ social.title|url_encode }}{% if share_text or social.description %} - {{ (share_text ?? social.description)|striptags|url_encode }}{% endif %}, via @{{ social_accounts.bluesky ?? 'greenpeace' }} {{ (socialLink ~ '&utm_source=bluesky')|url_encode }}"
+           onclick="window.dataLayerPush('Bluesky');"
+           target="_blank" class="share-btn bluesky">
+            {{ 'bluesky'|svgicon }}
+            <span class="visually-hidden">{{ __( 'Share on', 'planet4-master-theme' ) }} Bluesky</span>
+        </a>
+    {% endif %}
     <!-- Native (Gravity Forms only, for devices that support it) -->
     {% if share_platforms.native %}
         <a


### PR DESCRIPTION
Ref. https://jira.greenpeace.org/browse/PLANET-7749

### Requirements

- Add Bluesky as an option to Planet 4 > Social > Social sharing options (not enabled by default)
- Add Bluesky as an option on Forms sharing settings
- Use Bluesky's compose url to generate the sharing action
- We already have the Bluesky icon in our svg sprite so we can use the twig tag we have, same as we do for [Whatsapp](https://github.com/greenpeace/planet4-master-theme/blob/v1.308.0/templates/blocks/share_buttons.twig#L46). We can use #1185fe as the svg [fill color](https://github.com/greenpeace/planet4-master-theme/blob/c31f6667ff235855b2ac33759f6a35fe76659833/assets/src/scss/base/_colors.scss#L2).

### Testing Instructions:

1. Login to the [test instance](https://www-dev.greenpeace.org/test-titan/wp-admin/) or test it on your local environment.
2. Navigate to **Planet 4 > Social > Social Sharing Options** and enable the newly added **Bluesky** social share option.
3. Create a new post and check the frontend—you should see the Bluesky share option available in the social sharing list.
4. Create a new Gravity Form (GF) or edit an existing one:

      - Go to **Settings > Confirmation page**.
      
      - Under Confirmation Type 'text', verify that the **Bluesky** share button option is available.
      
      - If enabled, it should appear in the form confirmation's share buttons.

5. Verify the Bluesky compose URL and check if any changes are needed.