### PR TITLE
Fix cookies box text color

### DIFF
--- a/assets/src/scss/layout/_cookies.scss
+++ b/assets/src/scss/layout/_cookies.scss
@@ -2,6 +2,7 @@
   _-- {
     font-family: var(--font-family-paragraph-secondary);
   }
+  color: var(--grey-900);
   z-index: 100;
   position: fixed;
   width: 100vw;


### PR DESCRIPTION
### Summary
Set as `$grey-900` to avoid issues with templates, especially with the Resitance Hub.

#### Testing
Navigate through https://www-dev.greenpeace.org/international/act/resistance-hub/ (private mode), the cookies text should be black.