### PR TITLE
PLANET-7815: Add class for `text-transform: initial` 

### DIFF
--- a/assets/src/scss/base/_typography.scss
+++ b/assets/src/scss/base/_typography.scss
@@ -154,3 +154,7 @@ figcaption {
     @include shared-link-styles;
   }
 }
+
+.text-initial {
+  text-transform: initial !important;
+}


### PR DESCRIPTION
### Summary

This PR introduces the CSS class `text-initial`, adding the property `text-transform: initial`.
This class could be useful in some contexts, for example, to override the lowercase in right-to-left scenarios.

---

Ref: https://jira.greenpeace.org/browse/PLANET-7815

### Testing

<!-- Please add the steps required to test the changes in this Pull Request. -->
1. 
2. 
3. 
