### PR TITLE
PLANET-7832: Fix issues in the Posts List and Actions List blocks

### DIFF
--- a/assets/src/blocks/PostsList/index.js
+++ b/assets/src/blocks/PostsList/index.js
@@ -39,6 +39,7 @@ export const POSTS_LIST_BLOCK_ATTRIBUTES = {
     inherit: false,
     postIn: [],
     hasPassword: false,
+    block_name: POSTS_LIST_BLOCK_NAME,
   },
   layout: {
     type: 'default',

--- a/assets/src/scss/blocks/PostsList/PostsListStyle.scss
+++ b/assets/src/scss/blocks/PostsList/PostsListStyle.scss
@@ -167,6 +167,7 @@
       margin-bottom: $sp-1;
       font-size: var(--font-size-m--font-family-secondary);
       @include clamp-text(3);
+      word-break: break-word;
 
       @include large-and-up {
         line-height: 1.5;

--- a/src/Blocks/QueryLoopExtension.php
+++ b/src/Blocks/QueryLoopExtension.php
@@ -24,7 +24,6 @@ class QueryLoopExtension
     {
         $postInFilter = function ($args, $request) {
             $postIn = $request->get_param('postIn');
-            $hasPassword = $request->get_param('hasPassword');
             $block_name = $request->get_param('block_name');
 
             if ($block_name === self::ACTIONS_LIST_BLOCK) {
@@ -39,7 +38,8 @@ class QueryLoopExtension
                 $args['orderby'] = 'post__in';
             }
             // Exclude posts with the custom property `has_password` set to false
-            if ($hasPassword) {
+            if ($request->has_param('hasPassword')) {
+                $hasPassword = $request->get_param('hasPassword');
                 $args['has_password'] = $hasPassword !== false && $hasPassword !== 'false';
             }
             return $args;

--- a/src/Blocks/QueryLoopExtension.php
+++ b/src/Blocks/QueryLoopExtension.php
@@ -24,6 +24,7 @@ class QueryLoopExtension
     {
         $postInFilter = function ($args, $request) {
             $postIn = $request->get_param('postIn');
+            $hasPassword = $request->get_param('hasPassword');
             $block_name = $request->get_param('block_name');
 
             if ($block_name === self::ACTIONS_LIST_BLOCK) {
@@ -36,6 +37,10 @@ class QueryLoopExtension
             if (!empty($postIn)) {
                 $args['post__in'] = array_map('intval', (array) $postIn);
                 $args['orderby'] = 'post__in';
+            }
+            // Exclude posts with the custom property `has_password` set to false
+            if ($hasPassword) {
+                $args['has_password'] = $hasPassword !== false && $hasPassword !== 'false';
             }
             return $args;
         };
@@ -63,6 +68,10 @@ class QueryLoopExtension
                     $query['post__in'] = array_map('intval', (array) $blockQuery['postIn']);
                     $query['orderby'] = 'post__in';
                     $query['ignore_sticky_posts'] = true;
+                }
+                // Exclude posts with the custom property `has_password` set to false
+                if (isset($blockQuery['hasPassword'])) {
+                    $query['has_password'] = (bool) $blockQuery['hasPassword'];
                 }
                 return $query;
             },

--- a/src/Blocks/QueryLoopExtension.php
+++ b/src/Blocks/QueryLoopExtension.php
@@ -62,6 +62,7 @@ class QueryLoopExtension
                 if (isset($blockQuery['hasPassword'])) {
                     $query['has_password'] = (bool) $blockQuery['hasPassword'];
                 }
+                $query['post_status'] = 'publish'; // Ensure only published posts are queried
                 return $query;
             },
             10,
@@ -80,7 +81,8 @@ class QueryLoopExtension
     private static function buildActionListQuery(array $query, array $params = []): array
     {
         $is_new_ia = !empty(planet4_get_option('new_ia'));
-        $query['post_status'] = 'publish';
+        $query['post_status'] = 'publish'; // Ensure only published posts are queried
+        $query['has_password'] = false; // Exclude password-protected posts
 
         if (!$is_new_ia) {
             $query['post_type'] = ['page'];
@@ -119,10 +121,6 @@ class QueryLoopExtension
 
             if (!empty($params['postIn'])) {
                 $query['post__in'] = array_map('intval', (array) $params['postIn']);
-            }
-
-            if (!empty($params['hasPassword'])) {
-                $query['has_password'] = $params['hasPassword'] !== false && $params['hasPassword'] !== 'false';
             }
 
             $query['orderby'] = [

--- a/src/Blocks/QueryLoopExtension.php
+++ b/src/Blocks/QueryLoopExtension.php
@@ -12,6 +12,7 @@ namespace P4\MasterTheme\Blocks;
 class QueryLoopExtension
 {
     public const ACTIONS_LIST_BLOCK = 'planet4-blocks/actions-list';
+    public const POSTS_LIST_BLOCK = 'planet4-blocks/posts-list';
 
     public static function registerHooks(): void
     {
@@ -28,13 +29,13 @@ class QueryLoopExtension
             if ($block_name === self::ACTIONS_LIST_BLOCK) {
                 return self::buildActionListQuery($args, $request->get_params());
             }
+            if ($block_name === self::POSTS_LIST_BLOCK) {
+                $args['post_status'] = 'publish'; // Ensure only published posts are queried
+                $args['has_password'] = false; // Exclude password-protected posts
+            }
             if (!empty($postIn)) {
                 $args['post__in'] = array_map('intval', (array) $postIn);
                 $args['orderby'] = 'post__in';
-            }
-            if ($request->has_param('hasPassword')) {
-                $hasPassword = $request->get_param('hasPassword');
-                $args['has_password'] = $hasPassword !== false && $hasPassword !== 'false';
             }
             return $args;
         };
@@ -54,15 +55,15 @@ class QueryLoopExtension
                 if ($blockQuery['block_name'] === self::ACTIONS_LIST_BLOCK) {
                     return self::buildActionListQuery($query, $block->context['query'],);
                 }
+                if ($blockQuery['block_name'] === self::POSTS_LIST_BLOCK) {
+                    $query['post_status'] = 'publish'; // Ensure only published posts are queried
+                    $query['has_password'] = false; // Exclude password-protected posts
+                }
                 if (!empty($blockQuery['postIn'])) {
                     $query['post__in'] = array_map('intval', (array) $blockQuery['postIn']);
                     $query['orderby'] = 'post__in';
                     $query['ignore_sticky_posts'] = true;
                 }
-                if (isset($blockQuery['hasPassword'])) {
-                    $query['has_password'] = (bool) $blockQuery['hasPassword'];
-                }
-                $query['post_status'] = 'publish'; // Ensure only published posts are queried
                 return $query;
             },
             10,


### PR DESCRIPTION
### Summary

This PR fixes the following issues in the Posts List and the Actions List blocks:
- In the carousel layout of the Posts List block, column widths become distorted when a post excerpt contains a very long unbroken word ([example](https://www-dev.greenpeace.org/gutenberg/test-page-6/)).
- Private posts are incorrectly included in the query results.
- Password-protected posts are also being included in the query results.

---

Ref: https://jira.greenpeace.org/browse/PLANET-7832

### Testing

1. Run this branch locally, or use the test instance.
2. Add a very long, unbroken word to a post excerpt.
3. Add that post to a carousel layout Post List block.
4. Check that the width of the Post List block columns is equal.
5. Check that the Posts List block only includes published posts and excludes password-protected or private posts (in both, editor and the frontend).
6. Enable the new IA. Check that the Actions List block only includes published actions and child pages of the Take Action page, and excludes password-protected or private actions/pages (in both, editor and the frontend).
7. Disable the new IA. Check that the Actions List block only includes published child pages of the Act page, and excludes password-protected or private pages (in both, editor and the frontend).
