### PR TITLE
PLANET-7846 - Updated design in Actions List block

### DIFF
--- a/assets/src/scss/blocks/ActionsList/ActionsListStyle.scss
+++ b/assets/src/scss/blocks/ActionsList/ActionsListStyle.scss
@@ -65,7 +65,7 @@
 
     &:hover,
     &:focus {
-      box-shadow: 0 4px 14px rgba(0, 0, 0, .2);
+      box-shadow: 0 5px 15px rgba(0, 0, 0, .3);
 
       .btn-primary {
         background: var(--button-primary--hover--background);
@@ -101,7 +101,7 @@
   }
 
   .wp-block-post-title {
-    font-size: 20px;
+    font-size: var(--font-size-m--font-family-primary);
     margin-bottom: $sp-1;
 
     a {
@@ -111,12 +111,12 @@
 
   .wp-block-post-excerpt p {
     font-family: var(--font-family-tertiary);
-    font-size: 1rem;
-    line-height: 1.5rem;
+    font-size: var(--font-size-xxs--font-family-primary);
+    line-height: var(--line-height-m--font-family-tertiary);
     @include clamp-text(3);
 
     @include large-and-up {
-      line-height: 1.5;
+      line-height: var(--line-height-m--font-family-tertiary);
     }
   }
 
@@ -131,9 +131,10 @@
 
   .wp-block-post-terms a {
     color: var(--grey-600);
-    font-size: 14px;
-    font-weight: bold;
+    font-size: var(--font-size-s--font-family-tertiary);
+    font-weight: var(--font-weight-bold);
     font-family: var(--font-family-tertiary);
+    line-height: var(--line-height-s--font-family-tertiary);
   }
 
   &.is-custom-layout-grid {


### PR DESCRIPTION
### Summary

<!-- Please provide a brief summary of the change introduced in this Pull Request. -->

---

<!-- Please add a reference link to the ticket, if one exists. -->
**Ref: https://jira.greenpeace.org/browse/PLANET-7846**

### Testing

<!-- Please add the steps required to test the changes in this Pull Request. -->
1. Actions List block cards now have a 10% increase in the `dropshadow` cast on hover/focus
2. The _post-terms_ section(Category) has the updated font `weight`, `size` and `line-height` to match the Design System described in the ticket.
