### PR TITLE
PLANET-7810 Fix notice(Theme translations are loaded too early)

### DIFF
--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -89,15 +89,15 @@ class MasterSite extends TimberSite
         $this->theme_images_dir = $this->theme_dir . '/images/';
         $this->sort_options = [
             '_score' => [
-                'name' => __('Most relevant', 'planet4-master-theme'),
+                'name' => 'Most relevant',
                 'order' => 'DESC',
             ],
             'post_date' => [
-                'name' => __('Newest', 'planet4-master-theme'),
+                'name' => 'Newest',
                 'order' => 'DESC',
             ],
             'post_date_asc' => [
-                'name' => __('Oldest', 'planet4-master-theme'),
+                'name' => 'Oldest',
                 'order' => 'ASC',
             ],
         ];
@@ -137,7 +137,7 @@ class MasterSite extends TimberSite
         // Save "p4_global_project_tracking_id" on post save.
         add_action('save_post', [$this, 'save_global_project_id'], 10, 1);
         add_action('post_updated', [$this, 'clean_post_cache'], 10, 3);
-        add_action('after_setup_theme', [$this, 'p4_master_theme_setup']);
+        add_action('init', [$this, 'p4_master_theme_setup']);
         add_action('pre_insert_term', [$this, 'disallow_insert_term'], 1, 2);
         add_filter('wp_dropdown_users_args', [$this, 'filter_authors'], 10, 1);
         add_filter('wp_image_editors', [$this, 'allowedEditors']);


### PR DESCRIPTION
Ref https://jira.greenpeace.org/browse/PLANET-7810

### Summary
- We are calling the __() function (for translations) too early, likely during theme class instantiation — before the init action. Since translation functions like __() rely on the translation system being loaded, this is what's triggering:

```Notice: Function _load_textdomain_just_in_time was called incorrectly...```

- The correct way to load translations now(as of WP 6.7+) is to load translations using the init hook.

### Testing

1. Switch to the `main` branch locally, and ensure that `WP_DEBUG` is enabled.
2. Visit any page of the Planet4 local website.
3. You should see a PHP Notice similar to the one below in the logs:
```PHP Notice:  Function _load_textdomain_just_in_time was called incorrectly. Translation loading for the planet4-master-theme domain was triggered too early. This is usually an indicator of some code in the plugin or theme running too early. Translations should be loaded at the init action or later. Please see https://developer.wordpress.org/advanced-administration/debug/debug-wordpress/ for more information. (This message was added in version 6.7.0.) in /var/www/html/wp-includes/functions.php on line 6121```
4. Switch to the `PLANET-7810-fix-translations-notice` branch.
5. Refresh the same page of the Planet4 local site.
6. Confirm that the PHP notice no longer appears.