### PR TITLE
PLANET-7854 Actions/Posts List block headers are h3

### DIFF
--- a/assets/src/blocks/ActionsList/index.js
+++ b/assets/src/blocks/ActionsList/index.js
@@ -66,7 +66,7 @@ export const getActionsListBlockTemplate = (title = __('', 'planet4-blocks-backe
         taxonomy: LISTS_BREADCRUMBS[0].value,
         post_type: queryPostType,
       }],
-      ['core/post-title', {isLink: true}],
+      ['core/post-title', {isLink: true, level: 3}],
       ['core/post-excerpt'],
     ]],
     ['core/group', {className: 'read-more-nav'}, [

--- a/assets/src/blocks/PostsList/index.js
+++ b/assets/src/blocks/PostsList/index.js
@@ -100,7 +100,7 @@ export const getPostListBlockTemplate = (title = __('Related Posts', 'planet4-bl
             separator: ' ',
           }],
         ]],
-        ['core/post-title', {isLink: true, level: 4}],
+        ['core/post-title', {isLink: true, level: 3}],
         ['core/post-excerpt'],
         ['core/group', {className: 'posts-list-meta'}, [
           ['core/post-author-name', {isLink: true}],

--- a/src/Migrations/M054PostsActionsListHeaderButtonUpdate.php
+++ b/src/Migrations/M054PostsActionsListHeaderButtonUpdate.php
@@ -1,0 +1,159 @@
+<?php
+
+// phpcs:disable Generic.Files.LineLength.MaxExceeded
+
+namespace P4\MasterTheme\Migrations;
+
+use P4\MasterTheme\MigrationRecord;
+use P4\MasterTheme\MigrationScript;
+
+/**
+ * Migrate Posts List blocks with errors to Posts List blocks fix.
+ */
+class M054PostsActionsListHeaderButtonUpdate extends MigrationScript
+{
+    /**
+     * Perform the actual migration.
+     *
+     * @param MigrationRecord $record Information on the execution, can be used to add logs.
+     * phpcs:disable SlevomatCodingStandard.Functions.UnusedParameter -- interface implementation
+     */
+    public static function execute(MigrationRecord $record): void
+    {
+        $check_is_valid_block = function ($block) {
+            return self::check_is_valid_block($block);
+        };
+
+        $transform_block = function ($block) {
+            return self::transform_block($block);
+        };
+
+        Utils\Functions::execute_block_migration(
+            Utils\Constants::BLOCK_QUERY,
+            $check_is_valid_block,
+            $transform_block,
+        );
+    }
+    // phpcs:enable SlevomatCodingStandard.Functions.UnusedParameter
+
+    /**
+     * Check whether a block is a Query Loop block.
+     *
+     * @param array $block - A block data array.
+     */
+    private static function check_is_valid_block(array $block): bool
+    {
+        // Check if the block is valid.
+        if (!is_array($block)) {
+            return false;
+        }
+
+        // Check if the block has a 'blockName' key.
+        if (!isset($block['blockName'])) {
+            return false;
+        }
+
+        // Check if the block is a Posts/Actions List block.
+        return isset($block['blockName'], $block['attrs']['namespace']) &&
+            $block['blockName'] === Utils\Constants::BLOCK_QUERY &&
+            in_array($block['attrs']['namespace'], [
+                Utils\Constants::BLOCK_POSTS_LIST,
+                Utils\Constants::BLOCK_ACTIONS_LIST,
+            ], true);
+    }
+
+    /**
+     * Update the post title and buttons of Posts/Actions List blocks
+     *
+     * @param array $block - The current posts/actions list block.
+     * @return array - array of blocks.
+     */
+    private static function transform_block(array $block): array
+    {
+        self::update_posts_list_block_title($block['innerBlocks']);
+        self::update_posts_list_block_buttons($block['innerBlocks']);
+
+        return $block;
+    }
+
+    /**
+     * Update post titles.
+     *
+     * @param array $blocks - array of blocks.
+     */
+    private static function update_posts_list_block_title(array &$blocks): void
+    {
+        foreach ($blocks as &$block) {
+            if (isset($block['blockName']) && $block['blockName'] === Utils\Constants::BLOCK_TITLE) {
+                if (!isset($block['attrs'])) {
+                    $block['attrs'] = [];
+                }
+                $block['attrs']['isLink'] = true;
+                $block['attrs']['level'] = 3;
+            }
+
+            self::update_posts_list_block_title($block['innerBlocks']);
+        }
+    }
+
+     /**
+     * Update Posts/Actions List block carousel buttons.
+     *
+     * @param array $blocks - array of blocks.
+     */
+    private static function update_posts_list_block_buttons(array &$blocks): void
+    {
+        foreach ($blocks as &$block) {
+            if (isset($block['blockName']) && $block['blockName'] === Utils\Constants::BLOCK_BUTTONS) {
+                if (!empty($block['innerBlocks'])) {
+                    foreach ($block['innerBlocks'] as &$innerBlock) {
+                        if (
+                            !isset($innerBlock['blockName']) ||
+                            $innerBlock['blockName'] !== Utils\Constants::BLOCK_SINGLE_BUTTON
+                        ) {
+                            continue;
+                        }
+
+                        // Only change tagName if it's not already "button"
+                        if (
+                            !isset($innerBlock['attrs']['tagName']) ||
+                            $innerBlock['attrs']['tagName'] !== 'button'
+                        ) {
+                            $innerBlock['attrs']['tagName'] = 'button';
+
+                            // Remove href if it exists
+                            if (isset($innerBlock['attrs']['href'])) {
+                                unset($innerBlock['attrs']['href']);
+                            }
+                        }
+
+                        if (!isset($innerBlock['innerHTML'])) {
+                            continue;
+                        }
+
+                        $new_button_html = preg_replace(
+                            ['/<a\b([^>]*)>/', '/<\/a>/'],
+                            ['<button$1>', '</button>'],
+                            $innerBlock['innerHTML']
+                        );
+
+                        $innerBlock['innerHTML'] = $new_button_html;
+
+                        if (!isset($innerBlock['innerContent'][0])) {
+                            continue;
+                        }
+
+                        $innerBlock['innerContent'][0] = $new_button_html;
+                    }
+                }
+            }
+
+
+            if (!isset($block['innerBlocks']) || !is_array($block['innerBlocks'])) {
+                continue;
+            }
+
+            self::update_posts_list_block_buttons($block['innerBlocks']);
+        }
+    }
+}

--- a/src/Migrator.php
+++ b/src/Migrator.php
@@ -54,6 +54,7 @@ use P4\MasterTheme\Migrations\M049MigrateCoversBlockToActionsListBlock;
 use P4\MasterTheme\Migrations\M050AddTagsBackInPostsListBlock;
 use P4\MasterTheme\Migrations\M052RollbackToPreviousRevision;
 use P4\MasterTheme\Migrations\M053CustomisePostsListSeeAllLink;
+use P4\MasterTheme\Migrations\M054PostsActionsListHeaderButtonUpdate;
 
 /**
  * Run any new migration scripts and record results in the log.
@@ -125,6 +126,7 @@ class Migrator
             M050AddTagsBackInPostsListBlock::class,
             M052RollbackToPreviousRevision::class,
             M053CustomisePostsListSeeAllLink::class,
+            M054PostsActionsListHeaderButtonUpdate::class,
         ];
 
         // Loop migrations and run those that haven't run yet.


### PR DESCRIPTION
### Summary

<!-- Please provide a brief summary of the change introduced in this Pull Request. -->

---

<!-- Please add a reference link to the ticket, if one exists. -->
**Ref: https://jira.greenpeace.org/browse/PLANET-7854**

### Testing

<!-- Please add the steps required to test the changes in this Pull Request. -->
1.  Post titles are now H3
2. Carousel style elements (posts/actions list) created before this change have buttons with a broken style, this fixes that.
3. For the migration, you can test on the International instance locally, at the bottom of their home page, the have a Carousel styled Actions list block, this should fix the issue with the buttons.