### PR TITLE
PLANET-7702: Add Actions List Block CTA text for Screen Reader

### DIFF
--- a/assets/src/block-editor/Sidebar/ActionSidebar.js
+++ b/assets/src/block-editor/Sidebar/ActionSidebar.js
@@ -6,6 +6,7 @@ import {getSidebarFunctions} from './getSidebarFunctions';
 const FIELD_NAVTYPE = 'nav_type';
 const HIDE_PAGE_TITLE = 'p4_hide_page_title_checkbox';
 const BUTTON_TEXT = 'action_button_text';
+const BUTTON_ACCESSIBILITY_TEXT = 'action_button_accessibility_text';
 
 const {__} = wp.i18n;
 const {PluginDocumentSettingPanel} = wp.editor;
@@ -28,11 +29,15 @@ export const ActionSidebar = {
         </PluginDocumentSettingPanel>
         <PluginDocumentSettingPanel
           name="button-text-panel"
-          title={__('Covers block button text', 'planet4-blocks-backend')}
+          title={__('Action Lists block button text', 'planet4-blocks-backend')}
         >
           <TextSidebarField
-            label={__('Edit the button text shown on the Action covers block', 'planet4-blocks-backend')}
+            label={__('Set the text for the Actions List Block\'s Button (e.g., \'Sign Up\')', 'planet4-blocks-backend')}
             {...getParams(BUTTON_TEXT)}
+          />
+          <TextSidebarField
+            label={__('Add descriptive text for screen readers (e.g., \'Sign Up to Stop Meat and Dairy\').', 'planet4-blocks-backend')}
+            {...getParams(BUTTON_ACCESSIBILITY_TEXT)}
           />
         </PluginDocumentSettingPanel>
         <PluginDocumentSettingPanel

--- a/src/ActionPage.php
+++ b/src/ActionPage.php
@@ -215,7 +215,7 @@ class ActionPage
             'action_button_accessibility_text',
             array_merge(
                 $args,
-                [ 'default' => __('Get Involved', 'planet4-master-theme') ]
+                [ 'default' => __('Take action', 'planet4-master-theme') ]
             )
         );
 

--- a/src/ActionPage.php
+++ b/src/ActionPage.php
@@ -215,7 +215,7 @@ class ActionPage
             'action_button_accessibility_text',
             array_merge(
                 $args,
-                [ 'default' => __('Take action', 'planet4-master-theme') ]
+                [ 'default' => __('Get Involved', 'planet4-master-theme') ]
             )
         );
 

--- a/src/ActionPage.php
+++ b/src/ActionPage.php
@@ -210,6 +210,15 @@ class ActionPage
             )
         );
 
+        register_post_meta(
+            self::POST_TYPE,
+            'action_button_accessibility_text',
+            array_merge(
+                $args,
+                [ 'default' => __('Take action', 'planet4-master-theme') ]
+            )
+        );
+
         foreach (self::META_FIELDS as $field) {
             register_post_meta(self::POST_TYPE, $field, $args);
         }

--- a/src/Blocks/ActionButtonText.php
+++ b/src/Blocks/ActionButtonText.php
@@ -73,7 +73,7 @@ class ActionButtonText extends BaseBlock
         $options = get_option('planet4_options');
 
         $action_btn = $options['take_action_covers_button_text'] ?? __('Take action', 'planet4-blocks');
-        $action_acc_btn = __('Take action', 'planet4-blocks');
+        $action_acc_btn = __('Get Involved', 'planet4-blocks');
 
         $has_button_text = isset($meta['action_button_text']) && $meta['action_button_text'][0];
         $has_button_acc_text = isset($meta['action_button_accessibility_text']) && $meta['action_button_accessibility_text'][0];

--- a/src/Blocks/ActionButtonText.php
+++ b/src/Blocks/ActionButtonText.php
@@ -73,7 +73,7 @@ class ActionButtonText extends BaseBlock
         $options = get_option('planet4_options');
 
         $action_btn = $options['take_action_covers_button_text'] ?? __('Take action', 'planet4-blocks');
-        $action_acc_btn = __('Get Involved', 'planet4-blocks');
+        $action_acc_btn = __('Take action', 'planet4-blocks');
 
         $has_button_text = isset($meta['action_button_text']) && $meta['action_button_text'][0];
         $has_button_acc_text = isset($meta['action_button_accessibility_text']) && $meta['action_button_accessibility_text'][0];

--- a/src/Blocks/ActionButtonText.php
+++ b/src/Blocks/ActionButtonText.php
@@ -63,19 +63,26 @@ class ActionButtonText extends BaseBlock
      * @param  WP_Block $block      Block instance.
      * @return string   Returns the value for the field.
      * @phpcs:disable SlevomatCodingStandard.Functions.UnusedParameter.UnusedParameter
+     * @phpcs:disable Generic.Files.LineLength.MaxExceeded
     */
     public function render_block(array $attributes, string $content, WP_Block $block): string
     {
         $post_id = $block->context['postId'];
         $link = get_permalink($post_id);
         $meta = get_post_meta($post_id);
-        if (isset($meta['action_button_text']) && $meta['action_button_text'][0]) {
-            $button_text = $meta['action_button_text'][0];
-        } else {
-            $options = get_option('planet4_options');
-            $button_text = $options['take_action_covers_button_text'] ?? __('Take action', 'planet4-blocks');
-        }
-        return '<a href="' . $link . '" class="btn btn-primary btn-small">' . $button_text . '</a>';
+        $options = get_option('planet4_options');
+
+        $action_btn = $options['take_action_covers_button_text'] ?? __('Take action', 'planet4-blocks');
+        $action_acc_btn = __('Take action', 'planet4-blocks');
+
+        $has_button_text = isset($meta['action_button_text']) && $meta['action_button_text'][0];
+        $has_button_acc_text = isset($meta['action_button_accessibility_text']) && $meta['action_button_accessibility_text'][0];
+
+        $button_text = $has_button_text ? $meta['action_button_text'][0] : $action_btn;
+        $button_acc_text = $has_button_acc_text ? $meta['action_button_accessibility_text'][0] : $action_acc_btn;
+
+        return '<a href="' . $link . '" class="btn btn-primary btn-small" aria-label="' . $button_acc_text . '">' . $button_text . '</a>';
     }
+    // @phpcs:enable Generic.Files.LineLength.MaxExceeded
     // @phpcs:enable SlevomatCodingStandard.Functions.UnusedParameter.UnusedParameter
 }

--- a/src/Blocks/ActionButtonText.php
+++ b/src/Blocks/ActionButtonText.php
@@ -72,14 +72,27 @@ class ActionButtonText extends BaseBlock
         $meta = get_post_meta($post_id);
         $options = get_option('planet4_options');
 
-        $action_btn = $options['take_action_covers_button_text'] ?? __('Take action', 'planet4-blocks');
-        $action_acc_btn = __('Take action', 'planet4-blocks');
-
         $has_button_text = isset($meta['action_button_text']) && $meta['action_button_text'][0];
         $has_button_acc_text = isset($meta['action_button_accessibility_text']) && $meta['action_button_accessibility_text'][0];
+        $has_default_text = !empty($options['take_action_covers_button_text']);
 
-        $button_text = $has_button_text ? $meta['action_button_text'][0] : $action_btn;
-        $button_acc_text = $has_button_acc_text ? $meta['action_button_accessibility_text'][0] : $action_acc_btn;
+        if ($has_button_text) {
+            $button_text = $meta['action_button_text'][0];
+        } elseif ($has_default_text) {
+            $button_text = $options['take_action_covers_button_text'];
+        } else {
+            $button_text = __('Take action', 'planet4-blocks');
+        }
+
+        if ($has_button_acc_text) {
+            $button_acc_text = $meta['action_button_accessibility_text'][0];
+        } elseif ($has_button_text) {
+            $button_acc_text = $meta['action_button_text'][0];
+        } elseif ($has_default_text) {
+            $button_acc_text = $options['take_action_covers_button_text'];
+        } else {
+            $button_acc_text = __('Take action', 'planet4-blocks');
+        }
 
         return '<a href="' . $link . '" class="btn btn-primary btn-small" aria-label="' . $button_acc_text . '">' . $button_text . '</a>';
     }

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -127,13 +127,13 @@ class Settings
                 'title' => 'Defaults content',
                 'fields' => [
                     [
-                        'name' => __('Take Action Covers default button text', 'planet4-master-theme-backend'),
+                        'name' => __('Actions List default button text', 'planet4-master-theme-backend'),
                         'id' => 'take_action_covers_button_text',
                         'type' => 'text',
                         'attributes' => [
                             'type' => 'text',
                         ],
-                        'desc' => __('Add default button text which appears on <b>Take Action</b> card of <b>Take Action Covers</b> block. <br>Also it would be used for Take Action Cards inside Posts and Take Action Cards in search results', 'planet4-master-theme-backend'),
+                        'desc' => __('Add default button text which appears on <b>Take Action</b> card of <b>Actions List</b> block. <br>Also it would be used for Take Action Cards inside Posts and Take Action Cards in search results', 'planet4-master-theme-backend'),
                     ],
 
                     // Happy Point settings.


### PR DESCRIPTION
### Summary
This PR introduces an `aria-label` attribute to the Actions CTA to be read by screen readers. 
The text of the attribute can be edited from the sidebar of the Actions post type editor.
Also, some texts have been adjusted.

---

Ref: https://jira.greenpeace.org/browse/PLANET-7702

### Testing
1. Go to the editor of an Action post.
2. Check the new field ("Add descriptive text for screen readers...") exists in the sidebar.
3. Add text to the field and save the changes.
4. Visit a page containing an Actions List block with the Action edited in the previous steps.
5. Check that the CTA of that action in the Actions List block contains an `aria-label` attribute with the value added in step 3 (i.e., the Oceans action in [this page](https://www-dev.greenpeace.org/test-neptune/actions-list-test-page/)).
6. Check that a screen reader reads the value of the `aria-label` correctly.
