### PR TITLE
Align main Greenpeace logo

### DIFF
--- a/assets/src/scss/layout/navbar/_site-logo.scss
+++ b/assets/src/scss/layout/navbar/_site-logo.scss
@@ -1,16 +1,14 @@
 .site-logo {
   line-height: var(--navbar-menu-height--small);
 
-  @include large-and-up {
-    line-height: var(--navbar-menu-height--large);
-  }
-
   img {
     height: 26px;
   }
 
   @include large-and-up {
     margin-inline-start: calc((100vw - 960px) / 2);
+    line-height: var(--navbar-menu-height--large);
+    padding-left: $sp-1x;
   }
 
   @include x-large-and-up {


### PR DESCRIPTION
### Summary

This PR aligns the main logo with the left margin of the website content.
Additionally, it moves a line of CSS code to avoid repeating a media query.

**BEFORE:**
![image](https://github.com/user-attachments/assets/c5277792-64f6-44ba-b3bd-814b9becf9d9)

**NOW:**
![Screenshot from 2025-04-02 11-56-24](https://github.com/user-attachments/assets/afd4165a-79e0-4cef-ab0c-ab358771fc67)

---

Ref: https://greenpeace-gpi.slack.com/archives/G015K63081W/p1743580344148979