### PR TITLE
Add link styles to links within Quote citation

### DIFF
--- a/assets/src/scss/blocks/core-overrides/Quote.scss
+++ b/assets/src/scss/blocks/core-overrides/Quote.scss
@@ -33,5 +33,9 @@
 
   cite {
     font-style: normal;
+
+    a {
+      @include shared-link-styles;
+    }
   }
 }


### PR DESCRIPTION
This has been requested after the latest Quote block makeover, see [PLANET-7683](https://jira.greenpeace.org/browse/PLANET-7683?focusedCommentId=254819&atlLinkOrigin=c2xhY2staW50ZWdyYXRpb258Y29tbWVudA%3D%3D#comment-254819) comments.

### Testing

Add a Quote block to a page, use a link in the citation and why not in the quote itself, both should show our custom styles: 

<img width="259" alt="Screenshot 2025-06-18 at 15 21 44" src="https://github.com/user-attachments/assets/4ab71dae-1b82-4869-9753-29296df7304a" />

You can also check out [this page](https://www-dev.greenpeace.org/test-sinope/a-lovely-quote/) I made as an example.
