### PR TITLE
PLANET-7796: Pass the variable `cf_local_project` to GTM

### DIFF
--- a/src/EnqueueController.php
+++ b/src/EnqueueController.php
@@ -315,7 +315,7 @@ class EnqueueController
             'page_date' => $context['page_date'] ?? null,
             'cf_campaign_name' => $context['cf_campaign_name'] ?? null,
             'cf_project_id' => $context['cf_project_id'] ?? null,
-            'cf_local_project_id' => $context['cf_local_project_id'] ?? null,
+            'cf_local_project' => $context['cf_local_project'] ?? null,
             'cf_basket_name' => $context['cf_basket_name'] ?? null,
             'cf_scope' => $context['cf_scope'] ?? null,
             'cf_department' => $context['cf_department'] ?? null,


### PR DESCRIPTION
### Summary

This PR adds the value of `cf_local_project` to the `googleTagManagerData` global variable, which is missing.

---

Ref: https://jira.greenpeace.org/browse/PLANET-7796

### Testing

1. Edit an existing page or post, or create a new one.
2. In the page/post settings, go to "Analytics & Tracking"
3. Complete all the fields.
4. Visit the page/post front.
5. In the browser console, check the `googleTagManagerData.cf_local_project` variable. It should match the selection of step 3. 
