### PR TITLE
PLANET-7904 Fix Sentry TypeError in GF form filter

### DIFF
--- a/src/GravityFormsExtensions.php
+++ b/src/GravityFormsExtensions.php
@@ -251,7 +251,7 @@ class GravityFormsExtensions
      * @return array|bool The form setting.
      *
      */
-    public function enqueue_share_buttons(array $form): array|bool
+    public function enqueue_share_buttons($form): array|bool
     {
         if (!is_array($form['confirmations'])) {
             return $form;
@@ -844,8 +844,7 @@ class GravityFormsExtensions
      * Client side dynamic population of form fields
      *
      * @param array|bool $form The different form fields present
-     *
-     * @return mixed
+     * @return  array|bool The form setting.
      */
     public function p4_client_side_gravityforms_prefill($form): array|bool
     {

--- a/src/GravityFormsExtensions.php
+++ b/src/GravityFormsExtensions.php
@@ -247,11 +247,11 @@ class GravityFormsExtensions
      * Enqueue the share buttons script only if the confirmation type is a message.
      * Pass the social data to the script.
      *
-     * @param array $form The form setting.
-     * @return array The form setting.
+     * @param array|bool $form The form setting.
+     * @return array|bool The form setting.
      *
      */
-    public function enqueue_share_buttons(array $form): array
+    public function enqueue_share_buttons(array $form): array|bool
     {
         if (!is_array($form['confirmations'])) {
             return $form;
@@ -847,7 +847,7 @@ class GravityFormsExtensions
      *
      * @return mixed
      */
-    public function p4_client_side_gravityforms_prefill($form): array
+    public function p4_client_side_gravityforms_prefill($form): array|bool
     {
         if (!is_array($form)) {
             return $form;


### PR DESCRIPTION
Ref. https://greenpeace-planet4.atlassian.net/browse/PLANET-7904

### Summary

The `gform_pre_render` filter throughs a TypeError due to strict return type of array, now we make it array|bool (use php Union type)

> TypeError
> P4\MasterTheme\GravityFormsExtensions::p4_client_side_gravityforms_prefill(): Return value must be of type array, bool returned

