### PR TITLE
PLANET-7841: Add Action Deadline field

### DIFF
--- a/assets/src/block-editor/Sidebar/ActionSidebar.js
+++ b/assets/src/block-editor/Sidebar/ActionSidebar.js
@@ -2,8 +2,10 @@ import {NavigationType} from '../NavigationType/NavigationType';
 import {CheckboxSidebarField} from '../SidebarFields/CheckboxSidebarField';
 import {TextSidebarField} from '../SidebarFields/TextSidebarField';
 import {SelectSidebarField} from '../SidebarFields/SelectSidebarField';
+import {DatePickerSidebarField} from '../SidebarFields/DatePickerSidebarField';
 import {getSidebarFunctions} from './getSidebarFunctions';
 
+const DEADLINE = 'action_deadline';
 const FIELD_NAVTYPE = 'nav_type';
 const HIDE_PAGE_TITLE = 'p4_hide_page_title_checkbox';
 const BUTTON_TEXT = 'action_button_text';
@@ -21,14 +23,17 @@ export const ActionSidebar = {
   render: () => {
     const {getParams} = getSidebarFunctions();
 
+    const isTaskTypeEnabled = Boolean(window.p4_vars.features.actions_task_type);
+    const isDeadlineEnabled = Boolean(window.p4_vars.features.actions_deadline);
+
     return (
       <>
-        {Boolean(window.p4_vars.features.actions_task_type) && (
-          <>
-            <PluginDocumentSettingPanel
-              name="action-options-panel"
-              title={__('Action Options', 'planet4-blocks-backend')}
-            >
+        {(isTaskTypeEnabled || isDeadlineEnabled) && (
+          <PluginDocumentSettingPanel
+            name="action-options-panel"
+            title={__('Action Options', 'planet4-blocks-backend')}
+          >
+            {isTaskTypeEnabled && (
               <SelectSidebarField
                 label={__('Task Type', 'planet4-master-theme-backend')}
                 options={[
@@ -36,9 +41,17 @@ export const ActionSidebar = {
                   {label: __('Do it Online', 'planet4-blocks-backend'), value: 'online'},
                   {label: __('Do it IRL', 'planet4-blocks-backend'), value: 'irl'},
                 ]}
-                {...getParams(TASK_TYPE)}/>
-            </PluginDocumentSettingPanel>
-          </>
+                {...getParams(TASK_TYPE)}
+              />)}
+            {isDeadlineEnabled && (
+              <DatePickerSidebarField
+                id={DEADLINE}
+                label={__('Deadline Date', 'planet4-master-theme-backend')}
+                forceEndDate={true}
+                {...getParams(DEADLINE)}
+              />
+            )}
+          </PluginDocumentSettingPanel>
         )}
         <PluginDocumentSettingPanel
           name="page-header-panel"

--- a/assets/src/block-editor/Sidebar/ActionSidebar.js
+++ b/assets/src/block-editor/Sidebar/ActionSidebar.js
@@ -5,12 +5,12 @@ import {SelectSidebarField} from '../SidebarFields/SelectSidebarField';
 import {DatePickerSidebarField} from '../SidebarFields/DatePickerSidebarField';
 import {getSidebarFunctions} from './getSidebarFunctions';
 
-const DEADLINE = 'action_deadline';
 const FIELD_NAVTYPE = 'nav_type';
 const HIDE_PAGE_TITLE = 'p4_hide_page_title_checkbox';
 const BUTTON_TEXT = 'action_button_text';
 const BUTTON_ACCESSIBILITY_TEXT = 'action_button_accessibility_text';
 const TASK_TYPE = 'actions_task_type';
+const DEADLINE = 'actions_deadline';
 
 const {__} = wp.i18n;
 const {PluginDocumentSettingPanel} = wp.editor;
@@ -31,8 +31,7 @@ export const ActionSidebar = {
         {(isTaskTypeEnabled || isDeadlineEnabled) && (
           <PluginDocumentSettingPanel
             name="action-options-panel"
-            title={__('Action Options', 'planet4-blocks-backend')}
-          >
+            title={__('Action Options', 'planet4-blocks-backend')}>
             {isTaskTypeEnabled && (
               <SelectSidebarField
                 label={__('Task Type', 'planet4-master-theme-backend')}

--- a/assets/src/block-editor/SidebarFields/DatePickerSidebarField.js
+++ b/assets/src/block-editor/SidebarFields/DatePickerSidebarField.js
@@ -6,6 +6,11 @@ export const DatePickerSidebarField = ({id, value, setValue, label, forceEndDate
       id={id}
       currentDate={value}
       onChange={date => {
+        if(date === value) {
+          setValue(null);
+          return;
+        }
+
         if(forceEndDate) {
           setValue(`${date.slice(0,10)+'T23:59:59'}`);
         } else {

--- a/assets/src/block-editor/SidebarFields/DatePickerSidebarField.js
+++ b/assets/src/block-editor/SidebarFields/DatePickerSidebarField.js
@@ -11,11 +11,7 @@ export const DatePickerSidebarField = ({id, value, setValue, label, forceEndDate
           return;
         }
 
-        if(forceEndDate) {
-          setValue(`${date.slice(0,10)+'T23:59:59'}`);
-        } else {
-          setValue(date);
-        }
+        setValue(forceEndDate ? `${date.slice(0,10)+'T23:59:59'}` : date);
       }}
       __nextHasNoMarginBottom
     />

--- a/assets/src/block-editor/SidebarFields/DatePickerSidebarField.js
+++ b/assets/src/block-editor/SidebarFields/DatePickerSidebarField.js
@@ -1,0 +1,18 @@
+const {DatePicker, BaseControl} = wp.components;
+
+export const DatePickerSidebarField = ({id, value, setValue, label, forceEndDate = false}) => (
+  <BaseControl id={id} label={label}>
+    <DatePicker
+      id={id}
+      currentDate={value}
+      onChange={date => {
+        if(forceEndDate) {
+          setValue(`${date.slice(0,10)+'T23:59:59'}`);
+        } else {
+          setValue(date);
+        }
+      }}
+      __nextHasNoMarginBottom
+    />
+  </BaseControl>
+);

--- a/src/ActionPage.php
+++ b/src/ActionPage.php
@@ -227,6 +227,14 @@ class ActionPage
             )
         );
 
+        register_post_meta(
+            self::POST_TYPE,
+            'action_deadline',
+            array_merge(
+                $args,
+            )
+        );
+
         foreach (self::META_FIELDS as $field) {
             register_post_meta(self::POST_TYPE, $field, $args);
         }

--- a/src/ActionPage.php
+++ b/src/ActionPage.php
@@ -229,7 +229,7 @@ class ActionPage
 
         register_post_meta(
             self::POST_TYPE,
-            'action_deadline',
+            'actions_deadline',
             array_merge(
                 $args,
             )

--- a/src/Features/ActionsDeadline.php
+++ b/src/Features/ActionsDeadline.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace P4\MasterTheme\Features;
+
+use P4\MasterTheme\Feature;
+
+/**
+ * @see description().
+ */
+class ActionsDeadline extends Feature
+{
+    /**
+     * @inheritDoc
+     */
+    public static function id(): string
+    {
+        return 'actions_deadline';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected static function name(): string
+    {
+        return __('Actions Deadline', 'planet4-master-theme-backend');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected static function description(): string
+    {
+        return __(
+            // phpcs:ignore Generic.Files.LineLength.MaxExceeded
+            'Adds option for showing a countdown on Actions List block',
+            'planet4-master-theme-backend',
+        );
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function show_toggle_production(): bool
+    {
+        return true;
+    }
+}

--- a/src/Settings/Features.php
+++ b/src/Settings/Features.php
@@ -12,6 +12,7 @@ use P4\MasterTheme\Features\RedirectRedirectPages;
 use P4\MasterTheme\Features\Planet4Blocks;
 use P4\MasterTheme\Features\OldPostsArchiveNotice;
 use P4\MasterTheme\Features\ActionsTaskType;
+use P4\MasterTheme\Features\ActionsDeadline;
 use P4\MasterTheme\Loader;
 use P4\MasterTheme\Settings;
 use CMB2;
@@ -101,6 +102,7 @@ class Features
             Planet4Blocks::class,
             OldPostsArchiveNotice::class,
             ActionsTaskType::class,
+            ActionsDeadline::class,
 
             // Dev only.
             DisableDataSync::class,


### PR DESCRIPTION
### Summary
This will allow editors to set the Deadline field on Actions It works only if Actions Options is enabled from P4 Features.

### Related PRs
- Blocked by #2669 
- Full implementation #2656 
---

<!-- Please add a reference link to the ticket, if one exists. -->
Ref: https://jira.greenpeace.org/browse/PLANET-7841

### Testing
1. Go to Planet 4/Features and enable Action Options
2. If it's enabled, the can create or edit any Action page and set the Deadline from right panel

 
