### PR TITLE
PLANET-7793 Force WP to use UTC date for upload paths

### DIFF
--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -352,6 +352,19 @@ class MasterSite extends TimberSite
         QueryLoopPagination::hooks();
         Search\Search::hooks();
         Sendgrid::hooks();
+
+        // Force WordPress to use UTC date for upload paths to ensure consistency across different timezones.
+        // This prevents issues where uploads might be placed in a different month folder in the
+        // Stateless bucket than what WordPress expects.
+        add_filter(
+            'upload_dir',
+            function ($upload) {
+                $upload['subdir'] = '/' . gmdate('Y/m');
+                $upload['path'] = $upload['basedir'] . $upload['subdir'];
+                $upload['url'] = $upload['baseurl'] . $upload['subdir'];
+                return $upload;
+            }
+        );
     }
 
     /**


### PR DESCRIPTION
Ref. https://jira.greenpeace.org/browse/PLANET-7793

### Summary

In the media library, the missing image URL is:
https://storage.googleapis.com/planet4-aotearoa-stateless-develop/2025/04/bb77ca80-event-pic.jpeg

However, the image is actually saved in the Stateless bucket at:
https://storage.googleapis.com/planet4-aotearoa-stateless-develop/2025/03/bb77ca80-event-pic.jpeg

This suggests that if Stateless Storage is using server time (UTC) while WordPress is using Auckland time (UTC+12/13), the month may roll over differently. As a result, uploads might be placed in a different month folder in the Stateless bucket than what WordPress expects.

In this PR, we force WordPress to use UTC date for upload paths, ensuring consistency and preventing missing media library images.

### Testing

We don't have an exact scenario to test this use case (i.e., the first day of the month with Auckland timezone on the test instance). However, we can verify that media uploads work as expected with this fix.