### PR TITLE
PLANET-7848: Fix the error "undefined array key `post__in`"

### DIFF
--- a/src/Blocks/QueryLoopExtension.php
+++ b/src/Blocks/QueryLoopExtension.php
@@ -77,12 +77,8 @@ class QueryLoopExtension
             $query['orderby'] = 'post__in';
             $query['ignore_sticky_posts'] = true;
         }
-        if ($query['post__in'] && !empty($blockQuery['exclude'])) {
-            $excludes_posts = array_map('strval', $blockQuery['exclude']);
-            $query['post__in'] = array_values(array_diff($query['post__in'], $excludes_posts));
-        }
 
-        if (!empty($query['post__in']) && !empty($params['exclude'])) {
+        if (isset($query['post__in']) && !empty($query['post__in']) && !empty($params['exclude'])) {
             $exclude = array_map('intval', (array) $params['exclude']);
             $query['post__in'] = array_values(array_diff($query['post__in'], $exclude));
         }


### PR DESCRIPTION
### Summary

This PR removes from the `QueryLoopExtension` class a piece of code that was calling a non-existent variable.
It also adds an extra check to ensure that the variable `$query['post__in']` is set before being manipulated.

---

Ref: https://jira.greenpeace.org/browse/PLANET-7848

### Testing
In your local environment or the test instance, check both in the editor and the front-end that:
1. Query Loop blocks (existing and newly added) only query published posts (no draft, private, or password-protected) and exclude the current post.
2. Posts List blocks (existing and newly added) only query published posts (no draft, private, or password-protected) and exclude the current post.
3. Actions List blocks (existing and newly added) only query published posts (no draft, private, or password-protected) and exclude the current post. Check when the new IA is enabled and disabled.
4. Related Posts only query published posts (no draft, private, or password-protected) and exclude the current post.