### PR TITLE
PLANET-7817 Enable core Cover block

### DIFF
--- a/src/BlockSettings.php
+++ b/src/BlockSettings.php
@@ -134,6 +134,7 @@ class BlockSettings
         self::CORE_BLOCKS_PREFIX . '/group',
         self::CORE_BLOCKS_PREFIX . '/columns',
         self::CORE_BLOCKS_PREFIX . '/column',
+        self::CORE_BLOCKS_PREFIX . '/cover',
         self::CORE_BLOCKS_PREFIX . '/embed',
         self::CORE_BLOCKS_PREFIX . '/media-text',
         self::CORE_EMBED_BLOCKS_PREFIX . '/twitter',


### PR DESCRIPTION
### Summary

Ref: [PLANET-7817](https://jira.greenpeace.org/browse/PLANET-7817)

### Testing

The block should now be available in all post types.