### PR TITLE
PLANET-7914 Fix sort order by date desc in Action list

### DIFF
--- a/src/Blocks/QueryLoopExtension.php
+++ b/src/Blocks/QueryLoopExtension.php
@@ -76,6 +76,9 @@ class QueryLoopExtension
         if (!empty($params['block_name'])) {
             if ($params['block_name'] === self::ACTIONS_LIST_BLOCK) {
                 $query = self::buildActionListQuery($query);
+                if (!empty($params['postIn'])) {
+                    $query['orderby'] = 'post__in';
+                }
             }
 
             if ($params['block_name'] === self::POSTS_LIST_BLOCK) {
@@ -171,16 +174,12 @@ class QueryLoopExtension
             $query['post__in'] = [0];
         }
 
-        if (!empty($query['post__in'])) {
-            $query['orderby'] = 'post__in';
-        } else {
-            $query['orderby'] = [
-                'menu_order' => 'ASC',
-                'post_date' => 'DESC',
-                'post_title' => 'ASC',
-                'post__in' => 'ASC',
-            ];
-        }
+        $query['orderby'] = [
+            'menu_order' => 'ASC',
+            'post_date' => 'DESC',
+            'post_title' => 'ASC',
+            'post__in' => 'ASC',
+        ];
 
         return $query;
     }


### PR DESCRIPTION
Refactor action list sort order for manual override actions functionality

---

Ref: https://greenpeace-planet4.atlassian.net/browse/PLANET-7914

### Testing
**For Manual override -**
- On test instance or local, create a new Page and add the Actions List blocks.
- Add pages using manual override function.
- Block now displays actions based on order of manual override.

**Other than Manual override -**
- On test instance or local, create a new Page and add the Actions List blocks.
- Block now displays actions based on orderby newest to oldest