### PR TITLE
PLANET-6407 Fix Spreadsheet block indicators

### DIFF
--- a/assets/src/blocks/Spreadsheet/SpreadsheetEditor.js
+++ b/assets/src/blocks/Spreadsheet/SpreadsheetEditor.js
@@ -51,28 +51,24 @@ export const SpreadsheetEditor = ({
               debounceUrl(newUrl);
             }}
           />
-          <div className="sidebar-blocks-help">
-            <ul>
-              <li>
-                {/* eslint-disable-next-line no-restricted-syntax, @wordpress/i18n-no-collapsible-whitespace */}
-                { __(`From Your Google Spreadsheet Table choose File -> Publish on web.
-                No need to choose the output format, any of them will work.
-                A pop-up window will show up, click on the Publish button and then OK when the confirmation message is displayed.
-                Copy the URL that is highlighted and paste it in this block.`, 'planet4-blocks-backend') }
-              </li>
-              <li>
-                {/* eslint-disable-next-line no-restricted-syntax, @wordpress/i18n-no-collapsible-whitespace */}
-                { __(`If you make changes to the sheet after publishing
-                  then these changes do not always immediately get reflected,
-                  even when "Automatically republish when changes are made" is checked.`, 'planet4-blocks-backend') }
-              </li>
-              <li>
-                {/* eslint-disable-next-line no-restricted-syntax, @wordpress/i18n-no-collapsible-whitespace */}
-                { __(`You can force an update by unpublishing and republishing the sheet.
-                  This will not change the sheet's public url.`, 'planet4-blocks-backend') }
-              </li>
-            </ul>
-          </div>
+          <p className="FieldHelp">
+            {/* eslint-disable-next-line no-restricted-syntax, @wordpress/i18n-no-collapsible-whitespace */}
+            { __(`From Your Google Spreadsheet Table choose File -> Publish on web.
+            No need to choose the output format, any of them will work.
+            A pop-up window will show up, click on the Publish button and then OK when the confirmation message is displayed.
+            Copy the URL that is highlighted and paste it in this block.`, 'planet4-blocks-backend') }
+          </p>
+          <p className="FieldHelp">
+            {/* eslint-disable-next-line no-restricted-syntax, @wordpress/i18n-no-collapsible-whitespace */}
+            { __(`If you make changes to the sheet after publishing
+              then these changes do not always immediately get reflected,
+              even when "Automatically republish when changes are made" is checked.`, 'planet4-blocks-backend') }
+          </p>
+          <p className="FieldHelp">
+            {/* eslint-disable-next-line no-restricted-syntax, @wordpress/i18n-no-collapsible-whitespace */}
+            { __(`You can force an update by unpublishing and republishing the sheet.
+              This will not change the sheet's public url.`, 'planet4-blocks-backend') }
+          </p>
         </PanelBody>
         <PanelBody title={__('Learn more about this block ', 'planet4-blocks-backend')} initialOpen={false}>
           <p className="components-base-control__help">

--- a/assets/src/blocks/Spreadsheet/SpreadsheetFrontend.js
+++ b/assets/src/blocks/Spreadsheet/SpreadsheetFrontend.js
@@ -161,7 +161,7 @@ export const SpreadsheetFrontend = ({
                   <th
                     className={(
                       index === sortColumnIndex ?
-                        `spreadsheet-sorted-by sort-${sortDirection}` :
+                        `sort-${sortDirection}` :
                         ''
                     )}
                     onClick={onHeaderClick}

--- a/assets/src/scss/blocks/Spreadsheet.scss
+++ b/assets/src/scss/blocks/Spreadsheet.scss
@@ -63,6 +63,7 @@ table.spreadsheet-table {
       background-color: inherit;
       color: inherit;
       border: none;
+      display: flex;
     }
 
     color: var(--white);
@@ -74,11 +75,12 @@ table.spreadsheet-table {
     svg {
       width: $sp-2;
       margin-left: $sp-1;
-      // Compensate for a small baseline misalignment
-      margin-top: -2px;
-      // Use opacity instead of `display: none` to avoid jumpyness on headers
-      opacity: 0;
-      transition: opacity .3s, transform .4s;
+    }
+
+    &.sort-desc {
+      svg {
+        transform: rotate(180deg);
+      }
     }
   }
 }
@@ -122,18 +124,6 @@ table.spreadsheet-table.is-color-gp-green {
 
   tr:nth-child(odd) {
     background: var(--beige-200);
-  }
-}
-
-table.spreadsheet-table.spreadsheet-sorted-by {
-  svg {
-    opacity: 1;
-  }
-
-  &.sort-desc {
-    svg {
-      transform: rotate(180deg);
-    }
   }
 }
 

--- a/assets/src/scss/editorOverrides.scss
+++ b/assets/src/scss/editorOverrides.scss
@@ -248,7 +248,6 @@ input.describe[type=text][data-setting=caption] {
 // Sidebar help texts
 .components-base-control__help,
 .components-form-token-field__help,
-.sidebar-blocks-help ul li,
 .FieldHelp {
   font-size: 13px;
   line-height: 1.5;

--- a/assets/src/scss/editorOverrides.scss
+++ b/assets/src/scss/editorOverrides.scss
@@ -214,20 +214,6 @@ input.describe[type=text][data-setting=caption] {
   pointer-events: none;
 }
 
-.InlineToggleControl {
-  .components-toggle-control {
-    display: flex;
-
-    .components-base-control__field {
-      margin: 0;
-    }
-
-    p {
-      margin: 0;
-    }
-  }
-}
-
 .p4-plugin-pre-publish-panel-error {
   ul {
     background: var(--red-500);


### PR DESCRIPTION
### Summary

See [PLANET-6407](https://jira.greenpeace.org/browse/PLANET-6407).

This PR also includes a quick fix to remove an ugly padding in the sidebar settings:

**Before**
<img width="273" alt="Screenshot 2025-04-18 at 17 25 35" src="https://github.com/user-attachments/assets/a4948cbe-4421-42f4-80d2-b37aa025cd0a" />

**After**
<img width="272" alt="Screenshot 2025-04-18 at 17 25 42" src="https://github.com/user-attachments/assets/6ca5562e-c471-455f-bdb3-f042902da856" />

### Testing

Add a Spreadsheet block to a page, in the frontend you should now see the sorting indicators and they should rotate when you click on them. You can use [this sheet](https://docs.google.com/spreadsheets/d/e/2PACX-1vSbOPA0YEfvAYEKO2KguU_A1vIaIeJVJp1eC4zu9lrWpMRtJX0NiYC0iZwalvI3BUkOQSKYEaQwrt7Q/pubhtml) for testing purposes. Alternatively you can check out [this Post](https://www-dev.greenpeace.org/test-janus/press/1113/duis-posuere-6/) from the test instance.
