### PR TITLE
PLANET-7792 Register block pattern categories

### DIFF
--- a/src/Loader.php
+++ b/src/Loader.php
@@ -221,10 +221,18 @@ final class Loader
         new Blocks\Timeline();//NOSONAR
         new Blocks\TopicLink();//NOSONAR
 
-        register_block_pattern_category(
-            'page-headers',
-            [ 'label' => 'Page Headers' ],
-        );
+        $pattern_categories = [
+            'page-headers' => 'Page Headers',
+            'layouts' => 'Layouts',
+            'planet4' => 'Planet 4',
+        ];
+
+        foreach ($pattern_categories as $name => $label) {
+            register_block_pattern_category(
+                $name,
+                ['label' => $label],
+            );
+        }
 
         // Load block patterns.
         BlockPattern::register_all();


### PR DESCRIPTION
### Summary

See [PLANET-7792](https://jira.greenpeace.org/browse/PLANET-7792). We forgot to move them before deactivating the plugin 😬 

### Testing

You should now see the patterns properly categorised in the editor:

<img width="352" alt="Screenshot 2025-05-08 at 14 43 42" src="https://github.com/user-attachments/assets/a2825f1e-1932-409f-b437-90124c9ffb4c" />
