### PR TITLE
Move close nav element functionality to separate file

### DIFF
--- a/assets/src/js/header.js
+++ b/assets/src/js/header.js
@@ -1,6 +1,7 @@
 /* global hj */
 
 import setupAccessibleNavMenu from './header/setupAccessibleNavMenu';
+import setupCloseNavMenuButton from './header/setupCloseNavMenuButton';
 
 const updateGaAction = (element, elementName) => {
   element.dataset.gaAction = `${element.getAttribute('aria-expanded') === 'false' ? 'Open' : 'Close'} ${elementName}`;
@@ -114,12 +115,6 @@ const closeInactiveNavElements = event => {
       button.click();
     }
   });
-};
-
-const closeElement = (event, buttonClass) => {
-  event.preventDefault();
-  const closeButton = document.querySelector(buttonClass);
-  closeButton.click();
 };
 
 /**
@@ -249,16 +244,8 @@ export const setupHeader = () => {
     }
   };
 
-  // Close the elements if the user clicks on the corresponding close buttons
-  const closeNavbarButton = document.querySelector('.close-navbar-dropdown');
-  if (closeNavbarButton) {
-    closeNavbarButton.onclick = event => closeElement(event, '.navbar-dropdown-toggle');
-  }
-
-  const closeNavMenuButton = document.querySelector('.nav-menu-close');
-  if (closeNavMenuButton) {
-    closeNavMenuButton.onclick = event => closeElement(event, '.nav-menu-toggle');
-  }
+  // Spoof click on nav menu toggle when clicking on nav menu close button.
+  setupCloseNavMenuButton();
 
   let searchFocused = false;
   const searchInput = document.getElementById('search_input');

--- a/assets/src/js/header/setupCloseNavMenuButton.js
+++ b/assets/src/js/header/setupCloseNavMenuButton.js
@@ -1,0 +1,16 @@
+/**
+ * Spoof click on nav menu toggle when clicking on nav menu close button.
+ */
+export default () => {
+  const closeNavMenuButton = document.querySelector('.nav-menu-close');
+  const closeButton = document.querySelector('.nav-menu-toggle');
+
+  if (!closeNavMenuButton || !closeButton) {
+    return;
+  }
+
+  closeNavMenuButton.onclick = event => {
+    event.preventDefault();
+    closeButton.click();
+  };
+};

--- a/templates/burger-menu.twig
+++ b/templates/burger-menu.twig
@@ -61,9 +61,6 @@
         class="nav-menu-close"
         type="button"
         aria-label="{{ __( 'Close navigation mobile menu', 'planet4-master-theme' ) }}"
-        aria-expanded="false"
-        data-bs-toggle="open"
-        data-bs-target="#nav-main"
         tabindex="-1"
     >
         <span class="visually-hidden">


### PR DESCRIPTION
### Summary

This allows us to simplify `header.js` and hopefully makes the code easier to maintain. I've removed mentions of the `close-navbar-dropdown` because it seems it's no longer used.

Ref: [PLANET-7849](https://jira.greenpeace.org/browse/PLANET-7849)

I've also removed the Bootstrap attributes on the close nav button, we don't need them since we override the click function. The `aria-expanded` attribute wasn't updated anyways, see following screenshot where the button was open: 

<img width="561" height="53" alt="Screenshot 2025-07-22 at 15 25 40" src="https://github.com/user-attachments/assets/1d6cb903-1950-44a0-8a47-3368838d9875" />

### Testing

Closing the navigation menu should still work as expected.

[PLANET-7849]: https://greenpeace-planet4.atlassian.net/browse/PLANET-7849?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ