### PR TITLE
PLANET-7808: Add a global setting for taxonomy breadcrumb

### DIFF
--- a/assets/src/block-editor/QueryLoopBlockExtension/index.js
+++ b/assets/src/block-editor/QueryLoopBlockExtension/index.js
@@ -1,7 +1,6 @@
-import {POSTS_LIST_BLOCK_NAME, POSTS_LISTS_LAYOUT_TYPES, LISTS_BREADCRUMBS} from '../../blocks/PostsList';
+import {POSTS_LIST_BLOCK_NAME, POSTS_LISTS_LAYOUT_TYPES} from '../../blocks/PostsList';
 import {ACTIONS_LIST_BLOCK_NAME, ACTIONS_LIST_LAYOUT_TYPES} from '../../blocks/ActionsList';
 import {PostSelector} from '../PostSelector';
-import {TAX_BREADCRUMB_BLOCK_NAME} from '../setupTaxonomyBreadcrumbBlock';
 
 const {InspectorControls} = wp.blockEditor;
 const {RadioControl, PanelBody} = wp.components;
@@ -29,12 +28,10 @@ export const setupQueryLoopBlockExtension = () => {
 
         const [postTemplate, setPostTemplate] = useState();
         const [selectedBlock, setSelectedBlock] = useState();
-        const [breadcrumbTaxonomy, setBreadcrumbTaxonomy] = useState();
 
         const {className, query} = attributes;
         const layoutTypes = isActionsList ? ACTIONS_LIST_LAYOUT_TYPES : POSTS_LISTS_LAYOUT_TYPES;
         const currentPostId = wp.data.select('core/editor').getCurrentPostId();
-        const innerBlocks = wp.data.select('core/block-editor').getBlocks(attributes.clientId || props.clientId);
 
         const updateLayoutType = useCallback(type => {
           const layoutType = layoutTypes.find(t => t.value === type);
@@ -64,42 +61,6 @@ export const setupQueryLoopBlockExtension = () => {
           ...query,
           postIn: value && value.length > 0 ? value : [],
         }});
-
-        const loopInnerBlocks = (blocks, callback) => {
-          blocks.forEach(block => {
-            callback(block);
-
-            if (block.innerBlocks && block.innerBlocks.length > 0) {
-              loopInnerBlocks(block.innerBlocks, callback);
-            }
-          });
-        };
-
-        const updateBreadcrumbType = value => {
-          if (!isPostsList) {
-            return;
-          }
-          loopInnerBlocks(innerBlocks, block => {
-            if (block.name === TAX_BREADCRUMB_BLOCK_NAME && block.attributes.term !== value) {
-              setBreadcrumbTaxonomy(value);
-              wp.data.dispatch('core/block-editor').updateBlockAttributes(
-                block.clientId,
-                {taxonomy: value}
-              );
-            }
-          });
-        };
-
-        useEffect(() => {
-          if (!isPostsList) {
-            return;
-          }
-          loopInnerBlocks(innerBlocks, block => {
-            if (block.name === TAX_BREADCRUMB_BLOCK_NAME && block.attributes?.taxonomy) {
-              setBreadcrumbTaxonomy(block.attributes.taxonomy);
-            }
-          });
-        }, []);
 
         useEffect(() => {
           if (postTemplate) {
@@ -161,17 +122,6 @@ export const setupQueryLoopBlockExtension = () => {
                     selected={attributes.layout.type}
                     options={layoutTypes}
                     onChange={updateLayoutType}
-                  />
-                </PanelBody>
-              )}
-              {isPostsList && (
-                <PanelBody title={__('Taxonomy breadcrumbs', 'planet4-blocks-backend')} initialOpen={false}>
-                  <RadioControl
-                    label={__('Choose which taxonomy to display on Post breadcrumbs', 'planet4-blocks-backend')}
-                    selected={breadcrumbTaxonomy || LISTS_BREADCRUMBS[0].value}
-                    options={LISTS_BREADCRUMBS}
-                    onChange={updateBreadcrumbType}
-                    className="text-capitalize"
                   />
                 </PanelBody>
               )}

--- a/assets/src/block-editor/setupTaxonomyBreadcrumbBlock.js
+++ b/assets/src/block-editor/setupTaxonomyBreadcrumbBlock.js
@@ -31,15 +31,16 @@ export const setupTaxonomyBreadcrumbBlock = () => {
 };
 
 function editFunction({attributes, context}) {
-  const {taxonomy, post_type} = attributes;
+  const {post_type} = attributes;
   const postId = context.postId;
   const [term, setTerm] = wp.element.useState(null);
+  const TAXONOMY = window.p4_vars.options.taxonomy_breadcrumbs || null;
 
   wp.element.useEffect(() => {
-    if (!postId || !taxonomy || !post_type) {return;}
+    if (!postId || !TAXONOMY || !post_type) {return;}
 
     const postTypeField = post_type === 'post' ? 'posts' : post_type;
-    const taxonomyField = taxonomy === 'category' ? 'categories' : taxonomy;
+    const taxonomyField = (post_type === 'p4_action') || (TAXONOMY === 'category') ? 'categories' : TAXONOMY;
 
     wp.apiFetch({path: `/wp/v2/${postTypeField}/${postId}`}).then(post => {
       const termIds = post[taxonomyField];
@@ -49,7 +50,7 @@ function editFunction({attributes, context}) {
         });
       }
     });
-  }, [postId, taxonomy]);
+  }, [postId, TAXONOMY]);
 
   const linkAttrs = {href: '', onClick: e => e.preventDefault()};
   const contentAttrs = {className: 'taxonomy-category wp-block-post-terms'};
@@ -59,6 +60,53 @@ function editFunction({attributes, context}) {
 
   return content;
 }
+
+// function editFunction({attributes, context}) {
+//   const {post_type} = attributes;
+//   const postId = context.postId;
+//   const [term, setTerm] = wp.element.useState(null);
+//   const TAXONOMY = window.p4_vars.options.taxonomy_breadcrumbs || null;
+
+//   wp.element.useEffect(() => {
+//     (async () => {
+//       if (!postId || !TAXONOMY || !post_type) {return;}
+
+//       const taxonomyField = TAXONOMY === 'category' ? 'categories' : TAXONOMY;
+
+//     wp.apiFetch({path: `/wp/v2/${postTypeField}/${postId}`}).then(post => {
+//       const termIds = post[taxonomyField];
+//       if (termIds && termIds.length > 0) {
+//         wp.apiFetch({path: `/wp/v2/${taxonomyField}/${termIds[0]}`}).then(termData => {
+//           setTerm(termData.name);
+//         });
+//       }
+
+//       // Pluralize post types
+//       for(const type of [['post', 'posts'], ['page', 'pages']]) {
+//         if(postTypeField === type[0]) {
+//           postTypeField = type[1];
+//         }
+//       }
+
+//       wp.apiFetch({path: `/wp/v2/${postTypeField}/${postId}`}).then(post => {
+//         const termIds = post[taxonomyField];
+//         if (termIds && termIds.length > 0) {
+//           wp.apiFetch({path: `/wp/v2/${taxonomyField}/${termIds[0]}`}).then(termData => {
+//             setTerm(termData.name);
+//           });
+//         }
+//       });
+//     })();
+//   }, [postId, TAXONOMY]);
+
+//   const linkAttrs = {href: '', onClick: e => e.preventDefault()};
+//   const contentAttrs = {className: 'taxonomy-category wp-block-post-terms'};
+
+//   const link = wp.element.createElement('a', linkAttrs, term || 'Loading...');
+//   const content = wp.element.createElement('div', contentAttrs, link);
+
+//   return content;
+// }
 
 function saveFunction() {
   return null;

--- a/assets/src/block-editor/setupTaxonomyBreadcrumbBlock.js
+++ b/assets/src/block-editor/setupTaxonomyBreadcrumbBlock.js
@@ -61,53 +61,6 @@ function editFunction({attributes, context}) {
   return content;
 }
 
-// function editFunction({attributes, context}) {
-//   const {post_type} = attributes;
-//   const postId = context.postId;
-//   const [term, setTerm] = wp.element.useState(null);
-//   const TAXONOMY = window.p4_vars.options.taxonomy_breadcrumbs || null;
-
-//   wp.element.useEffect(() => {
-//     (async () => {
-//       if (!postId || !TAXONOMY || !post_type) {return;}
-
-//       const taxonomyField = TAXONOMY === 'category' ? 'categories' : TAXONOMY;
-
-//     wp.apiFetch({path: `/wp/v2/${postTypeField}/${postId}`}).then(post => {
-//       const termIds = post[taxonomyField];
-//       if (termIds && termIds.length > 0) {
-//         wp.apiFetch({path: `/wp/v2/${taxonomyField}/${termIds[0]}`}).then(termData => {
-//           setTerm(termData.name);
-//         });
-//       }
-
-//       // Pluralize post types
-//       for(const type of [['post', 'posts'], ['page', 'pages']]) {
-//         if(postTypeField === type[0]) {
-//           postTypeField = type[1];
-//         }
-//       }
-
-//       wp.apiFetch({path: `/wp/v2/${postTypeField}/${postId}`}).then(post => {
-//         const termIds = post[taxonomyField];
-//         if (termIds && termIds.length > 0) {
-//           wp.apiFetch({path: `/wp/v2/${taxonomyField}/${termIds[0]}`}).then(termData => {
-//             setTerm(termData.name);
-//           });
-//         }
-//       });
-//     })();
-//   }, [postId, TAXONOMY]);
-
-//   const linkAttrs = {href: '', onClick: e => e.preventDefault()};
-//   const contentAttrs = {className: 'taxonomy-category wp-block-post-terms'};
-
-//   const link = wp.element.createElement('a', linkAttrs, term || 'Loading...');
-//   const content = wp.element.createElement('div', contentAttrs, link);
-
-//   return content;
-// }
-
 function saveFunction() {
   return null;
 }

--- a/functions.php
+++ b/functions.php
@@ -300,10 +300,7 @@ function register_more_blocks(): void
                 $post_id = $block->context['postId'] ?? get_the_ID();
                 $options = get_option('planet4_options');
                 $global_taxonomy = $options['global_taxonomy_breadcrumbs'] ?? 'category';
-                $taxonomy = ($attributes['post_type'] === 'p4_action' || $attributes['post_type'] === 'post') ? 'category' : $global_taxonomy;
-                // $taxonomy = $options['global_taxonomy_breadcrumbs'] ?? 'category';
-                // $taxonomy = $attributes['post_type'] === 'p4_multipost' ? 'category' : $global_taxonomy;
-                // $taxonomy = ($attributes['post_type'] === 'p4_multipost' || $attributes['post_type'] === 'post') ? 'category' : $global_taxonomy;
+                $taxonomy = $attributes['post_type'] === 'p4_action' ? 'category' : $global_taxonomy;
 
                 $terms = get_the_terms($post_id, $taxonomy);
                 if (is_wp_error($terms) || empty($terms)) {

--- a/functions.php
+++ b/functions.php
@@ -302,6 +302,7 @@ function register_more_blocks(): void
                 $global_taxonomy = $options['global_taxonomy_breadcrumbs'] ?? 'category';
                 $taxonomy = ($attributes['post_type'] === 'p4_action' || $attributes['post_type'] === 'post') ? 'category' : $global_taxonomy;
                 // $taxonomy = $options['global_taxonomy_breadcrumbs'] ?? 'category';
+                $taxonomy = $attributes['post_type'] === 'p4_multipost' ? 'category' : $global_taxonomy;
 
                 $terms = get_the_terms($post_id, $taxonomy);
                 if (is_wp_error($terms) || empty($terms)) {

--- a/functions.php
+++ b/functions.php
@@ -302,7 +302,8 @@ function register_more_blocks(): void
                 $global_taxonomy = $options['global_taxonomy_breadcrumbs'] ?? 'category';
                 $taxonomy = ($attributes['post_type'] === 'p4_action' || $attributes['post_type'] === 'post') ? 'category' : $global_taxonomy;
                 // $taxonomy = $options['global_taxonomy_breadcrumbs'] ?? 'category';
-                $taxonomy = $attributes['post_type'] === 'p4_multipost' ? 'category' : $global_taxonomy;
+                // $taxonomy = $attributes['post_type'] === 'p4_multipost' ? 'category' : $global_taxonomy;
+                // $taxonomy = ($attributes['post_type'] === 'p4_multipost' || $attributes['post_type'] === 'post') ? 'category' : $global_taxonomy;
 
                 $terms = get_the_terms($post_id, $taxonomy);
                 if (is_wp_error($terms) || empty($terms)) {

--- a/functions.php
+++ b/functions.php
@@ -301,6 +301,7 @@ function register_more_blocks(): void
                 $options = get_option('planet4_options');
                 $global_taxonomy = $options['global_taxonomy_breadcrumbs'] ?? 'category';
                 $taxonomy = ($attributes['post_type'] === 'p4_action' || $attributes['post_type'] === 'post') ? 'category' : $global_taxonomy;
+                // $taxonomy = $options['global_taxonomy_breadcrumbs'] ?? 'category';
 
                 $terms = get_the_terms($post_id, $taxonomy);
                 if (is_wp_error($terms) || empty($terms)) {

--- a/functions.php
+++ b/functions.php
@@ -300,7 +300,7 @@ function register_more_blocks(): void
                 $post_id = $block->context['postId'] ?? get_the_ID();
                 $options = get_option('planet4_options');
                 $global_taxonomy = $options['global_taxonomy_breadcrumbs'] ?? 'category';
-                $taxonomy = ($attributes['post_type'] === 'p4_multipost' || $attributes['post_type'] === 'post') ? 'category' : $global_taxonomy;
+                $taxonomy = ($attributes['post_type'] === 'p4_action' || $attributes['post_type'] === 'post') ? 'category' : $global_taxonomy;
 
                 $terms = get_the_terms($post_id, $taxonomy);
                 if (is_wp_error($terms) || empty($terms)) {

--- a/functions.php
+++ b/functions.php
@@ -300,7 +300,7 @@ function register_more_blocks(): void
                 $post_id = $block->context['postId'] ?? get_the_ID();
                 $options = get_option('planet4_options');
                 $global_taxonomy = $options['global_taxonomy_breadcrumbs'] ?? 'category';
-                $taxonomy = $attributes['post_type'] === 'p4_multipost' ? 'category' : $global_taxonomy;
+                $taxonomy = ($attributes['post_type'] === 'p4_multipost' || $attributes['post_type'] === 'post') ? 'category' : $global_taxonomy;
 
                 $terms = get_the_terms($post_id, $taxonomy);
                 if (is_wp_error($terms) || empty($terms)) {
@@ -317,6 +317,10 @@ function register_more_blocks(): void
                 'taxonomy' => [
                     'type' => 'string',
                     'default' => 'category',
+                ],
+                'post_type' => [
+                    'type' => 'string',
+                    'default' => 'post',
                 ],
             ],
         ]

--- a/functions.php
+++ b/functions.php
@@ -299,7 +299,8 @@ function register_more_blocks(): void
             'render_callback' => function ($attributes, $block) {
                 $post_id = $block->context['postId'] ?? get_the_ID();
                 $options = get_option('planet4_options');
-                $taxonomy = $options['global_taxonomy_breadcrumbs'] ?? 'category';
+                $global_taxonomy = $options['global_taxonomy_breadcrumbs'] ?? 'category';
+                $taxonomy = $attributes['post_type'] === 'p4_multipost' ? 'category' : $global_taxonomy;
 
                 $terms = get_the_terms($post_id, $taxonomy);
                 if (is_wp_error($terms) || empty($terms)) {

--- a/functions.php
+++ b/functions.php
@@ -298,7 +298,8 @@ function register_more_blocks(): void
             'api_version' => 2,
             'render_callback' => function ($attributes, $block) {
                 $post_id = $block->context['postId'] ?? get_the_ID();
-                $taxonomy = $attributes['taxonomy'] ?? 'category';
+                $options = get_option('planet4_options');
+                $taxonomy = $options['global_taxonomy_breadcrumbs'] ?? 'category';
 
                 $terms = get_the_terms($post_id, $taxonomy);
                 if (is_wp_error($terms) || empty($terms)) {

--- a/src/MasterBlocks.php
+++ b/src/MasterBlocks.php
@@ -207,6 +207,7 @@ class MasterBlocks
             'page_text_404' => planet4_get_option('404_page_text', ''),
             'page_bg_image_404' => planet4_get_option('404_page_bg_image', ''),
             'cookies_field' => planet4_get_option('cookies_field', ''),
+            'taxonomy_breadcrumbs' => planet4_get_option('global_taxonomy_breadcrumbs', ''),
         ];
     }
 

--- a/src/Migrations/M048SetDefaultTaxonomyBreadcrumb.php
+++ b/src/Migrations/M048SetDefaultTaxonomyBreadcrumb.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace P4\MasterTheme\Migrations;
+
+use P4\MasterTheme\MigrationRecord;
+use P4\MasterTheme\MigrationScript;
+
+/**
+ * Set default Taxonomy Breadcrumb option via the P4 settings.
+ */
+class M048SetDefaultTaxonomyBreadcrumb extends MigrationScript
+{
+    /**
+     * Perform the actual migration.
+     *
+     * @param MigrationRecord $record Information on the execution, can be used to add logs.
+     * phpcs:disable SlevomatCodingStandard.Functions.UnusedParameter -- interface implementation
+     */
+    protected static function execute(MigrationRecord $record): void
+    {
+        $options = get_option('planet4_options');
+        $options['global_taxonomy_breadcrumbs'] = 'category';
+        update_option('planet4_options', $options);
+    }
+    // phpcs:enable SlevomatCodingStandard.Functions.UnusedParameter
+}

--- a/src/Migrator.php
+++ b/src/Migrator.php
@@ -49,6 +49,7 @@ use P4\MasterTheme\Migrations\M044SetDefaultUrlPassthroughOption;
 use P4\MasterTheme\Migrations\M045ReplaceTaxonomyInQueryBlock;
 use P4\MasterTheme\Migrations\M046MigrateArticlesBlockToPostsListBlock;
 use P4\MasterTheme\Migrations\M047EnableTransparentNavigation;
+use P4\MasterTheme\Migrations\M048SetDefaultTaxonomyBreadcrumb;
 
 /**
  * Run any new migration scripts and record results in the log.
@@ -115,6 +116,7 @@ class Migrator
             M045ReplaceTaxonomyInQueryBlock::class,
             M046MigrateArticlesBlockToPostsListBlock::class,
             M047EnableTransparentNavigation::class,
+            M048SetDefaultTaxonomyBreadcrumb::class,
         ];
 
         // Loop migrations and run those that haven't run yet.

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -140,6 +140,7 @@ class Settings
                         'options' => [
                             'category' => __('Category', 'planet4-master-theme-backend'),
                             'p4-page-type' => __('Post Type', 'planet4-master-theme-backend'),
+                            // 'post_type' => __('Post Type', 'planet4-master-theme-backend'),
                         ],
                         'default' => 'category',
                         'desc' => __('Choose which taxonomy to display on Post breadcrumbs', 'planet4-master-theme-backend'),

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -138,7 +138,7 @@ class Settings
                         'id' => 'global_taxonomy_breadcrumbs',
                         'type' => 'radio',
                         'options' => [
-                            'category' => __('Category', 'planet4-master-theme-backend'),
+                            'category' => __('Category (default)', 'planet4-master-theme-backend'),
                             'p4-page-type' => __('Post Type', 'planet4-master-theme-backend'),
                         ],
                         'default' => 'category',

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -140,7 +140,6 @@ class Settings
                         'options' => [
                             'category' => __('Category', 'planet4-master-theme-backend'),
                             'p4-page-type' => __('Post Type', 'planet4-master-theme-backend'),
-                            // 'post_type' => __('Post Type', 'planet4-master-theme-backend'),
                         ],
                         'default' => 'category',
                         'desc' => __('Choose which taxonomy to display on Post breadcrumbs', 'planet4-master-theme-backend'),

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -139,7 +139,7 @@ class Settings
                         'type' => 'radio',
                         'options' => [
                             'category' => __('Category', 'planet4-master-theme-backend'),
-                            'post_type' => __('Post Type', 'planet4-master-theme-backend'),
+                            'p4-page-type' => __('Post Type', 'planet4-master-theme-backend'),
                         ],
                         'default' => 'category',
                         'desc' => __('Choose which taxonomy to display on Post breadcrumbs', 'planet4-master-theme-backend'),

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -134,6 +134,17 @@ class Settings
                 'title' => 'Defaults content',
                 'fields' => [
                     [
+                        'name' => __('Taxonomy breadcrumbs', 'planet4-master-theme-backend'),
+                        'id' => 'global_taxonomy_breadcrumbs',
+                        'type' => 'radio',
+                        'options' => [
+                            'category' => __('Category', 'planet4-master-theme-backend'),
+                            'post_type' => __('Post Type', 'planet4-master-theme-backend'),
+                        ],
+                        'default' => 'category',
+                        'desc' => __('Choose which taxonomy to display on Post breadcrumbs', 'planet4-master-theme-backend'),
+                    ],
+                    [
                         'name' => __('Actions List default button text', 'planet4-master-theme-backend'),
                         'id' => 'take_action_covers_button_text',
                         'type' => 'text',


### PR DESCRIPTION
### Summary

This PR removes the configuration of the Taxonomy Breadcrumbs inner block from the Posts List block and creates a new global setting for it instead.

---

Ref: https://jira.greenpeace.org/browse/PLANET-7808

### Testing

1. In your local environment, reset the database by running the command `npm run db:reset`
2. Run the migration scripts: `npx wp-env run cli wp p4-run-activator`
3. Check that the Posts List and the Actions List blocks still work as expected.
4. Check that the new Settings exist in the Defaults Content admin page and work as expected: `wp-admin/admin.php?page=planet4_settings_defaults_content`
5. Change the settings and see if it alters the taxonomy of the Posts List and the Actions List blocks as expected. Also check the other instances of the Posts List block, such as listing pages and related posts.