### PR TITLE
PLANET-7791: Create `url_passthrough` setting

### DIFF
--- a/assets/src/js/google_tag_manager.js
+++ b/assets/src/js/google_tag_manager.js
@@ -8,6 +8,7 @@ if (googleTagManagerData?.google_tag_value) {
   const consent_default_ad_storage = googleTagManagerData.consent_default_ad_storage;
   const consent_default_ad_user_data = googleTagManagerData.consent_default_ad_user_data;
   const consent_default_ad_personalization = googleTagManagerData.consent_default_ad_personalization;
+  const consent_default_url_passthrough = googleTagManagerData.consent_default_url_passthrough;
   window.dataLayer = window.dataLayer || [];
 
   function gtag() { dataLayer.push(arguments); };
@@ -44,7 +45,7 @@ if (googleTagManagerData?.google_tag_value) {
       };
     }
     gtag('consent', 'default', capabilities);
-    gtag('set', 'url_passthrough', true);
+    gtag('set', 'url_passthrough', consent_default_url_passthrough);
     gtag('set', 'ads_data_redaction', capabilities.ad_storage === 'denied');
     dataLayer.push({event: 'defaultConsent', ...capabilities});
   }

--- a/src/EnqueueController.php
+++ b/src/EnqueueController.php
@@ -305,6 +305,7 @@ class EnqueueController
             'consent_default_ad_storage' => $context['consent_default_ad_storage'] ?? null,
             'consent_default_ad_user_data' => $context['consent_default_ad_user_data'] ?? null,
             'consent_default_ad_personalization' => $context['consent_default_ad_personalization'] ?? null,
+            'consent_default_url_passthrough' => $context['consent_default_url_passthrough'] ?? false,
             'page_category' => $context['page_category'] ?? null,
             'p4_signedin_status' => $context['p4_signedin_status'] ?? null,
             'p4_visitor_type' => $context['p4_visitor_type'] ?? null,

--- a/src/EnqueueController.php
+++ b/src/EnqueueController.php
@@ -305,7 +305,7 @@ class EnqueueController
             'consent_default_ad_storage' => $context['consent_default_ad_storage'] ?? null,
             'consent_default_ad_user_data' => $context['consent_default_ad_user_data'] ?? null,
             'consent_default_ad_personalization' => $context['consent_default_ad_personalization'] ?? null,
-            'consent_default_url_passthrough' => $context['consent_default_url_passthrough'] ?? false,
+            'consent_default_url_passthrough' => $context['consent_default_url_passthrough'] ? 'true' : 'false',
             'page_category' => $context['page_category'] ?? null,
             'p4_signedin_status' => $context['p4_signedin_status'] ?? null,
             'p4_visitor_type' => $context['p4_visitor_type'] ?? null,

--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -761,6 +761,8 @@ class MasterSite extends TimberSite
             planet4_get_option('consent_default_ad_user_data') ?? 'denied';
         $context['consent_default_ad_personalization'] =
             planet4_get_option('consent_default_ad_personalization') ?? 'denied';
+        $context['consent_default_url_passthrough'] =
+            planet4_get_option('consent_default_url_passthrough') ?? 'false';
         $context['facebook_page_id'] = $options['facebook_page_id'] ?? '';
         $context['preconnect_domains'] = [];
         $context['vwo_account_id'] = $options['vwo_account_id'] ?? null;

--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -762,7 +762,7 @@ class MasterSite extends TimberSite
         $context['consent_default_ad_personalization'] =
             planet4_get_option('consent_default_ad_personalization') ?? 'denied';
         $context['consent_default_url_passthrough'] =
-            planet4_get_option('consent_default_url_passthrough') ?? 'false';
+            planet4_get_option('consent_default_url_passthrough') ?? false;
         $context['facebook_page_id'] = $options['facebook_page_id'] ?? '';
         $context['preconnect_domains'] = [];
         $context['vwo_account_id'] = $options['vwo_account_id'] ?? null;

--- a/src/Migrations/M044SetDefaultUrlPassthroughOption.php
+++ b/src/Migrations/M044SetDefaultUrlPassthroughOption.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace P4\MasterTheme\Migrations;
+
+use P4\MasterTheme\MigrationRecord;
+use P4\MasterTheme\MigrationScript;
+
+/**
+ * Set default "Consent default: url_passthrough" option via the P4 settings.
+ */
+class M044SetDefaultUrlPassthroughOption extends MigrationScript
+{
+    /**
+     * Perform the actual migration.
+     *
+     * @param MigrationRecord $record Information on the execution, can be used to add logs.
+     * phpcs:disable SlevomatCodingStandard.Functions.UnusedParameter -- interface implementation
+     */
+    protected static function execute(MigrationRecord $record): void
+    {
+        $options = get_option('planet4_options');
+        $options['consent_default_url_passthrough'] = true;
+        update_option('planet4_options', $options);
+    }
+    // phpcs:enable SlevomatCodingStandard.Functions.UnusedParameter
+}

--- a/src/Migrator.php
+++ b/src/Migrator.php
@@ -45,6 +45,7 @@ use P4\MasterTheme\Migrations\M040ReplaceSpecialCharactersInPostsContent;
 use P4\MasterTheme\Migrations\M041SetDefaultSocialSharingOption;
 use P4\MasterTheme\Migrations\M042FixPostsListMigration;
 use P4\MasterTheme\Migrations\M043SwitchClassesInImageBlock;
+use P4\MasterTheme\Migrations\M044SetDefaultUrlPassthroughOption;
 
 /**
  * Run any new migration scripts and record results in the log.
@@ -107,6 +108,7 @@ class Migrator
             M041SetDefaultSocialSharingOption::class,
             M042FixPostsListMigration::class,
             M043SwitchClassesInImageBlock::class,
+            M044SetDefaultUrlPassthroughOption::class,
         ];
 
         // Loop migrations and run those that haven't run yet.

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -368,6 +368,20 @@ class Settings
                             'granted' => __('Granted', 'planet4-master-theme-backend'),
                         ],
                     ],
+                    [
+                        'name' => __('Consent default: url_passthrough', 'planet4-master-theme-backend'),
+                        'desc' => __(
+                            'Test description',
+                            'planet4-master-theme-backend'
+                        ),
+                        'id' => 'consent_default_url_passthrough',
+                        'type' => 'select',
+                        'default' => 'true',
+                        'options' => [
+                            'true' => __('True', 'planet4-master-theme-backend'),
+                            'false' => __('False', 'planet4-master-theme-backend'),
+                        ],
+                    ],
                 ],
             ],
             'planet4_settings_social' => [

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -376,10 +376,10 @@ class Settings
                         ),
                         'id' => 'consent_default_url_passthrough',
                         'type' => 'select',
-                        'default' => 'true',
+                        'default' => true,
                         'options' => [
-                            'true' => __('True', 'planet4-master-theme-backend'),
-                            'false' => __('False', 'planet4-master-theme-backend'),
+                            true => __('True', 'planet4-master-theme-backend'),
+                            false => __('False', 'planet4-master-theme-backend'),
                         ],
                     ],
                 ],

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -371,7 +371,7 @@ class Settings
                     [
                         'name' => __('Consent default: url_passthrough', 'planet4-master-theme-backend'),
                         'desc' => __(
-                            'Test description',
+                            'The default value for url_passthrough.<br>Allows information about ad clicks to be passed through URL parameters without cookies when consent is granted outside the landing page (Google Consent Mode V2).',
                             'planet4-master-theme-backend'
                         ),
                         'id' => 'consent_default_url_passthrough',


### PR DESCRIPTION
### Summary

This PR creates a new setting under `Planet 4 > Cookies` for NROs to set the `url_passthrough` variable.

---

Ref: https://jira.greenpeace.org/browse/PLANET-7791

### Testing

1. In your local environment, reset the database by running: `npm run db:reset` 
2. In the website editor, go to `Planet 4 > Cookies` and check that the new setting `Consent default: url_passthrough` exists and it's set as `true`
3. Visit the website front and look at the `googleTagManagerData.consent_default_url_passthrough` variable in the browser console. It should be empty.
4. Run the migration script: `npx wp-env run cli wp p4-run-activator`
5. Repeat step 3. Now the value of the variable should be `1`
6. Go to `Planet 4 > Cookies`, change the value of `url_passthrough`, and check in the browser console if the change is reflected as expected.
7. Visit the website front and look at the `dataLayer` variable in the browser console. It should be an empty array.
8. In the website editor, go to `Planet 4 > Analytics` and add some value to the `Google Tag Manager Container` field.
9. Repeat step 7. The array should contain an object similar to this: `Arguments { 0: "set", 1: "url_passthrough", 2: "1", … }` where the value of `set` should be equal to the value of the `Consent default: url_passthrough`  setting.
