### PR TITLE
PLANET-7101: Lightbox shows all images for Gallery 3 columns style

### DIFF
--- a/src/Blocks/Gallery.php
+++ b/src/Blocks/Gallery.php
@@ -25,6 +25,10 @@ class Gallery extends BaseBlock
     public const LAYOUT_THREE_COLUMNS = 2;
     public const LAYOUT_GRID = 3;
 
+    public const CLASS_LAYOUT_SLIDER = 'is-style-slider';
+    public const CLASS_LAYOUT_THREE_COLUMNS = 'is-style-three-columns';
+    public const CLASS_LAYOUT_GRID = 'is-style-grid';
+
     /**
      * Gallery constructor.
      */
@@ -196,6 +200,12 @@ class Gallery extends BaseBlock
             }
 
             $images[] = $image_data;
+        }
+
+        // If the gallery style is "3 Columns" we need to limit the number of images to 3
+        // to avoid the lightbox carousel to show more images than that.
+        if ($fields['className'] === self::CLASS_LAYOUT_THREE_COLUMNS) {
+            $images = array_slice($images, 0, 3);
         }
 
         return $images;


### PR DESCRIPTION
### Summary

This PR limits the number of images shown by the lightbox carousel of the block "Gallery" with style "3 columns".

Without this implementation, When we create a Gallery block with the 3 Columns style, even if more images are selected in the backend only 3 will show in the frontend. However, when clicking on one of these images to open the Lightbox, all images show there which is confusing.

---

Ref: https://jira.greenpeace.org/browse/PLANET-7101

### Testing

1. Check the testing page: https://www-dev.greenpeace.org/test-neptune/planet-7101/
2. Check that all the galleries are working as expected. Each gallery contains the same 6 images.
3. Check that the gallery using the "3 columns" style shows only the corresponding 3 images when the lightbox carousel is opened.
