### PR TITLE
Fix TermSelector findTerm function

### DIFF
--- a/assets/src/block-editor/TermSelector/index.js
+++ b/assets/src/block-editor/TermSelector/index.js
@@ -75,7 +75,7 @@ export function sortBySelected(termsTree, terms) {
  * @return {Object} Term object.
  */
 export function findTerm(terms, name) {
-  return terms.find(terms, term => term.name.toLowerCase() === name.toLowerCase());
+  return terms.find(term => term.name.toLowerCase() === name.toLowerCase());
 }
 
 /**


### PR DESCRIPTION
### Summary

Without this it wasn't possible to add new tags via the editor:

<img width="351" alt="Screenshot 2025-05-16 at 10 35 40" src="https://github.com/user-attachments/assets/a053d02a-4d13-461f-b276-6db42f01ca43" />

It's probably related to the WordPress upgrade? Or it's been broken for a while 😬 

### Testing

Try adding new tags to a Post or Page via the editor sidebar. On `main` branch it won't work, but on this branch it will be possible.
