### PR TITLE
PLANET-7865 Enable Load More functionality in Actions List

### DIFF
--- a/assets/src/block-editor/QueryLoopBlockExtension/index.js
+++ b/assets/src/block-editor/QueryLoopBlockExtension/index.js
@@ -135,7 +135,7 @@ export const setupQueryLoopBlockExtension = () => {
             },
             query: {
               ...query,
-              perPage: layoutType.columnCount,
+              perPage: layoutType.perPage || layoutType.columnCount,
             },
             className: ((className.includes(pattern)) ?
               className.replace(/\is-custom-layout-.*/, `${pattern}${layoutType.label}`) :

--- a/assets/src/block-editor/QueryLoopBlockExtension/index.js
+++ b/assets/src/block-editor/QueryLoopBlockExtension/index.js
@@ -135,7 +135,7 @@ export const setupQueryLoopBlockExtension = () => {
             },
             query: {
               ...query,
-              perPage: layoutType.perPage || layoutType.columnCount,
+              perPage: layoutType.maxPosts || layoutType.columnCount,
             },
             className: ((className.includes(pattern)) ?
               className.replace(/\is-custom-layout-.*/, `${pattern}${layoutType.label}`) :

--- a/assets/src/blocks/ActionsList/index.js
+++ b/assets/src/blocks/ActionsList/index.js
@@ -4,7 +4,7 @@ import {TAX_BREADCRUMB_BLOCK_NAME} from '../../block-editor/setupTaxonomyBreadcr
 export const ACTIONS_LIST_BLOCK_NAME = 'planet4-blocks/actions-list';
 
 export const ACTIONS_LIST_LAYOUT_TYPES = [
-  {label: 'Grid', value: 'grid', columnCount: 3, perPage: 100},
+  {label: 'Grid', value: 'grid', columnCount: 3, perPage: 24},
   {label: 'Carousel', value: 'flex', columnCount: 6},
 ];
 
@@ -21,7 +21,7 @@ export const ACTIONS_LIST_BLOCK_ATTRIBUTES = {
   className: 'actions-list p4-query-loop is-custom-layout-grid',
   query: {
     pages: 0,
-    perPage: 100,
+    perPage: 24,
     offset: 0,
     order: 'desc',
     orderBy: 'date',

--- a/assets/src/blocks/ActionsList/index.js
+++ b/assets/src/blocks/ActionsList/index.js
@@ -4,7 +4,7 @@ import {TAX_BREADCRUMB_BLOCK_NAME} from '../../block-editor/setupTaxonomyBreadcr
 export const ACTIONS_LIST_BLOCK_NAME = 'planet4-blocks/actions-list';
 
 export const ACTIONS_LIST_LAYOUT_TYPES = [
-  {label: 'Grid', value: 'grid', columnCount: 3, perPage: 24},
+  {label: 'Grid', value: 'grid', columnCount: 3, maxPosts: 24},
   {label: 'Carousel', value: 'flex', columnCount: 6},
 ];
 

--- a/assets/src/blocks/ActionsList/index.js
+++ b/assets/src/blocks/ActionsList/index.js
@@ -4,7 +4,7 @@ import {TAX_BREADCRUMB_BLOCK_NAME} from '../../block-editor/setupTaxonomyBreadcr
 export const ACTIONS_LIST_BLOCK_NAME = 'planet4-blocks/actions-list';
 
 export const ACTIONS_LIST_LAYOUT_TYPES = [
-  {label: 'Grid', value: 'grid', columnCount: 3},
+  {label: 'Grid', value: 'grid', columnCount: 3, perPage: 100},
   {label: 'Carousel', value: 'flex', columnCount: 6},
 ];
 
@@ -21,7 +21,7 @@ export const ACTIONS_LIST_BLOCK_ATTRIBUTES = {
   className: 'actions-list p4-query-loop is-custom-layout-grid',
   query: {
     pages: 0,
-    perPage: 3,
+    perPage: 100,
     offset: 0,
     order: 'desc',
     orderBy: 'date',
@@ -74,6 +74,18 @@ export const getActionsListBlockTemplate = (title = __('', 'planet4-blocks-backe
     ]],
   ]],
   carouselButtons,
+  ['core/buttons', {
+    className: 'load-more-actions-container',
+    layout: {type: 'flex', justifyContent: 'center'},
+  }, [
+    ['core/button',
+      {
+        className: 'is-style-secondary',
+        text: __('Load more', 'planet4-blocks'),
+        tagName: 'button',
+      },
+    ],
+  ]],
 ]);
 
 // Register the ActionsList block.

--- a/assets/src/js/actions_list_clickable_cards.js
+++ b/assets/src/js/actions_list_clickable_cards.js
@@ -5,7 +5,7 @@
  * @function setupClickabelActionsListCards
  */
 
-export const setupClickabelActionsListCards = () => {
+export const setupClickableActionsListCards = () => {
   const liElements = document.querySelectorAll('.actions-list ul li:not(.carousel-li)');
 
   liElements.forEach(li => {

--- a/assets/src/js/actions_list_load_more.js
+++ b/assets/src/js/actions_list_load_more.js
@@ -4,6 +4,11 @@
  */
 export const setupActionsListLoadMore = () => {
   const gridBlocks = document.querySelectorAll('.actions-list.is-custom-layout-grid');
+  let postsPerRow = 3;
+  // For medium screens we only show 2 posts per row.
+  if (window.innerWidth >= 768 && window.innerWidth < 992) {
+    postsPerRow = 2;
+  }
 
   if (!gridBlocks.length) {
     return;
@@ -17,7 +22,7 @@ export const setupActionsListLoadMore = () => {
     }
 
     const posts = [...block.querySelectorAll('.wp-block-post')];
-    if (!posts || posts.length <= 6) {
+    if (!posts || posts.length <= postsPerRow * 2) {
       loadMoreButtonContainer.classList.add('d-none');
       return;
     }
@@ -25,11 +30,11 @@ export const setupActionsListLoadMore = () => {
     const loadMoreButton = loadMoreButtonContainer.querySelector('button');
     loadMoreButton.onclick = () => {
       const hiddenPosts = posts.filter(post => window.getComputedStyle(post).display === 'none');
-      if (hiddenPosts.length <= 3) {
+      if (hiddenPosts.length <= postsPerRow) {
         hiddenPosts.forEach(post => post.style.display = 'flex');
         loadMoreButtonContainer.classList.add('d-none');
       } else {
-        hiddenPosts.slice(0, 3).forEach(post => post.style.display = 'flex');
+        hiddenPosts.slice(0, postsPerRow).forEach(post => post.style.display = 'flex');
       }
     };
   });

--- a/assets/src/js/actions_list_load_more.js
+++ b/assets/src/js/actions_list_load_more.js
@@ -1,0 +1,36 @@
+/**
+ * Handle the "load more" functionality for the Actions List block.
+ * This should only be applied to the grid layout.
+ */
+export const setupActionsListLoadMore = () => {
+  const gridBlocks = document.querySelectorAll('.actions-list.is-custom-layout-grid');
+
+  if (!gridBlocks.length) {
+    return;
+  }
+
+  // Implement "load more" behaviour for grid layouts.
+  gridBlocks.forEach(block => {
+    const loadMoreButtonContainer = block.querySelector('.load-more-actions-container');
+    if (!loadMoreButtonContainer) {
+      return;
+    }
+
+    const posts = [...block.querySelectorAll('.wp-block-post')];
+    if (!posts || posts.length <= 6) {
+      loadMoreButtonContainer.classList.add('d-none');
+      return;
+    }
+
+    const loadMoreButton = loadMoreButtonContainer.querySelector('button');
+    loadMoreButton.onclick = () => {
+      const hiddenPosts = posts.filter(post => window.getComputedStyle(post).display === 'none');
+      if (hiddenPosts.length <= 3) {
+        hiddenPosts.forEach(post => post.style.display = 'flex');
+        loadMoreButtonContainer.classList.add('d-none');
+      } else {
+        hiddenPosts.slice(0, 3).forEach(post => post.style.display = 'flex');
+      }
+    };
+  });
+};

--- a/assets/src/js/app.js
+++ b/assets/src/js/app.js
@@ -32,4 +32,6 @@ document.addEventListener('DOMContentLoaded', () => {
   setupClickableActionsListCards();
   setupCountrySelector();
   setupActionsListLoadMore();
+
+  window.addEventListener('resize', setupActionsListLoadMore);
 });

--- a/assets/src/js/app.js
+++ b/assets/src/js/app.js
@@ -7,10 +7,11 @@ import {setupPDFIcon} from './pdf_icon';
 import {setupSearch} from './search';
 import {setupExternalLinks} from './external_links';
 import {setupQueryLoopCarousel} from './query_loop_carousel';
-import {setupClickabelActionsListCards} from './actions_list_clickable_cards';
+import {setupClickableActionsListCards} from './actions_list_clickable_cards';
 import {removeNoPostText} from './query-no-posts';
 import {removeRelatedPostsSection} from './remove_related_section_no_posts';
 import {setupCountrySelector} from './country_selector';
+import {setupActionsListLoadMore} from './actions_list_load_more';
 
 function requireAll(r) {
   r.keys().forEach(r);
@@ -28,6 +29,7 @@ document.addEventListener('DOMContentLoaded', () => {
   setupQueryLoopCarousel();
   removeNoPostText();
   removeRelatedPostsSection();
-  setupClickabelActionsListCards();
+  setupClickableActionsListCards();
   setupCountrySelector();
+  setupActionsListLoadMore();
 });

--- a/assets/src/scss/blocks/ActionsList/ActionsListEditorStyle.scss
+++ b/assets/src/scss/blocks/ActionsList/ActionsListEditorStyle.scss
@@ -1,4 +1,8 @@
 .actions-list {
+  .load-more-actions-container {
+    margin-top: $sp-4;
+  }
+
   .wp-block-post-excerpt__more-link {
     display: none;
   }

--- a/assets/src/scss/blocks/ActionsList/ActionsListStyle.scss
+++ b/assets/src/scss/blocks/ActionsList/ActionsListStyle.scss
@@ -13,6 +13,10 @@
         grid-template-columns: repeat(3, 1fr);
       }
     }
+
+    .load-more-actions-container {
+      display: none;
+    }
   }
 
   ul li {
@@ -150,6 +154,10 @@
       @include large-and-up {
         grid-template-columns: repeat(3, minmax(0, 1fr));
       }
+    }
+
+    .wp-block-post:nth-child(n+7) {
+      display: none;
     }
   }
 }

--- a/assets/src/scss/blocks/ActionsList/ActionsListStyle.scss
+++ b/assets/src/scss/blocks/ActionsList/ActionsListStyle.scss
@@ -156,8 +156,22 @@
       }
     }
 
-    .wp-block-post:nth-child(n+7) {
-      display: none;
+    @include mobile-only {
+      .wp-block-post:nth-child(n+4) {
+        display: none;
+      }
+    }
+
+    @include medium-and-less {
+      .wp-block-post:nth-child(n+5) {
+        display: none;
+      }
+    }
+
+    @include large-and-up {
+      .wp-block-post:nth-child(n+7) {
+        display: none;
+      }
     }
   }
 }

--- a/assets/src/scss/components/_buttons.scss
+++ b/assets/src/scss/components/_buttons.scss
@@ -1,5 +1,6 @@
 .btn,
 .wp-block-button a,
+.wp-block-button button,
 .wp-block-file a.wp-block-file__button,
 .gfield button:not(.add_list_item):not(.delete_list_item):not([id^="mceu"]),
 .gform_button_select_files,
@@ -104,6 +105,7 @@
 
 .btn-secondary,
 .wp-block-button.is-style-secondary a,
+.wp-block-button.is-style-secondary button,
 [class="wp-block-button"] a,
 .wp-block-file a.wp-block-file__button,
 .gfield button:not(.add_list_item):not(.delete_list_item):not([id^="mceu"]),

--- a/src/Blocks/QueryLoopExtension.php
+++ b/src/Blocks/QueryLoopExtension.php
@@ -100,6 +100,7 @@ class QueryLoopExtension
                 $query['post__in'] = array_values(array_diff($query['post__in'], $exclude));
             }
         }
+
         return $query;
     }
 

--- a/src/Migrations/M057ActionsListBlockLoadMore.php
+++ b/src/Migrations/M057ActionsListBlockLoadMore.php
@@ -75,7 +75,7 @@ class M057ActionsListBlockLoadMore extends MigrationScript
         // Create the "load more" button.
         $load_more = Utils\Functions::create_block_buttons(
             [
-                'className' => 'load-more-button-container',
+                'className' => 'load-more-actions-container',
                 'layout' => ['type' => 'flex', 'justifyContent' => 'center'],
             ],
             [
@@ -88,6 +88,32 @@ class M057ActionsListBlockLoadMore extends MigrationScript
 
         // Add it to the inner blocks.
         $block['innerBlocks'] = array_merge($block['innerBlocks'], [$load_more]);
+
+        // Update the inner content accordingly.
+        // IMPORTANT: DO NOT MODIFY THIS FORMAT!
+        // phpcs:disable Generic.Files.LineLength.MaxExceeded
+        $block['innerContent'] = array (
+            0 => '
+        <div class="wp-block-query actions-list p4-query-loop is-custom-layout-actions-list p4-query-loop is-custom-layout-grid">',
+            1 => null,
+            2 => '
+        ',
+            3 => null,
+            4 => '
+        ',
+            5 => null,
+            6 => '
+        ',
+            7 => null,
+            8 => '
+        ',
+            9 => null,
+            10 => '
+        ',
+            11 => null,
+            12 => '</div>
+        ',
+        );
 
         // Change "perPage" query attribute to 100 if layout is grid.
         if (str_contains($block['attrs']['className'], 'is-custom-layout-grid')) {

--- a/src/Migrations/M057ActionsListBlockLoadMore.php
+++ b/src/Migrations/M057ActionsListBlockLoadMore.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace P4\MasterTheme\Migrations;
+
+use P4\MasterTheme\MigrationRecord;
+use P4\MasterTheme\MigrationScript;
+
+/**
+ * Add "Load more" button and functionality to the Actions List blocks.
+ */
+class M057ActionsListBlockLoadMore extends MigrationScript
+{
+    /**
+     * Perform the actual migration.
+     *
+     * @param MigrationRecord $record Information on the execution, can be used to add logs.
+     * phpcs:disable SlevomatCodingStandard.Functions.UnusedParameter -- interface implementation
+     */
+    public static function execute(MigrationRecord $record): void
+    {
+        $check_is_valid_block = function ($block) {
+            return self::check_is_valid_block($block);
+        };
+
+        $transform_block = function ($block) {
+            return self::transform_block($block);
+        };
+
+        Utils\Functions::execute_block_migration(
+            Utils\Constants::BLOCK_QUERY,
+            $check_is_valid_block,
+            $transform_block,
+        );
+    }
+    // phpcs:enable SlevomatCodingStandard.Functions.UnusedParameter
+
+    /**
+     * Check whether a block is an Actions List block without a "Load more" button.
+     *
+     * @param array $block - A block data array.
+     */
+    private static function check_is_valid_block(array $block): bool
+    {
+        // Check if the block is an array, has a 'blockName' key and a namespace.
+        if (!is_array($block) || !isset($block['blockName']) || !isset($block['attrs']['namespace'])) {
+            return false;
+        }
+
+        // Check if the block is an Actions List block.
+        if (
+            $block['blockName'] !== Utils\Constants::BLOCK_QUERY ||
+            $block['attrs']['namespace'] !== Utils\Constants::BLOCK_ACTIONS_LIST
+        ) {
+            return false;
+        }
+
+        // Check if the block has a "Load more" button already.
+        $load_more = array_find($block['innerBlocks'], function ($innerBlock) {
+            return $innerBlock['blockName'] === Utils\Constants::BLOCK_BUTTONS &&
+                $innerBlock['attrs']['className'] === 'load-more-button-container';
+        });
+
+        return empty($load_more);
+    }
+
+    /**
+     * Add "load more" functionality, which includes updating the amount of posts per page
+     * if the block uses the grid layout.
+     *
+     * @param array $block - A block data array.
+     * @return array - The transformed block.
+     */
+    private static function transform_block(array &$block): array
+    {
+        // Create the "load more" button.
+        $load_more = Utils\Functions::create_block_buttons(
+            [
+                'className' => 'load-more-button-container',
+                'layout' => ['type' => 'flex', 'justifyContent' => 'center'],
+            ],
+            [
+                Utils\Functions::create_block_single_button(
+                    ['className' => 'is-style-secondary', 'tagName' => 'button'],
+                    __('Load more', 'planet4-blocks-backend'),
+                ),
+            ],
+        );
+
+        // Add it to the inner blocks.
+        $block['innerBlocks'] = array_merge($block['innerBlocks'], [$load_more]);
+
+        // Change "perPage" query attribute to 100 if layout is grid.
+        if (str_contains($block['attrs']['className'], 'is-custom-layout-grid')) {
+            $block['attrs']['query']['perPage'] = 100;
+        }
+
+        return $block;
+    }
+}

--- a/src/Migrations/M057ActionsListBlockLoadMore.php
+++ b/src/Migrations/M057ActionsListBlockLoadMore.php
@@ -115,9 +115,9 @@ class M057ActionsListBlockLoadMore extends MigrationScript
         ',
         );
 
-        // Change "perPage" query attribute to 100 if layout is grid.
+        // Change "perPage" query attribute to 24 if layout is grid.
         if (str_contains($block['attrs']['className'], 'is-custom-layout-grid')) {
-            $block['attrs']['query']['perPage'] = 100;
+            $block['attrs']['query']['perPage'] = 24;
         }
 
         return $block;

--- a/src/Migrations/M057ActionsListBlockLoadMore.php
+++ b/src/Migrations/M057ActionsListBlockLoadMore.php
@@ -81,7 +81,7 @@ class M057ActionsListBlockLoadMore extends MigrationScript
             [
                 Utils\Functions::create_block_single_button(
                     ['className' => 'is-style-secondary', 'tagName' => 'button'],
-                    __('Load more', 'planet4-blocks-backend'),
+                    __('Load more', 'planet4-blocks'),
                 ),
             ],
         );

--- a/src/Migrations/Utils/Functions.php
+++ b/src/Migrations/Utils/Functions.php
@@ -398,9 +398,14 @@ class Functions
     public static function create_block_single_button(array $attrs, string $text, ?string $link = null): array
     {
         $classname = isset($attrs['className']) ? $attrs['className'] : '';
+        $is_button = isset($attrs['tagName']) && $attrs['tagName'] === 'button';
 
         // phpcs:disable Generic.Files.LineLength.MaxExceeded
-        if (!$link) {
+        if ($is_button) {
+            $html = '
+                <div class="wp-block-button ' . $classname . '"><button class="wp-block-button__link wp-element-button">' . $text . '</button></div>
+            ';
+        } elseif (!$link) {
             $html = '
             <div class="wp-block-button ' . $classname . '"><a class="wp-block-button__link wp-element-button">' . $text . '</a></div>
         ';

--- a/src/Migrator.php
+++ b/src/Migrator.php
@@ -57,6 +57,7 @@ use P4\MasterTheme\Migrations\M053CustomisePostsListSeeAllLink;
 use P4\MasterTheme\Migrations\M054PostsActionsListHeaderButtonUpdate;
 use P4\MasterTheme\Migrations\M055AddDefaultSiteIcon;
 use P4\MasterTheme\Migrations\M056UpdateQuickLinksClassName;
+use P4\MasterTheme\Migrations\M057ActionsListBlockLoadMore;
 
 /**
  * Run any new migration scripts and record results in the log.
@@ -131,6 +132,7 @@ class Migrator
             M054PostsActionsListHeaderButtonUpdate::class,
             M055AddDefaultSiteIcon::class,
             M056UpdateQuickLinksClassName::class,
+            M057ActionsListBlockLoadMore::class,
         ];
 
         // Loop migrations and run those that haven't run yet.


### PR DESCRIPTION
### Summary

Ref: [PLANET-7865](https://greenpeace-planet4.atlassian.net/browse/PLANET-7865)

**Requirements**

- [x] Load More Button every n cards, in the Grid Version of the Action List block: after the 6th card for  XXL, XL, L screen sizes, after 4 in M sizes, and after 3 in S.
- [x] Hide the button when there are no more items to show.
- [x] Write migration to add this new button to existing Actions List blocks.

### Testing

You can test the functionality on [this page](https://www-dev.greenpeace.org/test-janus/actions-list-test/) for example.

For the migration, on local you can use the [Take Action page](http://www.planet4.test/take-action/) which already has an Actions List. At first it shouldn't have the load more button, but when running `npx wp-env run cli wp p4-run-activator` you should see it (maybe only when inspecting, it's hidden if there are less than 6 items in the block).

To reset your local content you can use `npm run db:reset`

[PLANET-7865]: https://greenpeace-planet4.atlassian.net/browse/PLANET-7865?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ