### PR TITLE
Fix error with Entry Dates in Gravity Forms

### DIFF
--- a/src/GravityFormsExtensions.php
+++ b/src/GravityFormsExtensions.php
@@ -181,7 +181,7 @@ class GravityFormsExtensions
     public function fix_entries_file_link(
         string $value,
         int $form_id,
-        int $field_id,
+        mixed $field_id,
         mixed $entry
     ): string {
         $form = GFAPI::get_form($form_id);


### PR DESCRIPTION
### Summary

This PR fixes the issue with the Entry Date in the entries page of Gravity Forms:
![image](https://github.com/user-attachments/assets/20884a31-58f7-4b37-9242-4283ec38d339)

---

### Testing

1. Check the form entries on any dev site of an NRO ([example](https://www-dev.greenpeace.org/international/wp-admin/admin.php?page=gf_entries&id=67)). The Entry Date should show an error: `There has been a critical error on this website. Please check your site admin email inbox for instructions. If you continue to have problems, please try the support forums.`
2. Check the form entries locally. The Entry Date should show the expected data. If the Entry Date column is not visible, select it by clicking the cog icon at the end of the columns' titles.