### PR TITLE
PLANET-7483 Use padding instead of line height for buttons

### DIFF
--- a/assets/src/blocks/Columns/EditableColumns.js
+++ b/assets/src/blocks/Columns/EditableColumns.js
@@ -111,7 +111,7 @@ export const EditableColumns = ({
             <RichText
               tagName="div"
               className={isCampaign || [LAYOUT_NO_IMAGE, LAYOUT_TASKS].includes(columns_block_style) ?
-                `btn btn-${isCampaign ? 'primary' : 'secondary'}` :
+                `btn btn-${isCampaign ? 'primary' : 'secondary'} ${columns_block_style === LAYOUT_TASKS ? 'btn-small' : ''}` :
                 'standalone-link'}
               placeholder={[LAYOUT_NO_IMAGE, LAYOUT_TASKS].includes(columns_block_style) ?
                 __('Enter column button text', 'planet4-blocks-backend') :

--- a/assets/src/blocks/Covers/TakeActionCovers.js
+++ b/assets/src/blocks/Covers/TakeActionCovers.js
@@ -78,7 +78,7 @@ export const TakeActionCovers = ({
             <p className="cover-card-excerpt" dangerouslySetInnerHTML={{__html: excerpt}} />
           </div>
           <a
-            className="btn cover-card-btn btn-primary"
+            className="btn cover-card-btn btn-primary btn-small"
             data-ga-category="Take Action Covers"
             data-ga-action="Call to Action"
             data-ga-label="n/a"

--- a/assets/src/scss/blocks/Accordion/AccordionStyle.scss
+++ b/assets/src/scss/blocks/Accordion/AccordionStyle.scss
@@ -106,7 +106,6 @@
 
     .accordion-btn {
       margin: $sp-3 0 0;
-      line-height: 2.5;
       width: 80%;
     }
   }

--- a/assets/src/scss/blocks/Covers/styles/TakeActionCovers.scss
+++ b/assets/src/scss/blocks/Covers/styles/TakeActionCovers.scss
@@ -91,8 +91,6 @@
 
     .cover-card-btn {
       font-size: var(--font-size-xxxs--font-family-primary);
-      line-height: var(--line-height-s--font-family-primary);
-      padding: 10px 20px;
       right: $sp-3;
       bottom: $sp-3;
       left: auto;

--- a/assets/src/scss/blocks/TakeActionBoxout/TakeActionBoxoutStyle.scss
+++ b/assets/src/scss/blocks/TakeActionBoxout/TakeActionBoxoutStyle.scss
@@ -121,7 +121,6 @@
   .btn {
     _-- {
       font-size: var(--font-size-xxxs--font-family-primary);
-      line-height: 2.5;
     }
 
     white-space: nowrap;

--- a/assets/src/scss/components/_buttons.scss
+++ b/assets/src/scss/components/_buttons.scss
@@ -7,11 +7,10 @@
   --button-- {
     font-family: var(--font-family-button);
     font-size: $font-size-sm;
-    line-height: 3;
     text-align: center;
     font-weight: bold;
     border-radius: 4px;
-    padding: 0 30px;
+    padding: $sp-1x $sp-3x;
     transition-property: color, background-color, border-color;
     transition-duration: 150ms;
     transition-timing-function: linear;
@@ -71,15 +70,8 @@
 .gform_button_select_files {
   _-- {
     font-size: $font-size-xxs;
-    line-height: 2.8;
   }
-}
-
-.btn-large {
-  _-- {
-    font-size: $font-size-md;
-    line-height: 3.1;
-  }
+  padding: $sp-1 $sp-3;
 }
 
 .btn-primary,
@@ -118,7 +110,7 @@
 .gfield button:not(.add_list_item):not(.delete_list_item):not([id^="mceu"]),
 .gform_button_select_files {
   --button-secondary-- {
-    background: rgba($white, 0.7);
+    background: var(--white);
     border-color: var(--color-border-button--secondary);
     color: var(--color-text-button--secondary);
 
@@ -160,10 +152,9 @@
     background: var(--gp-green-400);
     color: var(--grey-900);
     min-width: 180px;
-    padding: 2px 30px;
+    padding: $sp-x $sp-4;
     border-width: 1px;
     border-color: transparent;
-    line-height: 1.65;
 
     &:hover {
       background: var(--gp-green-500);
@@ -201,15 +192,12 @@ button.load-more-mt {
 .post-tag-button {
   _-- {
     font-weight: var(--font-weight-regular);
-    line-height: 2.3;
+    border-color: var(--gp-green-100);
+    color: var(--grey-900);
+    background-color: var(--color-background-tag_button--passive);
   }
-
-  border-color: var(--gp-green-100);
-  color: var(--grey-900);
-  background-color: var(--color-background-tag_button--passive);
   margin-inline-end: $sp-2;
   margin-bottom: $sp-2;
-  padding: 0 $sp-2;
   transition-duration: 100ms;
 
   &:visited {

--- a/assets/src/scss/editorOverrides.scss
+++ b/assets/src/scss/editorOverrides.scss
@@ -48,8 +48,7 @@
   border-radius: 4px;
   border: 1px solid transparent;
   cursor: pointer;
-  line-height: 3;
-  padding: 0 $sp-4;
+  padding: $sp-1x $sp-4;
   appearance: none;
   transition-property: color, background-color, border-color;
   transition-duration: 150ms;
@@ -66,10 +65,9 @@
 [class="wp-block-button"] .wp-block-button__link[role="textbox"],
 .wp-block-file .wp-block-file__button {
   --button-secondary-- {
-    background: rgba($white, 0.7);
+    background: var(--white);
     border-color: var(--p4-dark-green-800);
     color: var(--p4-dark-green-800);
-    padding: 2px $sp-4;
   }
   white-space: nowrap;
   overflow: hidden;
@@ -77,10 +75,6 @@
 
   &.has-background {
     border-color: transparent;
-  }
-
-  html[dir="rtl"] & {
-    line-height: 2.5;
   }
 }
 

--- a/assets/src/scss/layout/_cookies-settings.scss
+++ b/assets/src/scss/layout/_cookies-settings.scss
@@ -97,12 +97,9 @@
 
   .btn {
     width: calc(50% - 8px);
-    line-height: 2.4;
     font-size: 14px;
-    padding: 0;
 
     @include medium-and-up {
-      padding: 0 $sp-2;
       width: auto;
     }
   }

--- a/assets/src/scss/layout/_cookies.scss
+++ b/assets/src/scss/layout/_cookies.scss
@@ -70,7 +70,6 @@
 .cookies-buttons {
   .btn {
     _-- {
-      line-height: 2.4;
       font-size: 14px;
     }
     width: 100%;
@@ -107,7 +106,6 @@
   border: none;
   color: var(--grey-600);
   margin: $sp-2 auto 0 auto;
-  line-height: 2.4;
   font-size: 14px;
   padding: 0;
 

--- a/assets/src/scss/layout/navbar/_search.scss
+++ b/assets/src/scss/layout/navbar/_search.scss
@@ -142,7 +142,6 @@
 
   @include x-large-and-up {
     display: inline-block;
-    line-height: var(--navbar-menu-height);
   }
 }
 

--- a/assets/src/scss/pages/post/_comments-block.scss
+++ b/assets/src/scss/pages/post/_comments-block.scss
@@ -6,10 +6,6 @@
     font-size: 16px;
     margin-bottom: $sp-2;
   }
-
-  .comment-respond button {
-    height: 48px;
-  }
 }
 
 .single-comment {

--- a/assets/src/scss/pages/search/_filter-sidebar.scss
+++ b/assets/src/scss/pages/search/_filter-sidebar.scss
@@ -122,7 +122,6 @@
     .btn-filter {
       height: 40px;
       width: 130px;
-      line-height: 40px;
       padding: 0 $sp-1;
 
       svg {

--- a/assets/src/scss/pages/search/_search-bar.scss
+++ b/assets/src/scss/pages/search/_search-bar.scss
@@ -62,7 +62,6 @@
 
   .search-btn {
     font-size: $font-size-sm;
-    line-height: 2.75;
 
     svg {
       margin-right: 4px;
@@ -78,7 +77,6 @@
 
     @include large-and-up {
       margin-top: 2px;
-      line-height: 3;
 
       svg {
         margin-right: 4px;

--- a/templates/cookies.twig
+++ b/templates/cookies.twig
@@ -10,7 +10,7 @@
             <div class="cookies-buttons">
                 {% if show_settings %}
                     <button
-                        class="btn btn-secondary p-0"
+                        class="btn btn-secondary btn-small"
                         id="show-cookies-settings"
                         data-ga-category="Cookies box"
                         data-ga-action="Settings"
@@ -19,7 +19,7 @@
                     </button>
                 {% endif %}
                 <button
-                    class="btn btn-primary p-0 allow-all-cookies"
+                    class="btn btn-primary allow-all-cookies btn-small"
                     data-ga-category="Cookies box"
                     data-ga-action="Accept all cookies"
                 >

--- a/templates/cookies/cookies_settings.twig
+++ b/templates/cookies/cookies_settings.twig
@@ -40,7 +40,7 @@
     <div class="cookies-settings-buttons {{ cookies.enable_reject_all_cookies ? 'with-reject-all' : '' }}">
         {% if cookies.enable_reject_all_cookies %}
             <button
-                class="btn btn-secondary reject-all-cookies"
+                class="btn btn-secondary reject-all-cookies btn-small"
                 data-ga-category="Cookies box"
                 data-ga-action="Reject all"
             >
@@ -48,14 +48,14 @@
             </button>
         {% endif %}
         <button
-            class="btn btn-secondary allow-all-cookies"
+            class="btn btn-secondary allow-all-cookies btn-small"
             data-ga-category="Cookies box"
             data-ga-action="Allow all"
         >
             {{ __( 'Allow all', 'planet4-master-theme' ) }}
         </button>
         <button
-            class="btn btn-primary"
+            class="btn btn-primary btn-small"
             id="save-cookies-settings"
             data-ga-category="Cookies box"
             data-ga-action="Save preferences"

--- a/templates/single.twig
+++ b/templates/single.twig
@@ -116,7 +116,7 @@
                 {% if ( post.tags ) %}
                     {% for tag in post.tags %}
                         <a
-                            class="btn post-tag-button"
+                            class="btn post-tag-button btn-small"
                             href="{{ tag.link }}"
                             data-ga-category="Post"
                             data-ga-action="Navigation Tag"


### PR DESCRIPTION
### Summary

Otherwise buttons look off if the text is longer than one line (see [PLANET-7483](https://jira.greenpeace.org/browse/PLANET-7483)). It also makes the code a bit more straightforward.

### Testing

Several things need to be checked:

- The Donate button in the navbar
- The cookies box buttons
- The Accordion block buttons, post tags, WordPress buttons and comment form buttons on [this post](https://www-dev.greenpeace.org/test-janus/story/1470/test-buttons/) for example
- The Covers, P4 Columns, and Actions List blocks on [this page](https://www-dev.greenpeace.org/test-janus/test-buttons/) for instance
- The buttons on the [Search page](https://www-dev.greenpeace.org/test-janus/?s=&orderby=_score) (also the filters modal on mobile)