### PR TITLE
Log errors during the migration process

### DIFF
--- a/src/Migrations/M046MigrateArticlesBlockToPostsListBlock.php
+++ b/src/Migrations/M046MigrateArticlesBlockToPostsListBlock.php
@@ -32,6 +32,7 @@ class M046MigrateArticlesBlockToPostsListBlock extends MigrationScript
             Utils\Constants::BLOCK_ARTICLES,
             $check_is_valid_block,
             $transform_block,
+            $record
         );
     }
     // phpcs:enable SlevomatCodingStandard.Functions.UnusedParameter

--- a/src/Migrations/M049MigrateCoversBlockToActionsListBlock.php
+++ b/src/Migrations/M049MigrateCoversBlockToActionsListBlock.php
@@ -32,6 +32,7 @@ class M049MigrateCoversBlockToActionsListBlock extends MigrationScript
             Utils\Constants::BLOCK_COVERS,
             $check_is_valid_block,
             $transform_block,
+            $record
         );
     }
     // phpcs:enable SlevomatCodingStandard.Functions.UnusedParameter

--- a/src/Migrations/Utils/Functions.php
+++ b/src/Migrations/Utils/Functions.php
@@ -5,6 +5,7 @@ namespace P4\MasterTheme\Migrations\Utils;
 use WP_Block_Parser;
 use P4\MasterTheme\BlockReportSearch\BlockSearch;
 use P4\MasterTheme\BlockReportSearch\Block\Query\Parameters;
+use P4\MasterTheme\MigrationRecord;
 
 /**
  * Utility functions for the migration scripts.
@@ -17,12 +18,14 @@ class Functions
      * @param string $block_name - The name of the block to be migrated.
      * @param callable $block_check_callback - Callback function to check if block is valid for migration.
      * @param callable $record block_transformation_callback - Callback function to transform a block.
+     * @param MigrationRecord $record - The record to log the migration results.
      * phpcs:disable SlevomatCodingStandard.Functions.UnusedParameter -- interface implementation
      */
     public static function execute_block_migration(
         string $block_name,
         callable $block_check_callback,
-        callable $block_transformation_callback
+        callable $block_transformation_callback,
+        ?MigrationRecord $record = null
     ): void {
         try {
             // Get the list of posts using the specified block.
@@ -94,12 +97,26 @@ class Functions
                 } catch (\Throwable $e) {
                     echo "Migration failed for post ID: ", $post->ID, "\n";
                     echo $e->getMessage(), "\n";
+
+                    if ($record) {
+                        $record->add_log(
+                            "Migration failed for post ID: " . $post->ID .
+                            " Error: " . $e->getMessage() . " - "
+                        );
+                    }
                     continue;
                 }
             }
         } catch (\Throwable $e) {
             echo "Migration wasn't executed for block: ", $block_name ?? 'unknown', "\n";
             echo $e->getMessage(), "\n";
+
+            if ($record) {
+                $record->add_log(
+                    "Migration wasn't executed for block: " . $block_name ?? 'unknown' .
+                    " Error: " . $e->getMessage()
+                );
+            }
         }
     }
     // phpcs:enable SlevomatCodingStandard.Functions.UnusedParameter

--- a/src/Migrations/Utils/Functions.php
+++ b/src/Migrations/Utils/Functions.php
@@ -100,8 +100,7 @@ class Functions
 
                     if ($record) {
                         $record->add_log(
-                            "Migration failed for post ID: " . $post->ID .
-                            " Error: " . $e->getMessage() . " - "
+                            "PID: " . $post->ID . " Error: " . $e->getMessage() . " - "
                         );
                     }
                     continue;
@@ -113,8 +112,7 @@ class Functions
 
             if ($record) {
                 $record->add_log(
-                    "Migration wasn't executed for block: " . $block_name ?? 'unknown' .
-                    " Error: " . $e->getMessage()
+                    "Block: " . $block_name ?? 'unknown' . " Error: " . $e->getMessage()
                 );
             }
         }


### PR DESCRIPTION
This PR enables migration scripts to log the errors during the migration process, making them accessible from the recently introduced "Data Migration" page in the admin area. It also logs the errors of migrations `M046MigrateArticlesBlockToPostsListBlock` and `M049MigrateCoversBlockToActionsListBlock` 

--- 

### Testing

1. Follow the testing steps mentioned here: https://github.com/greenpeace/planet4-master-theme/pull/2676 
2. Go to the Data Migration admin page: `/wp-admin/admin.php?page=planet4_migration_status` 
3. Check that errors were logged in the "Logs" column.
