### PR TITLE
PLANET-7857 Adjust See All link based on taxonomy filters

### DIFF
--- a/assets/src/block-editor/QueryLoopBlockExtension/index.js
+++ b/assets/src/block-editor/QueryLoopBlockExtension/index.js
@@ -206,18 +206,19 @@ export const setupQueryLoopBlockExtension = () => {
 
         // Update the News & Stories link based on the taxonomy filters selected in Posts List.
         useEffect(() => {
-          if (newsPageLink && selectedBlock && namespace === POSTS_LIST_BLOCK_NAME) {
-            const newsStoriesLinks = findNewsStoriesLinks(selectedBlock.innerBlocks);
-            if (!newsStoriesLinks.length) {
-              return;
-            }
-            const oldTaxonomies = selectedBlock.attributes.query.taxQuery || null;
-            const newTaxonomies = query.taxQuery || null;
-            if (!areTaxonomiesDifferent(oldTaxonomies, newTaxonomies)) {
-              return;
-            }
-            newsStoriesLinks.forEach(link => link.attributes.url = buildCustomNewsPageLinkFromTaxonomies(TAXONOMIES, newTaxonomies));
+          if (!newsPageLink || !selectedBlock || namespace !== POSTS_LIST_BLOCK_NAME) {
+            return;
           }
+          const newsStoriesLinks = findNewsStoriesLinks(selectedBlock.innerBlocks);
+          if (!newsStoriesLinks.length) {
+            return;
+          }
+          const oldTaxonomies = selectedBlock.attributes.query.taxQuery || null;
+          const newTaxonomies = query.taxQuery || null;
+          if (!areTaxonomiesDifferent(oldTaxonomies, newTaxonomies)) {
+            return;
+          }
+          newsStoriesLinks.forEach(link => link.attributes.url = buildCustomNewsPageLinkFromTaxonomies(TAXONOMIES, newTaxonomies));
         }, [attributes]);
 
         useEffect(() => {

--- a/assets/src/block-editor/QueryLoopBlockExtension/index.js
+++ b/assets/src/block-editor/QueryLoopBlockExtension/index.js
@@ -62,41 +62,23 @@ const buildCustomNewsPageLinkFromTaxonomies = (allTaxonomies, selected) => {
 };
 
 /**
- * Find all the "News & Stories" links within the Posts List inner blocks.
- *
- * @param {Array} innerBlocks - The list of inner blocks.
- *
- * @return {Array} - All the "News & Stories" links.
- */
-const findNewsStoriesLinks = innerBlocks => {
-  const links = [];
-  addNewsStoriesLink(0, innerBlocks, links);
-  return links;
-};
-
-/**
  * Add "News & Stories" links one by one, recursively looking through inner blocks.
  *
- * @param {number} index       - The index of the block currently being checked.
- * @param {Array}  innerBlocks - The inner blocks.
- * @param {Array}  links       - The links that have already been found.
+ * @param {Array} innerBlocks - The inner blocks.
+ * @param {Array} links       - The links that have already been found.
  */
-const addNewsStoriesLink = (index, innerBlocks, links) => {
-  if (index >= innerBlocks.length) {
-    return;
+const addNewsStoriesLink = (innerBlocks, links) => innerBlocks.forEach(innerBlock => {
+  if (
+    innerBlock.name === 'core/navigation-link' &&
+    innerBlock.attributes?.className === 'see-all-link'
+  ) {
+    links.push(innerBlock);
   }
 
-  innerBlocks.forEach(innerBlock => {
-    if (innerBlock.name === 'core/navigation-link' && innerBlock.attributes.className === 'see-all-link') {
-      links.push(innerBlock);
-    }
-    if (innerBlock.innerBlocks?.length > 0) {
-      addNewsStoriesLink(0, innerBlock.innerBlocks, links);
-    } else {
-      addNewsStoriesLink(index + 1, innerBlocks, links);
-    }
-  });
-};
+  if (innerBlock.innerBlocks?.length > 0) {
+    addNewsStoriesLink(innerBlock.innerBlocks, links);
+  }
+});
 
 /**
  * Sets up our custom implementation of the Query Loop block in the editor.
@@ -206,10 +188,12 @@ export const setupQueryLoopBlockExtension = () => {
 
         // Update the News & Stories link based on the taxonomy filters selected in Posts List.
         useEffect(() => {
-          if (!newsPageLink || !selectedBlock || namespace !== POSTS_LIST_BLOCK_NAME) {
+          if (!newsPageLink || !selectedBlock || namespace !== POSTS_LIST_BLOCK_NAME || !selectedBlock.innerBlocks) {
             return;
           }
-          const newsStoriesLinks = findNewsStoriesLinks(selectedBlock.innerBlocks);
+          const newsStoriesLinks = [];
+          addNewsStoriesLink(selectedBlock.innerBlocks, newsStoriesLinks);
+
           if (!newsStoriesLinks.length) {
             return;
           }

--- a/assets/src/block-editor/QueryLoopBlockExtension/index.js
+++ b/assets/src/block-editor/QueryLoopBlockExtension/index.js
@@ -25,20 +25,9 @@ const areTaxonomiesDifferent = (tax1, tax2) => {
     return true;
   }
 
-  let different = false;
-  if (tax1.post_tag && tax2.post_tag) {
-    different = tax1.post_tag.length !== tax2.post_tag.length;
-  }
-
-  if (tax1['p4-page-type'] && tax2['p4-page-type'] && !different) {
-    different = tax1['p4-page-type'].length !== tax2['p4-page-type'].length;
-  }
-
-  if (tax1.category && tax2.category && !different) {
-    different = tax1.category.length !== tax2.category.length;
-  }
-
-  return different;
+  return tax1?.post_tag?.length !== tax2?.post_tag?.length ||
+    tax1['p4-page-type']?.length !== tax2['p4-page-type']?.length ||
+    tax1?.category?.length !== tax2?.category?.length;
 };
 
 const targetP4Blocks = [ACTIONS_LIST_BLOCK_NAME, POSTS_LIST_BLOCK_NAME];
@@ -98,7 +87,7 @@ export const setupQueryLoopBlockExtension = () => {
           }
 
           // Remove the '&' character at the end if needed.
-          return customSeeAllLink.slice(-1) === '&' ? customSeeAllLink.slice(0, -1) : customSeeAllLink;
+          return customSeeAllLink.endsWith('&') ? customSeeAllLink.slice(0, -1) : customSeeAllLink;
         };
 
         const [postTemplate, setPostTemplate] = useState();

--- a/assets/src/block-editor/QueryLoopBlockExtension/index.js
+++ b/assets/src/block-editor/QueryLoopBlockExtension/index.js
@@ -34,6 +34,34 @@ const targetP4Blocks = [ACTIONS_LIST_BLOCK_NAME, POSTS_LIST_BLOCK_NAME];
 const newsPageLink = window.p4_vars.news_page_link;
 
 /**
+ * Build a custom "see all" link url based on selected taxonomy filters.
+ *
+ * @param {Array} allTaxonomies - All the available taxonomies.
+ * @param {Array} selected      - The selected taxonomy filters.
+ *
+ * @return {string} - The new "see all" link url.
+ */
+const buildCustomNewsPageLinkFromTaxonomies = (allTaxonomies, selected) => {
+  if (!selected) {
+    return newsPageLink;
+  }
+  let customSeeAllLink = newsPageLink + '?';
+  const {category, post_tag, 'p4-page-type': postType} = selected;
+  if (category?.length) {
+    customSeeAllLink += `category=${allTaxonomies.categories.find(cat => cat.id === category[0]).slug}&`;
+  }
+  if (post_tag?.length) {
+    customSeeAllLink += `tag=${allTaxonomies.tags.find(tag => tag.id === post_tag[0]).slug}&`;
+  }
+  if (postType?.length) {
+    customSeeAllLink += `post-type=${allTaxonomies.postTypes.find(pt => pt.id === postType[0]).slug}`;
+  }
+
+  // Remove the '&' character at the end if needed.
+  return customSeeAllLink.endsWith('&') ? customSeeAllLink.slice(0, -1) : customSeeAllLink;
+};
+
+/**
  * Sets up our custom implementation of the Query Loop block in the editor.
  */
 export const setupQueryLoopBlockExtension = () => {
@@ -62,33 +90,6 @@ export const setupQueryLoopBlockExtension = () => {
             categories: select('core').getEntityRecords('taxonomy', 'category') || [],
           };
         });
-
-        /**
-         * Build a custom "see all" link url based on selected taxonomy filters.
-         *
-         * @param {Array} taxonomies - The taxonomy filters.
-         *
-         * @return {string} - The new "see all" link url.
-         */
-        const buildCustomNewsPageLinkFromTaxonomies = taxonomies => {
-          if (!taxonomies) {
-            return newsPageLink;
-          }
-          let customSeeAllLink = newsPageLink + '?';
-          const {category, post_tag, 'p4-page-type': postType} = taxonomies;
-          if (category?.length) {
-            customSeeAllLink += `category=${TAXONOMIES.categories.find(cat => cat.id === category[0]).slug}&`;
-          }
-          if (post_tag?.length) {
-            customSeeAllLink += `tag=${TAXONOMIES.tags.find(tag => tag.id === post_tag[0]).slug}&`;
-          }
-          if (postType?.length) {
-            customSeeAllLink += `post-type=${TAXONOMIES.postTypes.find(pt => pt.id === postType[0]).slug}`;
-          }
-
-          // Remove the '&' character at the end if needed.
-          return customSeeAllLink.endsWith('&') ? customSeeAllLink.slice(0, -1) : customSeeAllLink;
-        };
 
         const [postTemplate, setPostTemplate] = useState();
         const [selectedBlock, setSelectedBlock] = useState();
@@ -176,7 +177,7 @@ export const setupQueryLoopBlockExtension = () => {
             if (!areTaxonomiesDifferent(oldTaxonomies, newTaxonomies)) {
               return;
             }
-            seeAllLink.attributes.url = buildCustomNewsPageLinkFromTaxonomies(newTaxonomies);
+            seeAllLink.attributes.url = buildCustomNewsPageLinkFromTaxonomies(TAXONOMIES, newTaxonomies);
           }
         }, [attributes]);
 

--- a/assets/src/block-editor/QueryLoopBlockExtension/index.js
+++ b/assets/src/block-editor/QueryLoopBlockExtension/index.js
@@ -122,9 +122,9 @@ export const setupQueryLoopBlockExtension = () => {
          */
         const TAXONOMIES = useSelect(select => {
           const core = select('core');
-          const postTypes = core.getEntityRecords('taxonomy', 'p4-page-type') || [];
-          const tags = core.getEntityRecords('taxonomy', 'post_tag') || [];
-          const categories = core.getEntityRecords('taxonomy', 'category') || [];
+          const postTypes = core.getEntityRecords('taxonomy', 'p4-page-type', {per_page: -1}) || [];
+          const tags = core.getEntityRecords('taxonomy', 'post_tag', {per_page: -1}) || [];
+          const categories = core.getEntityRecords('taxonomy', 'category', {per_page: -1}) || [];
 
           return {postTypes, tags, categories};
         },

--- a/assets/src/block-editor/QueryLoopBlockExtension/index.js
+++ b/assets/src/block-editor/QueryLoopBlockExtension/index.js
@@ -57,8 +57,8 @@ const buildCustomNewsPageLinkFromTaxonomies = (allTaxonomies, selected) => {
     customSeeAllLink += `post-type=${allTaxonomies.postTypes.find(pt => pt.id === postType[0]).slug}`;
   }
 
-  // Remove the '&' character at the end if needed.
-  return customSeeAllLink.endsWith('&') ? customSeeAllLink.slice(0, -1) : customSeeAllLink;
+  // Remove the '&' or '?' character at the end if needed.
+  return customSeeAllLink.endsWith('&') || customSeeAllLink.endsWith('?') ? customSeeAllLink.slice(0, -1) : customSeeAllLink;
 };
 
 /**
@@ -84,12 +84,14 @@ export const setupQueryLoopBlockExtension = () => {
          * All the taxonomy filters that are available for the Query Loop block.
          */
         const TAXONOMIES = useSelect(select => {
-          return {
-            postTypes: select('core').getEntityRecords('taxonomy', 'p4-page-type') || [],
-            tags: select('core').getEntityRecords('taxonomy', 'post_tag') || [],
-            categories: select('core').getEntityRecords('taxonomy', 'category') || [],
-          };
-        });
+          const core = select('core');
+          const postTypes = core.getEntityRecords('taxonomy', 'p4-page-type') || [];
+          const tags = core.getEntityRecords('taxonomy', 'post_tag') || [];
+          const categories = core.getEntityRecords('taxonomy', 'category') || [];
+
+          return {postTypes, tags, categories};
+        },
+        []);
 
         const [postTemplate, setPostTemplate] = useState();
         const [selectedBlock, setSelectedBlock] = useState();
@@ -167,7 +169,7 @@ export const setupQueryLoopBlockExtension = () => {
 
         // Update the News & Stories link based on the taxonomy filters selected in Posts List.
         useEffect(() => {
-          if (newsPageLink && selectedBlock && namespace === 'planet4-blocks/posts-list') {
+          if (newsPageLink && selectedBlock && namespace === POSTS_LIST_BLOCK_NAME) {
             const seeAllLink = selectedBlock.innerBlocks.find(block => block.name === 'core/navigation-link');
             if (!seeAllLink) {
               return;

--- a/assets/src/block-editor/QueryLoopBlockExtension/index.js
+++ b/assets/src/block-editor/QueryLoopBlockExtension/index.js
@@ -96,7 +96,9 @@ export const setupQueryLoopBlockExtension = () => {
           if (postType?.length) {
             customSeeAllLink += `post-type=${TAXONOMIES.postTypes.find(pt => pt.id === postType[0]).slug}`;
           }
-          return customSeeAllLink;
+
+          // Remove the '&' character at the end if needed.
+          return customSeeAllLink.slice(-1) === '&' ? customSeeAllLink.slice(0, -1) : customSeeAllLink;
         };
 
         const [postTemplate, setPostTemplate] = useState();


### PR DESCRIPTION
### Summary

**Ref:** [PLANET-7857](https://jira.greenpeace.org/browse/PLANET-7857)

**Related PR:** https://github.com/greenpeace/planet4-master-theme/pull/2677 (migration script for existing blocks)

### Testing

On local or on the test instance, add a Posts List block to a page and update the taxonomy filters in the sidebar. After doing so, check in the editor that the corresponding "see all" link has been updated, save the page and make sure that the custom link also shows in the frontend.