### PR TITLE
PLANET-7861: Tag description field not visible on mobile

### DIFF
--- a/assets/src/scss/layout/_page-header.scss
+++ b/assets/src/scss/layout/_page-header.scss
@@ -186,13 +186,3 @@
     margin-top: 36px;
   }
 }
-
-.page-header-content {
-  display: none;
-  margin-top: 0;
-
-  @include medium-and-up {
-    display: block;
-    margin-bottom: 0;
-  }
-}

--- a/templates/blocks/header.twig
+++ b/templates/blocks/header.twig
@@ -61,7 +61,9 @@
                 <h3 class="page-header-subtitle">{{ header_subtitle }}</h3>
             {% endif %}
             {% if ( header_description ) %}
-                <div class="page-header-content">{{ header_description|e('wp_kses_post')|raw }}</div>
+                <div class="page-header-content d-none d-md-block mt-0 mb-md-0">
+                    {{ header_description|e('wp_kses_post')|raw }}
+                </div>
             {% endif %}
             {% if ( header_button_title and header_button_link ) %}
                 <div class="row">

--- a/templates/tag.twig
+++ b/templates/tag.twig
@@ -17,7 +17,9 @@
                 <h1 class="page-header-title">
                     <span aria-label="hashtag">#</span>{{ tag_name|e('wp_kses_post')|raw }}
                 </h1>
-                <div class="page-header-content">{{ tag_description|e('wp_kses_post')|raw }}</div>
+                <div class="page-header-content mt-0 mb-md-0">
+                    {{ tag_description|e('wp_kses_post')|raw }}
+                </div>
                 {% if ( featured_action ) %}
                     {% include 'featured-action.twig'
                         with {

--- a/templates/taxonomy.twig
+++ b/templates/taxonomy.twig
@@ -15,7 +15,7 @@
                 {% endif %}
             </div>
             <h1 class="page-header-title">{{ taxonomy.name }}</h1>
-            <div class="page-header-content">
+            <div class="page-header-content mt-0 mb-md-0">
                 <p>{{ taxonomy.description|e('wp_kses_post')|raw }}</p>
             </div>
             {% if ( featured_action ) %}


### PR DESCRIPTION
### Summary

This PR turns the header description visible on small screens in the tags and taxonomies pages.

---

Ref: https://jira.greenpeace.org/browse/PLANET-7861

### Testing

<!-- Please add the steps required to test the changes in this Pull Request. -->
1. 
2. 
3. 
