### PR TITLE
PLANET-7783: Fixed issue with the main navigation arrows

### DIFF
--- a/assets/src/scss/layout/_navbar.scss
+++ b/assets/src/scss/layout/_navbar.scss
@@ -292,9 +292,19 @@ a.nav-link:hover:before,
     padding: 0;
   }
 
+  &.has-children {
+    a {
+      padding-right: 36px;
+    }
+  }
+
   .accessible-nav-link {
     @include dropdown-icon;
     right: $sp-2;
+
+    &:focus {
+      @include focus-styles;
+    }
   }
 }
 

--- a/assets/src/scss/layout/_navbar.scss
+++ b/assets/src/scss/layout/_navbar.scss
@@ -293,18 +293,22 @@ a.nav-link:hover:before,
     padding: 0;
   }
 
-  &.has-children {
-    a {
-      padding-right: 36px;
-    }
+  &.has-children a {
+    padding-inline-end: $sp-4;
   }
 
   .accessible-nav-link {
     @include dropdown-icon;
     right: $sp-2;
+    left: auto;
 
     &:focus {
       @include focus-styles;
+    }
+
+    html[dir="rtl"] & {
+      left: $sp-2;
+      right: auto;
     }
   }
 }
@@ -338,6 +342,7 @@ a.nav-link:hover:before,
   .accessible-nav-link {
     @include dropdown-icon;
     right: -$sp-2;
+    left: auto;
     opacity: 0;
 
     &:focus {
@@ -346,6 +351,11 @@ a.nav-link:hover:before,
       height: 10px;
       pointer-events: none;
       @include focus-styles;
+    }
+
+    html[dir="rtl"] & {
+      left: -$sp-2;
+      right: auto;
     }
   }
 }

--- a/assets/src/scss/layout/_navbar.scss
+++ b/assets/src/scss/layout/_navbar.scss
@@ -328,18 +328,15 @@ a.nav-link:hover:before,
     @include dropdown-icon;
     right: -$sp-2;
     opacity: 0;
-    width: 0;
-    height: 0;
-  }
-}
 
-.nav-item:has(.nav-submenu:focus-within) .accessible-nav-link,
-.accessible-nav-link:focus {
-  opacity: 1;
-  width: 10px;
-  height: 10px;
-  pointer-events: auto;
-  @include focus-styles;
+    &:focus {
+      opacity: 1;
+      width: 10px;
+      height: 10px;
+      pointer-events: none;
+      @include focus-styles;
+    }
+  }
 }
 
 .nav-donate .nav-submenu {

--- a/assets/src/scss/layout/_navbar.scss
+++ b/assets/src/scss/layout/_navbar.scss
@@ -182,6 +182,7 @@
 
       &:hover {
         background: var(--grey-200);
+        border-radius: 0;
       }
 
       &:before {

--- a/templates/desktop-menu.twig
+++ b/templates/desktop-menu.twig
@@ -33,7 +33,7 @@
 
             {% if donate_menu_items is not empty %}
                 {% set donate_menu = donate_menu_items|first %}
-                <li class="nav-donate">
+                <li class="nav-donate {{ donate_menu.children is not empty ? 'has-children' : '' }}">
                     <a
                         class="btn btn-donate"
                         href="{{ donate_menu.link }}"


### PR DESCRIPTION
### Summary
This PR fixes the following issues:
- When clicking on the main navigation dropdown items, the arrow suddenly appears.
- On the Donate button, the arrow is always there over the text.

Video reference: [2025-03-10 14-18-39.mp4](https://jira.greenpeace.org/secure/attachment/39410/39410_2025-03-10+14-18-39.mp4)

---

Ref: https://jira.greenpeace.org/browse/PLANET-7783

### Testing

1. Go to the test instance: https://www-dev.greenpeace.org/test-tavros/ 
2. Check the arrow in the Donate button. It should not overlap the button label.
3. Click on the submenu links of any menu item with children (except the Donate button). The arrow should not appear.
