### PR TITLE
PLANET-7686: Hide WP-Stateless admin notices

### DIFF
--- a/admin/css/dashboard.css
+++ b/admin/css/dashboard.css
@@ -27,3 +27,8 @@
 #gf_dashboard_message {
   display: none;
 }
+
+/* Temporarily hide the Stateless Media notices in the admin area. */
+.stateless-admin-notice {
+  display: none !important;
+}


### PR DESCRIPTION
### Summary

This PR temporarily hides the Stateless Media notices in the admin area.

---

Ref: https://jira.greenpeace.org/browse/PLANET-7686
Related PR: https://github.com/greenpeace/planet4-base/pull/335