### PR TITLE
PLANET-7770 Added default site icon

### DIFF
--- a/src/Migrations/M055AddDefaultSiteIcon.php
+++ b/src/Migrations/M055AddDefaultSiteIcon.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace P4\MasterTheme\Migrations;
+
+use P4\MasterTheme\MigrationRecord;
+use P4\MasterTheme\MigrationScript;
+
+/**
+ * Remove custom site icon, since we disabled the option to customize it.
+ */
+class M055AddDefaultSiteIcon extends MigrationScript
+{
+    /**
+     * Perform the actual migration.
+     *
+     * @param MigrationRecord $record Information on the execution, can be used to add logs.
+     * phpcs:disable SlevomatCodingStandard.Functions.UnusedParameter -- interface implementation
+     */
+    protected static function execute(MigrationRecord $record): void
+    {
+        $icon_path = get_template_directory() . '/favicon.ico';
+
+        if (!file_exists($icon_path)) {
+            echo 'favicon.ico not found at expected path.';
+            return;
+        }
+
+        $upload = wp_upload_bits('favicon.ico', null, file_get_contents($icon_path));
+        if ($upload['error']) {
+            echo 'Error uploading favicon: ' . $upload['error'];
+            return;
+        }
+
+        $filetype = wp_check_filetype($upload['file'], null);
+        $attachment = [
+            'post_mime_type' => $filetype['type'],
+            'post_title' => 'Site Icon',
+            'post_content' => '',
+            'post_status' => 'inherit',
+        ];
+
+        $attach_id = wp_insert_attachment($attachment, $upload['file']);
+        require_once ABSPATH . 'wp-admin/includes/image.php';
+        $attach_data = wp_generate_attachment_metadata($attach_id, $upload['file']);
+        wp_update_attachment_metadata($attach_id, $attach_data);
+
+        update_option('site_icon', $attach_id);
+    }
+    // phpcs:enable SlevomatCodingStandard.Functions.UnusedParameter
+}

--- a/src/Migrator.php
+++ b/src/Migrator.php
@@ -55,6 +55,7 @@ use P4\MasterTheme\Migrations\M050AddTagsBackInPostsListBlock;
 use P4\MasterTheme\Migrations\M052RollbackToPreviousRevision;
 use P4\MasterTheme\Migrations\M053CustomisePostsListSeeAllLink;
 use P4\MasterTheme\Migrations\M054PostsActionsListHeaderButtonUpdate;
+use P4\MasterTheme\Migrations\M055AddDefaultSiteIcon;
 
 /**
  * Run any new migration scripts and record results in the log.
@@ -127,6 +128,7 @@ class Migrator
             M052RollbackToPreviousRevision::class,
             M053CustomisePostsListSeeAllLink::class,
             M054PostsActionsListHeaderButtonUpdate::class,
+            M055AddDefaultSiteIcon::class,
         ];
 
         // Loop migrations and run those that haven't run yet.


### PR DESCRIPTION
### Summary

<!-- Please provide a brief summary of the change introduced in this Pull Request. -->

---

<!-- Please add a reference link to the ticket, if one exists. -->
Ref: https://greenpeace-planet4.atlassian.net/browse/PLANET-7770

### Testing

<!-- Please add the steps required to test the changes in this Pull Request. -->
1. On test instance, the Dashboard should now have the same favicon as on the frontend
2. Locally, run migration and test the same icon is used in Dashboard as on frontend favicons
3. Also because embed use this icon as a default, we should now have the G icon on embeds and not the WP default.
