### PR TITLE
Fix VWO script

### DIFF
--- a/assets/src/js/vwo_smart_code.js
+++ b/assets/src/js/vwo_smart_code.js
@@ -18,6 +18,6 @@ if (vwoSmartScriptCodeData?.vwo_account_id) {
 
   const fragment = document.createRange().createContextualFragment(vwoScript);
 
-  document.head.appendChild(fragment);
+  document.head.prepend(fragment);
 }
 

--- a/src/HttpHeaders.php
+++ b/src/HttpHeaders.php
@@ -47,7 +47,7 @@ class HttpHeaders
         $enable_vwo = planet4_get_option('vwo_account_id') ?? null;
         if ($enable_vwo) {
             // phpcs:disable Generic.Files.LineLength.MaxExceeded
-            $directives[0] = $directives[0] . ' blob: *.visualwebsiteoptimizer.com *visualwebsiteoptimizer.com app.vwo.com useruploads.vwo.io';
+            $directives[0] = $directives[0] . ' blob: *.visualwebsiteoptimizer.com app.vwo.com useruploads.vwo.io';
         }
 
         $csp_header = implode('; ', $directives);

--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -358,7 +358,20 @@ class MasterSite extends TimberSite
                     return;
                 }
 
-                echo '<script>vwo_$("body").vwoCss({"visibility":"visible !important"});</script>' . PHP_EOL;
+                echo '
+                    <script>
+                        window.vwo_$ = window.vwo_$ || function() {
+                            (window._vwoQueue = window._vwoQueue || []).push(arguments);
+                            return {
+                            vwoCss: function() {}
+                            };
+                        };
+                    </script>
+
+                    <script>
+                        vwo_$("body").vwoCss({"visibility":"visible !important"});
+                    </script>
+                ';
             },
             10
         );


### PR DESCRIPTION
### Summary

<!-- Please provide a brief summary of the change introduced in this Pull Request. -->

---

<!-- Please add a reference link to the ticket, if one exists. -->

<!-- Please add the steps required to test the changes in this Pull Request. -->
This fix removes the `*visualwebsiteoptimizer.com ` subdomain from the CSP headers. This was throwing an error on the console.
Also added a fallback function to queue `vwo_$` requests if they run before the script is loaded.
Now loading the VWO Smart code at the beginning of the head tag.
