### PR TITLE
PLANET-7779 Posts List: Fixed cards height

### DIFF
--- a/assets/src/scss/base/_variables.scss
+++ b/assets/src/scss/base/_variables.scss
@@ -9,6 +9,9 @@ $extra-extra-large-width: 1600px;
 // Override html selectors
 $checkbox-size: 20px;
 
+// Posts List default height
+$posts-list-container-height: 468px;
+
 // Spacing
 @function space($base) {
   @return $base * 8px;

--- a/assets/src/scss/blocks/ActionsList/ActionsListStyle.scss
+++ b/assets/src/scss/blocks/ActionsList/ActionsListStyle.scss
@@ -128,12 +128,17 @@
     }
   }
 
-  .wp-block-post-terms a {
-    color: var(--grey-600);
-    font-size: var(--font-size-s--font-family-tertiary);
-    font-weight: var(--font-weight-bold);
-    font-family: var(--font-family-tertiary);
-    line-height: var(--line-height-s--font-family-tertiary);
+  .wp-block-post-terms {
+    margin-bottom: $sp-1;
+
+    a {
+      color: var(--grey-600);
+      font-size: var(--font-size-s--font-family-tertiary);
+      font-weight: var(--font-weight-bold);
+      font-family: var(--font-family-tertiary);
+      line-height: var(--line-height-s--font-family-tertiary);
+      @include clamp-text(1);
+    }
   }
 
   &.is-custom-layout-grid {

--- a/assets/src/scss/blocks/PostsList/PostsListStyle.scss
+++ b/assets/src/scss/blocks/PostsList/PostsListStyle.scss
@@ -32,6 +32,10 @@
         }
       }
     }
+
+    @include medium-and-less {
+      margin-top: $sp-4;
+    }
   }
 
   // In List and Grid layouts, we only show the link at the bottom of the block.
@@ -127,6 +131,10 @@
       align-self: flex-start;
     }
 
+    .carousel-item-wrapper li {
+      height: $posts-list-container-height;
+    }
+
     // We don't show tags in this layout because they often break the design.
     .taxonomy-post_tag {
       display: none;
@@ -163,10 +171,6 @@
       .carousel-controls + .see-all-link {
         display: none;
         visibility: hidden;
-      }
-
-      .wp-block-post-terms:not(:first-child) {
-        display: block;
       }
 
       .carousel-item-wrapper {
@@ -208,16 +212,10 @@
     font-size: calc(var(--font-size-xxs--font-family-primary) - 2px);
     display: flex;
 
+    &,
     a {
       color: var(--grey-600);
       font-weight: var(--font-weight-semibold);
-    }
-
-    &::after {
-      content: ".";
-      font-size: calc(var(--font-size-m--font-family-primary) + 5px);
-      margin-top: -6px;
-      margin-inline-start: $sp-x;
     }
   }
 
@@ -291,6 +289,38 @@
 
       @include large-and-up {
         grid-template-columns: repeat(4, minmax(0, 1fr));
+
+        li {
+          height: $posts-list-container-height;
+        }
+      }
+    }
+  }
+
+  &.is-custom-layout-grid,
+  &.is-custom-layout-carousel {
+    .wp-block-post-terms a {
+      @include clamp-text(1);
+
+      overflow-wrap: break-word;
+      word-break: break-word;
+      hyphens: auto;
+    }
+  }
+
+  .posts-list-meta {
+    flex-direction: column;
+    line-height: var(--line-height-xs--font-family-tertiary);
+
+    .article-list-item-author {
+      @include clamp-text(1);
+
+      &:focus-within {
+        @include focus-styles();
+      }
+
+      a:focus {
+        outline: none;
       }
     }
   }

--- a/assets/src/scss/layout/_featured-posts.scss
+++ b/assets/src/scss/layout/_featured-posts.scss
@@ -97,7 +97,16 @@
 
       &:not(:first-child) {
         .wp-post-image {
-          height: 152px;
+          height: 164px;
+        }
+
+        .wp-block-post-terms,
+        .wrapper-post-tag:before {
+          margin-top: -12px;
+        }
+
+        .wp-block-post-title {
+          margin-top: -5px;
         }
       }
     }

--- a/assets/src/scss/layout/_query-loop-overrides.scss
+++ b/assets/src/scss/layout/_query-loop-overrides.scss
@@ -70,6 +70,7 @@
         top: 0;
         bottom: 0;
         margin: auto;
+        z-index: -1;
 
         .wp-block-button {
           overflow: hidden;

--- a/assets/src/scss/pages/_listing-page.scss
+++ b/assets/src/scss/pages/_listing-page.scss
@@ -46,8 +46,11 @@
   color: var(--gp-green-800);
 
   a {
-    white-space: nowrap;
     color: inherit;
+    @include clamp-text(1);
+    overflow-wrap: break-word;
+    word-break: break-word;
+    hyphens: auto;
 
     &:visited {
       color: var(--gp-green-800);
@@ -102,34 +105,43 @@
 }
 
 .query-list-item-meta {
+  display: flex;
+  flex-direction: column;
   font-family: var(--font-family-tertiary);
   font-size: $font-size-xxs;
   font-weight: var(--font-weight-regular);
   color: var(--color-text-meta_item);
   line-height: var(--line-height-s--font-family-tertiary);
 
-  .query-list-item-bullet {
-    display: inline-block;
-    padding: 0 $sp-x;
-  }
-
   .article-list-item-author {
     font-weight: var(--font-weight-semibold);
+    @include clamp-text(1);
+
+    &:focus-within {
+      @include focus-styles();
+    }
   }
 
   .article-list-item-author a {
     color: var(--color-text-meta_item);
+
+    &:focus {
+      outline: none;
+    }
   }
 
   .article-list-item-readtime {
     display: flex;
     @include render-bullet($sp-x);
+    margin-inline-start: 5px;
+  }
+
+  .query-list-meta-date-reading-time {
+    display: flex;
   }
 }
 
 .wp-block-post {
-  margin-bottom: $sp-4;
-
   figure {
     margin-bottom: 0;
   }
@@ -185,6 +197,10 @@
           width: calc((100% / 2) - 1.25em + (1.25em / 2)) !important;
         }
 
+        @include medium-and-up {
+          height: $posts-list-container-height;
+        }
+
         @include large-and-up {
           width: calc((100% / 3) - 1.25em + (1.25em / 3)) !important;
         }
@@ -197,7 +213,7 @@
 
     .query-list-item-headline.wp-block-post-title a {
       @include large-and-up {
-        @include clamp-text(3);
+        @include clamp-text(2);
       }
     }
 

--- a/parts/query-listing-page.html
+++ b/parts/query-listing-page.html
@@ -22,9 +22,10 @@
 
 			<div class="query-list-item-meta d-flex flex-wrap">
 				<!-- wp:p4/post-author-name /-->
-				<span class="query-list-item-bullet" aria-hidden="true">•</span>
-				<!-- wp:post-date /-->
-				<!-- wp:p4/reading-time /-->
+				<div class="query-list-meta-date-reading-time">
+          <!-- wp:post-date /-->
+          <!-- wp:p4/reading-time /-->
+        </div>
 			</div>
 		</div>
 	<!-- /wp:post-template -->

--- a/templates/featured-posts.twig
+++ b/templates/featured-posts.twig
@@ -13,7 +13,7 @@
                             <!-- wp:post-terms {"term":"p4-page-type"} /-->
                         </div>
                         <div class="wrapper-post-tag">
-                            <!-- wp:post-terms {"term":"post_tag"} /-->
+                            <!-- wp:post-terms {"term":"post_tag","separator":" "} /-->
                         </div>
                     </div>
 
@@ -24,9 +24,10 @@
 
                     <div class="query-list-item-meta d-flex flex-wrap">
                         <!-- wp:p4/post-author-name /-->
-                        <span class="query-list-item-bullet" aria-hidden="true">•</span>
-                        <!-- wp:post-date /-->
-                        <!-- wp:p4/reading-time /-->
+                       <div class="query-list-meta-date-reading-time">
+                            <!-- wp:post-date /-->
+                            <!-- wp:p4/reading-time /-->
+                       </div>
                     </div>
                 </div>
             <!-- /wp:post-template -->


### PR DESCRIPTION
### Summary

<!-- Please provide a brief summary of the change introduced in this Pull Request. -->

---

<!-- Please add a reference link to the ticket, if one exists. -->
**Ref: https://greenpeace-planet4.atlassian.net/browse/PLANET-7779**

### Testing

<!-- Please add the steps required to test the changes in this Pull Request. -->
For Posts List block with Carousel style, next and prev arrows should no longer bounce as cards now have a fixed height .

We are now following the design below with the fixed height and updated `posts-list-meta` section

<img width="1400" height="791" alt="Frame 1" src="https://github.com/user-attachments/assets/2f9b8270-3c57-48ca-80b5-8a74c5a20af6" />



[Test Page](https://www-dev.greenpeace.org/test-saturn/test-page/) (with fix)
[Control Page](https://www-dev.greenpeace.org/test-venus/) (without fix)
