### PR TITLE
PLANET-7776 Remove link styles from Quick Links & Deep Dive patterns

### DIFF
--- a/assets/src/scss/variations/stretched-link/edit.scss
+++ b/assets/src/scss/variations/stretched-link/edit.scss
@@ -1,4 +1,10 @@
 .group-stretched-link {
   outline: 1px dashed grey;
   outline-offset: 2px;
+
+  a,
+  a:hover {
+    border: none;
+    background: none;
+  }
 }

--- a/assets/src/scss/variations/stretched-link/index.scss
+++ b/assets/src/scss/variations/stretched-link/index.scss
@@ -1,6 +1,12 @@
 .group-stretched-link {
   position: relative;
 
+  a,
+  a:hover {
+    border: none;
+    background: none;
+  }
+
   [class*="is-style-rounded-"].force-no-caption {
     overflow: hidden;
     border-radius: 50%;


### PR DESCRIPTION
### Description

See [PLANET-7776](https://jira.greenpeace.org/browse/PLANET-7776). We added our usual link styles by mistake.

### Testing

You can check out the changes on [this page](https://www-dev.greenpeace.org/test-pluto/patterns/) that I made for UAT, both in the editor and in the frontend.