### PR TITLE
PLANET-7869: Return back `post__not_in` to main query

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -414,6 +414,7 @@ add_action(
             'field' => 'term_id',
             'terms' => [$post_type->term_id],
         ]]);
+        $query->set('post__not_in', get_option('sticky_posts'));
     }
 );
 


### PR DESCRIPTION
### Summary
We might need to rollback this functionality to avoid displaying sticky posts through main query. For somehow it's been removed removed [here](https://github.com/greenpeace/planet4-master-theme/commit/d1fa83eab88813ff4e32ea1c850954a5158bcb12#diff-01c9525afc2c87cfcb03124117c9d0ebb067029f6c955a607fa0fd4274aca556L392).

<!-- Please add a reference link to the ticket, if one exists. -->
Ref: https://jira.greenpeace.org/browse/PLANET-7869

### Testing

<!-- Please add the steps required to test the changes in this Pull Request. -->
1. Set at least 4 post as `sticky`
2. Then navigate to the News & Stories page
3. Expected bahaviour:
  3.a Featured posts must be displayed on top
  3.b Sticky posts that are displayed on top, shouldn't be displayed on bottom

![Screen Shot 2025-07-07 at 11 17 07](https://github.com/user-attachments/assets/160c934a-4579-42b7-92a4-c4f352e4186a)
