### PR TITLE
PLANET-7803 Fix mobile tabs transition

### DIFF
--- a/assets/src/scss/layout/navbar/mobile.scss
+++ b/assets/src/scss/layout/navbar/mobile.scss
@@ -7,6 +7,7 @@
   overflow-y: hidden;
   scrollbar-width: none;
   transition: height 0.2s linear;
+  height: 50px;
 
   @include large-and-up {
     display: none;
@@ -38,7 +39,7 @@
   .nav-item {
     line-height: 50px;
     font-weight: var(--font-weight-regular);
-    margin: 5px 20px;
+    margin: 0 20px;
   }
 
   .nav-link {


### PR DESCRIPTION
### Summary

See [PLANET-7803](https://jira.greenpeace.org/browse/PLANET-7803). It was broken when working on accessibility.

### Testing

Either on local or on the [titan test instance](https://www-dev.greenpeace.org/test-titan/), on mobile/tablet the mobile tabs should again have a height transition when (dis)appearing.