### PR TITLE
PLANET-7882 Mark Action as completed based on user interaction

### DIFF
--- a/assets/src/scss/pages/_resistance-hub-campaign.scss
+++ b/assets/src/scss/pages/_resistance-hub-campaign.scss
@@ -17,7 +17,7 @@
 @mixin btn-cta {
   position: static;
   width: 100%;
-  font-size: 25px;
+  font-size: 18px;
   line-height: 100%;
   padding-top: 18px;
   padding-bottom: 18px;
@@ -72,7 +72,7 @@
   }
 
   .boxout {
-    height: auto;
+    height: 300px;
     box-shadow: none;
     margin-top: 90px;
 
@@ -86,7 +86,7 @@
     }
 
     .boxout-excerpt {
-      font-size: 24px;
+      font-size: 18px;
       line-clamp: unset;
       -webkit-line-clamp: unset;
     }
@@ -117,13 +117,13 @@
       overflow: visible;
 
       .wp-block-post-title {
-        font-size: 42px;
-        line-height: 46px;
+        font-size: 32px;
+        line-height: 1.275;
       }
 
       .wp-block-post-excerpt p {
-        font-size: 24px;
-        line-height: 30px;
+        font-size: 18px;
+        line-height: 1.5;
       }
 
       .actions-list-links {
@@ -165,7 +165,7 @@
         @include btn-cta;
       }
 
-      & *:not(.read-more-nav .btn) {
+      *:not(.read-more-nav .btn):not(.chip-deadline) {
         color: var(--white);
       }
     }
@@ -243,6 +243,87 @@
   @media (min-width: 1440px) {
     .boxout {
       width: 66%;
+    }
+  }
+
+  .boxout.completed,
+  .wp-block-post.completed {
+    background-color: var(--gp-green-500);
+    border-color: transparent;
+    padding: 24px;
+    min-height: auto;
+    height: 240px;
+    display: block;
+
+    .chip-tasktype {
+      display: none;
+    }
+
+    .boxout-content {
+      padding: 0;
+      margin: 0;
+    }
+
+    .boxout-excerpt,
+    .wp-block-post-excerpt p {
+      line-clamp: 2;
+      -webkit-line-clamp: 2;
+      line-height: 1.5;
+      font-size: 18px;
+    }
+
+    .wp-block-post-terms {
+      display: none;
+    }
+
+    .wp-block-post-title,
+    .boxout-heading {
+      font-size: 32px;
+
+      a {
+        line-clamp: 1;
+        -webkit-line-clamp: 1;
+      }
+    }
+
+    .completed-message {
+      padding-top: 0;
+      font-family: var(--font-family-primary);
+      display: flex;
+      align-items: center;
+      margin-bottom: 8px;
+
+      span:first-child {
+        background-image: url("../../images/checkmark.svg");
+        min-width: 50px;
+        min-height: 50px;
+        background-color: var(--white);
+        border-radius: 50%;
+        margin-inline-end: 8px;
+        background-repeat: no-repeat;
+        background-position: center;
+        background-size: 30px;
+      }
+    }
+
+    .chip-deadline {
+      display: none;
+    }
+
+    *:not(.read-more-nav .btn):not(.chip-deadline) {
+      color: var(--grey-900);
+    }
+
+    .wp-block-group.is-layout-flow {
+      padding: 0;
+      margin-bottom: 0;
+    }
+
+    .btn {
+      background-color: transparent;
+      width: auto;
+      padding: 0;
+      font-size: 18px;
     }
   }
 }

--- a/assets/src/scss/pages/_resistance-hub-campaign.scss
+++ b/assets/src/scss/pages/_resistance-hub-campaign.scss
@@ -34,7 +34,9 @@
     }
 
     .container {
-      padding: 0;
+      @media (min-width: 768px) {
+        padding: 0;
+      }
     }
 
     .site-logo {
@@ -72,9 +74,9 @@
   }
 
   .boxout {
-    height: 300px;
     box-shadow: none;
     margin-top: 90px;
+    margin-bottom: 0;
 
     .boxout-heading {
       font-size: 42px;
@@ -103,6 +105,10 @@
     .chip-tasktype {
       @include chip-task-type;
     }
+
+    @media (min-width: 768px) {
+      height: 300px;
+    }
   }
 
   .actions-list {
@@ -115,6 +121,7 @@
       border: 2px solid var(--white);
       margin-top: 44px;
       overflow: visible;
+      margin-bottom: 0;
 
       .wp-block-post-title {
         font-size: 32px;
@@ -254,7 +261,6 @@
     min-height: auto;
     height: 240px;
     display: block;
-    margin-bottom: 0;
 
     .chip-tasktype {
       display: none;

--- a/assets/src/scss/pages/_resistance-hub-campaign.scss
+++ b/assets/src/scss/pages/_resistance-hub-campaign.scss
@@ -254,6 +254,7 @@
     min-height: auto;
     height: 240px;
     display: block;
+    margin-bottom: 0;
 
     .chip-tasktype {
       display: none;

--- a/single-p4_action-resistance_hub.php
+++ b/single-p4_action-resistance_hub.php
@@ -10,6 +10,8 @@
  * @since    Timber 0.1
  */
 
+namespace P4\MasterTheme;
+
 $features = get_option('planet4_features');
 
 // Enqueue Resistance Hub styles and script only for this template
@@ -28,14 +30,14 @@ add_action('wp_enqueue_scripts', function (): void {
         'p4-action-resistance-hub-styles',
         get_template_directory_uri() . '/assets/build/resistance-hub-campaign-styles.css',
         [],
-        true,
+        Loader::theme_file_ver('/assets/build/resistance-hub-campaign-styles.css'),
     );
 
     wp_enqueue_script(
         'p4-action-resistance-hub-script',
         get_template_directory_uri() . '/assets/build/resistance-hub-campaign.js',
         ['wp-i18n'],
-        true,
+        Loader::theme_file_ver('/assets/build/resistance-hub-campaign.js'),
     );
 });
 

--- a/single-p4_action-resistance_hub.php
+++ b/single-p4_action-resistance_hub.php
@@ -28,12 +28,14 @@ add_action('wp_enqueue_scripts', function (): void {
         'p4-action-resistance-hub-styles',
         get_template_directory_uri() . '/assets/build/resistance-hub-campaign-styles.css',
         [],
+        true,
     );
 
     wp_enqueue_script(
         'p4-action-resistance-hub-script',
         get_template_directory_uri() . '/assets/build/resistance-hub-campaign.js',
-        [],
+        ['wp-i18n'],
+        true,
     );
 });
 

--- a/src/Blocks/TakeActionBoxout.php
+++ b/src/Blocks/TakeActionBoxout.php
@@ -170,6 +170,7 @@ class TakeActionBoxout extends BaseBlock
                 'image_srcset' => $src_set ?? '',
                 'stickyMobile' => $fields['stickyOnMobile'] ?? false,
                 'headingFontSize' => $fields['headingFontSize'] ?? 'medium',
+                'page_id' => $page_id,
             ],
         ];
     }

--- a/src/Features/ActionsTaskType.php
+++ b/src/Features/ActionsTaskType.php
@@ -32,7 +32,7 @@ class ActionsTaskType extends Feature
     {
         return __(
             // phpcs:ignore Generic.Files.LineLength.MaxExceeded
-            'Adds option for showing whether an Action is either Online or IRL on Actions List block',
+            'Adds option for showing whether an Action is either Online or IRL on Actions List block. This feature only works on Actions that use the Resistance Hub template.',
             'planet4-master-theme-backend',
         );
     }

--- a/src/Features/ActionsUserPersonalization.php
+++ b/src/Features/ActionsUserPersonalization.php
@@ -7,14 +7,14 @@ use P4\MasterTheme\Feature;
 /**
  * @see description().
  */
-class ActionsDeadline extends Feature
+class ActionsUserPersonalization extends Feature
 {
     /**
      * @inheritDoc
      */
     public static function id(): string
     {
-        return 'actions_deadline';
+        return 'actions_user_personalization';
     }
 
     /**
@@ -22,7 +22,7 @@ class ActionsDeadline extends Feature
      */
     protected static function name(): string
     {
-        return __('Actions Deadline', 'planet4-master-theme-backend');
+        return __('Actions User Personalization', 'planet4-master-theme-backend');
     }
 
     /**
@@ -32,7 +32,7 @@ class ActionsDeadline extends Feature
     {
         return __(
             // phpcs:ignore Generic.Files.LineLength.MaxExceeded
-            'Adds option for showing a countdown on Actions List block. This feature only works on Actions that use the Resistance Hub template.',
+            'Shows Actions as completed if the user has visited them already. This feature only works on Actions that use the Resistance Hub template.',
             'planet4-master-theme-backend',
         );
     }

--- a/src/Settings/Features.php
+++ b/src/Settings/Features.php
@@ -13,6 +13,7 @@ use P4\MasterTheme\Features\Planet4Blocks;
 use P4\MasterTheme\Features\OldPostsArchiveNotice;
 use P4\MasterTheme\Features\ActionsTaskType;
 use P4\MasterTheme\Features\ActionsDeadline;
+use P4\MasterTheme\Features\ActionsUserPersonalization;
 use P4\MasterTheme\Loader;
 use P4\MasterTheme\Settings;
 use CMB2;
@@ -103,6 +104,7 @@ class Features
             OldPostsArchiveNotice::class,
             ActionsTaskType::class,
             ActionsDeadline::class,
+            ActionsUserPersonalization::class,
 
             // Dev only.
             DisableDataSync::class,

--- a/templates/blocks/take-action-boxout.twig
+++ b/templates/blocks/take-action-boxout.twig
@@ -1,7 +1,7 @@
 {% block take_action_boxout %}
 	{% if ( boxout ) %}
 		<section
-			class="boxout{% if boxout.stickyMobile %} sticky-bottom-mobile collapse show{% endif %}"
+			class="boxout {% if boxout.page_id %}post-{{boxout.page_id}}{% endif %} {% if boxout.stickyMobile %} sticky-bottom-mobile collapse show{% endif %}"
 			{{ boxout.stickyMobile ? 'id="action-card"' }}
 		>
 			<a


### PR DESCRIPTION
### Summary

Ref: [PLANET-7882](https://greenpeace-planet4.atlassian.net/browse/PLANET-7882)

**Requirements:**

- [x] When a user clicks the button and visits a certain Action then that item in that Actions List block should marked as completed, as shown in the [design mockups](https://www.figma.com/design/g8VVK7TqRGr2B2jFnGdnE1/Time-To-Resist---Fair-Share---GPI?node-id=148-857&t=9J15V8PA0omtHK7j-4)
- [x] The functionality should also cover the Take Action Boxout block.
- [x] This implementation should be enabled only when a feature flag is enabled (off by default) under Planet 4 > Features
  - Label: Actions User Personalization
  - Description: Shows Actions as completed if the user has visited them already
  - Make sure it's clear these new features are only applied to the Resistance Hub template.
- [x] The feature should be only implemented in the [Resistance Hub template](https://github.com/greenpeace/planet4-master-theme/blob/main/single-p4_action-resistance_hub.php).
- [x] We can explore using LocalStorage instead of Cookies, in order to not depend on the Cookies acceptance status.
- [x] We would probably need to identify each Action with a unique id in order to track whether the user has visited it or not.
- [x] The implementation should be done on the client side (JS) to avoid cache issues with Cloudflare.

### Testing

You can use [this page](https://www-dev.greenpeace.org/test-phoebe/petitions/resistance-hub/) I created for UAT in order to test the new functionality.

[PLANET-7882]: https://greenpeace-planet4.atlassian.net/browse/PLANET-7882?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ