### PR TITLE
PLANET-7719 Fixed screen reader issue and Carousel style accessibility

### DIFF
--- a/assets/src/blocks/ActionsList/index.js
+++ b/assets/src/blocks/ActionsList/index.js
@@ -1,4 +1,4 @@
-import {LISTS_BREADCRUMBS} from '../PostsList';
+import {LISTS_BREADCRUMBS, carouselButtons} from '../PostsList';
 import {TAX_BREADCRUMB_BLOCK_NAME} from '../../block-editor/setupTaxonomyBreadcrumbBlock';
 
 export const ACTIONS_LIST_BLOCK_NAME = 'planet4-blocks/actions-list';
@@ -73,14 +73,7 @@ export const getActionsListBlockTemplate = (title = __('', 'planet4-blocks-backe
       ['planet4-blocks/action-button-text'],
     ]],
   ]],
-  ['core/buttons', {
-    className: 'carousel-controls',
-    lock: {move: true},
-    layout: {type: 'flex', justifyContent: 'space-between', orientation: 'horizontal', flexWrap: 'nowrap'},
-  }, [
-    ['core/button', {className: 'carousel-control-prev', text: __('Prev', 'planet4-blocks-backend')}],
-    ['core/button', {className: 'carousel-control-next', text: __('Next', 'planet4-blocks-backend')}],
-  ]],
+  carouselButtons,
 ]);
 
 // Register the ActionsList block.

--- a/assets/src/blocks/PostsList/index.js
+++ b/assets/src/blocks/PostsList/index.js
@@ -22,6 +22,27 @@ const seeAllLink = ['core/navigation-link', {...!newsPageLink ? {className: 'd-n
   className: 'see-all-link',
 }}];
 
+export const carouselButtons = ['core/buttons', {
+  className: 'carousel-controls',
+  lock: {move: true},
+  layout: {type: 'flex', justifyContent: 'space-between', orientation: 'horizontal', flexWrap: 'nowrap'},
+}, [
+  ['core/button',
+    {
+      className: 'carousel-control-prev',
+      text: __('Previous Carousel Slide', 'planet4-blocks-backend'),
+      tagName: 'button',
+    },
+  ],
+  ['core/button',
+    {
+      className: 'carousel-control-next',
+      text: __('Next Carousel Slide', 'planet4-blocks-backend'),
+      tagName: 'button',
+    },
+  ],
+]];
+
 export const POSTS_LIST_BLOCK_ATTRIBUTES = {
   namespace: POSTS_LIST_BLOCK_NAME,
   className: 'posts-list p4-query-loop is-custom-layout-list',
@@ -88,14 +109,7 @@ export const getPostListBlockTemplate = (title = __('Related Posts', 'planet4-bl
       ]],
     ]],
   ]],
-  ['core/buttons', {
-    className: 'carousel-controls',
-    lock: {move: true},
-    layout: {type: 'flex', justifyContent: 'space-between', orientation: 'horizontal', flexWrap: 'nowrap'},
-  }, [
-    ['core/button', {className: 'carousel-control-prev', text: __('Prev', 'planet4-blocks-backend')}],
-    ['core/button', {className: 'carousel-control-next', text: __('Next', 'planet4-blocks-backend')}],
-  ]],
+  carouselButtons,
   seeAllLink,
 ]);
 

--- a/assets/src/js/actions_list_clickable_cards.js
+++ b/assets/src/js/actions_list_clickable_cards.js
@@ -1,20 +1,38 @@
+/**
+ * Update the tabbing functionality of the Actions list block by making only the
+ * card and the take action button focusable.
+ *
+ * @function setupClickabelActionsListCards
+ */
+
 export const setupClickabelActionsListCards = () => {
   const liElements = document.querySelectorAll('.actions-list ul li:not(.carousel-li)');
 
   liElements.forEach(li => {
-    const linkElement = li.querySelector('.wp-block-post-title > a');
-    if (linkElement) {
-      const url = linkElement.getAttribute('href');
-      li.tabIndex = 0;
-      const anchor = document.createElement('a');
-      anchor.setAttribute('href', url);
-      anchor.classList.add('actions-list-links');
+    const titleLink = li.querySelector('.wp-block-post-title > a');
 
-      while (li.firstChild) {
-        anchor.appendChild(li.firstChild);
-      }
-
-      li.appendChild(anchor);
+    if (!titleLink) {
+      return;
     }
+
+    // Add overlay to make whole card clickable
+    const url = titleLink.getAttribute('href');
+    const anchor = document.createElement('a');
+    anchor.setAttribute('href', url);
+    anchor.classList.add('actions-list-links');
+
+    while (li.firstChild) {
+      anchor.appendChild(li.firstChild);
+    }
+
+    li.appendChild(anchor);
+
+    // Remove keyboard access for the image, tag, title, and the card itself.
+    const imageLink = li.querySelector('.wp-block-post-featured-image > a');
+    const tagLink = li.querySelector('.taxonomy-post_tag > a');
+    const postTerms = li.querySelector('.wp-block-post-terms > a');
+    const NO_KEYBOARD_ACCESS_ELEMENTS = [titleLink, imageLink, tagLink, li, postTerms];
+
+    NO_KEYBOARD_ACCESS_ELEMENTS.forEach(element => element?.setAttribute('tabindex', -1));
   });
 };

--- a/assets/src/scss/blocks/ActionsList/ActionsListStyle.scss
+++ b/assets/src/scss/blocks/ActionsList/ActionsListStyle.scss
@@ -58,7 +58,6 @@
     border-radius: 4px;
     background: var(--white);
     cursor: pointer;
-    overflow: hidden;
     display: flex;
     flex-direction: column;
     min-height: 490px;

--- a/assets/src/scss/blocks/CarouselHeader/CarouselHeaderEditorStyle.scss
+++ b/assets/src/scss/blocks/CarouselHeader/CarouselHeaderEditorStyle.scss
@@ -7,7 +7,16 @@ div[data-type="planet4-blocks/carousel-header"] {
 }
 
 .visually-hidden {
-  display: none;
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  border: 0;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
 }
 
 .slide-number-row {

--- a/assets/src/scss/components/_skip-links.scss
+++ b/assets/src/scss/components/_skip-links.scss
@@ -19,3 +19,25 @@
     }
   }
 }
+
+// Styles for carousel skip link
+.carousel-skip-link {
+  position: absolute;
+  left: -9999px;
+  top: auto;
+  width: 1px;
+  height: 1px;
+  font-family: var(--font-family-tertiary);
+  font-size: var(--font-size-m--font-family-tertiary);
+}
+
+.carousel-skip-link:focus {
+  left: 50px;
+  bottom: 10px;
+  width: auto;
+  height: auto;
+  background-color: white;
+  color: var(--grey-900);
+  border-radius: $sp-x;
+  padding: 5px 10px;
+}

--- a/assets/src/scss/style.scss
+++ b/assets/src/scss/style.scss
@@ -169,3 +169,11 @@ body.transparent-nav {
     height: 26px;
   }
 }
+
+// Override Carousel div focus
+.wp-block-button.carousel-control-next,
+.wp-block-button.carousel-control-prev {
+  &:focus-within {
+    @include focus-styles();
+  }
+}


### PR DESCRIPTION
### Summary

<!-- Please provide a brief summary of the change introduced in this Pull Request. -->

---

<!-- Please add a reference link to the ticket, if one exists. -->
**Ref: https://jira.greenpeace.org/browse/PLANET-7719**

### Testing

<!-- Please add the steps required to test the changes in this Pull Request. -->
Tabbing through a page with a carousel styled element should flow from the individual posts to the _prev_ and _next_ buttons for the slides. If a user clicks on the buttons to go to the next slide it resets the focus so the user can continue tabbing through the individual posts. 