### PR TITLE
PLANET-7828: Add Task Type field

### DIFF
--- a/assets/src/block-editor/Sidebar/ActionSidebar.js
+++ b/assets/src/block-editor/Sidebar/ActionSidebar.js
@@ -1,12 +1,14 @@
 import {NavigationType} from '../NavigationType/NavigationType';
 import {CheckboxSidebarField} from '../SidebarFields/CheckboxSidebarField';
 import {TextSidebarField} from '../SidebarFields/TextSidebarField';
+import {SelectSidebarField} from '../SidebarFields/SelectSidebarField';
 import {getSidebarFunctions} from './getSidebarFunctions';
 
 const FIELD_NAVTYPE = 'nav_type';
 const HIDE_PAGE_TITLE = 'p4_hide_page_title_checkbox';
 const BUTTON_TEXT = 'action_button_text';
 const BUTTON_ACCESSIBILITY_TEXT = 'action_button_accessibility_text';
+const TASK_TYPE = 'action_task_type';
 
 const {__} = wp.i18n;
 const {PluginDocumentSettingPanel} = wp.editor;
@@ -21,6 +23,23 @@ export const ActionSidebar = {
 
     return (
       <>
+        {Boolean(window.p4_vars.features.action_options) && (
+          <>
+            <PluginDocumentSettingPanel
+              name="action-options-panel"
+              title={__('Action Options', 'planet4-blocks-backend')}
+            >
+              <SelectSidebarField
+                label={__('Task Type', 'planet4-master-theme-backend')}
+                options={[
+                  {label: __('- Select Task Type -', 'planet4-blocks-backend'), value: 'not set'},
+                  {label: __('Do it Online', 'planet4-blocks-backend'), value: 'online'},
+                  {label: __('Do it IRL', 'planet4-blocks-backend'), value: 'irl'},
+                ]}
+                {...getParams(TASK_TYPE)}/>
+            </PluginDocumentSettingPanel>
+          </>
+        )}
         <PluginDocumentSettingPanel
           name="page-header-panel"
           title={__('Page header', 'planet4-blocks-backend')}

--- a/assets/src/block-editor/Sidebar/ActionSidebar.js
+++ b/assets/src/block-editor/Sidebar/ActionSidebar.js
@@ -8,7 +8,7 @@ const FIELD_NAVTYPE = 'nav_type';
 const HIDE_PAGE_TITLE = 'p4_hide_page_title_checkbox';
 const BUTTON_TEXT = 'action_button_text';
 const BUTTON_ACCESSIBILITY_TEXT = 'action_button_accessibility_text';
-const TASK_TYPE = 'action_task_type';
+const TASK_TYPE = 'actions_task_type';
 
 const {__} = wp.i18n;
 const {PluginDocumentSettingPanel} = wp.editor;
@@ -23,7 +23,7 @@ export const ActionSidebar = {
 
     return (
       <>
-        {Boolean(window.p4_vars.features.action_options) && (
+        {Boolean(window.p4_vars.features.actions_task_type) && (
           <>
             <PluginDocumentSettingPanel
               name="action-options-panel"

--- a/src/ActionPage.php
+++ b/src/ActionPage.php
@@ -219,6 +219,14 @@ class ActionPage
             )
         );
 
+        register_post_meta(
+            self::POST_TYPE,
+            'action_task_type',
+            array_merge(
+                $args,
+            )
+        );
+
         foreach (self::META_FIELDS as $field) {
             register_post_meta(self::POST_TYPE, $field, $args);
         }

--- a/src/ActionPage.php
+++ b/src/ActionPage.php
@@ -221,7 +221,7 @@ class ActionPage
 
         register_post_meta(
             self::POST_TYPE,
-            'action_task_type',
+            'actions_task_type',
             array_merge(
                 $args,
             )

--- a/src/Features/ActionOptions.php
+++ b/src/Features/ActionOptions.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace P4\MasterTheme\Features;
+
+use P4\MasterTheme\Feature;
+
+/**
+ * @see description().
+ */
+class ActionOptions extends Feature
+{
+    /**
+     * @inheritDoc
+     */
+    public static function id(): string
+    {
+        return 'action_options';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected static function name(): string
+    {
+        return __('Action Options', 'planet4-master-theme-backend');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected static function description(): string
+    {
+        return __(
+            // phpcs:ignore Generic.Files.LineLength.MaxExceeded
+            'Adds options for showing whether an Action is either Online or IRL and deadline on Actions List block',
+            'planet4-master-theme-backend',
+        );
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function show_toggle_production(): bool
+    {
+        return true;
+    }
+}

--- a/src/Features/ActionsTaskType.php
+++ b/src/Features/ActionsTaskType.php
@@ -7,14 +7,14 @@ use P4\MasterTheme\Feature;
 /**
  * @see description().
  */
-class ActionOptions extends Feature
+class ActionsTaskType extends Feature
 {
     /**
      * @inheritDoc
      */
     public static function id(): string
     {
-        return 'action_options';
+        return 'actions_task_type';
     }
 
     /**
@@ -22,7 +22,7 @@ class ActionOptions extends Feature
      */
     protected static function name(): string
     {
-        return __('Action Options', 'planet4-master-theme-backend');
+        return __('Actions Task Type', 'planet4-master-theme-backend');
     }
 
     /**
@@ -32,7 +32,7 @@ class ActionOptions extends Feature
     {
         return __(
             // phpcs:ignore Generic.Files.LineLength.MaxExceeded
-            'Adds options for showing whether an Action is either Online or IRL and deadline on Actions List block',
+            'Adds option for showing whether an Action is either Online or IRL on Actions List block',
             'planet4-master-theme-backend',
         );
     }

--- a/src/Settings/Features.php
+++ b/src/Settings/Features.php
@@ -11,7 +11,7 @@ use P4\MasterTheme\Features\LazyYoutubePlayer;
 use P4\MasterTheme\Features\RedirectRedirectPages;
 use P4\MasterTheme\Features\Planet4Blocks;
 use P4\MasterTheme\Features\OldPostsArchiveNotice;
-use P4\MasterTheme\Features\ActionOptions;
+use P4\MasterTheme\Features\ActionsTaskType;
 use P4\MasterTheme\Loader;
 use P4\MasterTheme\Settings;
 use CMB2;
@@ -100,7 +100,7 @@ class Features
             RedirectRedirectPages::class,
             Planet4Blocks::class,
             OldPostsArchiveNotice::class,
-            ActionOptions::class,
+            ActionsTaskType::class,
 
             // Dev only.
             DisableDataSync::class,

--- a/src/Settings/Features.php
+++ b/src/Settings/Features.php
@@ -11,6 +11,7 @@ use P4\MasterTheme\Features\LazyYoutubePlayer;
 use P4\MasterTheme\Features\RedirectRedirectPages;
 use P4\MasterTheme\Features\Planet4Blocks;
 use P4\MasterTheme\Features\OldPostsArchiveNotice;
+use P4\MasterTheme\Features\ActionOptions;
 use P4\MasterTheme\Loader;
 use P4\MasterTheme\Settings;
 use CMB2;
@@ -99,6 +100,7 @@ class Features
             RedirectRedirectPages::class,
             Planet4Blocks::class,
             OldPostsArchiveNotice::class,
+            ActionOptions::class,
 
             // Dev only.
             DisableDataSync::class,


### PR DESCRIPTION
### Summary
This will allow to editor to set the action page as In Real Life or Online.
Also it will used by the Resistance Hub campaign page.

Related PRs:
- #2670 
- Full implementation #2656 

---

<!-- Please add a reference link to the ticket, if one exists. -->
Ref: [PLANET-7828](https://jira.greenpeace.org/browse/PLANET-7828)

### Testing
1. Go to [`Planet 4/Features`](https://www-dev.greenpeace.org/test-venus/wp-admin/admin.php?page=planet4_settings_features) and enable `Action Options`
2. If it's enabled, the can create or edit any Action page and set the Task Type of right panel
