### PR TITLE
PLANET-7801 Remove unwanted margin bottom in sticky Take Action Boxout

### DIFF
--- a/assets/src/scss/blocks/TakeActionBoxout/TakeActionBoxoutStyle.scss
+++ b/assets/src/scss/blocks/TakeActionBoxout/TakeActionBoxoutStyle.scss
@@ -175,6 +175,7 @@
       border-radius: 0;
       transition: all 0.5s;
       padding: $sp-2;
+      margin-bottom: 0;
 
       img,
       .boxout-placeholder {


### PR DESCRIPTION
### Summary

Ref: [PLANET-7801](https://jira.greenpeace.org/browse/PLANET-7801)

### Testing

On local, add a Take Action Boxout block to a page or a post, enable the `Make block stick to the bottom of the page on mobile` setting in the sidebar. Alternatively you can check out [this page](https://www-dev.greenpeace.org/test-venus/about-us-2/) and [this post](https://www-dev.greenpeace.org/test-venus/press/1113/duis-posuere-6/) I made on the test instance.
In the frontend on mobile and tablets you should see the block stick to the bottom of the page, without any extra margin.