### PR TITLE
Replace a fallback solution for loading a language files

### DIFF
--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -689,7 +689,8 @@ class MasterSite extends TimberSite
 
         foreach ($domains as $domain) {
             $mofile = get_template_directory() . '/languages/' . $domain . '-' . $locale . '.mo';
-            load_theme_textdomain(str_replace('blocks/', '', $domain), $mofile);
+            //TODO: Temporary fix.
+            load_textdomain(str_replace('blocks/', '', $domain), $mofile);
         }
     }
 


### PR DESCRIPTION
From wp6.7 the translation files path location change to 'wp-content/languages/themes/' for now we have keep language files in theme language folder and use load_textdomain() to load translations

### Summary

<!-- Please provide a brief summary of the change introduced in this Pull Request. -->

---

<!-- Please add a reference link to the ticket, if one exists. -->
[Ref: ](https://wordpress.org/support/topic/translations-are-no-longer-loading-from-the-theme-folder/#post-18132409)

### Testing

TBD
