### PR TITLE
Migrate posts without title

### DIFF
--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -501,6 +501,11 @@ class MasterSite extends TimberSite
      */
     public static function require_post_title(array $data): ?array
     {
+        // Skip the post title requirement if the global variable is set.
+        if (!empty($GLOBALS['p4_skip_require_post_title'])) {
+            return $data;
+        }
+
         $types = Search\Filters\ContentTypes::get_all();
         if (
             empty($data['post_title'])

--- a/src/Migrations/Utils/Functions.php
+++ b/src/Migrations/Utils/Functions.php
@@ -41,6 +41,11 @@ class Functions
 
             $parser = new WP_Block_Parser();
 
+            // Set a global variable to skip the post title requirement.
+            // This is necessary to avoid the "Title is a required field" error when updating posts
+            // that do not have a title, which is common in migrations.
+            $GLOBALS['p4_skip_require_post_title'] = true;
+
             foreach ($posts as $post) {
                 try {
                     if (empty($post->post_content)) {
@@ -97,6 +102,9 @@ class Functions
                     continue;
                 }
             }
+
+            // Remove the global variable to skip the post title requirement.
+            unset($GLOBALS['p4_skip_require_post_title']);
         } catch (\Throwable $e) {
             echo "Migration wasn't executed for block: ", $block_name ?? 'unknown', "\n";
             echo $e->getMessage(), "\n";


### PR DESCRIPTION
### Summary

This PR enables the migration of posts and pages without titles.
To do so, the `MasterSite:require_post_title` function checks if the `p4_skip_require_post_title` global variable is defined and not empty. That variable is temporarily created during the migration process and then unset at the end of it.

---

### Testing

1. Reset the local website database by running `npm run db:reset` 
2. Remove temporarily the `MasterSite::require_post_title` function by commenting this line of code in the `src/MasterSite.php` file: `add_filter('wp_insert_post_data', [$this, 'require_post_title'], 10, 1);` 
3. Create some posts and pages without a title, by adding this to the `functions.php` file. The elements will be created because of the changes in the previous step.
```php
add_action( 'init', 'p4_create_sample_posts_and_pages' );

function p4_create_sample_posts_and_pages() {
    $content = '<!-- wp:paragraph --><p>Test Paragraph</p><!-- /wp:paragraph -->';

    // Create 3 posts
    for ( $i = 0; $i < 3; $i++ ) {
        wp_insert_post( array(
            'post_type'    => 'post',
            'post_title'   => '',
            'post_content' => $content,
            'post_status'  => 'publish',
        ) );
    }

    // Create 3 pages
    for ( $i = 0; $i < 3; $i++ ) {
        wp_insert_post( array(
            'post_type'    => 'page',
            'post_title'   => '',
            'post_content' => $content,
            'post_status'  => 'publish',
        ) );
    }
}
``` 
4. Go to the website or refresh a page to execute the function of the previous step.
5. Check that the posts and pages with no title were created.
6. Remove the function of step 3. 
7. Add back the `MasterSite::require_post_title` function removed on step 2.
8. Create a new migration script, just for testing purposes:
```php
<?php

namespace P4\MasterTheme\Migrations;
use P4\MasterTheme\MigrationRecord;
use P4\MasterTheme\MigrationScript;

class M053TestMigration extends MigrationScript
{
    public static function execute(MigrationRecord $record): void
    {
        $check_is_valid_block = function ($block) {
            return self::check_is_valid_block($block);
        };

        $transform_block = function ($block) {
            return self::transform_block($block);
        };

        Utils\Functions::execute_block_migration(
            Utils\Constants::BLOCK_PARAGRAPH,
            $check_is_valid_block,
            $transform_block,
        );
    }
    // phpcs:enable SlevomatCodingStandard.Functions.UnusedParameter

    private static function check_is_valid_block(array $block): bool
    {
        return
            is_array($block) &&
            isset($block['blockName']) &&
            $block['blockName'] === Utils\Constants::BLOCK_PARAGRAPH;
    }

    private static function transform_block(array $block): void
    {
        if (isset($block['innerHTML']) && $block['innerHTML'] === '<p>Test Paragraph</p>') {
            var_dump($block);
        }
    }
}
``` 
9. Run the migrations: `npx wp-env run cli wp p4-run-activator` 
10. Check the console logs and confirm that posts and pages without a title were migrated.
