### PR TITLE
Move metabox search functionalities out of MasterSite.php

### DIFF
--- a/src/MetaboxRegister.php
+++ b/src/MetaboxRegister.php
@@ -131,7 +131,10 @@ class MetaboxRegister
         $options = get_option('planet4_options');
 
         echo '<label for="my_meta_box_text">'
-            . esc_html__('Weight', 'planet4-master-theme-backend')
+            . esc_html__(
+                'Set the weight for the current Post/Page in the search results',
+                'planet4-master-theme-backend'
+            )
             . ' (1-' . esc_attr(Search\Search::DEFAULT_MAX_WEIGHT) . ')</label>
                 <input id="weight" type="text" name="weight" value="' . esc_attr($weight) . '" />';
 

--- a/src/MetaboxRegister.php
+++ b/src/MetaboxRegister.php
@@ -2,6 +2,8 @@
 
 namespace P4\MasterTheme;
 
+use WP_Post;
+
 /**
  * Class MetaboxRegister
  */
@@ -28,6 +30,8 @@ class MetaboxRegister
     private function hooks(): void
     {
         add_action('cmb2_init', [ $this, 'register_p4_meta_box' ]);
+        add_action('add_meta_boxes', [$this, 'add_meta_box_search'], 10, 2);
+        add_action('save_post', [$this, 'save_meta_box_search'], 10, 2);
     }
 
     /**
@@ -91,5 +95,93 @@ class MetaboxRegister
                 'preview_size' => 'large',
             ]
         );
+    }
+
+    /**
+     * Creates a Metabox on the side of the Add/Edit Post/Page
+     * that is used for applying weight to the current Post/Page in search results.
+     *
+     * @param string  $post_type Post type.
+     * @param WP_Post|WP_Comment $post      Post object.
+     * phpcs:disable SlevomatCodingStandard.Functions.UnusedParameter -- add_meta_boxes callback
+     */
+    public function add_meta_box_search(string $post_type, $post): void
+    {
+        add_meta_box(
+            'meta-box-search',
+            'Search',
+            [$this, 'view_meta_box_search'],
+            ['post', 'page'],
+            'side',
+            'default',
+            [$post]
+        );
+    }
+    // phpcs:enable SlevomatCodingStandard.Functions.UnusedParameter
+
+    /**
+     * Renders a Metabox on the side of the Add/Edit Post/Page.
+     *
+     * @param WP_Post $post The currently Added/Edited post.
+     * phpcs:disable Generic.WhiteSpace.ScopeIndent
+     */
+    public function view_meta_box_search(WP_Post $post): void
+    {
+        $weight = get_post_meta($post->ID, 'weight', true);
+        $options = get_option('planet4_options');
+
+        echo '<label for="my_meta_box_text">'
+            . esc_html__('Weight', 'planet4-master-theme-backend')
+            . ' (1-' . esc_attr(Search\Search::DEFAULT_MAX_WEIGHT) . ')</label>
+                <input id="weight" type="text" name="weight" value="' . esc_attr($weight) . '" />';
+
+        $script_data = [
+            'act_page' => $options['act_page'] ?? null,
+            'action_weight' => Search\Search::DEFAULT_ACTION_WEIGHT,
+            'page_weight' => Search\Search::DEFAULT_PAGE_WEIGHT,
+        ];
+
+        do_action('enqueue_metabox_search_script', $script_data);
+    }
+    // phpcs:enable Generic.WhiteSpace.ScopeIndent
+
+    /**
+     * Saves the Search weight of the Post/Page.
+     *
+     * @param int     $post_id The ID of the current Post.
+     * @param WP_Post $post The current Post.
+     */
+    public function save_meta_box_search(int $post_id, WP_Post $post): void
+    {
+        global $pagenow;
+
+        // Ignore autosave.
+        if (defined('DOING_AUTOSAVE') && DOING_AUTOSAVE) {
+            return;
+        }
+        // Check user's capabilities.
+        if (!current_user_can('edit_post', $post_id)) {
+            return;
+        }
+        // Make sure there's input.
+        $weight = filter_input(
+            INPUT_POST,
+            'weight',
+            FILTER_VALIDATE_INT,
+            [
+                'options' => [
+                    'min_range' => Search\Search::DEFAULT_MIN_WEIGHT,
+                    'max_range' => Search\Search::DEFAULT_MAX_WEIGHT,
+                ],
+            ]
+        );
+
+        // If this is a new Page then set default weight for it.
+        if (!$weight && 'post-new.php' === $pagenow && 'page' === $post->post_type) {
+            $weight = Search\Search::DEFAULT_PAGE_WEIGHT;
+        }
+
+        // Store weight.
+        update_post_meta($post_id, 'weight', $weight);
     }
 }


### PR DESCRIPTION
### Summary

This is part of our efforts to make this file shorter 🩳 

### Testing

This box should still be present in the sidebar for Posts and Pages, and work as expected:

<img width="281" height="125" alt="Screenshot 2025-07-21 at 11 53 14" src="https://github.com/user-attachments/assets/a7dbcb6b-89a8-4915-aa38-410570e7b864" />
