### PR TITLE
Fix blank page when no posts are found

### DIFF
--- a/assets/src/scss/pages/_listing-page.scss
+++ b/assets/src/scss/pages/_listing-page.scss
@@ -307,6 +307,7 @@
 
   @include medium-and-up {
     margin: $sp-5 0;
+    padding-bottom: $sp-4;
   }
 }
 
@@ -318,7 +319,7 @@
   }
 
   @include medium-and-up {
-    margin-bottom: $sp-5;
+    margin-bottom: $sp-7;
   }
 }
 
@@ -363,12 +364,17 @@
 
   .listing-page-select {
     width: 100%;
+    position: relative;
 
     select {
       margin-bottom: $sp-3;
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
+
+      @include medium-and-up {
+        margin-bottom: 0;
+      }
     }
   }
 
@@ -405,6 +411,12 @@
   font-size: var(--font-size-m--font-family-tertiary);
   margin-bottom: $sp-1;
   color: var(--grey-600);
+
+  @include medium-and-up {
+    position: absolute;
+    top: -$sp-4;
+    left: 0;
+  }
 }
 
 .filter-btn {

--- a/index.php
+++ b/index.php
@@ -16,10 +16,6 @@ global $post;
  * @since   Timber 0.1
  */
 
-if (!$post) {
-    return;
-}
-
 use P4\MasterTheme\Context;
 use P4\MasterTheme\Post;
 use P4\MasterTheme\ListingPage;

--- a/page-templates/evergreen.php
+++ b/page-templates/evergreen.php
@@ -20,10 +20,6 @@ global $post;
  * @since    Timber 0.1
  */
 
-if (!$post) {
-    return;
-}
-
 use P4\MasterTheme\Context;
 use P4\MasterTheme\Post;
 use Timber\Timber;

--- a/page.php
+++ b/page.php
@@ -30,10 +30,6 @@ global $post;
  * Post     : Action
  */
 
-if (!$post) {
-    return;
-}
-
 use P4\MasterTheme\Context;
 use P4\MasterTheme\Features\RedirectRedirectPages;
 use P4\MasterTheme\Post;

--- a/single-campaign.php
+++ b/single-campaign.php
@@ -8,10 +8,6 @@ global $post;
  * @package P4MT
  */
 
-if (!$post) {
-    return;
-}
-
 use P4\MasterTheme\Context;
 use P4\MasterTheme\Post;
 use Timber\Timber;

--- a/single-p4_action.php
+++ b/single-p4_action.php
@@ -14,10 +14,6 @@ global $post;
  * @since    Timber 0.1
  */
 
-if (!$post) {
-    return;
-}
-
 use P4\MasterTheme\Context;
 use P4\MasterTheme\Post;
 use Timber\Timber;

--- a/single.php
+++ b/single.php
@@ -12,10 +12,6 @@ global $post;
  * @since    Timber 0.1
  */
 
-if (!$post) {
-    return;
-}
-
 use P4\MasterTheme\Context;
 use P4\MasterTheme\Post;
 use P4\MasterTheme\Settings\CommentsGdpr;


### PR DESCRIPTION
### Summary

This PR fixes the blank page issue when no posts are found.
Additionally, it aligns the "Apply" button of the "News & Stories" page on desktop.

---

Ref: https://greenpeace-gpi.slack.com/archives/C0160MX64AG/p1753350675224669

### Testing

1. Go to the "News & Stories" page.
2. Select a combination of filters that return no posts.
3. Click on the "Apply" button.
4. Check the page after being reloaded: it should be rendered as expected and show the message "No posts found!"