### PR TITLE
PLANET-7608: Fix Quick Links layout issues on small screens

### DIFF
--- a/assets/src/block-templates/quick-links/template.js
+++ b/assets/src/block-templates/quick-links/template.js
@@ -26,6 +26,7 @@ const template = ({
   backgroundColor = 'beige-100',
 }) => ([
   ['core/group', {
+    className: 'block',
     align: 'full',
     backgroundColor,
   }, [

--- a/assets/src/block-templates/quick-links/template.js
+++ b/assets/src/block-templates/quick-links/template.js
@@ -26,7 +26,6 @@ const template = ({
   backgroundColor = 'beige-100',
 }) => ([
   ['core/group', {
-    className: 'block',
     align: 'full',
     backgroundColor,
   }, [
@@ -35,7 +34,7 @@ const template = ({
       ['core/heading', {level: 4, placeholder: __('Enter title', 'planet4-blocks-backend'), content: title}],
       ['core/columns', {
         isStackedOnMobile: false,
-        className: 'is-style-mobile-carousel',
+        className: 'is-style-mobile-carousel quick-links',
       },
       [...Array(5).keys()].map(() => category)],
     ]],

--- a/assets/src/scss/base/_mixins.scss
+++ b/assets/src/scss/base/_mixins.scss
@@ -433,3 +433,12 @@ $nested-comment-left-margin: 50px;
     content: "•";
   }
 }
+
+@mixin wide-block {
+  width: 100vw;
+  margin-left: calc(((100vw - 100%) / 2) * -1);
+
+  html[dir="rtl"] & {
+    margin-right: calc(((100vw - 100%) / 2) * -1);
+  }
+}

--- a/assets/src/scss/blocks/core-overrides/Columns.scss
+++ b/assets/src/scss/blocks/core-overrides/Columns.scss
@@ -35,11 +35,11 @@
       padding-left: $sp-1x;
       padding-right: $sp-1x;
 
-      @media (max-width: 340px) {
+      @media (max-width: 350px) {
         @include apply-item-width(0, 2);
       }
 
-      @media (min-width: 420px) {
+      @media (min-width: 480px) {
         @include apply-item-width(0, 4);
       }
     }

--- a/assets/src/scss/blocks/core-overrides/Columns.scss
+++ b/assets/src/scss/blocks/core-overrides/Columns.scss
@@ -1,3 +1,15 @@
+@mixin apply-item-width($gap, $items-count) {
+  $gap: 0;
+  $total-gap: calc($gap * $items-count);
+  $apply-item-width: calc(100vw / calc($items-count + .5));
+
+  gap: $gap !important;
+
+  .wp-block-column {
+    flex-basis: $apply-item-width;
+  }
+}
+
 .wp-block-columns.is-not-stacked-on-mobile.is-style-mobile-carousel {
   @include large-and-less {
     flex-wrap: nowrap;
@@ -18,30 +30,17 @@
   &.quick-links {
     @include mobile-only {
       @include wide-block;
-
-      $item-width: calc(100vw / 4);
+      @include apply-item-width(0, 3);
 
       padding-left: $sp-1x;
       padding-right: $sp-1x;
 
-      .wp-block-column {
-        flex-basis: $item-width;
-      }
-
-      @media (max-width: 380px) {
-        $item-width: calc(100vw / 3);
-
-        .wp-block-column {
-          flex-basis: $item-width;
-        }
+      @media (max-width: 340px) {
+        @include apply-item-width(0, 2);
       }
 
       @media (min-width: 420px) {
-        $item-width: calc(100vw / 5);
-
-        .wp-block-column {
-          flex-basis: $item-width;
-        }
+        @include apply-item-width(0, 4);
       }
     }
   }

--- a/assets/src/scss/blocks/core-overrides/Columns.scss
+++ b/assets/src/scss/blocks/core-overrides/Columns.scss
@@ -14,6 +14,38 @@
     }
   }
 
+  // These styles will be applied to the Quick Links Block only
+  &.quick-links {
+    @include mobile-only {
+      @include wide-block;
+
+      $item-width: calc(100vw / 4);
+
+      padding-left: $sp-1x;
+      padding-right: $sp-1x;
+
+      .wp-block-column {
+        flex-basis: $item-width;
+      }
+
+      @media (max-width: 380px) {
+        $item-width: calc(100vw / 3);
+
+        .wp-block-column {
+          flex-basis: $item-width;
+        }
+      }
+
+      @media (min-width: 420px) {
+        $item-width: calc(100vw / 5);
+
+        .wp-block-column {
+          flex-basis: $item-width;
+        }
+      }
+    }
+  }
+
   @include small-and-less {
     gap: $sp-2;
   }

--- a/assets/src/scss/layout/_wide-blocks.scss
+++ b/assets/src/scss/layout/_wide-blocks.scss
@@ -1,15 +1,7 @@
 // .block-wide kept for BC of existing content.
 // Can be removed once no content uses it anymore.
 .alignfull, .block-wide {
-  width: 100vw;
-  //     Screen width - block width
-  //  -  --------------------------
-  //                  2
-  margin-left: calc(((100vw - 100%) / 2) * -1);
-
-  html[dir="rtl"] & {
-    margin-right: calc(((100vw - 100%) / 2) * -1);
-  }
+  @include wide-block;
 
   .block-editor & {
     width: 100%;

--- a/src/Migrations/M056UpdateQuickLinksClassName.php
+++ b/src/Migrations/M056UpdateQuickLinksClassName.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace P4\MasterTheme\Migrations;
+
+use P4\MasterTheme\MigrationRecord;
+use P4\MasterTheme\MigrationScript;
+
+/**
+ * Update Quick Links Block with a new ClassName
+ */
+class M056UpdateQuickLinksClassName extends MigrationScript
+{
+    /**
+     * Perform the actual migration.
+     *
+     * @param MigrationRecord $record Information on the execution, can be used to add logs.
+     * phpcs:disable SlevomatCodingStandard.Functions.UnusedParameter -- interface implementation
+     */
+    public static function execute(MigrationRecord $record): void
+    {
+        $check_is_valid_block = function ($block) {
+            return self::check_is_valid_block($block);
+        };
+
+        $transform_block = function ($block) {
+            return self::transform_block($block);
+        };
+
+        Utils\Functions::execute_block_migration(
+            Utils\Constants::BLOCK_TEMPLATE_QUICK_LINKS,
+            $check_is_valid_block,
+            $transform_block,
+        );
+    }
+    // phpcs:enable SlevomatCodingStandard.Functions.UnusedParameter
+
+    /**
+     * Check whether the Quick Links blocks is into a page.
+     *
+     * @param array $block - A block data array.
+     */
+    private static function check_is_valid_block(array $block): bool
+    {
+       // Check if the block is an array, has a 'blockName' key.
+        if (!is_array($block) || !isset($block['blockName'])) {
+            return false;
+        }
+
+        // Check if the block is a Quick Links block.
+        return
+            $block['blockName'] === Utils\Constants::BLOCK_TEMPLATE_QUICK_LINKS
+        ;
+    }
+
+    /**
+     * Update class name
+     *
+     * @param array $block - A block data array.
+     * @return array - The transformed block.
+     */
+    private static function transform_block(array &$block): array // Using the parameter as a reference to update it
+    {
+        $iterate = function (array &$innerBlocks, string $blockName, array $path = []) use (&$iterate): ?array {
+            foreach ($innerBlocks as $index => &$innerBlock) {
+                $currentPath = array_merge($path, [$index]);
+                if ($innerBlock['blockName'] === $blockName) {
+                    if (!str_contains($innerBlock['attrs']['className'], "quick-links")) {
+                        $innerBlock['attrs']['className'] = ($innerBlock['attrs']['className'] ?? '') . ' quick-links';
+
+                        // Update inner content and replace className by adding the one related to Quick Links
+                        foreach ($innerBlock['innerContent'] as &$innerContent) {
+                            if (!is_string($innerContent) || !str_contains($innerContent, 'wp-block-columns')) {
+                                continue;
+                            }
+
+                            $innerContent = preg_replace(
+                                '/class="([^"]*)"/',
+                                'class="$1 quick-links"',
+                                $innerContent
+                            );
+                        }
+                    }
+                    return $innerBlocks;
+                }
+
+                if (empty($innerBlock['innerBlocks'])) {
+                    continue;
+                }
+
+                $found = $iterate($innerBlock['innerBlocks'], $blockName, $currentPath);
+                if (!empty($found)) {
+                    return $found;
+                }
+            }
+            return null;
+        };
+
+        if (!empty($block['innerBlocks'])) {
+            $iterate($block['innerBlocks'], 'core/columns');
+        }
+
+        return $block;
+    }
+}

--- a/src/Migrations/M056UpdateQuickLinksClassName.php
+++ b/src/Migrations/M056UpdateQuickLinksClassName.php
@@ -19,7 +19,9 @@ class M056UpdateQuickLinksClassName extends MigrationScript
     public static function execute(MigrationRecord $record): void
     {
         $check_is_valid_block = function ($block) {
-            return self::check_is_valid_block($block);
+            if (!empty($block['innerBlocks'])) {
+                return self::check_is_valid_block($block);
+            }
         };
 
         $transform_block = function ($block) {
@@ -60,10 +62,7 @@ class M056UpdateQuickLinksClassName extends MigrationScript
      */
     private static function transform_block(array &$block): array // Using the parameter as a reference to update it
     {
-        if (!empty($block['innerBlocks'])) {
-            self::update_class_name($block['innerBlocks'], 'core/columns');
-        }
-
+        self::update_class_name($block['innerBlocks'], 'core/columns');
         return $block;
     }
 

--- a/src/Migrations/M056UpdateQuickLinksClassName.php
+++ b/src/Migrations/M056UpdateQuickLinksClassName.php
@@ -53,52 +53,61 @@ class M056UpdateQuickLinksClassName extends MigrationScript
     }
 
     /**
-     * Update class name
+     * Modify the Quick Links block to add the quick-links class name.
      *
      * @param array $block - A block data array.
      * @return array - The transformed block.
      */
     private static function transform_block(array &$block): array // Using the parameter as a reference to update it
     {
-        $iterate = function (array &$innerBlocks, string $blockName, array $path = []) use (&$iterate): ?array {
-            foreach ($innerBlocks as $index => &$innerBlock) {
-                $currentPath = array_merge($path, [$index]);
-                if ($innerBlock['blockName'] === $blockName) {
-                    if (!str_contains($innerBlock['attrs']['className'], "quick-links")) {
-                        $innerBlock['attrs']['className'] = ($innerBlock['attrs']['className'] ?? '') . ' quick-links';
-
-                        // Update inner content and replace className by adding the one related to Quick Links
-                        foreach ($innerBlock['innerContent'] as &$innerContent) {
-                            if (!is_string($innerContent) || !str_contains($innerContent, 'wp-block-columns')) {
-                                continue;
-                            }
-
-                            $innerContent = preg_replace(
-                                '/class="([^"]*)"/',
-                                'class="$1 quick-links"',
-                                $innerContent
-                            );
-                        }
-                    }
-                    return $innerBlocks;
-                }
-
-                if (empty($innerBlock['innerBlocks'])) {
-                    continue;
-                }
-
-                $found = $iterate($innerBlock['innerBlocks'], $blockName, $currentPath);
-                if (!empty($found)) {
-                    return $found;
-                }
-            }
-            return null;
-        };
-
         if (!empty($block['innerBlocks'])) {
-            $iterate($block['innerBlocks'], 'core/columns');
+            self::update_class_name($block['innerBlocks'], 'core/columns');
         }
 
         return $block;
+    }
+
+    /**
+     * Update the class name of the Quick Links block.
+     *
+     * @param array $innerBlocks - The inner-block of the Quick Links block.
+     * @param string $blockName - The name of the block to update.
+     * @param array $path - The path of the block to update.
+     * @return array|null - The updated inner blocks.
+     */
+    private static function update_class_name(array &$innerBlocks, string $blockName, array $path = []): ?array
+    {
+        foreach ($innerBlocks as $index => &$innerBlock) {
+            $currentPath = array_merge($path, [$index]);
+            if ($innerBlock['blockName'] === $blockName) {
+                if (!str_contains($innerBlock['attrs']['className'], "quick-links")) {
+                    $innerBlock['attrs']['className'] = ($innerBlock['attrs']['className'] ?? '') . ' quick-links';
+
+                    // Update inner content and replace className by adding the one related to Quick Links
+                    foreach ($innerBlock['innerContent'] as &$innerContent) {
+                        if (!is_string($innerContent) || !str_contains($innerContent, 'wp-block-columns')) {
+                            continue;
+                        }
+
+                        $innerContent = preg_replace(
+                            '/class="([^"]*)"/',
+                            'class="$1 quick-links"',
+                            $innerContent
+                        );
+                    }
+                }
+                return $innerBlocks;
+            }
+
+            if (empty($innerBlock['innerBlocks'])) {
+                continue;
+            }
+
+            $found = self::update_class_name($innerBlock['innerBlocks'], $blockName, $currentPath);
+            if (!empty($found)) {
+                return $found;
+            }
+        }
+        return null;
     }
 }

--- a/src/Migrations/M056UpdateQuickLinksClassName.php
+++ b/src/Migrations/M056UpdateQuickLinksClassName.php
@@ -19,9 +19,7 @@ class M056UpdateQuickLinksClassName extends MigrationScript
     public static function execute(MigrationRecord $record): void
     {
         $check_is_valid_block = function ($block) {
-            if (!empty($block['innerBlocks'])) {
-                return self::check_is_valid_block($block);
-            }
+            return self::check_is_valid_block($block);
         };
 
         $transform_block = function ($block) {
@@ -44,7 +42,7 @@ class M056UpdateQuickLinksClassName extends MigrationScript
     private static function check_is_valid_block(array $block): bool
     {
        // Check if the block is an array, has a 'blockName' key.
-        if (!is_array($block) || !isset($block['blockName'])) {
+        if (!is_array($block) || !isset($block['blockName']) && !empty($block['innerBlocks'])) {
             return false;
         }
 

--- a/src/Migrations/M056UpdateQuickLinksClassName.php
+++ b/src/Migrations/M056UpdateQuickLinksClassName.php
@@ -42,7 +42,7 @@ class M056UpdateQuickLinksClassName extends MigrationScript
     private static function check_is_valid_block(array $block): bool
     {
        // Check if the block is an array, has a 'blockName' key.
-        if (!is_array($block) || !isset($block['blockName']) && !empty($block['innerBlocks'])) {
+        if (!is_array($block) || !isset($block['blockName']) || !empty($block['innerBlocks'])) {
             return false;
         }
 

--- a/src/Migrations/Utils/Constants.php
+++ b/src/Migrations/Utils/Constants.php
@@ -8,6 +8,7 @@ namespace P4\MasterTheme\Migrations\Utils;
 class Constants
 {
     private const PREFIX_P4_BLOCKS = 'planet4-blocks';
+    private const PREFIX_P4_BLOCK_TEMPLATES = 'planet4-block-templates';
     private const PREFIX_CORE_BLOCKS = 'core';
 
     public const POSTS_LIST = 'posts-list';
@@ -23,6 +24,9 @@ class Constants
     public const BLOCK_ACTIONS_LIST = self::PREFIX_P4_BLOCKS . '/' . self::ACTIONS_LIST;
     public const BLOCK_ARTICLES = self::PREFIX_P4_BLOCKS . '/articles';
     public const ACTION_BUTTON = self::PREFIX_P4_BLOCKS . '/action-button-text';
+
+    // P4 Block Templates
+    public const BLOCK_TEMPLATE_QUICK_LINKS = self::PREFIX_P4_BLOCK_TEMPLATES . '/quick-links';
 
     public const BLOCK_EMBED = self::PREFIX_CORE_BLOCKS . '/embed';
     public const BLOCK_AUDIO = self::PREFIX_CORE_BLOCKS . '/audio';

--- a/src/Migrator.php
+++ b/src/Migrator.php
@@ -56,6 +56,7 @@ use P4\MasterTheme\Migrations\M052RollbackToPreviousRevision;
 use P4\MasterTheme\Migrations\M053CustomisePostsListSeeAllLink;
 use P4\MasterTheme\Migrations\M054PostsActionsListHeaderButtonUpdate;
 use P4\MasterTheme\Migrations\M055AddDefaultSiteIcon;
+use P4\MasterTheme\Migrations\M056UpdateQuickLinksClassName;
 
 /**
  * Run any new migration scripts and record results in the log.
@@ -129,6 +130,7 @@ class Migrator
             M053CustomisePostsListSeeAllLink::class,
             M054PostsActionsListHeaderButtonUpdate::class,
             M055AddDefaultSiteIcon::class,
+            M056UpdateQuickLinksClassName::class,
         ];
 
         // Loop migrations and run those that haven't run yet.


### PR DESCRIPTION
Ref: https://greenpeace-planet4.atlassian.net/browse/PLANET-7608

### Summary
The currently layout displays the items fine, however, some times the users don't understand if there are more quick links availble to scroll within small screens. The idea is to display at least a tiny part of the last item visible on viewport to let them know that there are more items available to see.

#### Extra implementations
Convert block to wide and remove the grey spaces in both sides.

Demo page: https://www-dev.greenpeace.org/test-pandora/quick-links-demo/

https://github.com/user-attachments/assets/c99d1f22-3887-4c8d-b7f4-5a43cc1cdf6a

---

<!-- Please add a reference link to the ticket, if one exists. -->
Ref: https://jira.greenpeace.org/browse/PLANET-7608

### Testing
Use small sizes `< 576px` (mobile recommended).

