### PR TITLE
Allow links in Accordion content

### DIFF
--- a/assets/src/blocks/Accordion/AccordionEditor.js
+++ b/assets/src/blocks/Accordion/AccordionEditor.js
@@ -68,7 +68,7 @@ const renderView = ({title, description, tabs, className}, setAttributes, isSele
               placeholder={__('Enter text', 'planet4-blocks-backend')}
               value={tab.text}
               onChange={updateTabAttribute('text', index)}
-              allowedFormats={['core/bold', 'core/italic']}
+              allowedFormats={['core/bold', 'core/italic', 'core/link']}
             />
             {tab.button ?
               <div className="button-container">


### PR DESCRIPTION
### Summary

Otherwise it's not convenient to add links there. This was requested by Quentin to facilitate Handbook updates!

### Testing

You should now see the link option in the Accordion tab content:

<img width="298" alt="Screenshot 2025-05-07 at 14 48 54" src="https://github.com/user-attachments/assets/6e3915b9-f071-458a-bb32-c8e1a59cbcb9" />

