### PR TITLE
 PLANET-7832: Fix issues in the Posts List excerpt

### DIFF
--- a/assets/src/scss/blocks/PostsList/PostsListStyle.scss
+++ b/assets/src/scss/blocks/PostsList/PostsListStyle.scss
@@ -167,6 +167,7 @@
       margin-bottom: $sp-1;
       font-size: var(--font-size-m--font-family-secondary);
       @include clamp-text(3);
+      word-break: break-word;
 
       @include large-and-up {
         line-height: 1.5;


### PR DESCRIPTION
### Summary

This PR fixes the following issues in the Posts List and the Actions List blocks:
- In the carousel layout of the Posts List block, column widths become distorted when a post excerpt contains a very long unbroken word ([example](https://www-dev.greenpeace.org/gutenberg/test-page-6/)).
- Private posts are incorrectly included in the query results.
- Password-protected posts are also being included in the query results.

---

Ref: https://jira.greenpeace.org/browse/PLANET-7832

### Testing

1. Run this branch locally, or use the test instance.
2. Add a very long, unbroken word to a post excerpt.
3. Add that post to a carousel layout Post List block.
4. Check that the width of the Post List block columns is equal.
5. Check that the Posts List block only includes published posts and excludes password-protected or private posts (in both, editor and the frontend).
6. Enable the new IA. Check that the Actions List block only includes published actions and child pages of the Take Action page, and excludes password-protected or private actions/pages (in both, editor and the frontend).
7. Disable the new IA. Check that the Actions List block only includes published child pages of the Act page, and excludes password-protected or private pages (in both, editor and the frontend).
