### PR TITLE
Fix lists' font size in the editor

### DIFF
--- a/assets/src/scss/editorOverrides.scss
+++ b/assets/src/scss/editorOverrides.scss
@@ -20,10 +20,6 @@
 }
 
 .edit-post-visual-editor {
-  li {
-    font-size: unset;
-  }
-
   @include table;
 }
 


### PR DESCRIPTION
### Summary

This PR fixes the lists in the editor (not in the frontend) that have a smaller font size than normal paragraphs.

---

Ref: https://greenpeace.slack.com/archives/C014UMRC4AJ/p1741786765906429

### Testing
1. In the editor, add a list block and a paragraph block.
2. Add content to both blocks.
3. The font size of the blocks has to be the same.
