### PR TITLE
PLANET-7769 Remove PageHeader box-shadow

### DIFF
--- a/assets/src/scss/blocks/PageHeader.scss
+++ b/assets/src/scss/blocks/PageHeader.scss
@@ -72,13 +72,11 @@ $text-column-padding-in: 24px;
 
   .wp-block-heading.has-background {
     display: inline;
-    padding: 0;
     font-size: inherit;
     font-weight: inherit;
     line-height: 150%;
     box-decoration-break: clone;
-    box-shadow: 8px 0 0 var(--white);
-    padding-inline-start: $sp-1;
+    padding: 0 $sp-1;
   }
 
   p {


### PR DESCRIPTION
### Description

See [PLANET-7769](https://jira.greenpeace.org/browse/PLANET-7769). We can use padding instead. This was causing issues with other background colors.

### Testing

- [Broken](https://www-dev.greenpeace.org/test-rhea/take-action/)
- [Fixed](https://www-dev.greenpeace.org/test-janus/take-action/)