### PR TITLE
PLANET-7650 Fix News & Stories top spacing on mobile

### DIFF
--- a/assets/src/scss/base/_body.scss
+++ b/assets/src/scss/base/_body.scss
@@ -16,6 +16,18 @@ body {
   .mejs-container {
     clear: initial;
   }
+
+  @include medium-and-less {
+    &.with-mobile-tabs {
+      .page-header {
+        padding-top: 140px;
+      }
+
+      .no-page-title {
+        padding-top: 110px;
+      }
+    }
+  }
 }
 
 .container > * {

--- a/assets/src/scss/layout/_page-header.scss
+++ b/assets/src/scss/layout/_page-header.scss
@@ -87,15 +87,6 @@
   }
 }
 
-.with-mobile-tabs {
-  ~ .page-header,
-  ~ article .page-header {
-    @include medium-and-less {
-      padding-top: 140px;
-    }
-  }
-}
-
 .page-header-background {
   overflow: hidden;
   position: absolute;

--- a/assets/src/scss/pages/_page.scss
+++ b/assets/src/scss/pages/_page.scss
@@ -70,18 +70,6 @@
   }
 }
 
-.with-mobile-tabs {
-  @include medium-and-less {
-    & ~ :not(.page-header) + .page-content {
-      padding-top: calc(var(--navbar-menu-height--small));
-    }
-
-    & ~ .featured-posts + .page-content {
-      padding: 0;
-    }
-  }
-}
-
 .single-campaign {
   .page-content {
     > p:last-child {

--- a/templates/base.twig
+++ b/templates/base.twig
@@ -4,8 +4,10 @@
 
 {% endblock %}
 
+{% set mobile_tabs_class = mobile_tabs_menu ? 'with-mobile-tabs' : '' %}
+
 <body
-    class="{{ body_class }} {{ custom_body_classes|default("") }}"
+    class="{{ body_class }} {{ custom_body_classes|default("") }} {{ mobile_tabs_class }}"
     data-nro="{{ site.link }}"
     data-post-type="{{ fn( 'get_post_type' ) }}"
     data-post-categories="{{ fn( 'get_the_category')|map(cat => cat.term_id)|join(',') }}"

--- a/templates/navigation-bar.twig
+++ b/templates/navigation-bar.twig
@@ -1,6 +1,4 @@
-{% set header_classes = 'top-navigation navbar'
-    ~ (custom_styles.nav_border == 'border' ? ' navigation-bar_border' : '')
-    ~ (mobile_tabs_menu ? ' with-mobile-tabs' : '') %}
+{% set header_classes = 'top-navigation navbar' ~ (custom_styles.nav_border == 'border' ? ' navigation-bar_border' : '') %}
 {% set search_icon = 'search'|svgicon %}
 {% set search_input_id = 'search_input' %}
 {% set data_ga_attrs = 'data-ga-category="Menu Navigation" data-ga-action="Search" data-ga-label="' ~ page_category ~ '"' %}


### PR DESCRIPTION
### Description

See [PLANET-7650](https://jira.greenpeace.org/browse/PLANET-7650). This was due to the presence of a `clearfix` div between the content and the header.

### Testing

Please make sure that the spacing looks good in all screen sizes in the following examples:
- [News & Stories page](https://www-dev.greenpeace.org/test-jupiter/news-stories/)
- [Listing page](https://www-dev.greenpeace.org/test-jupiter/category/energy/)
- [Post](https://www-dev.greenpeace.org/test-jupiter/press/1113/duis-posuere-6/)
- [Page with title](https://www-dev.greenpeace.org/test-jupiter/get-informed/energy/)
- [Page with hidden title](https://www-dev.greenpeace.org/test-jupiter/get-informed/nature/)