### PR TITLE
PLANET-7718 Improve search page accessibility

### DIFF
--- a/assets/src/scss/pages/search/_sort-filter.scss
+++ b/assets/src/scss/pages/search/_sort-filter.scss
@@ -2,6 +2,23 @@ div.search-filter-results {
   margin-top: 48px;
   z-index: auto;
 
+  .skip-link {
+    background: var(--white);
+    padding: $sp-x;
+    position: absolute;
+    transform: translateX(-100vw);
+    border-radius: 4px;
+    top: -$sp-5;
+    width: fit-content;
+    font-size: var(--font-size-m--font-family-tertiary);
+    font-family: var(--font-family-tertiary);
+  }
+
+  .skip-link:focus {
+    transform: translateX(0%);
+    text-decoration: none;
+  }
+
   @include small-and-up {
     margin-top: 75px;
   }

--- a/templates/base.twig
+++ b/templates/base.twig
@@ -18,7 +18,7 @@
         <!-- End Google Tag Manager (noscript) -->
     {% endif %}
 
-    <ul class="skip-links" aria-hidden="true">
+    <ul class="skip-links">
         <li><a href="#header">{{ __( 'Skip to Navigation', 'planet4-master-theme' ) }}</a></li>
         <li><a href="#content">{{ __( 'Skip to Content', 'planet4-master-theme' ) }}</a></li>
         <li><a href="#footer">{{ __( 'Skip to Footer', 'planet4-master-theme' ) }}</a></li>

--- a/templates/search.twig
+++ b/templates/search.twig
@@ -56,11 +56,7 @@
                 </div>
             </div>
             <div class="search-filter-results row clearfix">
-                <a
-                    class="skip-link"
-                    href="#search-results"
-                    aria-hidden="true"
-                >
+                <a class="skip-link" href="#search-results">
                     {{ __( 'Skip to search results', 'planet4-master-theme' ) }}
                 </a>
                 <aside class="col-lg-4">

--- a/templates/search.twig
+++ b/templates/search.twig
@@ -5,7 +5,7 @@
     {% set collapsed = posts or (not has_aggregation) ? '' : 'collapsed' %}
     {% set show      = posts or (not has_aggregation)? 'show' : '' %}
     {% set expanded  = posts ? true : false %}
-    {% set search_label = __( 'Search', 'planet4-master-theme' ) %}
+    {% set search_label = __( 'Search by name, keyword, or topic', 'planet4-master-theme' ) %}
 
     <div class="search-block">
         <div class="container">
@@ -56,7 +56,14 @@
                 </div>
             </div>
             <div class="search-filter-results row clearfix">
-                <div class="col-lg-4">
+                <a
+                    class="skip-link"
+                    href="#search-results"
+                    aria-hidden="true"
+                >
+                    {{ __( 'Skip to search results', 'planet4-master-theme' ) }}
+                </a>
+                <aside class="col-lg-4">
                     <div class="filter-sidebar">
                         <div class="filter-button d-lg-none">
                             <button class="btn btn-filter btn-secondary {{ disabled }}" data-bs-toggle="modal" data-bs-target="#filtermodal">
@@ -104,7 +111,11 @@
                                     <div class="activefilter-list">
                                         {% for filter_type in filters %}
                                             {% for filter in filter_type %}
-                                                <button class="activefilter-tag" data-id="{{ filter.id }}">
+                                                <button
+                                                    aria-label="{{__('Remove %s filter', 'planet4-master-theme')|format(filter.name)}}"
+                                                    class="activefilter-tag"
+                                                    data-id="{{ filter.id }}"
+                                                >
                                                     {{ filter.name|e('wp_kses_post')|raw }} <i class="icon-cross">{{ 'times'|svgicon }}</i>
                                                 </button>
                                             {% endfor %}
@@ -119,8 +130,8 @@
                             {% include 'search/content_types.twig' with {'is_modal': false} %}
                         </div>
                     </div>
-                </div>
-                <div class="col-lg-8">
+                </aside>
+                <section class="col-lg-8">
                     <div class="result-area">
                         <div class="sort-filter clearfix">
                             <div class="select-container">
@@ -142,7 +153,7 @@
                                 </select>
                             </div>
                         </div>
-                        <div class="multiple-search-result">
+                        <div id="search-results" class="multiple-search-result">
                             <ul class="list-unstyled">
                                 {% for post in paged_posts %}
                                     {% include ['tease-search.twig', 'tease-'~post.post_type~'.twig', 'tease.twig'] %}
@@ -164,7 +175,7 @@
                             {% endif %}
                         </div>
                     </div>
-                </div>
+                </section>
             </div>
         </div>
     </div>

--- a/templates/search/action_types.twig
+++ b/templates/search/action_types.twig
@@ -20,7 +20,7 @@
                             data-ga-category="Search Page"
                             data-ga-action="Content Filter"
                             data-ga-label="{{ action_type.name|e('wp_kses_post')|raw }}"
-                            aria-label="{{__('%s, %d results', 'planet4-master-theme')|format(action_type.name, action_type.results)}}"
+                            aria-label="{{__('Filter results by action type %s, %d results were found', 'planet4-master-theme')|format(action_type.name, action_type.results)}}"
                             {{ action_type.checked }} />
                         <span class="custom-control-description">{{ action_type.name }} {{ action_type.results > 0 ? '('~action_type.results~')' : '' }}</span>
                     </label>

--- a/templates/search/action_types.twig
+++ b/templates/search/action_types.twig
@@ -20,6 +20,7 @@
                             data-ga-category="Search Page"
                             data-ga-action="Content Filter"
                             data-ga-label="{{ action_type.name|e('wp_kses_post')|raw }}"
+                            aria-label="{{__('%s, %d results', 'planet4-master-theme')|format(action_type.name, action_type.results)}}"
                             {{ action_type.checked }} />
                         <span class="custom-control-description">{{ action_type.name }} {{ action_type.results > 0 ? '('~action_type.results~')' : '' }}</span>
                     </label>

--- a/templates/search/action_types.twig
+++ b/templates/search/action_types.twig
@@ -10,6 +10,11 @@
         <ul class="list-unstyled">
             {% for id, action_type in action_types %}
                 {% if (action_type.results > 0) or (not has_aggregation) %}
+                {% if (action_type.results == 1) %}
+                    {% set aria_label = __('Filter results by action type %s, 1 result was found', 'planet4-master-theme')|format(action_type.name) %}
+                {% else %}
+                    {% set aria_label = __('Filter results by action type %s, %d results were found', 'planet4-master-theme')|format(action_type.name, action_type.results) %}
+                {% endif %}
                 <li>
                     <label class="custom-control">
                         <input
@@ -20,7 +25,7 @@
                             data-ga-category="Search Page"
                             data-ga-action="Content Filter"
                             data-ga-label="{{ action_type.name|e('wp_kses_post')|raw }}"
-                            aria-label="{{__('Filter results by action type %s, %d results were found', 'planet4-master-theme')|format(action_type.name, action_type.results)}}"
+                            aria-label="{{ aria_label }}"
                             {{ action_type.checked }} />
                         <span class="custom-control-description">{{ action_type.name }} {{ action_type.results > 0 ? '('~action_type.results~')' : '' }}</span>
                     </label>

--- a/templates/search/categories.twig
+++ b/templates/search/categories.twig
@@ -20,7 +20,7 @@
                 data-ga-category="Search Page"
                 data-ga-action="Category Filter"
                 data-ga-label="{{ category.name|e('wp_kses_post')|raw }}"
-                aria-label="{{__('%s, %d results', 'planet4-master-theme')|format(category.name, category.results)}}"
+                aria-label="{{__('Filter results by category %s, %d results were found', 'planet4-master-theme')|format(category.name, category.results)}}"
                 {{ category.checked }} />
             <span class="custom-control-description">{{ category.name|e('wp_kses_post')|raw }} {{ category.results > 0 ? '('~category.results~')' : '' }}</span>
         </label>

--- a/templates/search/categories.twig
+++ b/templates/search/categories.twig
@@ -20,6 +20,7 @@
                 data-ga-category="Search Page"
                 data-ga-action="Category Filter"
                 data-ga-label="{{ category.name|e('wp_kses_post')|raw }}"
+                aria-label="{{__('%s, %d results', 'planet4-master-theme')|format(category.name, category.results)}}"
                 {{ category.checked }} />
             <span class="custom-control-description">{{ category.name|e('wp_kses_post')|raw }} {{ category.results > 0 ? '('~category.results~')' : '' }}</span>
         </label>

--- a/templates/search/categories.twig
+++ b/templates/search/categories.twig
@@ -10,6 +10,11 @@
     <ul class="list-unstyled">
     {% for category in categories %}
         {% if (category.results > 0) or (not has_aggregation) %}
+        {% if (category.results == 1) %}
+            {% set aria_label = __('Filter results by category %s, 1 result was found', 'planet4-master-theme')|format(category.name) %}
+        {% else %}
+            {% set aria_label = __('Filter results by category %s, %d results were found', 'planet4-master-theme')|format(category.name, category.results) %}
+        {% endif %}
         <li>
         <label class="custom-control">
             <input
@@ -20,7 +25,7 @@
                 data-ga-category="Search Page"
                 data-ga-action="Category Filter"
                 data-ga-label="{{ category.name|e('wp_kses_post')|raw }}"
-                aria-label="{{__('Filter results by category %s, %d results were found', 'planet4-master-theme')|format(category.name, category.results)}}"
+                aria-label="{{ aria_label }}"
                 {{ category.checked }} />
             <span class="custom-control-description">{{ category.name|e('wp_kses_post')|raw }} {{ category.results > 0 ? '('~category.results~')' : '' }}</span>
         </label>

--- a/templates/search/content_types.twig
+++ b/templates/search/content_types.twig
@@ -10,6 +10,11 @@
         <ul class="list-unstyled">
         {% for id, content_type in content_types %}
             {% if (content_type.results > 0) or (not has_aggregation) %}
+            {% if (content_type.results == 1) %}
+                {% set aria_label = __('Filter results by content type %s, 1 result was found', 'planet4-master-theme')|format(content_type.name) %}
+            {% else %}
+                {% set aria_label = __('Filter results by content type %s, %d results were found', 'planet4-master-theme')|format(content_type.name, content_type.results) %}
+            {% endif %}
             <li>
             <label class="custom-control">
                 <input
@@ -20,7 +25,7 @@
                     data-ga-category="Search Page"
                     data-ga-action="Content Filter"
                     data-ga-label="{{ content_type.name|e('wp_kses_post')|raw }}"
-                    aria-label="{{__('Filter results by content type %s, %d results were found', 'planet4-master-theme')|format(content_type.name, content_type.results)}}"
+                    aria-label="{{ aria_label }}"
                     {{ content_type.checked }} />
                 <span class="custom-control-description">{{ content_type.name }} {{ content_type.results > 0 ? '('~content_type.results~')' : '' }}</span>
             </label>

--- a/templates/search/content_types.twig
+++ b/templates/search/content_types.twig
@@ -20,6 +20,7 @@
                     data-ga-category="Search Page"
                     data-ga-action="Content Filter"
                     data-ga-label="{{ content_type.name|e('wp_kses_post')|raw }}"
+                    aria-label="{{__('%s, %d results', 'planet4-master-theme')|format(content_type.name, content_type.results)}}"
                     {{ content_type.checked }} />
                 <span class="custom-control-description">{{ content_type.name }} {{ content_type.results > 0 ? '('~content_type.results~')' : '' }}</span>
             </label>

--- a/templates/search/content_types.twig
+++ b/templates/search/content_types.twig
@@ -20,7 +20,7 @@
                     data-ga-category="Search Page"
                     data-ga-action="Content Filter"
                     data-ga-label="{{ content_type.name|e('wp_kses_post')|raw }}"
-                    aria-label="{{__('%s, %d results', 'planet4-master-theme')|format(content_type.name, content_type.results)}}"
+                    aria-label="{{__('Filter results by content type %s, %d results were found', 'planet4-master-theme')|format(content_type.name, content_type.results)}}"
                     {{ content_type.checked }} />
                 <span class="custom-control-description">{{ content_type.name }} {{ content_type.results > 0 ? '('~content_type.results~')' : '' }}</span>
             </label>

--- a/templates/search/post_types.twig
+++ b/templates/search/post_types.twig
@@ -10,6 +10,11 @@
     <ul class="list-unstyled">
     {% for post_type in post_types %}
         {% if (post_type.results > 0) or (not has_aggregation) %}
+        {% if (post_type.results == 1) %}
+            {% set aria_label = __('Filter results by post type %s, 1 result was found', 'planet4-master-theme')|format(post_type.name) %}
+        {% else %}
+            {% set aria_label = __('Filter results by post type %s, %d results were found', 'planet4-master-theme')|format(post_type.name, post_type.results) %}
+        {% endif %}
         <li>
             <label class="custom-control">
                 <input
@@ -20,7 +25,7 @@
                     data-ga-category="Search Page"
                     data-ga-action="Post Type Filter"
                     data-ga-label="{{ post_type.name|e('wp_kses_post')|raw }}"
-                    aria-label="{{__('Filter results by post type %s, %d results were found', 'planet4-master-theme')|format(post_type.name, post_type.results)}}"
+                    aria-label="{{ aria_label }}"
                     {{ post_type.checked }} />
                 <span class="custom-control-description">{{ post_type.name|e('wp_kses_post')|raw }} {{ post_type.results > 0 ? '('~post_type.results~')' : '' }}</span>
             </label>

--- a/templates/search/post_types.twig
+++ b/templates/search/post_types.twig
@@ -20,6 +20,7 @@
                     data-ga-category="Search Page"
                     data-ga-action="Post Type Filter"
                     data-ga-label="{{ post_type.name|e('wp_kses_post')|raw }}"
+                    aria-label="{{__('%s, %d results', 'planet4-master-theme')|format(post_type.name, post_type.results)}}"
                     {{ post_type.checked }} />
                 <span class="custom-control-description">{{ post_type.name|e('wp_kses_post')|raw }} {{ post_type.results > 0 ? '('~post_type.results~')' : '' }}</span>
             </label>

--- a/templates/search/post_types.twig
+++ b/templates/search/post_types.twig
@@ -20,7 +20,7 @@
                     data-ga-category="Search Page"
                     data-ga-action="Post Type Filter"
                     data-ga-label="{{ post_type.name|e('wp_kses_post')|raw }}"
-                    aria-label="{{__('%s, %d results', 'planet4-master-theme')|format(post_type.name, post_type.results)}}"
+                    aria-label="{{__('Filter results by post type %s, %d results were found', 'planet4-master-theme')|format(post_type.name, post_type.results)}}"
                     {{ post_type.checked }} />
                 <span class="custom-control-description">{{ post_type.name|e('wp_kses_post')|raw }} {{ post_type.results > 0 ? '('~post_type.results~')' : '' }}</span>
             </label>


### PR DESCRIPTION
### Description

See [PLANET-7718](https://jira.greenpeace.org/browse/PLANET-7718)

**Requirements**

- [x] Add a Skip Link to the results section
- [x] Update the placeholder text of the search input to make it more descriptive (e.g., "Search by name, keyword, or topic").
- [x] Add an `aria-label` for filter checkboxes to ensure they clearly communicate the number of results (e.g., "People, 3 results").
- [x] Add an `aria-label` to active filter button removal (e.g. "Remove Energy filter")
- [x] Use proper HTML tags on the page
  - Use `<section>` or `<aside>` HTML tags for Filters
  - ~Use `<form>` for the Search Input.~ (already implemented)

### Testing

You can test all of these changes on the oberon instance [Search page](https://www-dev.greenpeace.org/test-oberon/?s=&orderby=_score).