### PR TITLE
PLANET-7862: Apply standalone style to links inside texts on tag pages

### DIFF
--- a/assets/src/scss/layout/_page-header.scss
+++ b/assets/src/scss/layout/_page-header.scss
@@ -85,6 +85,12 @@
       line-height: 1.1;
     }
   }
+
+  .tag & {
+    p a {
+      @include shared-link-styles;
+    }
+  }
 }
 
 .page-header-background {


### PR DESCRIPTION
### Summary
Apply link styles anchors manually added. It affects to tag pages inherited from Listing pages.

<!-- Please provide a brief summary of the change introduced in this Pull Request. -->

---

<!-- Please add a reference link to the ticket, if one exists. -->
Ref: https://greenpeace-planet4.atlassian.net/browse/PLANET-7862

### Testing
1. Go to the News & Stories page
2. Click on any tag
3. If you add an anchor through the tagp's description, it should be styled with standalone UI
