### PR TITLE
PLANET-7890 Fix backend link to settings for News Stories page

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -451,7 +451,7 @@ add_action(
         wp_add_inline_script(
             'wp-notices',
             sprintf(
-                'wp.data.dispatch( "core/notices" ).createNotice("warning", "%s" , { isDismissible: false, actions: [ { label: "%s", url: "/wp-admin/options-reading.php"} ] } )',
+                'wp.data.dispatch( "core/notices" ).createNotice("warning", "%s" , { isDismissible: false, actions: [ { label: "%s", url: "options-reading.php"} ] } )',
                 __('The content on this page is hidden because this page is being used as your \"All Posts\" listing page. You can disable this by un-setting the \"Posts page\"', 'planet4-master-theme'),
                 __('here', 'planet4-master-theme')
             )


### PR DESCRIPTION
### Summary

This wasn't working properly

Ref: [PLANET-7890](https://greenpeace-planet4.atlassian.net/browse/PLANET-7890)

### Testing

- [Broken](https://www-dev.greenpeace.org/test-rhea/wp-admin/post.php?post=1147&action=edit)
- [Fixed](https://www-dev.greenpeace.org/test-venus/wp-admin/post.php?post=1147&action=edit)

[PLANET-7890]: https://greenpeace-planet4.atlassian.net/browse/PLANET-7890?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ