### PR TITLE
PLANET-7432 Revert fix added for missing default avatar for author override

### DIFF
--- a/templates/single.twig
+++ b/templates/single.twig
@@ -46,7 +46,7 @@
                 </nav>
                 <h1 class="page-header-title">{{ post.title|raw }}</h1>
                 <div class="single-post-meta">
-                    {% if post.author.avatar %}
+                    {% if not post.get_author_override and post.author.avatar %}
                         <img itemprop="image" class="author-pic"
                             src="{{ fn('get_avatar_url', post.author.id, {'size' : 50, 'default': default_avatar}) }}"
                             alt="{{ post.author.avatar }}">


### PR DESCRIPTION
Revert fix added earlier in [PR#2616](https://github.com/greenpeace/planet4-master-theme/pull/2616#discussion_r2074790055)

### Summary

Ref: 
https://jira.greenpeace.org/browse/PLANET-7432

### Testing
- Edit a post and update the Author Override setting.
- Check the frontend — the default avatar image should no longer appear alongside the author name.

[Before this fix eg.](https://www-dev.greenpeace.org/test-titan/press/1113/duis-posuere-6/)

[After this fix eg.](https://www-dev.greenpeace.org/test-proteus/press/1113/duis-posuere-6/)
