### PR TITLE
PLANET-7880 Fix navbar search form background

### DIFF
--- a/assets/src/scss/layout/navbar/_search.scss
+++ b/assets/src/scss/layout/navbar/_search.scss
@@ -1,5 +1,5 @@
 .nav-search-form {
-  background-color: var(--body--background-color);
+  background-color: inherit;
   border: none;
   border-top: var(--top-navigation--separation);
   box-shadow: 0 2px 4px rgba($grey-900, 0.15);
@@ -60,7 +60,6 @@
   }
 
   @include x-large-and-up {
-    background: var(--top-navigation--background, inherit);
     border-inline-start: var(--top-navigation--separation);
     border-top: none;
     box-shadow: none;


### PR DESCRIPTION
### Summary

Instead of using CSS variables we should always use the inherited value there

Ref: [PLANET-7880](https://jira.greenpeace.org/browse/PLANET-7880)

### Testing

Check the navigation bar in all screen sizes, with or without the transparent background enabled. It should behave as expected.


[PLANET-7880]: https://greenpeace-planet4.atlassian.net/browse/PLANET-7880?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ