### PR TITLE
PLANET-7782 & PLANET-7738 Improve comments form

### DIFF
--- a/assets/src/scss/layout/_forms.scss
+++ b/assets/src/scss/layout/_forms.scss
@@ -155,6 +155,11 @@ textarea.form-control {
       opacity: 0;
       transition: all .3s ease;
       margin-bottom: 0;
+
+      html[dir="rtl"] & {
+        right: 0;
+        left: auto;
+      }
     }
 
     .form-control:not(:placeholder-shown) {

--- a/assets/src/scss/pages/post/_comments-block.scss
+++ b/assets/src/scss/pages/post/_comments-block.scss
@@ -27,6 +27,10 @@
   line-height: 1.5;
   margin-bottom: 8px;
   overflow-wrap: break-word;
+
+  a {
+    @include shared-link-styles;
+  }
 }
 
 .single-comment-meta {
@@ -50,6 +54,11 @@
     font-weight: bold;
     font-size: 14px;
     margin-top: 16px;
+    @include shared-link-styles;
+
+    &:hover {
+      color: var(--grey-900);
+    }
   }
 }
 

--- a/assets/src/scss/pages/post/_comments-block.scss
+++ b/assets/src/scss/pages/post/_comments-block.scss
@@ -4,7 +4,7 @@
 .comments-block {
   h3 {
     font-size: 16px;
-    margin-bottom: 16px;
+    margin-bottom: $sp-2;
   }
 
   .comment-respond button {
@@ -14,18 +14,18 @@
 
 .single-comment {
   font-family: var(--font-family-paragraph-secondary);
-  padding-bottom: 24px;
+  padding-bottom: $sp-3;
 
   &:not(:first-of-type) {
     border-top: 1px solid rgba($grey-500, 0.5);
-    padding-top: 24px;
+    padding-top: $sp-3;
   }
 }
 
 .single-comment-text {
   font-size: 16px;
   line-height: 1.5;
-  margin-bottom: 8px;
+  margin-bottom: $sp-1;
   overflow-wrap: break-word;
 
   a {
@@ -45,15 +45,15 @@
 
   .author-info::after {
     content: "\2022";
-    padding-inline-start: 8px;
-    padding-inline-end: 6px;
+    padding-inline-start: $sp-1;
+    padding-inline-end: $sp-x;
   }
 
   .comment-reply-link {
     display: block;
     font-weight: bold;
     font-size: 14px;
-    margin-top: 16px;
+    margin-top: $sp-2;
     @include shared-link-styles;
 
     &:hover {
@@ -63,10 +63,6 @@
 }
 
 @include medium-and-up {
-  .comments-block h3 {
-    margin-bottom: 24px;
-  }
-
   .single-comment-meta {
     .comment-reply-link {
       _-- {

--- a/assets/src/scss/pages/post/_comments-block.scss
+++ b/assets/src/scss/pages/post/_comments-block.scss
@@ -54,6 +54,7 @@
     font-weight: bold;
     font-size: 14px;
     margin-top: $sp-2;
+    width: fit-content;
     @include shared-link-styles;
 
     &:hover {
@@ -69,7 +70,6 @@
         font-family: var(--font-family-primary);
         font-weight: var(--font-weight-regular);
       }
-
       float: right;
       margin-top: 0;
 

--- a/assets/src/scss/pages/post/_comments-form.scss
+++ b/assets/src/scss/pages/post/_comments-form.scss
@@ -2,12 +2,12 @@
   .form-section .comment-respond {
     background: var(--color-background-comments_block);
     border-radius: 4px;
-    padding: 24px 16px;
+    padding: $sp-3 $sp-2;
   }
 
   .comment-respond {
     font-size: 0;
-    margin-bottom: 32px;
+    margin-bottom: $sp-4;
 
     input,
     textarea {
@@ -19,20 +19,20 @@
     }
 
     button {
-      margin-top: 8px;
+      margin-top: $sp-1;
       margin-bottom: 0;
     }
 
     @include medium-and-up {
       .comment-author,
       .comment-email {
-        width: calc(50% - 8px);
+        width: calc(50% - $sp-1);
         display: inline-block;
         vertical-align: bottom;
       }
 
       .comment-author {
-        margin-inline-end: 16px;
+        margin-inline-end: $sp-2;
       }
     }
   }
@@ -42,11 +42,11 @@
   --comments-compliance-- {
     font-family: var(--font-family-primary);
   }
-  margin-bottom: 8px;
+  margin-bottom: $sp-1;
 
   #gdpr-comments-checkbox {
     display: inline-block;
-    margin-inline-end: 8px;
+    margin-inline-end: $sp-1;
     width: $checkbox-size !important;
     height: $checkbox-size;
     top: calc($sp-1 - 1px);
@@ -78,7 +78,7 @@
 }
 
 #cancel-comment-reply-link {
-  margin-inline-start: 8px;
+  margin: 0 $sp-1;
   color: var(--grey-600);
 
   &:hover,
@@ -89,49 +89,10 @@
 
 @include medium-and-up {
   .comment-form-cookies-consent {
-    margin-top: 8px;
+    margin-top: $sp-1;
   }
 
   .comments-block .form-section .comment-respond {
-    padding: 32px;
-
-    .logged-in-as {
-      position: absolute;
-      top: 32px;
-      right: 32px;
-      max-width: 70%;
-      line-height: 1.3;
-
-      html[dir="rtl"] & {
-        left: 32px;
-        right: auto;
-      }
-    }
-  }
-
-  .comments-block .comment-respond {
-    position: relative;
-
-    .logged-in-as {
-      position: absolute;
-      top: 0;
-      right: 0;
-
-      html[dir="rtl"] & {
-        left: 0;
-        right: auto;
-      }
-    }
-  }
-
-  .logged-in-as {
-    position: absolute;
-    top: 32px;
-    right: 32px;
-
-    html[dir="rtl"] & {
-      left: 32px;
-      right: auto;
-    }
+    padding: $sp-4;
   }
 }


### PR DESCRIPTION
### Description

See [PLANET-7782](https://jira.greenpeace.org/browse/PLANET-7782). The new style is applied to links within comments, and also to the Reply button.

See [PLANET-7738](https://jira.greenpeace.org/browse/PLANET-7738). 
- In RTL sites, the "cancel reply" link is missing spacing
- When the logged in user has a long name, in some screen sizes the "Logged in as..." message overlaps with the "cancel reply" link

### Testing

You can check the changes on [this post](https://www-dev.greenpeace.org/test-jupiter/press/1109/duis-posuere-4) for example.