### PR TITLE
Fixes in the `MediaReplacer` class

### DIFF
--- a/admin/js/media_replacer.js
+++ b/admin/js/media_replacer.js
@@ -49,7 +49,8 @@ document.addEventListener('DOMContentLoaded', () => {
             return;
           }
 
-          window.location.href = window.location.href + '&nocache=' + new Date().getTime();
+          // Reload the page once the replacement is completed.
+          location.replace(location.href);
         })
         .catch(error => {
           if (replaceMediaButton) {

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -97,7 +97,6 @@ final class Loader
             PostMeta::class,
             GravityFormsExtensions::class,
             BlockSettings::class,
-            MediaReplacer::class,
             EnqueueController::class,
         ];
 
@@ -109,6 +108,8 @@ final class Loader
             $this->default_services[] = MediaArchive\UiIntegration::class;
             $this->default_services[] = MediaArchive\Rest::class;
             $this->default_services[] = MigrationStatus::class;
+            $this->default_services[] = MediaReplacer::class;
+
             foreach (Features::external_settings() as $setting_class) {
                 $this->default_services[] = $setting_class;
             }

--- a/src/MediaReplacer.php
+++ b/src/MediaReplacer.php
@@ -378,7 +378,6 @@ class MediaReplacer
     ): void {
         // Handle image thumbnails.
         foreach ($old_image_meta['sizes'] as $size => $old_image_data) {
-
             // Get the image width and height from the file name.
             // This is necessary for the cases where the width and height
             // cannot be extracted from the "sizes" array.

--- a/src/MediaReplacer.php
+++ b/src/MediaReplacer.php
@@ -13,6 +13,8 @@ class MediaReplacer
 {
     private array $replacement_status;
     private array $user_messages;
+    private string $bucket_name;
+    private mixed $stateless;
 
     private const IMAGE_MIME_TYPES = [
         IMAGETYPE_JPEG => [
@@ -49,10 +51,20 @@ class MediaReplacer
             return;
         }
 
-        // If the stateless mode is disabled, abort.
-        if (function_exists('ud_get_stateless_media') && ud_get_stateless_media('sm.mode') === 'disabled') {
+        // If the stateless_media function does not exist, abort.
+        if (!function_exists('ud_get_stateless_media')) {
             return;
         }
+
+        /** @disregard P1010 Undefined function 'P4\MasterTheme\ud_get_stateless_media' */
+        $this->stateless = ud_get_stateless_media();
+
+        // If the stateless mode is disabled, abort.
+        if ($this->stateless->get('sm.mode') === 'disabled') {
+            return;
+        }
+
+        $this->bucket_name = $this->stateless->get('sm.bucket');
 
         $this->replacement_status = [
             'success' => [],
@@ -224,10 +236,6 @@ class MediaReplacer
         string $file_mime_type
     ): void {
         try {
-            if (!function_exists('ud_get_stateless_media')) {
-                throw new \LogicException($this->user_messages['error']);
-            }
-
             $file_meta = get_post_meta($old_file_id);
             $filename = $file_meta['_wp_attached_file'][0];
             $sm_cloud_data = unserialize($file_meta['sm_cloud'][0]);
@@ -239,7 +247,7 @@ class MediaReplacer
                 [
                     'size' => '__full',
                     'object-id' => $old_file_id,
-                    'source-id' => md5($filename . ud_get_stateless_media()->get('sm.bucket')), //NOSONAR
+                    'source-id' => md5($filename . $this->bucket_name), //NOSONAR
                     'file-hash' => md5($filename), //NOSONAR
                 ]
             );
@@ -300,17 +308,13 @@ class MediaReplacer
             $old_image_filename = pathinfo($old_image_meta['name'], PATHINFO_FILENAME);
             $image_name = $old_image_dirname . '/' . $old_image_filename;
 
-            if (!function_exists('ud_get_stateless_media')) {
-                throw new \LogicException($this->user_messages['image']);
-            }
-
             // Create metadata for uploading the main image.
             $metadata = [
                 'width' => $new_image_width,
                 'height' => $new_image_height,
                 'size' => '__full',
                 'object-id' => $id,
-                'source-id' => md5($old_image_filename . ud_get_stateless_media()->get('sm.bucket')), //NOSONAR
+                'source-id' => md5($old_image_filename . $this->bucket_name), //NOSONAR
                 'file-hash' => md5($old_image_filename), //NOSONAR
             ];
 
@@ -431,7 +435,7 @@ class MediaReplacer
      * @param int $new_image_height The height of the new image.
      * @param int $old_image_width The width of the thumbnail.
      * @param int $old_image_height The height of the thumbnail.
-     * @return object The generated thumbnail image.
+     * @return mixed The generated thumbnail image, or null in case of error.
      */
     private function create_image_thumbnail(
         object $image,
@@ -439,7 +443,7 @@ class MediaReplacer
         int $new_image_height,
         int $old_image_width,
         int $old_image_height
-    ): object {
+    ): mixed {
         try {
             // Determine cropping dimensions
             $src_aspect = $new_image_width / $new_image_height;
@@ -473,6 +477,7 @@ class MediaReplacer
             return $thumb;
         } catch (\LogicException $e) {
             $this->error_handler($e->getMessage());
+            return null;
         }
     }
 
@@ -503,12 +508,8 @@ class MediaReplacer
                 'force' => true,
             ];
 
-            if (!function_exists('ud_get_stateless_media')) {
-                throw new \LogicException($this->user_messages['error']);
-            }
-
             // Upload the file to Google Cloud Storage.
-            $status = ud_get_stateless_media()->get_client()->add_media($image_args);
+            $status = $this->stateless->get_client()->add_media($image_args);
 
             if ($status) {
                 $this->success_handler($this->user_messages['success'], $name);

--- a/src/MediaReplacer.php
+++ b/src/MediaReplacer.php
@@ -496,7 +496,7 @@ class MediaReplacer
                 'absolutePath' => $absolute_path,
                 'mimeType' => $mime,
                 'metadata' => $metadata,
-                'cacheControl' => 'public, max-age=36000, must-revalidate',
+                'cacheControl' => 'no-cache, max-age=0, must-revalidate',
                 'contentDisposition' => null,
                 'force' => true,
             ];

--- a/src/MediaReplacer.php
+++ b/src/MediaReplacer.php
@@ -372,8 +372,19 @@ class MediaReplacer
     ): void {
         // Handle image thumbnails.
         foreach ($old_image_meta['sizes'] as $size => $old_image_data) {
-            $old_image_width = $old_image_data['width'];
-            $old_image_height = $old_image_data['height'];
+
+            // Get the image width and height from the file name.
+            // This is necessary for the cases where the width and height
+            // cannot be extracted from the "sizes" array.
+            if ($old_image_data['name']) {
+                if (preg_match('/-(\d+)x(\d+)\.(jpg|jpeg|png|gif|webp)$/i', $old_image_data['name'], $matches)) {
+                    $old_width = (int) $matches[1];
+                    $old_height = (int) $matches[2];
+                }
+            }
+
+            $old_image_width = (int) ($old_image_data['width'] ?? $old_width);
+            $old_image_height = (int) ($old_image_data['height'] ?? $old_height);
 
             // Create metadata for the thumbnails.
             $metadata = [

--- a/src/MediaReplacer.php
+++ b/src/MediaReplacer.php
@@ -318,7 +318,7 @@ class MediaReplacer
 
             // Replace the main image.
             $status = $this->upload_file(
-                $old_image_filename . '.' . $old_image_extension,
+                $old_image_meta['name'],
                 $temporary_file_path,
                 $image_data['mime'],
                 $metadata

--- a/src/MediaReplacer.php
+++ b/src/MediaReplacer.php
@@ -378,18 +378,20 @@ class MediaReplacer
     ): void {
         // Handle image thumbnails.
         foreach ($old_image_meta['sizes'] as $size => $old_image_data) {
+            $old_image_width = (int) ($old_image_data['width']);
+            $old_image_height = (int) ($old_image_data['height']);
+
             // Get the image width and height from the file name.
             // This is necessary for the cases where the width and height
             // cannot be extracted from the "sizes" array.
-            if ($old_image_data['name']) {
-                if (preg_match('/-(\d+)x(\d+)\.(jpg|jpeg|png|gif|webp)$/i', $old_image_data['name'], $matches)) {
-                    $old_width = (int) $matches[1];
-                    $old_height = (int) $matches[2];
-                }
+            if (
+                (!$old_image_width || !$old_image_height) &&
+                $old_image_data['name'] &&
+                preg_match('/-(\d+)x(\d+)\.(jpg|jpeg|png|gif|webp)$/i', $old_image_data['name'], $matches)
+            ) {
+                $old_image_width = (int) $matches[1];
+                $old_image_height = (int) $matches[2];
             }
-
-            $old_image_width = (int) ($old_image_data['width'] ?? $old_width);
-            $old_image_height = (int) ($old_image_data['height'] ?? $old_height);
 
             // Create metadata for the thumbnails.
             $metadata = [

--- a/src/MediaReplacer.php
+++ b/src/MediaReplacer.php
@@ -228,10 +228,12 @@ class MediaReplacer
                 throw new \LogicException($this->user_messages['error']);
             }
 
-            $filename = get_post_meta($old_file_id)['_wp_attached_file'][0];
+            $file_meta = get_post_meta($old_file_id);
+            $filename = $file_meta['_wp_attached_file'][0];
+            $sm_cloud_data = unserialize($file_meta['sm_cloud'][0]);
 
             $status = $this->upload_file(
-                $filename,
+                $sm_cloud_data['name'],
                 $file['tmp_name'],
                 $file_mime_type,
                 [


### PR DESCRIPTION
### Summary

This PR adds the following fixes and improvements to the `MediaReplacer` class:
- Removes the `nocache` URL parameter which produces no benefit and could cause issues on page reload.
- Loads the class only in the admin area.
- Calls the `ud_get_stateless_media` function only once.
- Gets the name of the replaced file correctly, including the year and month as part of it.
- Gets the image width and height from the file name as an extra precaution.
- Reduces the file cache.

---

### Testing

1. Log in to the test instance: https://www-dev.greenpeace.org/test-venus/wp-admin/
2. Go to the Media Library: https://www-dev.greenpeace.org/test-venus/wp-admin/upload.php
3. Select an already existing image.
4. Replace it by clicking on the Replace Media button.
5. Wait for the page to reload and the message "File was succesfully replaced!" to appear.
6. Open the different variations of the image that are listed in the Stateless metabox.
7. Check that all of them were replaced. You should probably bypass the cache by adding an extra parameter to the file URL.
8. Repeat the same process using a non-image file.