### PR TITLE
PLANET-7872 Fix missing image dimensions in Library upload

### DIFF
--- a/src/AttachmentsController.php
+++ b/src/AttachmentsController.php
@@ -57,12 +57,12 @@ class AttachmentsController
      * @param int   $post_id  Attachment post ID.
      * @return array Metadata (unchanged).
      */
-    public function update_iptc_metadata(array $metadata, int $post_id): mixed
+    public function update_iptc_metadata(array $metadata, int $post_id): array
     {
         $file = get_attached_file($post_id);
 
         if (!file_exists($file)) {
-            return null;
+            return $metadata;
         }
 
         // Extracts image metadata and populates $image_info['APP13'] with raw IPTC data if available.
@@ -71,7 +71,7 @@ class AttachmentsController
         $info = @getimagesize($file, $image_info); //NOSONAR
 
         if (!is_array($image_info) || !isset($image_info['APP13'])) {
-            return null;
+            return $metadata;
         }
 
         $iptc = iptcparse($image_info['APP13']) ?: [];


### PR DESCRIPTION
### Summary

This would result in issues when using the images afterwards

Ref: [PLANET-7872](https://jira.greenpeace.org/browse/PLANET-7872)

### Testing

Try uploading an image to the Media Library, without this fix it won't have dimensions but on this branch they should be added as expected.

For example you can use the [image](https://www.greenpeace.org/luxembourg/wp-admin/upload.php?item=25132) cited by GP Luxembourg in the ticket.

<img width="1861" height="445" alt="example" src="https://github.com/user-attachments/assets/82723ba4-3225-441d-8cfe-6182ef7a8468" />
