### PR TITLE
PLANET-7921: Fix bug with the manual override feature in the Posts List block

### DIFF
--- a/src/Blocks/QueryLoopExtension.php
+++ b/src/Blocks/QueryLoopExtension.php
@@ -73,12 +73,10 @@ class QueryLoopExtension
         $query['post_status'] = 'publish';
         $query['has_password'] = false;
 
+        // If the type of block can be identified:
         if (!empty($params['block_name'])) {
             if ($params['block_name'] === self::ACTIONS_LIST_BLOCK) {
                 $query = self::buildActionListQuery($query);
-                if (!empty($params['postIn'])) {
-                    $query['orderby'] = 'post__in';
-                }
             }
 
             if ($params['block_name'] === self::POSTS_LIST_BLOCK) {
@@ -86,19 +84,20 @@ class QueryLoopExtension
                 $query['orderby'] = [
                     'post_date' => 'DESC',
                 ];
-
-                return $query;
             }
         }
 
+        // If the Manual Override is used:
         if (!empty($params['postIn'])) {
             $query['post__in'] = array_map('intval', (array) $params['postIn']);
             $query['ignore_sticky_posts'] = true;
+            $query['orderby'] = 'post__in';
+        }
 
-            if (!empty($query['post__in']) && !empty($params['exclude'])) {
-                $exclude = array_map('intval', (array) $params['exclude']);
-                $query['post__in'] = array_values(array_diff($query['post__in'], $exclude));
-            }
+        // If the Manual Override is not used, remove the current post from the query:
+        if (empty($params['postIn']) && !empty($query['post__in']) && !empty($params['exclude'])) {
+            $exclude = array_map('intval', (array) $params['exclude']);
+            $query['post__in'] = array_values(array_diff($query['post__in'], $exclude));
         }
 
         return $query;


### PR DESCRIPTION
### Summary

This PR fixes the bug that prevents the manual override feature not to working as expected in the Posts List block.
The problem was the early return of the query parameters on line 90 of the `src/Blocks/QueryLoopExtension.php` file.

---

Ref: https://greenpeace-planet4.atlassian.net/browse/PLANET-7921

### Testing

1. Add a Posts List block to a page or post.
2. Add posts to the manual override feature.
3. Check that the block displays the selected posts in the correct order.
4. Check that the current post is not displayed, even if selected from the manual override feature.
5. Check that the rest of the functionalities of the block still work correctly.
6. Check that the Actions List block still works correctly.
