### PR TITLE
 Reduce the length of the `MasterSite` class III

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -438,15 +438,6 @@ add_action(
                 margin-left: 5px;
             }
         </style>';
-
-        wp_add_inline_script(
-            'wp-notices',
-            sprintf(
-                'wp.data.dispatch( "core/notices" ).createNotice("warning", "%s" , { isDismissible: false, actions: [ { label: "%s", url: "options-reading.php"} ] } )',
-                __('The content on this page is hidden because this page is being used as your \"All Posts\" listing page. You can disable this by un-setting the \"Posts page\"', 'planet4-master-theme'),
-                __('here', 'planet4-master-theme')
-            )
-        );
     },
     100
 );

--- a/src/AdminNotificationsManager.php
+++ b/src/AdminNotificationsManager.php
@@ -27,7 +27,9 @@ class AdminNotificationsManager
     /**
      * Add a notification to the editor of the page used to show all posts.
      */
-    public function add_all_posts_notification(): void {
+    public function add_all_posts_notification(): void
+    {
+        // phpcs:disable Generic.Files.LineLength.MaxExceeded
         wp_add_inline_script(
             'wp-notices',
             sprintf(
@@ -36,6 +38,7 @@ class AdminNotificationsManager
                 __('here', 'planet4-master-theme')
             )
         );
+        // phpcs:enable Generic.Files.LineLength.MaxExceeded
     }
 
     /**

--- a/src/AdminNotificationsManager.php
+++ b/src/AdminNotificationsManager.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace P4\MasterTheme;
+
+/**
+ * Handles notifications in the dashboard and other admin areas.
+ */
+class AdminNotificationsManager
+{
+    /**
+     * Key of notice seen by user
+     */
+    private const DASHBOARD_MESSAGE_KEY = 'last_p4_notice';
+
+    /**
+     * Version of notice
+     */
+    private const DASHBOARD_MESSAGE_VERSION = '0.4';
+
+    public function __construct()
+    {
+        add_action('admin_notices', [$this, 'show_dashboard_notice']);
+        add_action('wp_ajax_dismiss_dashboard_notice', [$this, 'dismiss_dashboard_notice']);
+        add_action('admin_enqueue_scripts', [$this, 'add_all_posts_notification'], 100);
+    }
+
+    /**
+     * Add a notification to the editor of the page used to show all posts.
+     */
+    public function add_all_posts_notification(): void {
+        wp_add_inline_script(
+            'wp-notices',
+            sprintf(
+                'wp.data.dispatch( "core/notices" ).createNotice("warning", "%s" , { isDismissible: false, actions: [ { label: "%s", url: "options-reading.php"} ] } )',
+                __('The content on this page is hidden because this page is being used as your \"All Posts\" listing page. You can disable this by un-setting the \"Posts page\"', 'planet4-master-theme'),
+                __('here', 'planet4-master-theme')
+            )
+        );
+    }
+
+    /**
+     * Show P4 team message on dashboard.
+     */
+    public function show_dashboard_notice(): void
+    {
+        // Show only on dashboard.
+        $screen = get_current_screen();
+        if (null === $screen || 'dashboard' !== $screen->id) {
+            return;
+        }
+
+        // Don't show a dismissed version.
+        $last_notice = get_user_meta(get_current_user_id(), self::DASHBOARD_MESSAGE_KEY, true);
+        if (version_compare(self::DASHBOARD_MESSAGE_VERSION, $last_notice, '<=')) {
+            return;
+        }
+
+        // Don't show an empty message.
+        $message = trim($this->p4_message());
+        if (empty($message)) {
+            return;
+        }
+
+        do_action('enqueue_dismiss_dashboard_notice_script');
+
+        echo '<div id="p4-notice" class="notice notice-info is-dismissible">' . wp_kses_post($message) . '</div>';
+    }
+
+    /**
+     * A message from Planet4 team.
+     *
+     * Message title should be a <h2> tag.
+     * Message text should be written into <p> tags.
+     * Return an empty string if no message for this version.
+     *
+     * Version number DASHBOARD_MESSAGE_VERSION has to be incremented
+     * each time we add a new message.
+     *
+     * phpcs:disable Generic.Files.LineLength.MaxExceeded
+     */
+    private function p4_message(): string
+    {
+        return '<h2>Welcome to the new P4 message board!</h2>
+            <p>New to the Planet 4 platform? Here are some self - paced courses that can help you get up to speed. 👇
+                <ul>
+                    <li><span style="margin-right: 3px;">
+                        <a href="https://greenpeace.studytube.nl/courses/22122">Planet 4 Fundamentals</a> 🌏</span>
+                        learn the very basic of Planet 4.</li>
+                    <li><span style="margin-right: 3px;">
+                        <a href="https://greenpeace.studytube.nl/courses/23208/planet-4">Planet 4 Power User</a> 🚀</span>
+                        a more in-depth course to understand how to manage a P4 website and how to make best use of its engagement features.</li>
+                </ul>
+            </p>';
+    }
+    // phpcs:enable Generic.Files.LineLength.MaxExceeded
+
+    /**
+     * Dismiss P4 notice of dashboard, by saving the last version read in user meta field.
+     *
+     * @uses wp_die()
+     */
+    public function dismiss_dashboard_notice(): void
+    {
+        $user_id = get_current_user_id();
+        if (0 === $user_id) {
+            wp_die('User not logged in.', 401);
+        }
+
+        $res = update_user_meta(
+            $user_id,
+            self::DASHBOARD_MESSAGE_KEY,
+            self::DASHBOARD_MESSAGE_VERSION
+        );
+        if (false === $res) {
+            wp_die('User meta update failed.', 500);
+        }
+
+        wp_die('Notice dismissed.', 200);
+    }
+}

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -113,6 +113,7 @@ final class Loader
             $this->default_services[] = MediaArchive\Rest::class;
             $this->default_services[] = MigrationStatus::class;
             $this->default_services[] = MediaReplacer::class;
+            $this->default_services[] = AdminNotificationsManager::class;
 
             foreach (Features::external_settings() as $setting_class) {
                 $this->default_services[] = $setting_class;


### PR DESCRIPTION
### Summary

As part of our effort to reduce the size of the `MasterSite` class and the `functions.php` file, this PR moves from them all functions related to the admin and dashboard notifications.

---

Ref: https://greenpeace-gpi.slack.com/archives/C0160MX64AG/p1751531019331059 

### Testing

1. Go to the admin dashboard and check that our custom widgets and messages exist.
2. Go to the editor of the page used for News & Stories and check that the custom notification exists.