### PR TITLE
PLANET-7659 Hide empty restrictions text field in media library

### DIFF
--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -1567,11 +1567,14 @@ class MasterSite extends TimberSite
         ];
 
         // Add a Restrictions field.
-        $form_fields['restrictions_text'] = [
-            'label' => __('Restrictions', 'planet4-master-theme-backend'),
-            'input' => 'html',
-            'html' => get_post_meta($post->ID, self::RESTRICTIONS_META_FIELD, true),
-        ];
+        $img_restrictions = get_post_meta($post->ID, self::RESTRICTIONS_META_FIELD, true);
+        if ($img_restrictions) {
+            $form_fields['restrictions_text'] = [
+                'label' => __('Restrictions', 'planet4-master-theme-backend'),
+                'input' => 'html',
+                'html' => $img_restrictions,
+            ];
+        }
 
         return $form_fields;
     }


### PR DESCRIPTION
Ref. https://jira.greenpeace.org/browse/PLANET-7659

### Testing
- You can test this fix on a local environment or a [test instance](https://www-dev.greenpeace.org/test-venus/wp-admin/upload.php?item=771).
- Navigate to WP Admin → Media Library → View Image.
- If the image is imported from Greenpeace Media Library and has a restriction, the restriction field should be visible.
- If the image does not have a restriction, the restriction field should be hidden (previously, an empty input field was displayed).
