### PR TITLE
Reduce the length of the `MasterSite` class

### DIFF
--- a/src/Loader.php
+++ b/src/Loader.php
@@ -98,6 +98,7 @@ final class Loader
             GravityFormsExtensions::class,
             BlockSettings::class,
             EnqueueController::class,
+            YouTubeHandler::class,
         ];
 
         if (is_admin()) {

--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -3,7 +3,6 @@
 namespace P4\MasterTheme;
 
 use P4\MasterTheme\Features\Dev\CoreBlockPatterns;
-use P4\MasterTheme\Features\LazyYoutubePlayer;
 use Timber\Timber;
 use Timber\Site as TimberSite;
 use Timber\Menu as TimberMenu;
@@ -167,8 +166,6 @@ class MasterSite extends TimberSite
         add_filter('comment_form_submit_field', [$this, 'gdpr_cc_comment_form_add_class'], 150, 1);
         add_filter('comment_form_default_fields', [$this, 'comment_form_cookie_checkbox_add_class']);
         add_filter('comment_form_default_fields', [$this, 'comment_form_replace_inputs']);
-        add_filter('embed_oembed_html', [$this, 'filter_youtube_oembed_nocookie'], 10, 2);
-        add_filter('oembed_result', [$this, 'filter_youtube_oembed_nocookie'], 10, 2);
         add_filter(
             'editable_roles',
             function ($roles) {
@@ -1461,105 +1458,6 @@ class MasterSite extends TimberSite
         }
 
         return $fields;
-    }
-
-    /**
-     * Filter function for embed_oembed_html.
-     * Transform youtube embeds to youtube-nocookie.
-     *
-     * @see https://developer.wordpress.org/reference/hooks/embed_oembed_html/
-     *
-     * @param mixed  $cache The cached HTML result, stored in post meta.
-     * @param string $url The attempted embed URL.
-     *
-     * @return mixed
-     */
-    public function filter_youtube_oembed_nocookie($cache, string $url)
-    {
-        if (LazyYoutubePlayer::is_active()) {
-            return $this->new_youtube_filter($cache, $url);
-        }
-
-        return $this->old_youtube_filter($cache, $url);
-    }
-
-    /**
-     * Filter function for embed_oembed_html.
-     * Transform youtube embeds to youtube-nocookie.
-     *
-     * @see https://developer.wordpress.org/reference/hooks/embed_oembed_html/
-     *
-     * @param mixed  $cache The cached HTML result, stored in post meta.
-     * @param string $url The attempted embed URL.
-     *
-     * @return mixed
-     */
-    private function new_youtube_filter($cache, string $url)
-    {
-        if (is_admin() || (defined('REST_REQUEST') && REST_REQUEST)) {
-            return $cache;
-        }
-
-        if (!empty($url)) {
-            if (strpos($url, 'youtube.com') !== false || strpos($url, 'youtu.be') !== false) {
-                [$youtube_id, $query_string] = self::parse_youtube_url($url);
-
-                $style = "background-image: url('https://i.ytimg.com/vi/$youtube_id/hqdefault.jpg');";
-
-                return '<lite-youtube style="' . $style . '" videoid="' . $youtube_id
-                    . '" params="' . $query_string . '"></lite-youtube>';
-            }
-        }
-
-        return $cache;
-    }
-
-    /**
-     * Filter function for embed_oembed_html.
-     * Transform youtube embeds to youtube-nocookie.
-     *
-     * @see https://developer.wordpress.org/reference/hooks/embed_oembed_html/
-     *
-     * @param mixed  $cache The cached HTML result, stored in post meta.
-     * @param string $url The attempted embed URL.
-     *
-     * @return mixed
-     */
-    private function old_youtube_filter($cache, string $url)
-    {
-        if (!empty($url)) {
-            if (strpos($url, 'youtube.com') !== false || strpos($url, 'youtu.be') !== false) {
-                $replacements = [
-                    'youtube.com' => 'youtube-nocookie.com',
-                    'feature=oembed' => 'feature=oembed&rel=0',
-                ];
-
-                $cache = str_replace(array_keys($replacements), array_values($replacements), $cache);
-            }
-        }
-
-        return $cache;
-    }
-
-    /**
-     * Parse info out of a Youtube URL.
-     *
-     * @param string $url The embedded url.
-     *
-     * @return string[] The youtube ID and the query string.
-     */
-    private static function parse_youtube_url(string $url): ?array
-    {
-        // @see https://stackoverflow.com/questions/3392993/php-regex-to-get-youtube-video-id
-        // phpcs:ignore Generic.Files.LineLength.MaxExceeded
-        $re = "/^(?:http(?:s)?:\/\/)?(?:www\.)?(?:m\.)?(?:youtu\.be\/|youtube\.com\/(?:(?:watch)?\?(?:.*&)?v(?:i)?=|(?:embed|v|vi|user|shorts)\/))([^\?&\"'>]+)/";
-        preg_match_all($re, $url, $matches, PREG_SET_ORDER);
-        $youtube_id = $matches[0][1] ?? null;
-
-        // For now just rel, but we can extract more from the url.
-        $query_string = apply_filters('planet4_youtube_embed_parameters', 'rel=0');
-
-        return [$youtube_id, $query_string];
     }
 
     /**

--- a/src/YouTubeHandler.php
+++ b/src/YouTubeHandler.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace P4\MasterTheme;
+
+use P4\MasterTheme\Features\LazyYoutubePlayer;
+
+/**
+ * Class YouTubeHandler
+ */
+class YouTubeHandler
+{
+    /**
+     * Constructor.
+     */
+    public function __construct()
+    {
+        add_filter('embed_oembed_html', [$this, 'filter_youtube_oembed_nocookie'], 10, 2);
+        add_filter('oembed_result', [$this, 'filter_youtube_oembed_nocookie'], 10, 2);
+    }
+
+    /**
+     * Filter function for embed_oembed_html.
+     * Transform youtube embeds to youtube-nocookie.
+     *
+     * @see https://developer.wordpress.org/reference/hooks/embed_oembed_html/
+     *
+     * @param mixed  $cache The cached HTML result, stored in post meta.
+     * @param string $url The attempted embed URL.
+     *
+     * @return mixed
+     */
+    public function filter_youtube_oembed_nocookie($cache, string $url)
+    {
+        if (LazyYoutubePlayer::is_active()) {
+            return $this->new_youtube_filter($cache, $url);
+        }
+
+        return $this->old_youtube_filter($cache, $url);
+    }
+
+    /**
+     * Filter function for embed_oembed_html.
+     * Transform youtube embeds to youtube-nocookie.
+     *
+     * @see https://developer.wordpress.org/reference/hooks/embed_oembed_html/
+     *
+     * @param mixed  $cache The cached HTML result, stored in post meta.
+     * @param string $url The attempted embed URL.
+     *
+     * @return mixed
+     */
+    private function new_youtube_filter($cache, string $url)
+    {
+        if (is_admin() || (defined('REST_REQUEST') && REST_REQUEST)) {
+            return $cache;
+        }
+
+        if (!empty($url)) {
+            if (strpos($url, 'youtube.com') !== false || strpos($url, 'youtu.be') !== false) {
+                [$youtube_id, $query_string] = self::parse_youtube_url($url);
+
+                $style = "background-image: url('https://i.ytimg.com/vi/$youtube_id/hqdefault.jpg');";
+
+                return '<lite-youtube style="' . $style . '" videoid="' . $youtube_id
+                    . '" params="' . $query_string . '"></lite-youtube>';
+            }
+        }
+
+        return $cache;
+    }
+
+    /**
+     * Filter function for embed_oembed_html.
+     * Transform youtube embeds to youtube-nocookie.
+     *
+     * @see https://developer.wordpress.org/reference/hooks/embed_oembed_html/
+     *
+     * @param mixed  $cache The cached HTML result, stored in post meta.
+     * @param string $url The attempted embed URL.
+     *
+     * @return mixed
+     */
+    private function old_youtube_filter($cache, string $url)
+    {
+        if (!empty($url)) {
+            if (strpos($url, 'youtube.com') !== false || strpos($url, 'youtu.be') !== false) {
+                $replacements = [
+                    'youtube.com' => 'youtube-nocookie.com',
+                    'feature=oembed' => 'feature=oembed&rel=0',
+                ];
+
+                $cache = str_replace(array_keys($replacements), array_values($replacements), $cache);
+            }
+        }
+
+        return $cache;
+    }
+
+    /**
+     * Parse info out of a Youtube URL.
+     *
+     * @param string $url The embedded url.
+     *
+     * @return string[] The youtube ID and the query string.
+     */
+    private static function parse_youtube_url(string $url): ?array
+    {
+        // @see https://stackoverflow.com/questions/3392993/php-regex-to-get-youtube-video-id
+        // phpcs:ignore Generic.Files.LineLength.MaxExceeded
+        $re = "/^(?:http(?:s)?:\/\/)?(?:www\.)?(?:m\.)?(?:youtu\.be\/|youtube\.com\/(?:(?:watch)?\?(?:.*&)?v(?:i)?=|(?:embed|v|vi|user|shorts)\/))([^\?&\"'>]+)/";
+        preg_match_all($re, $url, $matches, PREG_SET_ORDER);
+        $youtube_id = $matches[0][1] ?? null;
+
+        // For now just rel, but we can extract more from the url.
+        $query_string = apply_filters('planet4_youtube_embed_parameters', 'rel=0');
+
+        return [$youtube_id, $query_string];
+    }
+}


### PR DESCRIPTION
### Summary

As part of our effort to reduce the size of the `MasterSite` class, this PR moves from it all functions related to YouTube into a new class called `YouTubeHandler`

---

Ref: https://greenpeace-gpi.slack.com/archives/C0160MX64AG/p1751531019331059 

### Testing

1. Embed a YouTube video in any post or page.
2. Check that the HTML of the video is filtered as expected.
3. Check that the filter changes based on whether the `LazyYoutubePlayer` feature is enabled or disabled.
