### PR TITLE
Add dashboard notice for our two new blocks

### DIFF
--- a/src/DashboardNotice.php
+++ b/src/DashboardNotice.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace P4\MasterTheme;
+
+/**
+ * Class DashboardNotice
+ */
+class DashboardNotice
+{
+    /**
+     * Key of notice seen by user
+     *
+     */
+    private const DASHBOARD_MESSAGE_KEY = 'last_p4_notice';
+
+    /**
+     * Version of notice
+     *
+     */
+    private const DASHBOARD_MESSAGE_VERSION = '0.6';
+
+    /**
+     * Constructor.
+     */
+    public function __construct()
+    {
+        add_action('admin_notices', [$this, 'show_dashboard_notice']);
+        add_action('wp_ajax_dismiss_dashboard_notice', [$this, 'dismiss_dashboard_notice']);
+    }
+
+    /**
+     * Show P4 team message on dashboard.
+     */
+    public function show_dashboard_notice(): void
+    {
+        // Show only on dashboard.
+        $screen = get_current_screen();
+        if (null === $screen || 'dashboard' !== $screen->id) {
+            return;
+        }
+
+        // Don't show a dismissed version.
+        $last_notice = get_user_meta(get_current_user_id(), self::DASHBOARD_MESSAGE_KEY, true);
+        if (version_compare(self::DASHBOARD_MESSAGE_VERSION, $last_notice, '<=')) {
+            return;
+        }
+
+        // Don't show an empty message.
+        $message = trim($this->p4_message());
+        if (empty($message)) {
+            return;
+        }
+
+        do_action('enqueue_dismiss_dashboard_notice_script');
+
+        echo '<div id="p4-notice" class="notice notice-info is-dismissible">' . wp_kses_post($message) . '</div>';
+    }
+
+    /**
+     * A message from Planet4 team.
+     *
+     * Message title should be a <h2> tag.
+     * Message text should be written into <p> tags.
+     * Return an empty string if no message for this version.
+     *
+     * Version number DASHBOARD_MESSAGE_VERSION has to be incremented
+     * each time we add a new message.
+     *
+     * phpcs:disable Generic.Files.LineLength.MaxExceeded
+     */
+    private function p4_message(): string
+    {
+        return '<h2>📢 The new Posts List and Actions List blocks are here!</h2>
+            <p>
+                <ul>
+                    <li><span style="margin-right: 3px;">
+                        <a href="https://planet4.greenpeace.org/content/blocks/posts-list/" target="_blank">Posts List</a>:
+                        <span> 📝 It replaces the Articles block and the Covers block Content Style</span>
+                    </li>
+                    <li><span style="margin-right: 3px;">
+                        <a href="https://planet4.greenpeace.org/content/blocks/actions-list/">Actions List</a>:
+                        <span> ✨ It replaces the Covers block Take Action Style</span>
+                    </li>
+                </ul>
+            </p>';
+    }
+    // phpcs:enable Generic.Files.LineLength.MaxExceeded
+
+    /**
+     * Dismiss P4 notice of dashboard, by saving the last version read in user meta field.
+     *
+     * @uses wp_die()
+     */
+    public function dismiss_dashboard_notice(): void
+    {
+        $user_id = get_current_user_id();
+        if (0 === $user_id) {
+            wp_die('User not logged in.', 401);
+        }
+
+        $res = update_user_meta(
+            $user_id,
+            self::DASHBOARD_MESSAGE_KEY,
+            self::DASHBOARD_MESSAGE_VERSION
+        );
+        if (false === $res) {
+            wp_die('User meta update failed.', 500);
+        }
+
+        wp_die('Notice dismissed.', 200);
+    }
+}

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -101,6 +101,7 @@ final class Loader
             YouTubeHandler::class,
             CommentFormCustomizer::class,
             CronJob::class,
+            DashboardNotice::class,
         ];
 
         if (is_admin()) {

--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -20,18 +20,6 @@ use WP_Post;
 class MasterSite extends TimberSite
 {
     /**
-     * Key of notice seen by user
-     *
-     */
-    private const DASHBOARD_MESSAGE_KEY = 'last_p4_notice';
-
-    /**
-     * Version of notice
-     *
-     */
-    private const DASHBOARD_MESSAGE_VERSION = '0.6';
-
-    /**
      * Credit meta field key
      *
      */
@@ -198,8 +186,6 @@ class MasterSite extends TimberSite
         version_compare(get_bloginfo('version'), '5.5', '<')
             ? add_action('init', [$this, 'p4_register_core_image_block'])
             : add_filter('register_block_type_args', [$this, 'register_core_blocks_callback']);
-        add_action('admin_notices', [$this, 'show_dashboard_notice']);
-        add_action('wp_ajax_dismiss_dashboard_notice', [$this, 'dismiss_dashboard_notice']);
 
         // Disable WordPress(WP5.5) Block Directory.
         $this->disable_block_directory();
@@ -1376,88 +1362,6 @@ class MasterSite extends TimberSite
         }
 
         return $args;
-    }
-
-    /**
-     * Show P4 team message on dashboard.
-     */
-    public function show_dashboard_notice(): void
-    {
-        // Show only on dashboard.
-        $screen = get_current_screen();
-        if (null === $screen || 'dashboard' !== $screen->id) {
-            return;
-        }
-
-        // Don't show a dismissed version.
-        $last_notice = get_user_meta(get_current_user_id(), self::DASHBOARD_MESSAGE_KEY, true);
-        if (version_compare(self::DASHBOARD_MESSAGE_VERSION, $last_notice, '<=')) {
-            return;
-        }
-
-        // Don't show an empty message.
-        $message = trim($this->p4_message());
-        if (empty($message)) {
-            return;
-        }
-
-        do_action('enqueue_dismiss_dashboard_notice_script');
-
-        echo '<div id="p4-notice" class="notice notice-info is-dismissible">' . wp_kses_post($message) . '</div>';
-    }
-
-    /**
-     * A message from Planet4 team.
-     *
-     * Message title should be a <h2> tag.
-     * Message text should be written into <p> tags.
-     * Return an empty string if no message for this version.
-     *
-     * Version number DASHBOARD_MESSAGE_VERSION has to be incremented
-     * each time we add a new message.
-     *
-     * phpcs:disable Generic.Files.LineLength.MaxExceeded
-     */
-    private function p4_message(): string
-    {
-        return '<h2>📢 The new Posts List and Actions List blocks are here!</h2>
-            <p>
-                <ul>
-                    <li><span style="margin-right: 3px;">
-                        <a href="https://planet4.greenpeace.org/content/blocks/posts-list/" target="_blank">Posts List</a>:
-                        <span> 📝 It replaces the Articles block and the Covers block Content Style</span>
-                    </li>
-                    <li><span style="margin-right: 3px;">
-                        <a href="https://planet4.greenpeace.org/content/blocks/actions-list/">Actions List</a>:
-                        <span> ✨ It replaces the Covers block Take Action Style</span>
-                    </li>
-                </ul>
-            </p>';
-    }
-    // phpcs:enable Generic.Files.LineLength.MaxExceeded
-
-    /**
-     * Dismiss P4 notice of dashboard, by saving the last version read in user meta field.
-     *
-     * @uses wp_die()
-     */
-    public function dismiss_dashboard_notice(): void
-    {
-        $user_id = get_current_user_id();
-        if (0 === $user_id) {
-            wp_die('User not logged in.', 401);
-        }
-
-        $res = update_user_meta(
-            $user_id,
-            self::DASHBOARD_MESSAGE_KEY,
-            self::DASHBOARD_MESSAGE_VERSION
-        );
-        if (false === $res) {
-            wp_die('User meta update failed.', 500);
-        }
-
-        wp_die('Notice dismissed.', 200);
     }
 
     /**


### PR DESCRIPTION
### Summary

- Adding documentation links for Actions and Posts List blocks
- Moving dashboard notice implementation to a new class

### Testing

1. The new notice should be visible once you login in the Admin Panel (see screenshot)
2. Check the links point to the right Handbook pages
3. Dismiss the notice
4. Refreshing the page should not make the notice appear again


<img width="1884" height="426" alt="image" src="https://github.com/user-attachments/assets/37d95c24-a944-49eb-8002-8c8ee2a40be6" />

