### PR TITLE
PLANET-7840 Enabled Greenpeace Media on Cover block

### DIFF
--- a/admin/css/archive-picker.css
+++ b/admin/css/archive-picker.css
@@ -296,7 +296,7 @@
   justify-content: space-between;
   width: 100%;
   min-height: 20px;
-  margin-bottom: 10px;
+  margin-bottom: 25px;
   position: relative;
 }
 
@@ -667,6 +667,6 @@
 
 .compat-field-restrictions_text .field,
 .restrictions-warning dd {
-  color: #d43B57; /* var(--red-500); */
+  color: #d43b57; /* var(--red-500); */
   font-weight: bold;
 }

--- a/assets/src/js/Components/ArchivePicker/ArchivePicker.js
+++ b/assets/src/js/Components/ArchivePicker/ArchivePicker.js
@@ -8,6 +8,7 @@ import {
   updateHappyPointAttributes,
   updateMediaAndTextAttributes,
   updateCarouselBlockAttributes,
+  updateCoverBlockAttributes,
 } from './blockUpdateFunctions';
 
 const {Spinner} = wp.components;
@@ -20,7 +21,13 @@ const timeout = delay => {
   return new Promise(resolve => setTimeout(resolve, delay));
 };
 
-const acceptedBlockTypes = ['core/image', 'planet4-blocks/happypoint', 'core/media-text', 'planet4-blocks/carousel-header'];
+const acceptedBlockTypes = [
+  'core/image',
+  'planet4-blocks/happypoint',
+  'core/media-text',
+  'planet4-blocks/carousel-header',
+  'core/cover',
+];
 
 export const EDITOR_VIEW = 'editor';
 export const ADMIN_VIEW = 'admin';
@@ -316,6 +323,8 @@ export default function ArchivePicker({view = ADMIN_VIEW}) {
         await processImageForBlock(id, updateCarouselBlockAttributes);
       } else if (currentBlock.name === 'core/media-text') {
         await processImageForBlock(id, updateMediaAndTextAttributes);
+      } else if (currentBlock.name === 'core/cover') {
+        await processImageForBlock(id, updateCoverBlockAttributes);
       } else {
         // Happy Point Block
         const updatedAttributes = updateHappyPointAttributes(id);

--- a/assets/src/js/Components/ArchivePicker/blockUpdateFunctions.js
+++ b/assets/src/js/Components/ArchivePicker/blockUpdateFunctions.js
@@ -1,22 +1,23 @@
 export const updateImageBlockAttributes = (image, currentBlock) => {
+  const {id, source_url, caption, alt_text} = image;
   const div = document.createElement('div');
 
-  if (image.id) {
+  if (id) {
     // Check if the current block has content already, then just replace it.
     if (currentBlock.originalContent) {
       div.innerHTML = currentBlock.originalContent;
-      div.querySelector('img').setAttribute('class', `wp-image-${image.id}`);
-      div.querySelector('img').src = image.source_url;
+      div.querySelector('img').setAttribute('class', `wp-image-${id}`);
+      div.querySelector('img').src = source_url;
       if (div.querySelector('figcaption')) {
-        div.querySelector('figcaption').textContent = image.caption.raw;
+        div.querySelector('figcaption').textContent = caption.raw;
       }
     } else {
       // If there is no content then create block content.
       div.innerHTML = `
         <figure class="wp-block-image size-large">
-          <img src=${image.source_url} alt=${image.alt_text} class="wp-image-${image.id}"/>
+          <img src=${source_url} alt=${alt_text} class="wp-image-${id}"/>
           <figcaption class="wp-element-caption">
-            ${image.caption.raw}
+            ${caption.raw}
           </figcaption>
         </figure>`;
     }
@@ -24,10 +25,10 @@ export const updateImageBlockAttributes = (image, currentBlock) => {
 
   return {
     attributes: {
-      id: image.id,
-      url: image.source_url,
-      caption: image.caption.raw,
-      alt: image.alt_text,
+      id,
+      url: source_url,
+      caption: caption.raw,
+      alt: alt_text,
     },
     originalContent: div.innerHTML,
   };
@@ -40,23 +41,24 @@ export const updateHappyPointAttributes = id => {
 
 export const updateMediaAndTextAttributes = (image, currentBlock) => {
   const div = document.createElement('div');
+  const {id, link, source_url, alt_text} = image;
 
   if (currentBlock.originalContent) {
     div.innerHTML = currentBlock.originalContent;
-    div.querySelector('img').setAttribute('class', `wp-image-${image.id}`);
-    div.querySelector('img').src = image.source_url;
+    div.querySelector('img').setAttribute('class', `wp-image-${id}`);
+    div.querySelector('img').src = source_url;
   } else {
     div.innerHTML = `
-      <div class="wp-block-media-text is-stacked-on-mobile"><figure class="wp-block-media-text__media"><img src=${image.source_url} alt=${image.alt_text} class="wp-image-${image.id} size-full"/></figure><div class="wp-block-media-text__content"></div></div>
+      <div class="wp-block-media-text is-stacked-on-mobile"><figure class="wp-block-media-text__media"><img src=${source_url} alt=${alt_text} class="wp-image-${id} size-full"/></figure><div class="wp-block-media-text__content"></div></div>
     `;
   }
 
   return {
     attributes: {
-      mediaLink: image.link,
-      mediaUrl: image.source_url,
-      mediaAlt: image.alt_text,
-      mediaId: image.id,
+      mediaLink: link,
+      mediaUrl: source_url,
+      mediaAlt: alt_text,
+      mediaId: id,
       mediaType: 'image',
       useFeaturedImage: false,
     },
@@ -88,28 +90,29 @@ export const updateCarouselBlockAttributes = (image, currentBlock) => {
 };
 
 export const updateCoverBlockAttributes = (image, currentBlock) => {
+  const {id, alt_text, source_url} = image;
   const sizes = image.media_details?.sizes || {};
   const sizeSlug = sizes.full ? 'full' : 'large';
   const div = document.createElement('div');
 
   if (currentBlock.originalContent) {
     div.innerHTML = currentBlock.originalContent;
-    div.querySelector('img').setAttribute('class', `wp-block-cover__image-background wp-image-${image.id} size-${sizeSlug}`);
-    div.querySelector('img').src = image.source_url;
-    div.querySelector('img').setAttribute('alt', image.alt_text);
+    div.querySelector('img').setAttribute('class', `wp-block-cover__image-background wp-image-${id} size-${sizeSlug}`);
+    div.querySelector('img').src = source_url;
+    div.querySelector('img').setAttribute('alt', alt_text);
   } else {
     div.innerHTML = `
-      <div class="wp-block-cover is-light"><img class="wp-block-cover__image-background wp-image-${image.id} size-${sizeSlug}" alt=${image.alt_text} src=${image.source_url} data-object-fit="cover"/><span aria-hidden="true" class="wp-block-cover__background has-background-dim" style="background-color:#FFF"></span><div class="wp-block-cover__inner-container"></div></div>
+      <div class="wp-block-cover is-light"><img class="wp-block-cover__image-background wp-image-${id} size-${sizeSlug}" alt=${alt_text} src=${source_url} data-object-fit="cover"/><span aria-hidden="true" class="wp-block-cover__background has-background-dim" style="background-color:#FFF"></span><div class="wp-block-cover__inner-container"></div></div>
     `;
   }
 
   return {
     attributes: {
-      alt: image.alt_text,
+      alt: alt_text,
       customOverlayColor: '#FFF',
       dimRatio: 50,
-      url: image.source_url,
-      id: image.id,
+      url: source_url,
+      id,
       isUserOverlayColor: false,
       isDark: false,
       sizeSlug,

--- a/assets/src/js/Components/ArchivePicker/blockUpdateFunctions.js
+++ b/assets/src/js/Components/ArchivePicker/blockUpdateFunctions.js
@@ -86,3 +86,34 @@ export const updateCarouselBlockAttributes = (image, currentBlock) => {
     },
   };
 };
+
+export const updateCoverBlockAttributes = (image, currentBlock) => {
+  const sizes = image.media_details?.sizes || {};
+  const sizeSlug = sizes.full ? 'full' : 'large';
+  const div = document.createElement('div');
+
+  if (currentBlock.originalContent) {
+    div.innerHTML = currentBlock.originalContent;
+    div.querySelector('img').setAttribute('class', `wp-block-cover__image-background wp-image-${image.id} size-${sizeSlug}`);
+    div.querySelector('img').src = image.source_url;
+    div.querySelector('img').setAttribute('alt', image.alt_text);
+  } else {
+    div.innerHTML = `
+      <div class="wp-block-cover is-light"><img class="wp-block-cover__image-background wp-image-${image.id} size-${sizeSlug}" alt=${image.alt_text} src=${image.source_url} data-object-fit="cover"/><span aria-hidden="true" class="wp-block-cover__background has-background-dim" style="background-color:#FFF"></span><div class="wp-block-cover__inner-container"></div></div>
+    `;
+  }
+
+  return {
+    attributes: {
+      alt: image.alt_text,
+      customOverlayColor: '#FFF',
+      dimRatio: 50,
+      url: image.source_url,
+      id: image.id,
+      isUserOverlayColor: false,
+      isDark: false,
+      sizeSlug,
+    },
+    originalContent: div.innerHTML,
+  };
+};


### PR DESCRIPTION
### Summary

<!-- Please provide a brief summary of the change introduced in this Pull Request. -->

---

<!-- Please add a reference link to the ticket, if one exists. -->
**Ref: https://jira.greenpeace.org/browse/PLANET-7840**

### Testing

<!-- Please add the steps required to test the changes in this Pull Request. -->
GP Media is now enabled for the Cover block. For testing, make sure to enable all blocks in _Planet4 -> Features_, then on the editor, you can add the Cover block and use the GP Media tab to add and update the images.
