### PR TITLE
PLANET-7603 Add an option to change TAB heading size 

### DIFF
--- a/assets/src/blocks/TakeActionBoxout/HeadingFontSizes.js
+++ b/assets/src/blocks/TakeActionBoxout/HeadingFontSizes.js
@@ -1,0 +1,32 @@
+const {__} = wp.i18n;
+
+export const FONT_SIZES = [
+  {
+    name: __('Small'),
+    slug: 'small',
+    size: '1.125rem',
+  },
+  {
+    name: __('Medium'),
+    slug: 'medium',
+    size: '1.25rem',
+  },
+  {
+    name: __('Large'),
+    slug: 'large',
+    size: '1.375rem',
+  },
+  {
+    name: __('Extra Large'),
+    slug: 'x-large',
+    size: '1.75rem',
+  },
+];
+
+export const getHeadingFontSizeClassName = fontSize => {
+  if (!fontSize || !FONT_SIZES.find(font => font.size === fontSize)) {
+    return 'medium';
+  }
+
+  return FONT_SIZES.find(font => font.size === fontSize).slug;
+};

--- a/assets/src/blocks/TakeActionBoxout/HeadingFontSizes.js
+++ b/assets/src/blocks/TakeActionBoxout/HeadingFontSizes.js
@@ -4,29 +4,21 @@ export const FONT_SIZES = [
   {
     name: __('Small'),
     slug: 'small',
-    size: '1.125rem',
+    size: 'small',
   },
   {
     name: __('Medium'),
     slug: 'medium',
-    size: '1.25rem',
+    size: 'medium',
   },
   {
     name: __('Large'),
     slug: 'large',
-    size: '1.375rem',
+    size: 'large',
   },
   {
     name: __('Extra Large'),
     slug: 'x-large',
-    size: '1.75rem',
+    size: 'x-large',
   },
 ];
-
-export const getHeadingFontSizeClassName = fontSize => {
-  if (!fontSize || !FONT_SIZES.find(font => font.size === fontSize)) {
-    return 'medium';
-  }
-
-  return FONT_SIZES.find(font => font.size === fontSize).slug;
-};

--- a/assets/src/blocks/TakeActionBoxout/TakeActionBoxoutBlock.js
+++ b/assets/src/blocks/TakeActionBoxout/TakeActionBoxoutBlock.js
@@ -62,6 +62,10 @@ export const registerTakeActionBoxoutBlock = () => {
         type: 'boolean',
         default: false,
       },
+      headingFontSize: {
+        type: 'string',
+        default: '1.25rem',
+      },
     },
     edit: TakeActionBoxoutEditor,
     save() {

--- a/assets/src/blocks/TakeActionBoxout/TakeActionBoxoutBlock.js
+++ b/assets/src/blocks/TakeActionBoxout/TakeActionBoxoutBlock.js
@@ -64,7 +64,7 @@ export const registerTakeActionBoxoutBlock = () => {
       },
       headingFontSize: {
         type: 'string',
-        default: '1.25rem',
+        default: 'medium',
       },
     },
     edit: TakeActionBoxoutEditor,

--- a/assets/src/blocks/TakeActionBoxout/TakeActionBoxoutEditor.js
+++ b/assets/src/blocks/TakeActionBoxout/TakeActionBoxoutEditor.js
@@ -2,6 +2,8 @@ import {URLInput} from '../../block-editor/URLInput/URLInput';
 import {ImageHoverControls} from '../../block-editor/ImageHoverControls';
 import {TakeActionBoxoutFrontend} from './TakeActionBoxoutFrontend';
 import {ImagePlaceholder} from './ImagePlaceholder';
+import {FONT_SIZES, getHeadingFontSizeClassName} from './HeadingFontSizes';
+import {FontSizePicker} from '@wordpress/components';
 
 const {useSelect} = wp.data;
 const {RichText, BlockControls, MediaUpload, MediaUploadCheck, InspectorControls} = wp.blockEditor;
@@ -34,6 +36,7 @@ export const TakeActionBoxoutEditor = ({
     imageId: customImageId,
     className,
     stickyOnMobile,
+    headingFontSize,
   } = attributes;
 
   const {options: p4_options} = window.p4_vars;
@@ -148,7 +151,7 @@ export const TakeActionBoxoutEditor = ({
       <div className="boxout-content">
         <RichText
           tagName="div"
-          className="boxout-heading"
+          className={`boxout-heading ${getHeadingFontSizeClassName(headingFontSize)}`}
           placeholder={__('Enter title', 'planet4-blocks-backend')}
           value={title}
           onChange={toAttribute('title')}
@@ -204,6 +207,12 @@ export const TakeActionBoxoutEditor = ({
               ...actPageOptions,
             ]}
             onChange={page => setAttributes({take_action_page: parseInt(page)})}
+          />
+          <FontSizePicker
+            fontSizes={FONT_SIZES}
+            value={headingFontSize}
+            onChange={fontSize => setAttributes({headingFontSize: fontSize})}
+            disableCustomFontSizes
           />
           {!takeActionPageSelected && <URLInput
             label={__('Custom link', 'planet4-blocks-backend')}

--- a/assets/src/blocks/TakeActionBoxout/TakeActionBoxoutEditor.js
+++ b/assets/src/blocks/TakeActionBoxout/TakeActionBoxoutEditor.js
@@ -2,7 +2,7 @@ import {URLInput} from '../../block-editor/URLInput/URLInput';
 import {ImageHoverControls} from '../../block-editor/ImageHoverControls';
 import {TakeActionBoxoutFrontend} from './TakeActionBoxoutFrontend';
 import {ImagePlaceholder} from './ImagePlaceholder';
-import {FONT_SIZES, getHeadingFontSizeClassName} from './HeadingFontSizes';
+import {FONT_SIZES} from './HeadingFontSizes';
 import {FontSizePicker} from '@wordpress/components';
 
 const {useSelect} = wp.data;
@@ -151,7 +151,7 @@ export const TakeActionBoxoutEditor = ({
       <div className="boxout-content">
         <RichText
           tagName="div"
-          className={`boxout-heading ${getHeadingFontSizeClassName(headingFontSize)}`}
+          className={`boxout-heading ${headingFontSize}`}
           placeholder={__('Enter title', 'planet4-blocks-backend')}
           value={title}
           onChange={toAttribute('title')}

--- a/assets/src/blocks/TakeActionBoxout/TakeActionBoxoutFrontend.js
+++ b/assets/src/blocks/TakeActionBoxout/TakeActionBoxoutFrontend.js
@@ -1,3 +1,5 @@
+import {getHeadingFontSizeClassName} from './HeadingFontSizes';
+
 export const TakeActionBoxoutFrontend = ({
   title,
   excerpt,
@@ -8,6 +10,7 @@ export const TakeActionBoxoutFrontend = ({
   imageAlt,
   className,
   stickyOnMobile,
+  headingFontSize,
 }) => (
   <section
     className={`boxout ${className || ''}`}
@@ -26,7 +29,7 @@ export const TakeActionBoxoutFrontend = ({
     <div className="boxout-content">
       {title &&
         <a
-          className="boxout-heading"
+          className={`boxout-heading ${getHeadingFontSizeClassName(headingFontSize)}`}
           data-ga-category="Take Action Boxout"
           data-ga-action="Title"
           data-ga-label="n/a"

--- a/assets/src/blocks/TakeActionBoxout/TakeActionBoxoutFrontend.js
+++ b/assets/src/blocks/TakeActionBoxout/TakeActionBoxoutFrontend.js
@@ -1,5 +1,3 @@
-import {getHeadingFontSizeClassName} from './HeadingFontSizes';
-
 export const TakeActionBoxoutFrontend = ({
   title,
   excerpt,
@@ -29,7 +27,7 @@ export const TakeActionBoxoutFrontend = ({
     <div className="boxout-content">
       {title &&
         <a
-          className={`boxout-heading ${getHeadingFontSizeClassName(headingFontSize)}`}
+          className={`boxout-heading ${headingFontSize}`}
           data-ga-category="Take Action Boxout"
           data-ga-action="Title"
           data-ga-label="n/a"

--- a/assets/src/scss/blocks/TakeActionBoxout/TakeActionBoxoutStyle.scss
+++ b/assets/src/scss/blocks/TakeActionBoxout/TakeActionBoxoutStyle.scss
@@ -27,6 +27,14 @@
   }
 }
 
+@mixin boxout-heading-font-size($mobile, $desktop) {
+  font-size: $mobile;
+
+  @include large-and-up {
+    font-size: $desktop;
+  }
+}
+
 .boxout {
   background: var(--white);
   width: 100%;
@@ -76,14 +84,38 @@
   .boxout-heading {
     _-- {
       font-family: var(--font-family-heading);
-      font-size: var(--font-size-m--font-family-primary);
       font-weight: var(--font-weight-regular);
       color: var(--color-text-body);
     }
-
     margin-bottom: $sp-1;
     word-break: break-word;
     @include clamp-text(2);
+    // Medium font size is the default.
+    @include boxout-heading-font-size(
+      var(--font-size-s--font-family-primary),
+      var(--font-size-m--font-family-primary)
+    );
+
+    &.small {
+      @include boxout-heading-font-size(
+        var(--font-size-xxs--font-family-primary),
+        var(--font-size-s--font-family-primary)
+      );
+    }
+
+    &.large {
+      @include boxout-heading-font-size(
+        var(--font-size-m--font-family-primary),
+        var(--font-size-l--font-family-primary)
+      );
+    }
+
+    &.x-large {
+      @include boxout-heading-font-size(
+        var(--font-size-l--font-family-primary),
+        var(--font-size-xl--font-family-primary)
+      );
+    }
   }
 
   .btn {
@@ -192,7 +224,6 @@
       @include mobile-only {
         .boxout-heading {
           margin-inline-end: $sp-3;
-          font-size: var(--font-size-xxs--font-family-primary);
         }
       }
     }

--- a/src/Blocks/TakeActionBoxout.php
+++ b/src/Blocks/TakeActionBoxout.php
@@ -24,18 +24,6 @@ class TakeActionBoxout extends BaseBlock
     public const BLOCK_NAME = 'take-action-boxout';
 
     /**
-     * The different possible values for the heading font size.
-     *
-     * @const array HEADING_FONT_SIZES.
-     */
-    public const HEADING_FONT_SIZES = [
-        '1.125rem' => 'small',
-        '1.25rem' => 'medium',
-        '1.375rem' => 'large',
-        '1.75rem' => 'x-large',
-    ];
-
-    /**
      * TakeActionBoxout constructor.
      */
     public function __construct()
@@ -94,7 +82,7 @@ class TakeActionBoxout extends BaseBlock
                     ],
                     'headingFontSize' => [
                         'type' => 'string',
-                        'default' => '1.25rem',
+                        'default' => 'medium',
                     ],
                 ],
             ]
@@ -133,8 +121,7 @@ class TakeActionBoxout extends BaseBlock
                     'image_alt' => $alt_text ?? '',
                     'image_srcset' => $src_set ?? '',
                     'stickyMobile' => $fields['stickyOnMobile'] ?? false,
-                    'headingClassName' => $fields['headingFontSize'] ?
-                        self::HEADING_FONT_SIZES[$fields['headingFontSize']] : 'medium',
+                    'headingFontSize' => $fields['headingFontSize'] ?? 'medium',
                 ],
             ];
         }
@@ -182,8 +169,7 @@ class TakeActionBoxout extends BaseBlock
                 'image_alt' => $image_alt ?? '',
                 'image_srcset' => $src_set ?? '',
                 'stickyMobile' => $fields['stickyOnMobile'] ?? false,
-                'headingClassName' => $fields['headingFontSize'] ?
-                    self::HEADING_FONT_SIZES[$fields['headingFontSize']] : 'medium',
+                'headingFontSize' => $fields['headingFontSize'] ?? 'medium',
             ],
         ];
     }

--- a/src/Blocks/TakeActionBoxout.php
+++ b/src/Blocks/TakeActionBoxout.php
@@ -24,6 +24,18 @@ class TakeActionBoxout extends BaseBlock
     public const BLOCK_NAME = 'take-action-boxout';
 
     /**
+     * The different possible values for the heading font size.
+     *
+     * @const array HEADING_FONT_SIZES.
+     */
+    public const HEADING_FONT_SIZES = [
+        '1.125rem' => 'small',
+        '1.25rem' => 'medium',
+        '1.375rem' => 'large',
+        '1.75rem' => 'x-large',
+    ];
+
+    /**
      * TakeActionBoxout constructor.
      */
     public function __construct()
@@ -80,6 +92,10 @@ class TakeActionBoxout extends BaseBlock
                         'type' => 'boolean',
                         'default' => false,
                     ],
+                    'headingFontSize' => [
+                        'type' => 'string',
+                        'default' => '1.25rem',
+                    ],
                 ],
             ]
         );
@@ -117,6 +133,8 @@ class TakeActionBoxout extends BaseBlock
                     'image_alt' => $alt_text ?? '',
                     'image_srcset' => $src_set ?? '',
                     'stickyMobile' => $fields['stickyOnMobile'] ?? false,
+                    'headingClassName' => $fields['headingFontSize'] ?
+                        self::HEADING_FONT_SIZES[$fields['headingFontSize']] : 'medium',
                 ],
             ];
         }
@@ -164,6 +182,8 @@ class TakeActionBoxout extends BaseBlock
                 'image_alt' => $image_alt ?? '',
                 'image_srcset' => $src_set ?? '',
                 'stickyMobile' => $fields['stickyOnMobile'] ?? false,
+                'headingClassName' => $fields['headingFontSize'] ?
+                    self::HEADING_FONT_SIZES[$fields['headingFontSize']] : 'medium',
             ],
         ];
     }

--- a/templates/blocks/take-action-boxout.twig
+++ b/templates/blocks/take-action-boxout.twig
@@ -24,7 +24,7 @@
 			<div class="boxout-content">
 				{% if ( boxout.title ) %}
 					<a
-						class="boxout-heading"
+						class="boxout-heading {{boxout.headingClassName}}"
 						data-ga-category="Take Action Boxout"
 						data-ga-action="Title"
 						data-ga-label="n/a"

--- a/templates/blocks/take-action-boxout.twig
+++ b/templates/blocks/take-action-boxout.twig
@@ -24,7 +24,7 @@
 			<div class="boxout-content">
 				{% if ( boxout.title ) %}
 					<a
-						class="boxout-heading {{boxout.headingClassName}}"
+						class="boxout-heading {{boxout.headingFontSize}}"
 						data-ga-category="Take Action Boxout"
 						data-ga-action="Title"
 						data-ga-label="n/a"


### PR DESCRIPTION
### Description

See [PLANET-7603](https://jira.greenpeace.org/browse/PLANET-7603)

**Requirements**

- Heading Sizes: The title should be able to be adjusted with the following options:
  - **Desktop XXL, XL, & L**
    - XL: 28px/1.75rem
    - L: 22px/1.1375rem
    - M: 20px/1.25rem - default
    - S: 18px/1.125rem
  
  - **Mobile M&S**
    - XL: 22px/1.1375rem
    - L: 20px/1.25rem
    - M: 18px/1.125rem - default
    - S: 16px/1rem

- Default Setting: The default title size will be set to Heading M.
- Use design tokens for font sizes
- Ideally use rem points for font sizes

[FontSizePicker documentation
](https://developer.wordpress.org/block-editor/reference-guides/components/font-size-picker/)

### Testing

You can test all the new variations on [this post](https://www-dev.greenpeace.org/test-sinope/press/1113/duis-posuere-6/) for example (different font sizes + custom vs selected Action card)