### PR TITLE
PLANET-7546 Increase Page Header title limit on mobile

### DIFF
--- a/assets/src/scss/blocks/PageHeader.scss
+++ b/assets/src/scss/blocks/PageHeader.scss
@@ -58,7 +58,7 @@ $text-column-padding-in: 24px;
   }
 
   .wp-block-group:first-child {
-    @include clamp-text(3);
+    @include clamp-text(5);
     overflow: hidden;
     font-size: $font-size-xxl;
     font-weight: 700;
@@ -67,6 +67,10 @@ $text-column-padding-in: 24px;
     @include medium-and-less {
       padding: 0 $sp-1;
       margin: 0 (-$sp-1);
+    }
+
+    @include medium-and-up {
+      @include clamp-text(3);
     }
   }
 


### PR DESCRIPTION
### Description

See [PLANET-7546](https://jira.greenpeace.org/browse/PLANET-7546)

### Testing

Add a Page Header pattern to a page with a very long title, on desktop/tablet it should be cut off after 3 lines but on mobile the limit should now be 5 lines. You can also just check [this page](https://www-dev.greenpeace.org/test-proteus/act/).