### PR TITLE
Skip the Audio and Video blocks tests

### DIFF
--- a/tests/e2e/blocks/audio-video.spec.js
+++ b/tests/e2e/blocks/audio-video.spec.js
@@ -65,7 +65,7 @@ const addVideoOrAudioBlock = async ({page}, mediaType, mediaLink) => {
 test.useAdminLoggedIn();
 
 TEST_MEDIA.forEach(({type, format, url, selector}) => {
-  test(`check the ${type} block with format ${format}`, async ({page, admin, editor}) => {
+  test.skip(`check the ${type} block with format ${format}`, async ({page, admin, editor}) => {
     await createPostWithFeaturedImage({page, admin, editor}, {title: `Test ${type} block`});
     await addVideoOrAudioBlock({page}, type, url);
     await publishPostAndVisit({page, editor});


### PR DESCRIPTION
### Summary

This PR skips the Audio and Video blocks tests until they're fixed, as they're failing.