### PR TITLE
Fix special characters escaping on migrations

### DIFF
--- a/src/Migrations/M051ReplaceSpecialCharactersInPostsContent.php
+++ b/src/Migrations/M051ReplaceSpecialCharactersInPostsContent.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace P4\MasterTheme\Migrations;
+
+use P4\MasterTheme\MigrationRecord;
+use P4\MasterTheme\MigrationScript;
+use WP_Query;
+
+/**
+ * Replace special characters in the posts content.
+ */
+class M051ReplaceSpecialCharactersInPostsContent extends MigrationScript
+{
+    /**
+     * Perform the actual migration.
+     *
+     * @param MigrationRecord $record Information on the execution, can be used to add logs.
+     * phpcs:disable SlevomatCodingStandard.Functions.UnusedParameter -- interface implementation
+     */
+    public static function execute(MigrationRecord $record): void
+    {
+        echo 'Replacing special characters in posts content...', "\n"; // phpcs:ignore
+
+        $post_types = array_diff(get_post_types(['public' => true], 'names'), ['archive']);
+        $paged = 1;
+        $per_page = 30;
+
+        do {
+            $query = new WP_Query([
+                'post_type' => $post_types,
+                'posts_per_page' => $per_page,
+                'paged' => $paged,
+                'post_status' => 'any',
+                'fields' => 'ids',
+            ]);
+
+            if (!$query->have_posts()) {
+                break;
+            }
+
+            foreach ($query->posts as $post_id) {
+                $content = get_post_field('post_content', $post_id);
+
+                if (empty($content)) {
+                    continue;
+                }
+
+                $updated_content = preg_replace_callback(
+                    '/\\\\?u([0-9a-fA-F]{4})/',
+                    fn ($matches) => html_entity_decode('&#x' . $matches[1] . ';', ENT_QUOTES, 'UTF-8'),
+                    $content
+                );
+
+                if ($updated_content === $content) {
+                    continue;
+                }
+
+                $result = wp_update_post([
+                    'ID' => $post_id,
+                    'post_content' => wp_slash($updated_content),
+                ]);
+
+                if (!is_wp_error($result) && $result > 0) {
+                    echo "Post updated successfully: ID ", $post_id, "\n"; // phpcs:ignore
+                } else {
+                    echo "Failed to update post: ID ", $post_id, "\n"; // phpcs:ignore
+                }
+            }
+
+            $paged++;
+            wp_reset_postdata();
+        } while ($query->found_posts > ($paged - 1) * $per_page);
+    }
+    // phpcs:enable SlevomatCodingStandard.Functions.UnusedParameter
+}

--- a/src/Migrations/Utils/Functions.php
+++ b/src/Migrations/Utils/Functions.php
@@ -78,7 +78,8 @@ class Functions
                 );
 
                 // Update the post with the replaced blocks.
-                $result = wp_update_post($post_update);
+                $post_update_slashed = wp_slash($post_update);
+                $result = wp_update_post($post_update_slashed);
 
                 if ($result === 0) {
                     throw new \Exception("There was an error trying to update the post #" . $current_post_id);

--- a/src/Migrator.php
+++ b/src/Migrator.php
@@ -52,6 +52,7 @@ use P4\MasterTheme\Migrations\M047EnableTransparentNavigation;
 use P4\MasterTheme\Migrations\M048SetDefaultTaxonomyBreadcrumb;
 use P4\MasterTheme\Migrations\M049MigrateCoversBlockToActionsListBlock;
 use P4\MasterTheme\Migrations\M050AddTagsBackInPostsListBlock;
+use P4\MasterTheme\Migrations\M051ReplaceSpecialCharactersInPostsContent;
 
 /**
  * Run any new migration scripts and record results in the log.
@@ -121,6 +122,7 @@ class Migrator
             M048SetDefaultTaxonomyBreadcrumb::class,
             M049MigrateCoversBlockToActionsListBlock::class,
             M050AddTagsBackInPostsListBlock::class,
+            M051ReplaceSpecialCharactersInPostsContent::class,
         ];
 
         // Loop migrations and run those that haven't run yet.


### PR DESCRIPTION
### Summary

This PR includes the `wp_slash` function as part of the migrations script to escape the post content correctly.
It also duplicates the `M040` migration to replace special characters again. However, the new migration was slightly modified as it proved to be unsuccessful in replacing content [here](https://www-dev.greenpeace.org/norway/klimaendringer/). The following piece of code was replaced in the new migration script:

Before:
```php
$updated_content = preg_replace('/(?<!\\\\)u003c/', '\u003c', $content);
$updated_content = preg_replace('/(?<!\\\\)u003e/', '\u003e', $updated_content);
$updated_content = preg_replace('/(?<!\\\\)u0022/', '\u0022', $updated_content);
```

Now:
```php
$updated_content = preg_replace_callback(
         '/\\\\?u([0-9a-fA-F]{4})/',
          fn ($matches) => html_entity_decode('&#x' . $matches[1] . ';', ENT_QUOTES, 'UTF-8'),
          $content
);
```

---

### Testing

1. Run this branch on your local instance.
2. Reset the database by running `npm run db:reset`
3. Add content to a post or page with special characters (you can use the block code at the end of this message).
4. Run the migration script: `npx wp-env run cli wp p4-run-activator` 
5. Check that the replacement worked as expected.

```
<!-- wp:paragraph {"placeholder":"Enter description","lock":{"move":true},"style":{"spacing":{"margin":{"top":"24px","bottom":"32px"}}}} -->
<p style="margin-top:24px;margin-bottom:32px">- Prøv å være bevisst på hvordan du reiser. Gjør reisen til en del av ferien! Bruk mindre fly og bil og mer buss, tog og sykkel når det er mulig. Bruk ferier på å utforske Norge og nærområder, fremfor å fly til utlandet. u003cbru003e- Spis mer grønt og mindre kjøtt. u003cbru003e- Snakk med venner og kjente om temaet. u003cbru003eu003cbru003eSamtidig som du kan gjøre mye i hverdagen for å leve mer klimanøytralt, er noe av det viktigste du kan gjøre, å bli med og legge press på politikere og næringsliv. I Greenpeace fokuserer vi aller mest på ansvaret politikerne og andre makthavere har for å redusere CO2-utslippene. Politikerne sitter på makten til å regulere klimaskadelige industrier og innføre miljø- og klimavennlige tiltak og lover.  Du kan bidra gjennom å:u003cbru003eu003cbru003e- skrive under på oppropu003cbru003e- støtte en miljøorganisasjonu003cbru003e- delta i demonstrasjoner og debatter om temaet, eller arrangere din egenu003cbru003e- engasjere deg på sosiale medier eller skrive leserinnleggu003cbru003e- løfte temaet på jobb, skole eller i foreninger du er med iu003cbru003e- kontakte politikerne (lokalt eller nasjonalt) og delta i demokratiske prosesser som folkemøter og valgu003cbru003e- bruke makten din som forbruker – kontakt selskaper og krev at de forbedrer segu003cbru003e- Stem på et parti med god politikk for klima og miljø. Se vår u003ca href=u0022https://www-dev.greenpeace.org/norway/klimaendringer/valg-2025-gronne-partier-som-er-best-pa-klima-og-miljo/u0022u003evelgerguide før stortingsvalget 2025 heru003c/au003e.u003cbru003eu003cbru003eEngasjer deg sammen med oss i Greenpeace:</p>
<!-- /wp:paragraph -->
``` 
