### PR TITLE
PLANET-7483 Use padding instead of line height for buttons

### DIFF
--- a/assets/src/blocks/Columns/EditableColumns.js
+++ b/assets/src/blocks/Columns/EditableColumns.js
@@ -111,7 +111,7 @@ export const EditableColumns = ({
             <RichText
               tagName="div"
               className={isCampaign || [LAYOUT_NO_IMAGE, LAYOUT_TASKS].includes(columns_block_style) ?
-                `btn btn-${isCampaign ? 'primary' : 'secondary'}` :
+                `btn btn-${isCampaign ? 'primary' : 'secondary'} ${columns_block_style === LAYOUT_TASKS ? 'btn-small' : ''}` :
                 'standalone-link'}
               placeholder={[LAYOUT_NO_IMAGE, LAYOUT_TASKS].includes(columns_block_style) ?
                 __('Enter column button text', 'planet4-blocks-backend') :

--- a/assets/src/scss/components/_buttons.scss
+++ b/assets/src/scss/components/_buttons.scss
@@ -7,11 +7,10 @@
   --button-- {
     font-family: var(--font-family-button);
     font-size: $font-size-sm;
-    line-height: 3;
     text-align: center;
     font-weight: bold;
     border-radius: 4px;
-    padding: 0 30px;
+    padding: $sp-1x $sp-3x;
     transition-property: color, background-color, border-color;
     transition-duration: 150ms;
     transition-timing-function: linear;
@@ -71,14 +70,7 @@
 .gform_button_select_files {
   _-- {
     font-size: $font-size-xxs;
-    line-height: 2.8;
-  }
-}
-
-.btn-large {
-  _-- {
-    font-size: $font-size-md;
-    line-height: 3.1;
+    padding: $sp-1 $sp-3;
   }
 }
 
@@ -118,7 +110,7 @@
 .gfield button:not(.add_list_item):not(.delete_list_item):not([id^="mceu"]),
 .gform_button_select_files {
   --button-secondary-- {
-    background: rgba($white, 0.7);
+    background: var(--white);
     border-color: var(--color-border-button--secondary);
     color: var(--color-text-button--secondary);
 
@@ -160,10 +152,9 @@
     background: var(--gp-green-400);
     color: var(--grey-900);
     min-width: 180px;
-    padding: 2px 30px;
+    padding: $sp-x $sp-4;
     border-width: 1px;
     border-color: transparent;
-    line-height: 1.65;
 
     &:hover {
       background: var(--gp-green-500);
@@ -201,15 +192,12 @@ button.load-more-mt {
 .post-tag-button {
   _-- {
     font-weight: var(--font-weight-regular);
-    line-height: 2.3;
+    border-color: var(--gp-green-100);
+    color: var(--grey-900);
+    background-color: var(--color-background-tag_button--passive);
   }
-
-  border-color: var(--gp-green-100);
-  color: var(--grey-900);
-  background-color: var(--color-background-tag_button--passive);
   margin-inline-end: $sp-2;
   margin-bottom: $sp-2;
-  padding: 0 $sp-2;
   transition-duration: 100ms;
 
   &:visited {

--- a/assets/src/scss/editorOverrides.scss
+++ b/assets/src/scss/editorOverrides.scss
@@ -48,8 +48,7 @@
   border-radius: 4px;
   border: 1px solid transparent;
   cursor: pointer;
-  line-height: 3;
-  padding: 0 $sp-4;
+  padding: $sp-1x $sp-4;
   appearance: none;
   transition-property: color, background-color, border-color;
   transition-duration: 150ms;
@@ -66,10 +65,9 @@
 [class="wp-block-button"] .wp-block-button__link[role="textbox"],
 .wp-block-file .wp-block-file__button {
   --button-secondary-- {
-    background: rgba($white, 0.7);
+    background: var(--white);
     border-color: var(--p4-dark-green-800);
     color: var(--p4-dark-green-800);
-    padding: 2px $sp-4;
   }
   white-space: nowrap;
   overflow: hidden;
@@ -77,10 +75,6 @@
 
   &.has-background {
     border-color: transparent;
-  }
-
-  html[dir="rtl"] & {
-    line-height: 2.5;
   }
 }
 


### PR DESCRIPTION
### Description

See [PLANET-7483](https://jira.greenpeace.org/browse/PLANET-7483)

I've also added a small fix for the P4 Columns block, to show the correct button classes in the editor for the Tasks style. And I updated the secondary buttons' background to be white instead of slightly transparent, because it looked ugly in case a background is added:

<img width="382" alt="Screenshot 2025-03-28 at 15 46 50" src="https://github.com/user-attachments/assets/7aaeb00a-e111-4544-90da-ac71c5c9c043" />

### Testing

Please test all Button styles (primary, secondary, transparent, donate)! In all screen sizes they should still look good. You can do this on local or use [this page](https://www-dev.greenpeace.org/test-janus/button-tests/) I created.