### PR TITLE
Remove modal functionality on Resistance hub campaign page

### DIFF
--- a/assets/src/js/resistance-hub-campaign.js
+++ b/assets/src/js/resistance-hub-campaign.js
@@ -110,32 +110,6 @@ document.addEventListener('DOMContentLoaded', () => {
     columns.classList.add('container');
     columnsWrapper.append(columns);
     actionsList.parentNode.insertBefore(columnsWrapper, actionsList.nextSibling);
-
-    // Add functionatility of leaving a message
-    const openModalButton = columnsWrapper.querySelector('.wp-element-button');
-
-    if (openModalButton) {
-      openModalButton.addEventListener('click', () => {
-        let overlay = document.querySelector('.gform-overlay');
-        if (!overlay) {
-          overlay = document.createElement('div');
-          overlay.classList.add('gform-overlay');
-          document.body.append(overlay);
-        }
-
-        overlay.style.display = 'block';
-
-        const form = document.querySelector('.gform_wrapper');
-        if (form) {
-          form.style.display = 'flex';
-        }
-
-        overlay.addEventListener('click', () => {
-          overlay.style.display = 'none';
-          form.style.display = 'none';
-        });
-      });
-    }
   }
 
   // Iterate posts

--- a/assets/src/scss/pages/_resistance-hub-campaign.scss
+++ b/assets/src/scss/pages/_resistance-hub-campaign.scss
@@ -197,32 +197,6 @@
     @include btn-cta;
   }
 
-  .gform_wrapper {
-    display: none;
-    z-index: 9999;
-    margin: auto;
-    left: 0;
-    right: 0;
-    top: 0;
-    bottom: 0;
-    position: fixed;
-    flex-direction: column;
-    align-self: center;
-    background-color: var(--white);
-    padding: 20px 40px;
-  }
-
-  .gform-overlay {
-    cursor: pointer;
-    width: 100vw;
-    height: 100vh;
-    background: rgba(69, 73, 76, .8);
-    position: fixed;
-    left: 0;
-    top: 0;
-    z-index: 999;
-  }
-
   @media (max-width: 992px) {
     .boxout .boxout-placeholder {
       order: 1;


### PR DESCRIPTION
### Summary
We will use a button to link an external page instead.

Ref: No ticket needed

Demo page: https://www-dev.greenpeace.org/test-umbriel/petitions/resistance-hub/

