### PR TITLE
PLANET-7716: Make the layout toggle button operable by screen readers

### DIFF
--- a/templates/listing-page.twig
+++ b/templates/listing-page.twig
@@ -7,11 +7,19 @@
             <h2>{{ listing_page_title ?? __( 'All articles', 'planet4-master-theme' ) }}</h2>
         {% endif %}
         {% if layout == 'list' %}
-            <button class="grid-view-toggle" title="{{__( 'Grid layout', 'planet4-master-theme' ) }}">
+            <button
+                class="grid-view-toggle"
+                title="{{__( 'Grid layout', 'planet4-master-theme' ) }}"
+                aria-label="{{__( 'Switch to grid view', 'planet4-master-theme' ) }}"
+            >
                 {{ 'grid-view'|svgicon }}
             </button>
         {% else %}
-            <button class="list-view-toggle" title="{{__( 'List layout', 'planet4-master-theme' ) }}">
+            <button
+                class="list-view-toggle"
+                title="{{__( 'List layout', 'planet4-master-theme' ) }}"
+                aria-label="{{__( 'Switch to list view', 'planet4-master-theme' ) }}"
+            >
                 {{ 'list-view'|svgicon }}
             </button>
         {% endif %}


### PR DESCRIPTION
### Summary

This PR adds text to be read by screen readers to the layout toggle button.

---

Ref: https://jira.greenpeace.org/browse/PLANET-7716

### Testing

1. Visit a page that uses a layout toggle button (ie https://www-dev.greenpeace.org/test-umbriel/tag/consumption/).
2. Reach the button by using only the keyboard.
3. Once the button is focused, the screen reader must read "Switch to grid view" or "Switch to list view".
4. Press "Enter" or "Space" and check that the button works as expected.
