### PR TITLE
PLANET-7829 Enable Footnotes block

### DIFF
--- a/index.php
+++ b/index.php
@@ -14,6 +14,10 @@
  * @since   Timber 0.1
  */
 
+if (!$post) {
+    return;
+}
+
 use P4\MasterTheme\Context;
 use P4\MasterTheme\Post;
 use P4\MasterTheme\ListingPage;
@@ -23,11 +27,11 @@ $context = Timber::get_context();
 $templates = [ 'index.twig' ];
 
 if (is_home()) {
-    $post = new Post(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-    $post->set_data_layer();
-    $data_layer = $post->get_data_layer();
+    $timber_post = new Post($post->ID);
+    $timber_post->set_data_layer();
+    $data_layer = $timber_post->get_data_layer();
 
-    $page_meta_data = get_post_meta($post->ID);
+    $page_meta_data = get_post_meta($timber_post->ID);
     $page_meta_data = array_map(fn ($v) => reset($v), $page_meta_data);
 
     $context['title'] = ( $page_meta_data['p4_title'] ?? '' )
@@ -37,9 +41,9 @@ if (is_home()) {
 
     Context::set_header($context, $page_meta_data, $context['title']);
     Context::set_background_image($context);
-    Context::set_og_meta_fields($context, $post);
+    Context::set_og_meta_fields($context, $timber_post);
     Context::set_campaign_datalayer($context, $page_meta_data);
-    Context::set_utm_params($context, $post);
+    Context::set_utm_params($context, $timber_post);
 
     array_unshift($templates, 'all-posts.twig');
 

--- a/index.php
+++ b/index.php
@@ -1,5 +1,7 @@
 <?php
 
+global $post;
+
 /**
  * The main template file
  * This is the most generic template file in a WordPress theme

--- a/page-templates/evergreen.php
+++ b/page-templates/evergreen.php
@@ -23,15 +23,15 @@ use P4\MasterTheme\Post;
 use Timber\Timber;
 
 $context = Timber::get_context();
-$post = new Post(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-$page_meta_data = get_post_meta($post->ID);
+$timber_post = new Post($post->ID);
+$page_meta_data = get_post_meta($timber_post->ID);
 $page_meta_data = array_map(fn ($v) => reset($v), $page_meta_data);
 
 // Set Navigation Issues links.
-$post->set_issues_links();
+$timber_post->set_issues_links();
 
 // Get Navigation Campaigns links.
-$page_tags = wp_get_post_tags($post->ID);
+$page_tags = wp_get_post_tags($timber_post->ID);
 $tags = [];
 
 if (is_array($page_tags) && $page_tags) {
@@ -44,17 +44,17 @@ if (is_array($page_tags) && $page_tags) {
     $context['campaigns'] = $tags;
 }
 
-$context['post'] = $post;
+$context['post'] = $timber_post;
 $context['custom_body_classes'] = 'white-bg';
 $context['page_category'] = 'Evergreen Page';
-$context['social_accounts'] = $post->get_social_accounts($context['footer_social_menu'] ?: []);
+$context['social_accounts'] = $timber_post->get_social_accounts($context['footer_social_menu'] ?: []);
 
-Context::set_header($context, $page_meta_data, $post->title);
+Context::set_header($context, $page_meta_data, $timber_post->title);
 Context::set_background_image($context);
-Context::set_og_meta_fields($context, $post);
-Context::set_p4_blocks_datalayer($context, $post);
+Context::set_og_meta_fields($context, $timber_post);
+Context::set_p4_blocks_datalayer($context, $timber_post);
 
-if (post_password_required($post->ID)) {
+if (post_password_required($timber_post->ID)) {
     $context['login_url'] = wp_login_url();
 
     do_action('enqueue_google_tag_manager_script', $context);

--- a/page-templates/evergreen.php
+++ b/page-templates/evergreen.php
@@ -1,5 +1,7 @@
 <?php
 
+global $post;
+
 /**
  * Template Name: Evergreen Page
  * The template for displaying evergreen pages.

--- a/page-templates/evergreen.php
+++ b/page-templates/evergreen.php
@@ -18,6 +18,10 @@
  * @since    Timber 0.1
  */
 
+if (!$post) {
+    return;
+}
+
 use P4\MasterTheme\Context;
 use P4\MasterTheme\Post;
 use Timber\Timber;

--- a/page.php
+++ b/page.php
@@ -34,8 +34,8 @@ use P4\MasterTheme\Post;
 use Timber\Timber;
 
 $context = Timber::get_context();
-$post = new Post(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-$page_meta_data = get_post_meta($post->ID) ?: [];
+$timber_post = new Post($post->ID);
+$page_meta_data = get_post_meta($timber_post->ID) ?: [];
 $page_meta_data = array_map(fn($v) => reset($v), $page_meta_data);
 
 // Ensure redirect is only performed if we're not already on a tag URL. Because tag.php includes this file.
@@ -46,7 +46,7 @@ if (! is_tag() && RedirectRedirectPages::is_active()) {
         'meta_query' => [
             [
                 'key' => 'redirect_page',
-                'value' => $post->ID,
+                'value' => $timber_post->ID,
                 'compare' => '=',
             ],
         ],
@@ -63,10 +63,10 @@ if (! is_tag() && RedirectRedirectPages::is_active()) {
 }
 
 // Set Navigation Issues links.
-$post->set_issues_links();
+$timber_post->set_issues_links();
 
 // Get Navigation Campaigns links.
-$page_tags = wp_get_post_tags($post->ID);
+$page_tags = wp_get_post_tags($timber_post->ID);
 $tags = [];
 
 if (is_array($page_tags) && $page_tags) {
@@ -80,30 +80,30 @@ if (is_array($page_tags) && $page_tags) {
 }
 
 // Set GTM Data Layer values.
-$post->set_data_layer();
-$data_layer = $post->get_data_layer();
+$timber_post->set_data_layer();
+$data_layer = $timber_post->get_data_layer();
 
-Context::set_header($context, $page_meta_data, $post->title);
+Context::set_header($context, $page_meta_data, $timber_post->title);
 Context::set_background_image($context);
-Context::set_og_meta_fields($context, $post);
+Context::set_og_meta_fields($context, $timber_post);
 Context::set_campaign_datalayer($context, $page_meta_data);
-Context::set_utm_params($context, $post);
-Context::set_p4_blocks_datalayer($context, $post);
+Context::set_utm_params($context, $timber_post);
+Context::set_p4_blocks_datalayer($context, $timber_post);
 
-$context['post'] = $post;
-$context['social_accounts'] = $post->get_social_accounts($context['footer_social_menu'] ?: []);
+$context['post'] = $timber_post;
+$context['social_accounts'] = $timber_post->get_social_accounts($context['footer_social_menu'] ?: []);
 $context['page_category'] = $data_layer['page_category'];
-$context['post_tags'] = implode(', ', $post->tags());
-$context['post_categories'] = implode(', ', $post->categories());
+$context['post_tags'] = implode(', ', $timber_post->tags());
+$context['post_categories'] = implode(', ', $timber_post->categories());
 $context['custom_body_classes'] = 'brown-bg ';
 
 if (is_tag()) {
     $context['canonical_link'] = home_url($wp->request);
 }
 
-if (post_password_required($post->ID)) {
+if (post_password_required($timber_post->ID)) {
     // Password protected form validation.
-    $context['is_password_valid'] = $post->is_password_valid();
+    $context['is_password_valid'] = $timber_post->is_password_valid();
 
     // Hide the page title from links to the extra feeds.
     remove_action('wp_head', 'feed_links_extra', 3);
@@ -114,5 +114,5 @@ if (post_password_required($post->ID)) {
     Timber::render('single-page.twig', $context);
 } else {
     do_action('enqueue_google_tag_manager_script', $context);
-    Timber::render([ 'page-' . $post->post_name . '.twig', 'page.twig' ], $context);
+    Timber::render([ 'page-' . $timber_post->post_name . '.twig', 'page.twig' ], $context);
 }

--- a/page.php
+++ b/page.php
@@ -1,5 +1,7 @@
 <?php
 
+global $post;
+
 /**
  * The template for displaying all pages.
  *

--- a/page.php
+++ b/page.php
@@ -28,6 +28,10 @@
  * Post     : Action
  */
 
+if (!$post) {
+    return;
+}
+
 use P4\MasterTheme\Context;
 use P4\MasterTheme\Features\RedirectRedirectPages;
 use P4\MasterTheme\Post;

--- a/single-campaign.php
+++ b/single-campaign.php
@@ -6,6 +6,10 @@
  * @package P4MT
  */
 
+if (!$post) {
+    return;
+}
+
 use P4\MasterTheme\Context;
 use P4\MasterTheme\Post;
 use Timber\Timber;

--- a/single-campaign.php
+++ b/single-campaign.php
@@ -1,5 +1,7 @@
 <?php
 
+global $post;
+
 /**
  * Template Variables for Campaigns.
  *

--- a/single-campaign.php
+++ b/single-campaign.php
@@ -12,26 +12,20 @@ use Timber\Timber;
 
 // Initializing variables.
 $context = Timber::get_context();
-
-/**
- * Post object.
- *
- * @var Post $post
- * */
-$post = Timber::query_post(false, Post::class); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-$context['post'] = $post;
+$timber_post = new Post($post->ID);
+$context['post'] = $timber_post;
 
 // Get the cmb2 custom fields data.
-$meta = $post->custom;
+$meta = $timber_post->custom;
 
-$current_level_campaign_id = $post->ID;
+$current_level_campaign_id = $timber_post->ID;
 
 do {
     $top_level_campaign_id = $current_level_campaign_id;
     $current_level_campaign_id = wp_get_post_parent_id($current_level_campaign_id);
 } while ($current_level_campaign_id);
 
-if ($top_level_campaign_id === $post->ID) {
+if ($top_level_campaign_id === $timber_post->ID) {
     $campaign_meta = $meta;
 } else {
     $parent_meta = get_post_meta($top_level_campaign_id);
@@ -44,7 +38,7 @@ if ($top_level_campaign_id === $post->ID) {
 // This is just an example of how to get children pages, this will probably be done in some kind of menu block.
 $sub_pages = get_children(
     [
-        'post_parent' => $post->ID,
+        'post_parent' => $timber_post->ID,
         'post_type' => 'campaign',
     ]
 );
@@ -66,18 +60,18 @@ if ($theme_name) {
 }
 
 // Set GTM Data Layer values.
-$post->set_data_layer();
-$data_layer = $post->get_data_layer();
+$timber_post->set_data_layer();
+$data_layer = $timber_post->get_data_layer();
 
-Context::set_header($context, $meta, $post->title);
+Context::set_header($context, $meta, $timber_post->title);
 Context::set_background_image($context);
-Context::set_og_meta_fields($context, $post);
+Context::set_og_meta_fields($context, $timber_post);
 Context::set_campaign_datalayer($context, $campaign_meta);
-Context::set_utm_params($context, $post);
+Context::set_utm_params($context, $timber_post);
 Context::set_custom_styles($context, $campaign_meta, 'campaign');
 
-$context['post'] = $post;
-$context['social_accounts'] = $post->get_social_accounts($context['footer_social_menu'] ?: []);
+$context['post'] = $timber_post;
+$context['social_accounts'] = $timber_post->get_social_accounts($context['footer_social_menu'] ?: []);
 $context['page_category'] = $data_layer['page_category'];
 
 $context['custom_font_families'] = [
@@ -107,11 +101,11 @@ foreach (range(1, 5) as $i) {
     $context['social_overrides'][$i]['icon'] = $campaign_footer_item['icon'];
 }
 
-Context::set_p4_blocks_datalayer($context, $post);
+Context::set_p4_blocks_datalayer($context, $timber_post);
 
-if (post_password_required($post->ID)) {
+if (post_password_required($timber_post->ID)) {
     // Password protected form validation.
-    $context['is_password_valid'] = $post->is_password_valid();
+    $context['is_password_valid'] = $timber_post->is_password_valid();
 
     // Hide the campaign title from links to the extra feeds.
     remove_action('wp_head', 'feed_links_extra', 3);
@@ -123,7 +117,7 @@ if (post_password_required($post->ID)) {
 } else {
     do_action('enqueue_google_tag_manager_script', $context);
     Timber::render(
-        ['single-' . $post->ID . '.twig', 'single-' . $post->post_type . '.twig', 'single.twig'],
+        ['single-' . $timber_post->ID . '.twig', 'single-' . $timber_post->post_type . '.twig', 'single.twig'],
         $context
     );
 }

--- a/single-p4_action.php
+++ b/single-p4_action.php
@@ -1,5 +1,7 @@
 <?php
 
+global $post;
+
 /**
  * The Template for displaying all action pages
  *

--- a/single-p4_action.php
+++ b/single-p4_action.php
@@ -17,33 +17,33 @@ use P4\MasterTheme\Post;
 use Timber\Timber;
 
 $context = Timber::get_context();
-$post = new Post(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-$page_meta_data = get_post_meta($post->ID);
+$timber_post = new Post($post->ID);
+$page_meta_data = get_post_meta($timber_post->ID);
 $page_meta_data = array_map(fn ($v) => reset($v), $page_meta_data);
 
 // Set GTM Data Layer values.
-$post->set_data_layer();
-$data_layer = $post->get_data_layer();
+$timber_post->set_data_layer();
+$data_layer = $timber_post->get_data_layer();
 
-Context::set_header($context, $page_meta_data, $post->title);
+Context::set_header($context, $page_meta_data, $timber_post->title);
 Context::set_background_image($context);
-Context::set_og_meta_fields($context, $post);
+Context::set_og_meta_fields($context, $timber_post);
 Context::set_campaign_datalayer($context, $page_meta_data);
-Context::set_utm_params($context, $post);
+Context::set_utm_params($context, $timber_post);
 Context::set_custom_styles($context, $page_meta_data);
 
-$context['post'] = $post;
-$context['social_accounts'] = $post->get_social_accounts($context['footer_social_menu'] ?: []);
+$context['post'] = $timber_post;
+$context['social_accounts'] = $timber_post->get_social_accounts($context['footer_social_menu'] ?: []);
 $context['page_category'] = 'Actions';
-$context['post_tags'] = implode(', ', $post->tags());
-$context['post_categories'] = implode(', ', $post->categories());
+$context['post_tags'] = implode(', ', $timber_post->tags());
+$context['post_categories'] = implode(', ', $timber_post->categories());
 $context['custom_body_classes'] = 'brown-bg ';
 
-Context::set_p4_blocks_datalayer($context, $post);
+Context::set_p4_blocks_datalayer($context, $timber_post);
 
-if (post_password_required($post->ID)) {
+if (post_password_required($timber_post->ID)) {
     // Password protected form validation.
-    $context['is_password_valid'] = $post->is_password_valid();
+    $context['is_password_valid'] = $timber_post->is_password_valid();
 
     // Hide the page title from links to the extra feeds.
     remove_action('wp_head', 'feed_links_extra', 3);
@@ -54,5 +54,5 @@ if (post_password_required($post->ID)) {
     Timber::render('single-page.twig', $context);
 } else {
     do_action('enqueue_google_tag_manager_script', $context);
-    Timber::render([ 'page-' . $post->post_name . '.twig', 'page.twig' ], $context);
+    Timber::render([ 'page-' . $timber_post->post_name . '.twig', 'page.twig' ], $context);
 }

--- a/single-p4_action.php
+++ b/single-p4_action.php
@@ -12,6 +12,10 @@
  * @since    Timber 0.1
  */
 
+if (!$post) {
+    return;
+}
+
 use P4\MasterTheme\Context;
 use P4\MasterTheme\Post;
 use Timber\Timber;

--- a/single.php
+++ b/single.php
@@ -1,5 +1,7 @@
 <?php
 
+global $post;
+
 /**
  * The Template for displaying all single posts
  *

--- a/single.php
+++ b/single.php
@@ -17,24 +17,19 @@ use Timber\Timber;
 
 // Initializing variables.
 $context = Timber::get_context();
-/**
- * P4 Post Object
- *
- * @var Post $post
- */
-$post = Timber::query_post(false, Post::class); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-$context['post'] = $post;
+$timber_post = new Post($post->ID);
+$context['post'] = $timber_post;
 
 // Set Navigation Issues links.
-$post->set_issues_links();
+$timber_post->set_issues_links();
 
 // Get the cmb2 custom fields data
 // Articles block parameters to populate the related-posts block(previously known as articles block)
 // p4_take_action_page parameter to populate the take action boxout block
 // Author override parameter. If this is set then the author profile section will not be displayed.
-$page_meta_data = get_post_meta($post->ID);
+$page_meta_data = get_post_meta($timber_post->ID);
 $page_meta_data = array_map(fn($v) => reset($v), $page_meta_data);
-$page_terms_data = get_the_terms($post, 'p4-page-type');
+$page_terms_data = get_the_terms($timber_post, 'p4-page-type');
 $page_terms_data = is_array($page_terms_data) ? reset($page_terms_data) : null;
 $context['background_image'] = $page_meta_data['p4_background_image_override'] ?? '';
 $take_action_page = $page_meta_data['p4_take_action_page'] ?? '';
@@ -42,18 +37,18 @@ $context['page_type'] = $page_terms_data->name ?? '';
 $context['page_term_id'] = $page_terms_data->term_id ?? '';
 $context['custom_body_classes'] = 'white-bg';
 $context['page_type_slug'] = $page_terms_data->slug ?? '';
-$context['social_accounts'] = $post->get_social_accounts($context['footer_social_menu'] ?: []);
+$context['social_accounts'] = $timber_post->get_social_accounts($context['footer_social_menu'] ?: []);
 $context['page_category'] = 'Post Page';
-$context['post_tags'] = implode(', ', $post->tags());
-$context['post_categories'] = implode(', ', $post->categories());
+$context['post_tags'] = implode(', ', $timber_post->tags());
+$context['post_categories'] = implode(', ', $timber_post->categories());
 // We need the explode because we want to remove "+00:00" at the end of the string.
-$context['page_date'] = explode('+', get_the_date('c', $post->ID))[0];
-$context['old_posts_archive_notice'] = $post->get_old_posts_archive_notice();
+$context['page_date'] = explode('+', get_the_date('c', $timber_post->ID))[0];
+$context['old_posts_archive_notice'] = $timber_post->get_old_posts_archive_notice();
 
-Context::set_og_meta_fields($context, $post);
+Context::set_og_meta_fields($context, $timber_post);
 Context::set_campaign_datalayer($context, $page_meta_data);
-Context::set_utm_params($context, $post);
-Context::set_reading_time_datalayer($context, $post);
+Context::set_utm_params($context, $timber_post);
+Context::set_reading_time_datalayer($context, $timber_post);
 
 $context['filter_url'] = add_query_arg(
     [
@@ -65,13 +60,13 @@ $context['filter_url'] = add_query_arg(
 );
 
 // Build the shortcode for related-posts block.
-if ('yes' === $post->include_articles) {
+if ('yes' === $timber_post->include_articles) {
     $tag_id_array = [];
-    foreach ($post->tags() as $post_tag) {
-        $tag_id_array[] = $post_tag->id;
+    foreach ($timber_post->tags() as $timber_post_tag) {
+        $tag_id_array[] = $timber_post_tag->id;
     }
     $category_id_array = [];
-    foreach ($post->terms('category') as $category) {
+    foreach ($timber_post->terms('category') as $category) {
         $category_id_array[] = $category->id;
     }
 
@@ -83,7 +78,7 @@ if ('yes' === $post->include_articles) {
                 'post_tag' => $tag_id_array,
                 'category' => $category_id_array,
             ],
-            'exclude' => [$post->ID],
+            'exclude' => [$timber_post->ID],
         ],
         'className' => 'posts-list p4-query-loop is-custom-layout-list',
         'layout' => [
@@ -93,17 +88,19 @@ if ('yes' === $post->include_articles) {
         'namespace' => 'planet4-blocks/posts-list',
     ];
 
-    $post->articles = '<!-- wp:p4/related-posts {"query_attributes" : ' . wp_json_encode($block_attributes) . '} /-->';
+    $timber_post->articles = '<!-- wp:p4/related-posts {"query_attributes" : '
+        . wp_json_encode($block_attributes) .
+    '} /-->';
 }
 
 if (! empty($take_action_page) && ! has_block('planet4-blocks/take-action-boxout')) {
-    $post->take_action_page = $take_action_page;
+    $timber_post->take_action_page = $take_action_page;
 
     $block_attributes = [
         'take_action_page' => $take_action_page,
     ];
 
-    $post->take_action_boxout = '<!-- wp:planet4-blocks/take-action-boxout '
+    $timber_post->take_action_boxout = '<!-- wp:planet4-blocks/take-action-boxout '
     . wp_json_encode($block_attributes, JSON_UNESCAPED_SLASHES)
     . ' /-->';
 }
@@ -128,21 +125,21 @@ $comments_args = [
 ];
 
 $context['comments_args'] = $comments_args;
-$context['show_comments'] = comments_open($post->ID);
+$context['show_comments'] = comments_open($timber_post->ID);
 $context['post_comments_count'] = get_comments(
     [
-        'post_id' => $post->ID,
+        'post_id' => $timber_post->ID,
         'status' => 'approve',
         'type' => 'comment',
         'count' => true,
     ]
 );
 
-Context::set_p4_blocks_datalayer($context, $post);
+Context::set_p4_blocks_datalayer($context, $timber_post);
 
-if (post_password_required($post->ID)) {
+if (post_password_required($timber_post->ID)) {
     // Password protected form validation.
-    $context['is_password_valid'] = $post->is_password_valid();
+    $context['is_password_valid'] = $timber_post->is_password_valid();
 
     // Hide the post title from links to the extra feeds.
     remove_action('wp_head', 'feed_links_extra', 3);
@@ -154,7 +151,7 @@ if (post_password_required($post->ID)) {
 } else {
     do_action('enqueue_google_tag_manager_script', $context);
     Timber::render(
-        [ 'single-' . $post->ID . '.twig', 'single-' . $post->post_type . '.twig', 'single.twig' ],
+        [ 'single-' . $timber_post->ID . '.twig', 'single-' . $timber_post->post_type . '.twig', 'single.twig' ],
         $context
     );
 }

--- a/single.php
+++ b/single.php
@@ -10,6 +10,10 @@
  * @since    Timber 0.1
  */
 
+if (!$post) {
+    return;
+}
+
 use P4\MasterTheme\Context;
 use P4\MasterTheme\Post;
 use P4\MasterTheme\Settings\CommentsGdpr;

--- a/src/BlockSettings.php
+++ b/src/BlockSettings.php
@@ -133,6 +133,7 @@ class BlockSettings
         self::CORE_BLOCKS_PREFIX . '/column',
         self::CORE_BLOCKS_PREFIX . '/cover',
         self::CORE_BLOCKS_PREFIX . '/embed',
+        self::CORE_BLOCKS_PREFIX . '/footnotes',
         self::CORE_BLOCKS_PREFIX . '/media-text',
         self::CORE_EMBED_BLOCKS_PREFIX . '/twitter',
         self::CORE_EMBED_BLOCKS_PREFIX . '/youtube',


### PR DESCRIPTION
### Summary

Ref: [PLANET-7829](https://jira.greenpeace.org/browse/PLANET-7829)

This feature was added with WordPress 6.3. For it to be rendered in the frontend, we need to use the global WP post ID to construct the Timber post.

### Testing

You can check out the Footnotes block in the various available post types:

- [Page](https://www-dev.greenpeace.org/test-tavros/about-us-2/)
- [Post](https://www-dev.greenpeace.org/test-tavros/press/1113/duis-posuere-6/)
- [Action](https://www-dev.greenpeace.org/test-tavros/petitions/consectetur-adipiscing/)
- [Campaign](https://www-dev.greenpeace.org/test-tavros/campaign/this-is-a-campaign-for-testing-purposes/)
- [Homepage](https://www-dev.greenpeace.org/test-tavros/)
- [Evergreen page](https://www-dev.greenpeace.org/test-tavros/just-an-evergreen-page/)
