### PR TITLE
Add scss support for stylelint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,11 +95,11 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Install dependencies
+          command: PUPPETEER_SKIP_DOWNLOAD=true PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true npm ci --unsafe-perm=true --legacy-peer-deps
+      - run:
           name: Lint CSS
           command: stylelint "assets/src/scss/**/*.scss"
-      - run:
-          name: Install eslint react plugin
-          command: PUPPETEER_SKIP_DOWNLOAD=true PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true npm install eslint-plugin-react --unsafe-perm=true --legacy-peer-deps
       - run:
           name: Lint JS
           command: eslint "assets/src/**/*.js" "tests/e2e/**/*.js" "admin/js/**/*.js"

--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,10 +1,21 @@
 {
+  "extends": ["stylelint-config-recommended"],
+  "overrides": [
+    {
+      "files": ["**/*.scss"],
+      "customSyntax": "postcss-scss",
+      "rules": {
+        "at-rule-no-unknown": null
+      }
+    }
+  ],
   "rules": {
     "color-hex-case": "lower",
     "color-no-invalid-hex": true,
 
     "font-family-no-duplicate-names": true,
     "font-family-name-quotes": "always-where-recommended",
+    "font-family-no-missing-generic-family-keyword": [true, {"ignoreFontFamilies": ["ForkAwesome"]}],
 
     "function-calc-no-unspaced-operator": true,
     "function-comma-space-after": "always",
@@ -81,6 +92,7 @@
 
     "indentation": 2,
     "max-nesting-depth": 7,
+    "no-descending-specificity": null,
     "no-duplicate-selectors": true,
     "no-eol-whitespace": true,
     "no-extra-semicolons": true,

--- a/assets/src/scss/base/_icons.scss
+++ b/assets/src/scss/base/_icons.scss
@@ -4,7 +4,7 @@
   flex-shrink: 0;
   height: 1em;
   width: 1em;
-  fill: currentColor;
+  fill: currentcolor;
   transition: fill .3s;
 }
 
@@ -17,7 +17,7 @@ a.standalone-link {
   &::after {
     content: "";
     display: inline-block;
-    background-color: currentColor;
+    background-color: currentcolor;
     pointer-events: none;
     margin-inline-start: .2rem;
     height: .7rem;
@@ -34,7 +34,7 @@ a.pdf-link {
   &::after {
     content: "";
     display: inline-block;
-    background-color: currentColor;
+    background-color: currentcolor;
     height: 1rem;
     width: 1rem;
     margin-bottom: -2px;
@@ -50,7 +50,7 @@ a.external-link {
   &::after {
     content: "";
     display: inline-block;
-    background-color: currentColor;
+    background-color: currentcolor;
     height: .7rem;
     width: .7rem;
     margin-inline-start: .2rem;

--- a/assets/src/scss/base/_typography.scss
+++ b/assets/src/scss/base/_typography.scss
@@ -1,5 +1,5 @@
 html {
-  text-rendering: optimizeLegibility;
+  text-rendering: optimizelegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }

--- a/assets/src/scss/blocks.scss
+++ b/assets/src/scss/blocks.scss
@@ -1,6 +1,5 @@
 // Beta blocks
 @import "blocks/ActionsList/ActionsListStyle";
-@import "blocks/PostsList/PostsListStyle";
 
 // P4 Blocks
 @import "blocks/Accordion/AccordionStyle";
@@ -11,6 +10,7 @@
 @import "blocks/Counter/CounterStyle";
 @import "blocks/Covers/CoversStyle";
 @import "blocks/HappyPoint/HappyPointStyle";
+@import "blocks/PostsList/PostsListStyle";
 @import "blocks/SocialMedia/SocialMediaStyle";
 @import "blocks/Spreadsheet";
 @import "blocks/TableOfContents/TableOfContentsStyle";

--- a/assets/src/scss/blocks/Accordion/AccordionStyle.scss
+++ b/assets/src/scss/blocks/Accordion/AccordionStyle.scss
@@ -75,7 +75,7 @@
         mask-repeat: no-repeat;
         mask-size: contain;
         background-repeat: no-repeat;
-        background-color: currentColor;
+        background-color: currentcolor;
 
         html[dir="rtl"] & {
           right: auto;

--- a/assets/src/scss/blocks/Columns/ColumnsStyle.scss
+++ b/assets/src/scss/blocks/Columns/ColumnsStyle.scss
@@ -97,7 +97,8 @@
   // Columns block, layout icons.
   &.block-style-icons {
     .row {
-      margin-bottom: -$sp-4; // Compensate for last row margin
+      // Compensate for last row margin
+      margin-bottom: -$sp-4;
 
       @include large-and-up {
         margin-bottom: 0;
@@ -296,7 +297,7 @@
             mask-repeat: no-repeat;
             mask-size: contain;
             background-repeat: no-repeat;
-            background-color: currentColor;
+            background-color: currentcolor;
 
             html[dir="rtl"] & {
               right: auto;

--- a/assets/src/scss/blocks/PostsList/PostsListStyle.scss
+++ b/assets/src/scss/blocks/PostsList/PostsListStyle.scss
@@ -16,7 +16,7 @@
       &::after {
         content: "";
         display: inline-block;
-        background-color: currentColor;
+        background-color: currentcolor;
         pointer-events: none;
         margin-inline-start: .2rem;
         height: .7rem;

--- a/assets/src/scss/blocks/TopicLink/TopicLinkStyle.scss
+++ b/assets/src/scss/blocks/TopicLink/TopicLinkStyle.scss
@@ -52,7 +52,7 @@
         mask-repeat: no-repeat;
         mask-size: contain;
         background-repeat: no-repeat;
-        background-color: currentColor;
+        background-color: currentcolor;
 
         html[dir="rtl"] & {
           right: auto;

--- a/assets/src/scss/blocks/core-overrides/Heading.scss
+++ b/assets/src/scss/blocks/core-overrides/Heading.scss
@@ -10,7 +10,7 @@
     mask-repeat: no-repeat;
     mask-size: contain;
     background-repeat: no-repeat;
-    background-color: currentColor;
+    background-color: currentcolor;
     vertical-align: middle;
 
     html[dir="rtl"] & {

--- a/assets/src/scss/layout/_navbar.scss
+++ b/assets/src/scss/layout/_navbar.scss
@@ -79,7 +79,7 @@
           mask: url("../../images/chevron.svg") 0 0/10px 10px;
           transform: rotate(90deg);
           transition: transform 150ms linear;
-          background-color: currentColor;
+          background-color: currentcolor;
           background-repeat: no-repeat;
         }
       }

--- a/assets/src/scss/layout/navbar/_burger-menu.scss
+++ b/assets/src/scss/layout/navbar/_burger-menu.scss
@@ -197,7 +197,7 @@ $transition-duration: .2s;
     mask-size: contain;
     mask-position: center;
     background-repeat: no-repeat;
-    background-color: currentColor;
+    background-color: currentcolor;
     transform: rotate(-90deg);
     transition: transform 0.3s linear;
     color: var(--color-text-nav_link);

--- a/assets/src/scss/layout/navbar/languages.scss
+++ b/assets/src/scss/layout/navbar/languages.scss
@@ -21,7 +21,7 @@
       mask: url("../../images/chevron.svg") 0 0/10px 10px;
       transform: rotate(90deg);
       transition: transform 150ms linear;
-      background-color: currentColor;
+      background-color: currentcolor;
       background-repeat: no-repeat;
     }
 

--- a/assets/src/scss/pages/_listing-page.scss
+++ b/assets/src/scss/pages/_listing-page.scss
@@ -276,7 +276,7 @@
   mask-size: contain;
   mask-position: center;
   background-repeat: no-repeat;
-  background-color: currentColor;
+  background-color: currentcolor;
   color: var(--grey-900);
 }
 

--- a/assets/src/scss/pages/post/_author-block.scss
+++ b/assets/src/scss/pages/post/_author-block.scss
@@ -125,7 +125,7 @@
     mask-size: contain;
     mask-position: center;
     background-repeat: no-repeat;
-    background-color: currentColor;
+    background-color: currentcolor;
     transform: rotate(90deg);
     margin-inline-start: $sp-x;
   }

--- a/assets/src/scss/vendors/photoswipe/main.scss
+++ b/assets/src/scss/vendors/photoswipe/main.scss
@@ -1,5 +1,4 @@
 // This file was obtained from: https://github.com/dimsemenov/PhotoSwipe/blob/v4.1.3/src/css/main.scss
-
 /* pswp = photoswipe */
 .pswp {
   display: none;

--- a/assets/src/scss/vendors/photoswipe/p4-skin.scss
+++ b/assets/src/scss/vendors/photoswipe/p4-skin.scss
@@ -1,29 +1,19 @@
 // This file is based in: https://github.com/dimsemenov/PhotoSwipe/blob/v4.1.3/src/css/default-skin/default-skin.scss
 // ...with some minor tweaks/additions.
-
 /*! PhotoSwipe Default UI CSS by Dmitry Semenov | photoswipe.com | MIT license */
-
 /*
-
 Contents:
-
 1. Buttons
 2. Share modal and links
 3. Index indicator ("1 of X" counter)
 4. Caption
 5. Loading indicator
 6. Additional styles (root element, top bar, idle state, hidden state, etc.)
-
 */
-
 // PhotoSwipe uses Autoprefixer, so vendor prefixed are added automatically when needed.
-
 /*
-
 1. Buttons
-
 */
-
 /* <button> css reset */
 .pswp__button {
   width: 44px;

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "mini-css-extract-plugin": "^2.7.6",
         "postcss": "^8.4.16",
         "postcss-loader": "^6.2.1",
+        "postcss-scss": "^4.0.9",
         "sass": "^1.77.7",
         "sass-loader": "^16.0.2",
         "svg-sprite-loader": "^6.0.11",
@@ -2391,7 +2392,7 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
       "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.9"
       },
@@ -2403,7 +2404,7 @@
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
       "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -3482,7 +3483,7 @@
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
       "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@sinclair/typebox": "^0.27.8"
       },
@@ -3570,7 +3571,7 @@
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
       "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@jest/schemas": "^29.6.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -4563,7 +4564,7 @@
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
       "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@sinonjs/commons": {
       "version": "3.0.1",
@@ -5106,25 +5107,25 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
       "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@tsconfig/node12": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
       "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
       "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -5550,7 +5551,7 @@
       "version": "17.0.33",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.33.tgz",
       "integrity": "sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/yargs-parser": "*"
       }
@@ -8395,6 +8396,7 @@
       "resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-21.41.0.tgz",
       "integrity": "sha512-2wxFu8ICeRGF3Lxz7H7o2SU1u6pTI4mjuog39DgtCNb+v+f6yhgREDuNQEeti3Svb0rjj63AJ7r2CqLZk+EQIQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "stylelint-config-recommended": "^6.0.0",
         "stylelint-config-recommended-scss": "^5.0.2"
@@ -8590,7 +8592,7 @@
       "version": "8.3.4",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
       "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "acorn": "^8.11.0"
       },
@@ -8794,7 +8796,7 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/argparse": {
       "version": "1.0.10",
@@ -9081,6 +9083,7 @@
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
       "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -11003,7 +11006,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/cross-fetch": {
       "version": "3.1.5",
@@ -11085,10 +11088,11 @@
       }
     },
     "node_modules/css-functions-list": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.2.2.tgz",
-      "integrity": "sha512-c+N0v6wbKVxTu5gOBBFkr9BEdBWaqqjQeiJ8QvSRIJOf+UxlJh930m8e6/WNeODIK0mYLFkoONrnj16i2EcvfQ==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.2.3.tgz",
+      "integrity": "sha512-IQOkD3hbR5KrN93MtcYuad6YPuTSUhntLHDuLEbFWE+ff2/XSZNdZG+LcbbIW5AXKg/WFIfYItIzVoHngHXZzA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12 || >=16"
       }
@@ -15593,7 +15597,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.0.tgz",
       "integrity": "sha512-0AOCmOip+xgJwEVTQj1EfiDDOkPmuyllDuTuEX+DDXUgapLAsBIfkg3sxCYyCEA8mQqZrrxPUGjcOQ2JS3WLkg==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
@@ -15623,6 +15627,7 @@
       "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-4.0.0.tgz",
       "integrity": "sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -16760,7 +16765,7 @@
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
       "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
@@ -16769,7 +16774,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
       "integrity": "sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
         "@types/graceful-fs": "^4.1.3",
@@ -17388,7 +17393,7 @@
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
       "integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
@@ -17397,7 +17402,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.7.0.tgz",
       "integrity": "sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.9",
@@ -17538,7 +17543,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
       "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
         "@types/node": "*",
@@ -17555,7 +17560,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.7.0.tgz",
       "integrity": "sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
         "camelcase": "^6.2.0",
@@ -17572,7 +17577,7 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
       "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=10"
       },
@@ -17603,7 +17608,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
       "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/node": "*",
         "jest-util": "^29.7.0",
@@ -17618,7 +17623,7 @@
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
       "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -17925,7 +17930,8 @@
       "version": "0.26.0",
       "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.26.0.tgz",
       "integrity": "sha512-5FZRzrZzNTBruuurWpvZnvP9pum+fe0HcK8z/ooo+U+Hmp4vtbyp1/QDsqmufirXy4egGzbaH/y2uCZf+6W5Kg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/language-subtag-registry": {
       "version": "0.3.22",
@@ -18413,7 +18419,8 @@
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
       "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lodash.uniq": {
       "version": "4.5.0",
@@ -18515,7 +18522,7 @@
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/makeerror": {
       "version": "1.0.12",
@@ -21715,6 +21722,7 @@
       "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-6.0.0.tgz",
       "integrity": "sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12.0"
       },
@@ -21745,6 +21753,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "engines": {
         "node": ">=12.0"
       },
@@ -22142,7 +22151,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
       "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@jest/schemas": "^29.6.3",
         "ansi-styles": "^5.0.0",
@@ -22156,7 +22165,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=10"
       },
@@ -22168,7 +22177,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
@@ -22825,7 +22834,6 @@
       "version": "0.14.2",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
       "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -26006,7 +26014,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.2.tgz",
       "integrity": "sha512-X2UW6Nw3n/aMgDVy+0rSqgHlv39WZAlZrXCdnbyEiKm17DSqHX4MmQMaST3FbeWR5FTuRcUwYAziZajji0Y7mg==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=10"
       }
@@ -26244,7 +26252,7 @@
       "version": "1.77.7",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.77.7.tgz",
       "integrity": "sha512-9ywH75cO+rLjbrZ6en3Gp8qAMwPGBapFtlsMJoDTkcMU/bSe5a6cjKVUn5Jr4Gzg5GbP3HE8cm+02pLCgcoMow==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",
@@ -26985,6 +26993,7 @@
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
       "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "astral-regex": "^2.0.0",
@@ -27871,7 +27880,8 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/style-search/-/style-search-0.1.0.tgz",
       "integrity": "sha512-Dj1Okke1C3uKKwQcetra4jSuk0DqbzbYtXipzFlFMZtowbF1x7BKJwB9AayVMyFARvU8EDrZdcax4At/452cAg==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/stylehacks": {
       "version": "6.1.1",
@@ -27894,6 +27904,7 @@
       "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-14.16.1.tgz",
       "integrity": "sha512-ErlzR/T3hhbV+a925/gbfc3f3Fep9/bnspMiJPorfGEmcBbXdS+oo6LrVtoUZ/w9fqD6o6k7PtUlCOsCRdjX/A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@csstools/selector-specificity": "^2.0.2",
         "balanced-match": "^2.0.0",
@@ -27950,6 +27961,7 @@
       "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-6.0.0.tgz",
       "integrity": "sha512-ZorSSdyMcxWpROYUvLEMm0vSZud2uB7tX1hzBZwvVY9SV/uly4AvvJPPhCcymZL3fcQhEQG5AELmrxWqtmzacw==",
       "dev": true,
+      "license": "MIT",
       "peerDependencies": {
         "stylelint": "^14.0.0"
       }
@@ -27959,6 +27971,7 @@
       "resolved": "https://registry.npmjs.org/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-5.0.2.tgz",
       "integrity": "sha512-b14BSZjcwW0hqbzm9b0S/ScN2+3CO3O4vcMNOw2KGf8lfVSwJ4p5TbNEXKwKl1+0FMtgRXZj6DqVUe/7nGnuBg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "postcss-scss": "^4.0.2",
         "stylelint-config-recommended": "^6.0.0",
@@ -27973,6 +27986,7 @@
       "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-4.7.0.tgz",
       "integrity": "sha512-TSUgIeS0H3jqDZnby1UO1Qv3poi1N8wUYIJY6D1tuUq2MN3lwp/rITVo0wD+1SWTmRm0tNmGO0b7nKInnqF6Hg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "postcss-media-query-parser": "^0.2.3",
         "postcss-resolve-nested-selector": "^0.1.1",
@@ -28038,6 +28052,7 @@
       "resolved": "https://registry.npmjs.org/meow/-/meow-9.0.0.tgz",
       "integrity": "sha512-+obSblOQmRhcyBt62furQqRAQpNyWXo8BuQ5bN7dG8wmwQ+vwHKp/rCFD4CrTP8CsDQD1sjoZ94K417XEUk8IQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/minimist": "^1.2.0",
         "camelcase-keys": "^6.2.2",
@@ -28060,16 +28075,18 @@
       }
     },
     "node_modules/stylelint/node_modules/picocolors": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.0.tgz",
-      "integrity": "sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw==",
-      "dev": true
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/stylelint/node_modules/type-fest": {
       "version": "0.18.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
       "integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==",
       "dev": true,
+      "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=10"
       },
@@ -28632,10 +28649,11 @@
       }
     },
     "node_modules/table": {
-      "version": "6.8.2",
-      "resolved": "https://registry.npmjs.org/table/-/table-6.8.2.tgz",
-      "integrity": "sha512-w2sfv80nrAh2VCbqR5AK27wswXhqcck2AhfnNW76beQXskGZ1V12GwS//yYVa3d3fcvAip2OUnbDAjW2k3v9fA==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.9.0.tgz",
+      "integrity": "sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "ajv": "^8.0.1",
         "lodash.truncate": "^4.4.2",
@@ -29185,7 +29203,7 @@
       "version": "10.9.1",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
       "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -29408,7 +29426,6 @@
       "version": "4.9.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -29916,13 +29933,14 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.4.0.tgz",
       "integrity": "sha512-ocyWc3bAHBB/guyqJQVI5o4BZkPhznPYUG2ea80Gond/BgNWpap8TOmLSeeQG7bnh2KMISxskdADG59j7zruhw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",
@@ -31191,7 +31209,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=6"
       }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "mini-css-extract-plugin": "^2.7.6",
     "postcss": "^8.4.16",
     "postcss-loader": "^6.2.1",
+    "postcss-scss": "^4.0.9",
     "sass": "^1.77.7",
     "sass-loader": "^16.0.2",
     "svg-sprite-loader": "^6.0.11",


### PR DESCRIPTION
### Summary

It looks like our `stylelint` config was not working lately. For the version of stylelint we use (`14.16.1`) we also need to use `postcss-scss` for support SASS.

So what this PR does:
- Adds postcss on the stylelint configuration
- Fixes minor styling issues accumulated overtime in scss code

---

### Testing

1. On the main branch run: `npx stylelint "assets/src/scss/**/*.scss"` You should get multiple warnings about `Unknown word  CssSyntaxError` and suggestion for using `postcss-scss`.
2. Switch to this branch and run: `npm run install`
3. Then re-run `npx stylelint "assets/src/scss/**/*.scss"`
4. Everything should work fine
