### PR TITLE
PLANET-7780 Update Posts List block Handbook link

### DIFF
--- a/assets/src/block-editor/QueryLoopBlockExtension/index.js
+++ b/assets/src/block-editor/QueryLoopBlockExtension/index.js
@@ -152,7 +152,7 @@ export const setupQueryLoopBlockExtension = () => {
                     )}
                     {isPostsList && (
                       <>
-                        <a target="_blank" href="https://planet4.greenpeace.org/content/blocks/articles/" rel="noreferrer">
+                        <a target="_blank" href="https://planet4.greenpeace.org/content/blocks/posts-list/" rel="noreferrer">
                       P4 Handbook Posts List
                         </a>
                         {' '} &#128478;&#65039;


### PR DESCRIPTION
### Description

See [PLANET-7780](https://jira.greenpeace.org/browse/PLANET-7780). It used to be the Articles block link. We'll need to do the same thing for the Actions List once the page is created in the Handbook.