### PR TITLE
Fix error with GTM and Google Consent Mode

### DIFF
--- a/src/EnqueueController.php
+++ b/src/EnqueueController.php
@@ -264,7 +264,7 @@ class EnqueueController
             'cf_scope' => $context['cf_scope'] ?? null,
             'cf_department' => $context['cf_department'] ?? null,
             'enforce_cookies_policy' => $context['enforce_cookies_policy'] ?? null,
-            'cookies_enable_google_consent_mode' => $context['cookies']->enable_google_consent_mode ?? null,
+            'cookies_enable_google_consent_mode' => $context['cookies']['enable_google_consent_mode'] ?? null,
             'post_password_required' => $context['post']->password_required ?? null,
             'search_results' => $context['found_posts'] ?? '',
         ];


### PR DESCRIPTION
### Summary

This PR fixes the error with the Google Consent Mode value not being passed correctly to Google Tag Manager.

---

Ref: https://greenpeace.slack.com/archives/C014UMRC4AJ/p1742291992761149

### Testing

1. Go to the admin panel > Planet 4 > Cookies (`/admin.php?page=planet4_settings_cookies_text`)
2. Check or uncheck the "Enable Google Consent Mode" option and save the changes.
3. Go to the front and review the `googleTagManagerData.cookies_enable_google_consent_mode` global variable in the browser console. Its value should be `on` or `null` based on the selection in step 3.