### PR TITLE
PLANET-7793 Revert fix added in 2582 PR

### DIFF
--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -382,19 +382,6 @@ class MasterSite extends TimberSite
         Search\Search::hooks();
         Sendgrid::hooks();
 
-        // Force WordPress to use UTC date for upload paths to ensure consistency across different timezones.
-        // This prevents issues where uploads might be placed in a different month folder in the
-        // Stateless bucket than what WordPress expects.
-        add_filter(
-            'upload_dir',
-            function ($upload) {
-                $upload['subdir'] = '/' . gmdate('Y/m');
-                $upload['path'] = $upload['basedir'] . $upload['subdir'];
-                $upload['url'] = $upload['baseurl'] . $upload['subdir'];
-                return $upload;
-            }
-        );
-
         // Enable Transparent nav for homepage
         add_filter(
             'body_class',


### PR DESCRIPTION
Revert "PLANET-7793 Force WP to use UTC date for upload paths PR 2582"

### Summary
Since we've found that this fix does not affect the upload directory path and the issue was resolved by updating the ACL settings on the Stateless bucket, we can safely revert these changes.