### PR TITLE
PLANET-7752 Make Table Of Contents content links by default

### DIFF
--- a/assets/src/blocks/TableOfContents/TableOfContentsBlock.js
+++ b/assets/src/blocks/TableOfContents/TableOfContentsBlock.js
@@ -25,7 +25,7 @@ export const registerTableOfContentsBlock = () => {
       },
       levels: {
         type: 'array',
-        default: [{heading: 2, link: false, style: 'none'}],
+        default: [{heading: 2, link: true, style: 'none'}],
       },
       isExample: {
         type: 'boolean',

--- a/assets/src/blocks/TableOfContents/TableOfContentsEditor.js
+++ b/assets/src/blocks/TableOfContents/TableOfContentsEditor.js
@@ -14,7 +14,7 @@ const renderEdit = (attributes, setAttributes) => {
   function addLevel() {
     const [previousLastLevel] = attributes.levels.slice(-1);
     const newLevel = previousLastLevel.heading + 1;
-    setAttributes({levels: attributes.levels.concat({heading: newLevel, link: false, style: 'none'})});
+    setAttributes({levels: attributes.levels.concat({heading: newLevel, link: true, style: 'none'})});
   }
 
   function onHeadingChange(index, value) {

--- a/src/Blocks/TableOfContents.php
+++ b/src/Blocks/TableOfContents.php
@@ -69,12 +69,15 @@ class TableOfContents extends BaseBlock
                             'properties' => [
                                 'heading' => [
                                     'type' => 'integer',
+                                    'default' => 2,
                                 ],
                                 'link' => [
                                     'type' => 'boolean',
+                                    'default' => true,
                                 ],
                                 'style' => [
                                     'type' => 'string',
+                                    'default' => 'none',
                                 ],
                             ],
                         ],


### PR DESCRIPTION
### Description

See [PLANET-7752](https://jira.greenpeace.org/browse/PLANET-7752). This should not affect existing blocks

### Testing

Either on local or on the [janus test instance](https://www-dev.greenpeace.org/test-janus/), add a new Table Of Contents block to a page and make sure the level's "Link" option is checked by default. If you add an extra level, you should see the "Link" option checked there too.