### PR TITLE
Planet 7821 full es sync

### DIFF
--- a/src/CronJob.php
+++ b/src/CronJob.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace P4\MasterTheme;
+
+/**
+ * Class CronJob
+ */
+class CronJob
+{
+    /**
+     * Constructor.
+     */
+    public function __construct()
+    {
+        add_action('p4_full_es_sync_action', [ $this, 'p4_full_es_sync' ], 10);
+    }
+
+    /**
+     * Triggers a full Elastic search indexing.
+     */
+    public function p4_full_es_sync(): void
+    {
+        // Check if indexing is in progress.
+        if (\ElasticPress\Utils\get_indexing_status()) {
+            \Sentry\captureMessage(
+                'ES indexing already in progress. ' . date("Y-m-d H:i:s")
+            );
+            return;
+        }
+
+        \Sentry\captureMessage(
+            'P4 ES sync cronjob started. ' . date("Y-m-d H:i:s")
+        );
+
+        // Trigger a full index.
+        try {
+            \ElasticPress\IndexHelper::factory()->full_index([
+                'put_mapping' => true,
+                'method' => 'dashboard',
+                'network_wide' => false,
+                'show_errors' => false,
+                'trigger' => 'manual',
+                'output_method' => [],
+            ]);
+        } catch (\Exception $e) {
+            function_exists('\Sentry\captureException') && \Sentry\captureException($e);
+        }
+
+        \Sentry\captureMessage(
+            'P4 ES sync cronjob finish. ' . date("Y-m-d H:i:s")
+        );
+    }
+}

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -100,6 +100,7 @@ final class Loader
             EnqueueController::class,
             YouTubeHandler::class,
             CommentFormCustomizer::class,
+            CronJob::class,
         ];
 
         if (is_admin()) {

--- a/src/Search/ElasticSearch.php
+++ b/src/Search/ElasticSearch.php
@@ -108,19 +108,11 @@ class ElasticSearch
                 return;
             }
 
-            // Trigger a full index
-            try {
-                \ElasticPress\IndexHelper::factory()->full_index([
-                    'put_mapping' => true,
-                    'method' => 'dashboard',
-                    'network_wide' => false,
-                    'show_errors' => false,
-                    'trigger' => 'manual',
-                    'output_method' => [],
-                ]);
-            } catch (\Exception $e) {
-                function_exists('\Sentry\captureException') && \Sentry\captureException($e);
-            }
+            \Sentry\captureMessage(
+                'P4 ES sync cron job scheduled in 30 sec. ' . date("Y-m-d H:i:s")
+            );
+            // Schedule cron job to execute in 30 sec.
+            wp_schedule_single_event(time() + 30, 'p4_full_es_sync_action');
         }, 1, 10);
     }
 

--- a/src/Search/ElasticSearch.php
+++ b/src/Search/ElasticSearch.php
@@ -103,6 +103,24 @@ class ElasticSearch
                     'ElasticPress Query FAILED: Unknown response format: ' . print_r($response, true)
                 );
             }
+            // Check if indexing is in progress.
+            if (\ElasticPress\Utils\get_indexing_status()) {
+                return;
+            }
+
+            // Trigger a full index
+            try {
+                \ElasticPress\IndexHelper::factory()->full_index([
+                    'put_mapping' => true,
+                    'method' => 'dashboard',
+                    'network_wide' => false,
+                    'show_errors' => false,
+                    'trigger' => 'manual',
+                    'output_method' => [],
+                ]);
+            } catch (\Exception $e) {
+                function_exists('\Sentry\captureException') && \Sentry\captureException($e);
+            }
         }, 1, 10);
     }
 

--- a/src/Search/ElasticSearch.php
+++ b/src/Search/ElasticSearch.php
@@ -125,33 +125,4 @@ class ElasticSearch
         }
         return \ElasticPress\Features::factory()->get_registered_feature('facets')->is_active();
     }
-
-    /**
-     * Fix the mapping for post_date and post_date_gmt fields.
-     *
-     * @param array $mapping The current mapping.
-     * @return array The updated mapping.
-     */
-    public static function fix_post_date_mapping(array $mapping): array
-    {
-        if (
-            isset($mapping['mappings']['properties']['post_date']) &&
-            "text" === $mapping['mappings']['properties']['post_date']['type']
-        ) {
-            $mapping['mappings']['properties']['post_date'] = [
-                'type' => 'date',
-                'format' => 'yyyy-MM-dd HH:mm:ss',
-            ];
-        }
-        if (
-            isset($mapping['mappings']['properties']['post_date_gmt']) &&
-            "text" === $mapping['mappings']['properties']['post_date_gmt']['type']
-        ) {
-            $mapping['mappings']['properties']['post_date_gmt'] = [
-                'type' => 'date',
-                'format' => 'yyyy-MM-dd HH:mm:ss',
-            ];
-        }
-        return $mapping;
-    }
 }

--- a/src/Search/ElasticSearch.php
+++ b/src/Search/ElasticSearch.php
@@ -103,8 +103,6 @@ class ElasticSearch
                     'ElasticPress Query FAILED: Unknown response format: ' . print_r($response, true)
                 );
             }
-            \Sentry\captureMessage('ElasticPress Query FAILED Response Code:' .
-                $response['response']['code'] . ' Response Body:' . $response['body']);
         }, 1, 10);
     }
 

--- a/src/Search/ElasticSearch.php
+++ b/src/Search/ElasticSearch.php
@@ -123,4 +123,22 @@ class ElasticSearch
         }
         return \ElasticPress\Features::factory()->get_registered_feature('facets')->is_active();
     }
+
+    public static function fix_post_date_mapping( $mapping ) {
+        if ( isset( $mapping['mappings']['properties']['post_date'] ) &&
+            "text" === $mapping['mappings']['properties']['post_date']['type'] ) {
+            $mapping['mappings']['properties']['post_date'] = [
+                'type' => 'date',
+                'format' => 'yyyy-MM-dd HH:mm:ss'
+            ];
+        }
+        if ( isset( $mapping['mappings']['properties']['post_date_gmt'] ) &&
+            "text" === $mapping['mappings']['properties']['post_date_gmt']['type'] ) {
+            $mapping['mappings']['properties']['post_date_gmt'] = [
+                'type' => 'date',
+                'format' => 'yyyy-MM-dd HH:mm:ss'
+            ];
+        }
+        return $mapping;
+    }
 }

--- a/src/Search/ElasticSearch.php
+++ b/src/Search/ElasticSearch.php
@@ -103,6 +103,8 @@ class ElasticSearch
                     'ElasticPress Query FAILED: Unknown response format: ' . print_r($response, true)
                 );
             }
+            \Sentry\captureMessage('ElasticPress Query FAILED Response Code:' .
+                $response['response']['code'] . ' Response Body:' . $response['body']);
         }, 1, 10);
     }
 
@@ -124,19 +126,30 @@ class ElasticSearch
         return \ElasticPress\Features::factory()->get_registered_feature('facets')->is_active();
     }
 
-    public static function fix_post_date_mapping( $mapping ) {
-        if ( isset( $mapping['mappings']['properties']['post_date'] ) &&
-            "text" === $mapping['mappings']['properties']['post_date']['type'] ) {
+    /**
+     * Fix the mapping for post_date and post_date_gmt fields.
+     *
+     * @param array $mapping The current mapping.
+     * @return array The updated mapping.
+     */
+    public static function fix_post_date_mapping(array $mapping): array
+    {
+        if (
+            isset($mapping['mappings']['properties']['post_date']) &&
+            "text" === $mapping['mappings']['properties']['post_date']['type']
+        ) {
             $mapping['mappings']['properties']['post_date'] = [
                 'type' => 'date',
-                'format' => 'yyyy-MM-dd HH:mm:ss'
+                'format' => 'yyyy-MM-dd HH:mm:ss',
             ];
         }
-        if ( isset( $mapping['mappings']['properties']['post_date_gmt'] ) &&
-            "text" === $mapping['mappings']['properties']['post_date_gmt']['type'] ) {
+        if (
+            isset($mapping['mappings']['properties']['post_date_gmt']) &&
+            "text" === $mapping['mappings']['properties']['post_date_gmt']['type']
+        ) {
             $mapping['mappings']['properties']['post_date_gmt'] = [
                 'type' => 'date',
-                'format' => 'yyyy-MM-dd HH:mm:ss'
+                'format' => 'yyyy-MM-dd HH:mm:ss',
             ];
         }
         return $mapping;


### PR DESCRIPTION
### Summary

Add a cron job for full ES sync

---
[Related PR](https://github.com/greenpeace/planet4-master-theme/pull/2713)


<!-- Please add a reference link to the ticket, if one exists. -->
Ref: https://greenpeace-planet4.atlassian.net/browse/PLANET-7821

**Note:**: Please connect to local elastic search container using `npm run elastic:activate` cmd.

We don’t have specific steps to reproduce this issue, but we can simulate it by adding the following code to the `functions.php` file. To trigger the code execution, you’ll need to run an ElasticPress sync(`npx wp-env run cli wp elasticpress sync --setup --yes --force`):

```
add_filter( 'ep_post_mapping', function( $mapping ) {
    $mapping['mappings']['properties']['post_date'] = [
        'type' => 'text'
    ];
    return $mapping;
} );
```

To check the mapping locally, run the following command:
`npx wp-env run cli wp elasticpress get-mapping`
or 
Connect to php shell(`npm run shell:php`) and run ` curl -X GET "elasticsearch:9200/planet4test-post-1/_mapping?pretty"`

**Steps to test this fix:**

1. Checkout the main branch.
2. Add the above code snippet to the functions.php file.
3. Run an ElasticPress sync from the admin dashboard or wp cli.
4. Verify that the `post_date` field in the mapping is set to `text` and search results are coming from Mysql, also you can check the [status report](http://www.planet4.test/wp-admin/admin.php?page=elasticpress-status-report) page for ES error.
5. Now, checkout the `PLANET-7821-full-es-sync` branch.
6. Go to P4 search page
7. Run `npx wp-env run cli wp cron event list` command, you can see a cron schedule with `p4_full_es_sync_action ` name in few sec
8. Once the cron execution is completed, please check the search results, [ES sync setting](http://www.planet4.test/wp-admin/admin.php?page=elasticpress-sync) on the admin page, and mapping.