### PR TITLE
 Reduce the length of the `MasterSite` class II

### DIFF
--- a/assets/src/scss/pages/post/_comments-form.scss
+++ b/assets/src/scss/pages/post/_comments-form.scss
@@ -64,10 +64,6 @@
   }
 }
 
-.comment-form-cookies-consent input[type="checkbox"] ~ .custom-control-description {
-  font-size: 14px;
-}
-
 .logged-in-as {
   font-size: var(--font-size-s--font-family-tertiary);
   font-family: var(--font-family-tertiary);
@@ -93,10 +89,6 @@
 }
 
 @include medium-and-up {
-  .comment-form-cookies-consent {
-    margin-top: $sp-1;
-  }
-
   .comments-block .form-section .comment-respond {
     padding: $sp-4;
   }

--- a/src/CommentFormCustomizer.php
+++ b/src/CommentFormCustomizer.php
@@ -15,7 +15,6 @@ class CommentFormCustomizer
     public function __construct()
     {
         add_filter('comment_form_submit_field', [$this, 'gdpr_cc_comment_form_add_class'], 150, 1);
-        add_filter('comment_form_default_fields', [$this, 'comment_form_cookie_checkbox_add_class']);
         add_filter('comment_form_default_fields', [$this, 'comment_form_replace_inputs']);
     }
 
@@ -39,28 +38,6 @@ class CommentFormCustomizer
         $submit_field = preg_replace($pattern, $replacement, $submit_field);
 
         return $submit_field;
-    }
-
-    /**
-     * Add classes to the default comment form cookie checkbox.
-     *
-     * @param array $fields The default fields of the comment form.
-     *
-     * @return array the new fields.
-     */
-    public function comment_form_cookie_checkbox_add_class(array $fields): array
-    {
-
-        if (isset($fields['cookies'])) {
-            $pattern[0] = '/(class=["\']comment-form-cookies-consent["\'])/';
-            $replacement[0] = 'class="comment-form-cookies-consent custom-control"';
-            $pattern[1] = '/(for=["\']wp-comment-cookies-consent["\'])/';
-            $replacement[1] = '$1 class="custom-control-description"';
-
-            $fields['cookies'] = preg_replace($pattern, $replacement, $fields['cookies']);
-        }
-
-        return $fields;
     }
 
     /**

--- a/src/CommentFormCustomizer.php
+++ b/src/CommentFormCustomizer.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace P4\MasterTheme;
+
+use Timber\Timber;
+
+/**
+ * Class CommentFormCustomizer
+ */
+class CommentFormCustomizer
+{
+    /**
+     * Constructor.
+     */
+    public function __construct()
+    {
+        add_filter('comment_form_submit_field', [$this, 'gdpr_cc_comment_form_add_class'], 150, 1);
+        add_filter('comment_form_default_fields', [$this, 'comment_form_cookie_checkbox_add_class']);
+        add_filter('comment_form_default_fields', [$this, 'comment_form_replace_inputs']);
+    }
+
+    /**
+     * Filter and add class to GDPR consent checkbox label after the GDPR fields appended to comment form submit field.
+     *
+     * @param string $submit_field The HTML content of comment form submit field.
+     *
+     * @return string HTML content of comment form submit field.
+     */
+    public function gdpr_cc_comment_form_add_class(string $submit_field): string
+    {
+
+        $pattern[0] = '/(for=["\']gdpr-comments-checkbox["\'])/';
+        $replacement[0] = '$1 class="custom-control-description"';
+        $pattern[1] = '/(id=["\']gdpr-comments-checkbox["\'])/';
+        $replacement[1] = '$1 style="width:auto;"';
+        $pattern[2] = '/id="gdpr-comments-compliance"/';
+        $replacement[2] = 'id="gdpr-comments-compliance" class="custom-control"';
+
+        $submit_field = preg_replace($pattern, $replacement, $submit_field);
+
+        return $submit_field;
+    }
+
+    /**
+     * Add classes to the default comment form cookie checkbox.
+     *
+     * @param array $fields The default fields of the comment form.
+     *
+     * @return array the new fields.
+     */
+    public function comment_form_cookie_checkbox_add_class(array $fields): array
+    {
+
+        if (isset($fields['cookies'])) {
+            $pattern[0] = '/(class=["\']comment-form-cookies-consent["\'])/';
+            $replacement[0] = 'class="comment-form-cookies-consent custom-control"';
+            $pattern[1] = '/(for=["\']wp-comment-cookies-consent["\'])/';
+            $replacement[1] = '$1 class="custom-control-description"';
+
+            $fields['cookies'] = preg_replace($pattern, $replacement, $fields['cookies']);
+        }
+
+        return $fields;
+    }
+
+    /**
+     * Use different templates for the comment form fields (name and email).
+     * Also remove the website field since we don't want to use it.
+     *
+     * @param array $fields The default fields of the comment form.
+     *
+     * @return array the new fields.
+     */
+    public function comment_form_replace_inputs(array $fields): array
+    {
+
+        $fields['author'] = Timber::compile('comment_form/author_field.twig');
+        $fields['email'] = Timber::compile('comment_form/email_field.twig');
+        if (isset($fields['url'])) {
+            unset($fields['url']);
+        }
+
+        return $fields;
+    }
+}

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -99,6 +99,7 @@ final class Loader
             BlockSettings::class,
             EnqueueController::class,
             YouTubeHandler::class,
+            CommentFormCustomizer::class,
         ];
 
         if (is_admin()) {

--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -161,9 +161,6 @@ class MasterSite extends TimberSite
         add_filter('login_headerurl', [$this, 'add_login_logo_url']);
         add_filter('login_headertext', [$this, 'add_login_logo_url_title']);
         add_action('login_enqueue_scripts', [$this, 'add_login_stylesheet']);
-        add_filter('comment_form_submit_field', [$this, 'gdpr_cc_comment_form_add_class'], 150, 1);
-        add_filter('comment_form_default_fields', [$this, 'comment_form_cookie_checkbox_add_class']);
-        add_filter('comment_form_default_fields', [$this, 'comment_form_replace_inputs']);
         add_filter(
             'editable_roles',
             function ($roles) {
@@ -1302,70 +1299,6 @@ class MasterSite extends TimberSite
         $sidebar .= '<p><a target="_blank" href="https://planet4.greenpeace.org/">Planet 4 Handbook</a></p>';
 
         $screen->set_help_sidebar($sidebar);
-    }
-
-    /**
-     * Filter and add class to GDPR consent checkbox label after the GDPR fields appended to comment form submit field.
-     *
-     * @param string $submit_field The HTML content of comment form submit field.
-     *
-     * @return string HTML content of comment form submit field.
-     */
-    public function gdpr_cc_comment_form_add_class(string $submit_field): string
-    {
-
-        $pattern[0] = '/(for=["\']gdpr-comments-checkbox["\'])/';
-        $replacement[0] = '$1 class="custom-control-description"';
-        $pattern[1] = '/(id=["\']gdpr-comments-checkbox["\'])/';
-        $replacement[1] = '$1 style="width:auto;"';
-        $pattern[2] = '/id="gdpr-comments-compliance"/';
-        $replacement[2] = 'id="gdpr-comments-compliance" class="custom-control"';
-
-        $submit_field = preg_replace($pattern, $replacement, $submit_field);
-
-        return $submit_field;
-    }
-
-    /**
-     * Add classes to the default comment form cookie checkbox.
-     *
-     * @param array $fields The default fields of the comment form.
-     *
-     * @return array the new fields.
-     */
-    public function comment_form_cookie_checkbox_add_class(array $fields): array
-    {
-
-        if (isset($fields['cookies'])) {
-            $pattern[0] = '/(class=["\']comment-form-cookies-consent["\'])/';
-            $replacement[0] = 'class="comment-form-cookies-consent custom-control"';
-            $pattern[1] = '/(for=["\']wp-comment-cookies-consent["\'])/';
-            $replacement[1] = '$1 class="custom-control-description"';
-
-            $fields['cookies'] = preg_replace($pattern, $replacement, $fields['cookies']);
-        }
-
-        return $fields;
-    }
-
-    /**
-     * Use different templates for the comment form fields (name and email).
-     * Also remove the website field since we don't want to use it.
-     *
-     * @param array $fields The default fields of the comment form.
-     *
-     * @return array the new fields.
-     */
-    public function comment_form_replace_inputs(array $fields): array
-    {
-
-        $fields['author'] = Timber::compile('comment_form/author_field.twig');
-        $fields['email'] = Timber::compile('comment_form/email_field.twig');
-        if (isset($fields['url'])) {
-            unset($fields['url']);
-        }
-
-        return $fields;
     }
 
     /**


### PR DESCRIPTION
### Summary

As part of our effort to reduce the size of the `MasterSite` class, this PR moves from it all functions related to the comment forms into a new class called `CommentFormCustomizer`

---

Ref: https://greenpeace-gpi.slack.com/archives/C0160MX64AG/p1751531019331059 

### Testing

1. Go to a post that contains a comment form.
2. Check in the form that the checkbox and its label contain the expected custom classes.
3. Check in the form that the website field was removed.