### PR TITLE
PLANET-7843: Preserve meaningful metadata when uploading to Media Library

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -417,35 +417,6 @@ add_action(
     }
 );
 
-
-
-
-add_action('add_attachment', function ($post_id) {
-    $file = get_attached_file($post_id);
-    $size = getimagesize($file, $info);
-    if (!isset($info['APP13'])) return;
-
-    $iptc = iptcparse($info['APP13']) ?: [];
-
-    var_dump($iptc); // Debugging line, remove in production
-
-    if (!empty($iptc['2#025'])) {
-        update_post_meta($post_id, '_meta_keywords', implode(', ', $iptc['2#025']));
-    }
-
-    if (!empty($iptc['2#005'])) {
-        update_post_meta($post_id, '_meta_title', $iptc['2#005'][0]);
-    }
-
-    if (!empty($iptc['2#120'])) {
-        update_post_meta($post_id, '_meta_caption', $iptc['2#120'][0]);
-    }
-
-    if (!empty($iptc['2#110'])) {
-        update_post_meta($post_id, '_meta_credit', $iptc['2#110'][0]);
-    }
-});
-
 // This action overrides the WordPress functionality for adding a notice message
 // https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-admin/edit-form-blocks.php#L303-L305
 // When it's a page for posts.

--- a/functions.php
+++ b/functions.php
@@ -168,15 +168,6 @@ add_filter(
     10,
     2
 );
-add_action(
-    'wpml_after_update_attachment_texts',
-    function ($original_attachment_id, $translation): void {
-        $original_sm_cloud = get_post_meta($original_attachment_id, 'sm_cloud', true);
-        update_post_meta($translation->element_id, 'sm_cloud', $original_sm_cloud);
-    },
-    1,
-    2
-);
 
 /**
  * This is not a column in WordPress by default, but is added by the Post Type Switcher plugin.
@@ -426,59 +417,34 @@ add_action(
     }
 );
 
-// Calls attachment metadata update on importer job.
-// This triggers the wp-stateless hook (if it exists),
-// which sets the sm_cloud metadata for the uploaded file.
-// Wp-stateless is then able to find the file on GCS on step 2,
-// instead of looking for it in the local uploads folder.
-add_action(
-    'add_attachment',
-    function ($post_id): void {
-        if (
-            ! defined('WP_IMPORTING')
-            || ! WP_IMPORTING
-            || ! isset($_GET['step']) // phpcs:ignore WordPress.Security.NonceVerification
-            || '1' !== $_GET['step'] // phpcs:ignore WordPress.Security.NonceVerification
-            || ! class_exists('wpCloud\StatelessMedia\Bootstrap')
-        ) {
-            return;
-        }
 
-        if (version_compare(\wpCloud\StatelessMedia\Bootstrap::$version, '3.0', '<')) {
-            return;
-        }
 
-        $post = get_post($post_id);
-        if (! $post || 'attachment' !== $post->post_type) {
-            return;
-        }
 
-        $cloud_meta = get_post_meta($post_id, 'sm_cloud', true);
-        if (! empty($cloud_meta)) {
-            return;
-        }
+add_action('add_attachment', function ($post_id) {
+    $file = get_attached_file($post_id);
+    $size = getimagesize($file, $info);
+    if (!isset($info['APP13'])) return;
 
-        $metadata = wp_get_attachment_metadata($post_id);
-        wp_update_attachment_metadata($post_id, $metadata);
-    },
-    99
-);
+    $iptc = iptcparse($info['APP13']) ?: [];
 
-// WP Stateless plugin short-circuits the image_downsize() process
-// with wpCloud\StatelessMedia\Bootstrap::image_downsize().
-// Contrary to the native function, it will return attachment data
-// even if the attachment is not an image.
-// The attachment is then treated as an image by the function
-// wp_get_attachment_link() generating the link, even for a PDF.
-// We overrule wp-stateless response if file is not an image.
-add_filter(
-    'image_downsize',
-    function ($downsize, $id) {
-        return wp_attachment_is_image($id) ? $downsize : false;
-    },
-    100,
-    2
-);
+    var_dump($iptc); // Debugging line, remove in production
+
+    if (!empty($iptc['2#025'])) {
+        update_post_meta($post_id, '_meta_keywords', implode(', ', $iptc['2#025']));
+    }
+
+    if (!empty($iptc['2#005'])) {
+        update_post_meta($post_id, '_meta_title', $iptc['2#005'][0]);
+    }
+
+    if (!empty($iptc['2#120'])) {
+        update_post_meta($post_id, '_meta_caption', $iptc['2#120'][0]);
+    }
+
+    if (!empty($iptc['2#110'])) {
+        update_post_meta($post_id, '_meta_credit', $iptc['2#110'][0]);
+    }
+});
 
 // This action overrides the WordPress functionality for adding a notice message
 // https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-admin/edit-form-blocks.php#L303-L305

--- a/src/AttachmentsController.php
+++ b/src/AttachmentsController.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace P4\MasterTheme;
+
+/**
+ * Handles custom attachment behaviors and metadata in the P4 Master Theme.
+ */
+class AttachmentsController
+{
+    public const META_FIELDS = [
+        'restriction' => '_media_restriction',
+        'credit'      => '_credit_text',
+    ];
+
+    public const IMG_ATTACHMENT_FIELDS = [
+        'restriction' => 'restrictions_text',
+        'credit'      => 'credit_text',
+    ];
+
+    public const SM_CLOUD = 'sm_cloud';
+
+    /**
+     * Constructor: Hooks into WordPress actions and filters to extend attachment functionality.
+     */
+    public function __construct()
+    {
+        add_action('add_attachment', [$this, 'set_sm_cloud_metadata'], 99);
+        add_action('wpml_after_update_attachment_texts', [$this, 'sync_translation_sm_cloud_meta'], 1, 2);
+        add_filter('image_downsize', [$this, 'overrule_wp_stateless_for_no_images'], 100, 2);
+        add_filter('attachment_fields_to_edit', [$this, 'add_image_attachment_fields_to_edit'], 10, 2);
+        add_filter('attachment_fields_to_save', [$this, 'add_image_attachment_fields_to_save'], 10, 2);
+    }
+
+    /**
+     * Forces the update of `sm_cloud` metadata on attachment import.
+     *
+     * Used during WP Import step 1 to ensure WP-Stateless can find the file
+     * in Google Cloud Storage (GCS) during subsequent steps.
+     *
+     * @param int $post_id Attachment post ID.
+     */
+    public function set_sm_cloud_metadata($post_id): void
+    {
+        if (
+            ! defined('WP_IMPORTING')
+            || ! WP_IMPORTING
+            || ! isset($_GET['step']) // phpcs:ignore WordPress.Security.NonceVerification
+            || '1' !== $_GET['step'] // phpcs:ignore WordPress.Security.NonceVerification
+            || ! class_exists('wpCloud\StatelessMedia\Bootstrap')
+        ) {
+            return;
+        }
+
+        if (version_compare(\wpCloud\StatelessMedia\Bootstrap::$version, '3.0', '<')) {
+            return;
+        }
+
+        $post = get_post($post_id);
+        if (! $post || 'attachment' !== $post->post_type) {
+            return;
+        }
+
+        $cloud_meta = get_post_meta($post_id, self::SM_CLOUD, true);
+        if (! empty($cloud_meta)) {
+            return;
+        }
+
+        $metadata = wp_get_attachment_metadata($post_id);
+        wp_update_attachment_metadata($post_id, $metadata);
+    }
+
+    /**
+     * Fix WP-Stateless behavior where non-images are incorrectly returned as images.
+     *
+     * Prevents functions like `wp_get_attachment_link()` from treating documents
+     * (e.g. PDFs) as images by returning false when the file isn't an image.
+     *
+     * @param mixed    $downsize Result from previous image_downsize filter.
+     * @param \WP_Post $id       Attachment ID.
+     *
+     * @return mixed Modified result or false if not an image.
+     */
+    public function overrule_wp_stateless_for_no_images($downsize, $id): mixed
+    {
+        return wp_attachment_is_image($id) ? $downsize : false;
+    }
+
+    /**
+     * Copy `sm_cloud` metadata to translated attachments (WPML support).
+     *
+     * @param int        $original_attachment_id ID of the original attachment.
+     * @param \stdClass  $translation            WPML translation object.
+     */
+    public function sync_translation_sm_cloud_meta($original_attachment_id, $translation): void
+    {
+        $original_sm_cloud = get_post_meta($original_attachment_id, self::SM_CLOUD, true);
+        update_post_meta($translation->element_id, self::SM_CLOUD, $original_sm_cloud);
+    }
+
+    /**
+     * Adds custom fields to the media attachment edit form.
+     *
+     * @param array    $form_fields Fields to display in the media form.
+     * @param \WP_Post $post        Attachment post object.
+     *
+     * @return array Modified array of fields.
+     */
+    public function add_image_attachment_fields_to_edit(array $form_fields, \WP_Post $post): array
+    {
+        // Add a Credit field.
+        $form_fields[self::IMG_ATTACHMENT_FIELDS['credit']] = [
+            'label' => __('Credit', 'planet4-master-theme-backend'),
+            'input' => 'text',
+            'value' => get_post_meta($post->ID, self::META_FIELDS['credit'], true),
+            'helps' => __('The owner of the image.', 'planet4-master-theme-backend'),
+        ];
+
+        // Add a Restrictions field (if present).
+        $img_restrictions = get_post_meta($post->ID, self::META_FIELDS['restriction'], true);
+        if ($img_restrictions) {
+            $form_fields[self::IMG_ATTACHMENT_FIELDS['restriction']] = [
+                'label' => __('Restrictions', 'planet4-master-theme-backend'),
+                'input' => 'html',
+                'html' => $img_restrictions,
+            ];
+        }
+
+        return $form_fields;
+    }
+
+    /**
+     * Saves the custom media metadata fields on attachment save.
+     *
+     * @param array $post       The attachment post data.
+     * @param array $attachment Form data submitted for the attachment.
+     *
+     * @return array Modified post data.
+     */
+    public function add_image_attachment_fields_to_save(array $post, array $attachment): array
+    {
+        if (isset($attachment[self::IMG_ATTACHMENT_FIELDS['credit']])) {
+            update_post_meta(
+                $post['ID'],
+                self::META_FIELDS['credit'],
+                $attachment[self::IMG_ATTACHMENT_FIELDS['credit']]
+            );
+        }
+
+        return $post;
+    }
+}

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -90,6 +90,7 @@ final class Loader
             Cookies::class,
             DevReport::class,
             MasterSite::class,
+            AttachmentsController::class,
             HttpHeaders::class,
             ActionPage::class,
             PageMeta::class,

--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -39,12 +39,6 @@ class MasterSite extends TimberSite
     public const CREDIT_META_FIELD = '_credit_text';
 
     /**
-     * Restrictions meta field key
-     *
-     */
-    public const RESTRICTIONS_META_FIELD = '_media_restriction';
-
-    /**
      * Theme directory
      *
      */
@@ -209,8 +203,6 @@ class MasterSite extends TimberSite
         );
 
         add_action('init', [$this, 'login_redirect'], 1);
-        add_filter('attachment_fields_to_edit', [$this, 'add_image_attachment_fields_to_edit'], 10, 2);
-        add_filter('attachment_fields_to_save', [$this, 'add_image_attachment_fields_to_save'], 10, 2);
         version_compare(get_bloginfo('version'), '5.5', '<')
             ? add_action('init', [$this, 'p4_register_core_image_block'])
             : add_filter('register_block_type_args', [$this, 'register_core_blocks_callback']);
@@ -1575,54 +1567,6 @@ class MasterSite extends TimberSite
         $query_string = apply_filters('planet4_youtube_embed_parameters', 'rel=0');
 
         return [$youtube_id, $query_string];
-    }
-
-    /**
-     * Add custom media metadata fields.
-     *
-     * @param array    $form_fields An array of fields included in the attachment form.
-     * @param \WP_Post $post The attachment record in the database.
-     *
-     * @return array Final array of form fields to use.
-     */
-    public function add_image_attachment_fields_to_edit(array $form_fields, \WP_Post $post): array
-    {
-        // Add a Credit field.
-        $form_fields['credit_text'] = [
-            'label' => __('Credit', 'planet4-master-theme-backend'),
-            'input' => 'text', // this is default if "input" is omitted.
-            'value' => get_post_meta($post->ID, self::CREDIT_META_FIELD, true),
-            'helps' => __('The owner of the image.', 'planet4-master-theme-backend'),
-        ];
-
-        // Add a Restrictions field.
-        $img_restrictions = get_post_meta($post->ID, self::RESTRICTIONS_META_FIELD, true);
-        if ($img_restrictions) {
-            $form_fields['restrictions_text'] = [
-                'label' => __('Restrictions', 'planet4-master-theme-backend'),
-                'input' => 'html',
-                'html' => $img_restrictions,
-            ];
-        }
-
-        return $form_fields;
-    }
-
-    /**
-     * Save custom media metadata fields
-     *
-     * @param array $post        The $post data for the attachment.
-     * @param array $attachment  The $attachment part of the form $_POST ($_POST[attachments][postID]).
-     *
-     * @return array $post
-     */
-    public function add_image_attachment_fields_to_save(array $post, array $attachment): array
-    {
-        if (isset($attachment['credit_text'])) {
-            update_post_meta($post['ID'], self::CREDIT_META_FIELD, $attachment['credit_text']);
-        }
-
-        return $post;
     }
 
     /**


### PR DESCRIPTION
### Summary

This PR preserves the metadata "Credit" and "Restrictions" when images that were downloaded from the Greenpeace Media are then manually uploaded from disk in the Media Library directly. This is performed by the class `AttachmentsController::update_iptc_metadata` 

Additionally, according to what was discussed and agreed in a previous meeting, the functions related to attachments management were moved from the `functions.php` and the `MasterSite.php` files into the newly created `AttachmentsController` class to improve clarity and maintainability.
---

Ref: https://jira.greenpeace.org/browse/PLANET-7843

### Testing

<!-- Please add the steps required to test the changes in this Pull Request. -->
1. 
2. 
3. 
