### PR TITLE
Move mobile tabs behaviour to separate file

### DIFF
--- a/assets/src/js/header.js
+++ b/assets/src/js/header.js
@@ -2,6 +2,7 @@
 
 import setupAccessibleNavMenu from './header/setupAccessibleNavMenu';
 import setupCloseNavMenuButton from './header/setupCloseNavMenuButton';
+import setupMobileTabsMenuScroll from './header/setupMobileTabsMenuScroll';
 
 const updateGaAction = (element, elementName) => {
   element.dataset.gaAction = `${element.getAttribute('aria-expanded') === 'false' ? 'Open' : 'Close'} ${elementName}`;
@@ -117,104 +118,6 @@ const closeInactiveNavElements = event => {
   });
 };
 
-/**
- * Set the mobile tabs menu behavior on scroll
- * Mobile tabs menu should hide when user scrolls down, and reappear when they scroll up
- */
-const setMobileTabsMenuScroll = () => {
-  const menu = document.getElementById('nav-mobile');
-  if (!menu) {
-    return;
-  }
-
-  const distToClose = 100;
-  const distToOpen = 50;
-  let lastScrollDir = null;
-  let lastScrollTop = window.pageYOffset || document.documentElement.scrollTop;
-  let lastScrollRef = lastScrollTop;
-
-  // Check support for eventlistener opts (passive option)
-  // Cf. https://github.com/WICG/EventListenerOptions/blob/gh-pages/explainer.md#feature-detection
-  let supportsPassive = false;
-  try {
-    const opts = Object.defineProperty({}, 'passive', {
-      get: () => {
-        supportsPassive = true;
-        return supportsPassive;
-      },
-    });
-    window.addEventListener('testPassive', null, opts);
-    window.removeEventListener('testPassive', null, opts);
-  } catch (e) {} // eslint-disable-line no-empty
-
-  /**
-   * Get scroll direction, distance from the lastScrollTop, and distance from a reference point
-   *
-   * @return {Object} {scroll direction, top position, distance scrolled, distance scrolled from ref point}
-   */
-  const scrollData = () => {
-    const scrollTop = window.pageYOffset || document.documentElement.scrollTop;
-    if (scrollTop === lastScrollTop) {
-      return {};
-    }
-
-    const dir = scrollTop > lastScrollTop ? 'down' : 'up';
-    const dist = Math.abs(scrollTop - lastScrollTop);
-    const ref = Math.abs(scrollTop - lastScrollRef);
-    lastScrollTop = Math.max(0, scrollTop);
-    return {dir, pos: scrollTop, dist, ref};
-  };
-
-  /**
-   * Show/hide tabs menu depending on scroll direction and distance scrolled from ref point
-   * Update reference point and reference direction only on state change
-   */
-  const toggleMobileTabsMenu = () => {
-    const {dir, pos, ref} = scrollData();
-    if (!dir || dir === lastScrollDir) {
-      return;
-    }
-
-    // Keep open, avoid glitches when scrolling up at max top
-    if (pos < distToOpen) {
-      lastScrollDir = 'up';
-      lastScrollRef = lastScrollTop;
-      menu.classList.remove('mobile-menu-hidden');
-      return;
-    }
-
-    const menuItems = menu.querySelectorAll('.nav-link');
-    // Hide
-    if (dir === 'down' && ref >= distToClose) {
-      lastScrollDir = dir;
-      lastScrollRef = lastScrollTop;
-      menu.classList.add('mobile-menu-hidden');
-      if (menuItems && menuItems.length > 0) {
-        menuItems.forEach(item => item.setAttribute('tabindex', -1));
-      }
-      return;
-    }
-
-    // Show
-    if (dir === 'up' && ref >= distToOpen) {
-      lastScrollDir = dir;
-      lastScrollRef = lastScrollTop;
-      menu.classList.remove('mobile-menu-hidden');
-      if (menuItems && menuItems.length > 0) {
-        menuItems.forEach(item => item.setAttribute('tabindex', 0));
-      }
-    }
-  };
-
-  ['touchmove', 'scroll'].forEach(eventName => {
-    document.addEventListener(
-      eventName,
-      toggleMobileTabsMenu,
-      supportsPassive ? {passive: true} : false
-    );
-  });
-};
-
 export const setupHeader = () => {
   const toggleElementClasses = [
     '.navbar-dropdown-toggle',
@@ -260,7 +163,8 @@ export const setupHeader = () => {
     });
   }
 
-  setMobileTabsMenuScroll();
+  // Set the mobile tabs menu behavior on scroll
+  setupMobileTabsMenuScroll();
 
   // Setup keyboard accessibility in the navigation menu.
   setupAccessibleNavMenu();

--- a/assets/src/js/header/setupMobileTabsMenuScroll.js
+++ b/assets/src/js/header/setupMobileTabsMenuScroll.js
@@ -1,0 +1,103 @@
+// Reusable class for hiding the mobile tabs.
+const HIDDEN_TABS_CLASS = 'mobile-menu-hidden';
+
+/**
+ * Set the mobile tabs menu behavior on scroll
+ * Mobile tabs menu should hide when user scrolls down, and reappear when they scroll up
+ */
+export default () => {
+  const menu = document.getElementById('nav-mobile');
+  if (!menu) {
+    return;
+  }
+
+  const distToClose = 100;
+  const distToOpen = 50;
+  let lastScrollDir = null;
+  let lastScrollTop = window.pageYOffset || document.documentElement.scrollTop;
+  let lastScrollRef = lastScrollTop;
+
+  // Check support for eventlistener opts (passive option)
+  // Cf. https://github.com/WICG/EventListenerOptions/blob/gh-pages/explainer.md#feature-detection
+  let supportsPassive = false;
+  try {
+    const opts = Object.defineProperty({}, 'passive', {
+      get: () => {
+        supportsPassive = true;
+        return supportsPassive;
+      },
+    });
+    window.addEventListener('testPassive', null, opts);
+    window.removeEventListener('testPassive', null, opts);
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.log(e);
+  }
+
+  /**
+   * Get scroll direction, distance from the lastScrollTop, and distance from a reference point
+   *
+   * @return {Object} {scroll direction, top position, distance scrolled, distance scrolled from ref point}
+   */
+  const scrollData = () => {
+    const scrollTop = window.pageYOffset || document.documentElement.scrollTop;
+    if (scrollTop === lastScrollTop) {
+      return {};
+    }
+
+    const dir = scrollTop > lastScrollTop ? 'down' : 'up';
+    const dist = Math.abs(scrollTop - lastScrollTop);
+    const ref = Math.abs(scrollTop - lastScrollRef);
+    lastScrollTop = Math.max(0, scrollTop);
+    return {dir, pos: scrollTop, dist, ref};
+  };
+
+  /**
+   * Show/hide tabs menu depending on scroll direction and distance scrolled from ref point
+   * Update reference point and reference direction only on state change
+   */
+  const toggleMobileTabsMenu = () => {
+    const {dir, pos, ref} = scrollData();
+    if (!dir || dir === lastScrollDir) {
+      return;
+    }
+
+    // Keep open, avoid glitches when scrolling up at max top
+    if (pos < distToOpen) {
+      lastScrollDir = 'up';
+      lastScrollRef = lastScrollTop;
+      menu.classList.remove(HIDDEN_TABS_CLASS);
+      return;
+    }
+
+    const menuItems = menu.querySelectorAll('.nav-link');
+    // Hide
+    if (dir === 'down' && ref >= distToClose) {
+      lastScrollDir = dir;
+      lastScrollRef = lastScrollTop;
+      menu.classList.add(HIDDEN_TABS_CLASS);
+      if (menuItems && menuItems.length > 0) {
+        menuItems.forEach(item => item.setAttribute('tabindex', -1));
+      }
+      return;
+    }
+
+    // Show
+    if (dir === 'up' && ref >= distToOpen) {
+      lastScrollDir = dir;
+      lastScrollRef = lastScrollTop;
+      menu.classList.remove(HIDDEN_TABS_CLASS);
+      if (menuItems && menuItems.length > 0) {
+        menuItems.forEach(item => item.setAttribute('tabindex', 0));
+      }
+    }
+  };
+
+  ['touchmove', 'scroll'].forEach(eventName => {
+    document.addEventListener(
+      eventName,
+      toggleMobileTabsMenu,
+      supportsPassive ? {passive: true} : false
+    );
+  });
+};


### PR DESCRIPTION
### Summary

This allows us to simplify `header.js` and hopefully makes the code easier to maintain. I've also created a constant to be used for the `mobile-menu-hidden` class.

Ref: [PLANET-7849](https://jira.greenpeace.org/browse/PLANET-7849)

### Testing

The mobile tabs should still behave as expected.


[PLANET-7849]: https://greenpeace-planet4.atlassian.net/browse/PLANET-7849?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ