### PR TITLE
Fix layout toggle size

### DIFF
--- a/assets/src/scss/pages/_listing-page.scss
+++ b/assets/src/scss/pages/_listing-page.scss
@@ -341,6 +341,8 @@
   @include medium-and-up {
     border-radius: 50%;
     display: inline-block;
+    width: 40px;
+    height: 40px;
 
     &:hover {
       background-color: var(--grey-200);
@@ -355,11 +357,10 @@
 
 .layout-toggle {
   mask-repeat: no-repeat;
-  mask-size: contain;
   mask-position: center;
-  height: 40px;
-  width: 40px;
   background-color: var(--grey-900);
+  width: 100%;
+  height: 100%;
 
   &.layout-toggle-grid {
     mask-image: url("../../images/grid-view.svg");


### PR DESCRIPTION
### Summary

**Before:**
<img width="114" alt="Screenshot 2025-04-18 at 16 13 52" src="https://github.com/user-attachments/assets/cc8a8a22-ca0e-461a-927e-5c0bbbc66188" />

**After:**
<img width="141" alt="Screenshot 2025-04-18 at 16 18 29" src="https://github.com/user-attachments/assets/4860f293-98a7-4303-a693-59e3bf0ecfe1" />

### Testing

Check any listing page, on `main` branch you should see the broken version but on this one it should be fixed. You can also check [this page](https://www-dev.greenpeace.org/test-proteus/press/) from the test instance.