### PR TITLE
Posts List: adjust "see all" link for consistency

### DIFF
--- a/assets/src/blocks/PostsList/index.js
+++ b/assets/src/blocks/PostsList/index.js
@@ -13,7 +13,7 @@ export const registerPostsListBlock = () => {
 
   const seeAllLink = ['core/navigation-link', {...!newsPageLink ? {className: 'd-none'} : {
     url: newsPageLink,
-    label: __('See all stories', 'planet4-blocks-backend'),
+    label: __('See all posts', 'planet4-blocks'),
     className: 'see-all-link',
   }}];
 


### PR DESCRIPTION
- This should be "posts" instead of "stories", to be consistent with the block name. We did the same thing with the "Related Articles/Posts" section
- It should also be part of the frontend text-domain

### Summary

<!-- Please provide a brief summary of the change introduced in this Pull Request. -->

---

<!-- Please add a reference link to the ticket, if one exists. -->
Ref: 

### Testing

<!-- Please add the steps required to test the changes in this Pull Request. -->
1. 
2. 
3. 
