### PR TITLE
Fix Gallery warning issue

### DIFF
--- a/src/Blocks/Gallery.php
+++ b/src/Blocks/Gallery.php
@@ -204,7 +204,7 @@ class Gallery extends BaseBlock
 
         // If the gallery style is "3 Columns" we need to limit the number of images to 3
         // to avoid the lightbox carousel to show more images than that.
-        if ($fields['className'] === self::CLASS_LAYOUT_THREE_COLUMNS) {
+        if (isset($fields['className']) && $fields['className'] === self::CLASS_LAYOUT_THREE_COLUMNS) {
             $images = array_slice($images, 0, 3);
         }
 


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-7802

### Summary
It needs an extra `className` validation to fix:
```
Warning: Undefined array key "className" in /var/www/html/wp-content/themes/planet4-master-theme/src/Blocks/Gallery.php on line 207
```

The PR is related to #2592.
