### PR TITLE
PLANET-7034: Show empty columns in the P4 Columns block

### DIFF
--- a/src/Blocks/Columns.php
+++ b/src/Blocks/Columns.php
@@ -113,13 +113,7 @@ class Columns extends BaseBlock
     {
         $columns_block_style = $attributes['columns_block_style'];
 
-        // Only show columns that have a title or a description.
-        $columns = array_filter(
-            $attributes['columns'],
-            static function (array $column) {
-                return !empty($column['title']) || !empty($column['description']);
-            }
-        );
+        $columns = $attributes['columns'];
 
         $columns = array_slice($columns, 0, self::MAX_COLUMNS);
 


### PR DESCRIPTION
### Summary

This PR includes in the front the empty columns of the P4 Columns block.

---

Ref: 
- https://jira.greenpeace.org/browse/PLANET-7034
- https://greenpeace-gpi.slack.com/archives/G015K63081W/p1744106076520599

### Testing

1. Visit https://www-dev.greenpeace.org/test-phoebe/p4-columns-test-page/
2. Check that all the columns of the P4 Columns block are rendered, regardless of whether they have content or not.