### PR TITLE
PLANET-7781: Fix image not displayed on RTL sites in the Media & Text block

### DIFF
--- a/assets/src/scss/blocks/core-overrides/MediaText.scss
+++ b/assets/src/scss/blocks/core-overrides/MediaText.scss
@@ -13,6 +13,14 @@
     overflow: hidden;
   }
 
+  &.is-image-fill-element {
+    html[dir="rtl"] & {
+      .wp-block-media-text__media img {
+        left: 0;
+      }
+    }
+  }
+
   &.alignfull .wp-block-media-text__content {
     max-width: 440px;
     width: 100%;


### PR DESCRIPTION
### Summary

This PR fixes images not being displayed on RTL sites in the Media & Text block, as can be seen here:
https://www-dev.greenpeace.org/mena/ar/

![image](https://github.com/user-attachments/assets/6aa7a9a2-5498-4f27-8c5e-0c8efaf086cd)

---

Ref: https://jira.greenpeace.org/browse/PLANET-7781

### Testing
1. Add a Media & Text block to any page.
2. In the block settings, select "Crop Image to Fill".
3. Save the changes and check the front in RTL mode (you can manually add the attribute `dir="rtl"` to the `html` tag).
4. The image should be visible on the left side of the block.
