### PR TITLE
PLANET-7649: Fix lightbox not using largest image

### DIFF
--- a/assets/src/blocks/components/Lightbox/Lightbox.js
+++ b/assets/src/blocks/components/Lightbox/Lightbox.js
@@ -37,6 +37,19 @@ export const Lightbox = ({index = 0, isOpen, items, onClose = () => {}}) => {
       photoSwipeOptions
     );
 
+    const getData = (i, galleryItem) => {
+      if (!galleryItem.w || !galleryItem.h) {
+        const img = new Image();
+        img.onload = function () {
+          galleryItem.w = this.width;
+          galleryItem.h = this.height;
+          photoSwipe.updateSize(true);
+        };
+        img.src = galleryItem.src;
+      }
+    };
+
+    photoSwipe.listen('gettingData', getData);
     photoSwipe.listen('destroy', onClose);
     photoSwipe.listen('close', onClose);
     photoSwipe.listen('afterChange', () => setCurrentIndex(photoSwipe.getCurrentIndex()));
@@ -44,7 +57,9 @@ export const Lightbox = ({index = 0, isOpen, items, onClose = () => {}}) => {
     photoSwipe.init();
 
     return () => {
-      photoSwipe.destroy();
+      if (photoSwipe && photoSwipe._listeners) {
+        photoSwipe.destroy();
+      }
     };
   }, [isOpen, items, photoSwipeOptions, onClose]);
 

--- a/assets/src/blocks/components/Lightbox/Lightbox.js
+++ b/assets/src/blocks/components/Lightbox/Lightbox.js
@@ -26,16 +26,12 @@ export const Lightbox = ({index, isOpen, items, onClose = () => {}}) => {
       return;
     }
 
-    const preloadItems = items.map(item => {
-      if (!item.w || !item.h) {
-        const img = new Image();
-        img.src = item.originalSrc.url;
-        item.w = item.originalSrc.width;
-        item.h = item.originalSrc.height;
-        item.src = item.originalSrc.url;
-      }
-      return item;
-    });
+    const preloadItems = items.map(item => ({
+      src: item.originalSrc?.url || item.src,
+      w: item.originalSrc?.width || item.w,
+      h: item.originalSrc?.height || item.h,
+      title: item.title,
+    }));
 
     const photoSwipe = new PhotoSwipe(photoSwipeElement, PhotoSwipeUI_Default, preloadItems, photoSwipeOptions);
 

--- a/assets/src/blocks/components/Lightbox/Lightbox.js
+++ b/assets/src/blocks/components/Lightbox/Lightbox.js
@@ -26,20 +26,18 @@ export const Lightbox = ({index, isOpen, items, onClose = () => {}}) => {
       return;
     }
 
-    const photoSwipe = new PhotoSwipe(photoSwipeElement, PhotoSwipeUI_Default, items, photoSwipeOptions);
-
-    // eslint-disable-next-line no-shadow
-    photoSwipe.listen('gettingData', (index, galleryItem) => {
-      if (galleryItem.w < 1 || galleryItem.h < 1) {
-        const imageSizeHandler = new Image();
-        imageSizeHandler.onload = function() {
-          galleryItem.w = this.width;
-          galleryItem.h = this.height;
-          photoSwipe.updateSize(true);
-        };
-        imageSizeHandler.src = galleryItem.src;
+    const preloadItems = items.map(item => {
+      if (!item.w || !item.h) {
+        const img = new Image();
+        img.src = item.originalSrc.url;
+        item.w = item.originalSrc.width;
+        item.h = item.originalSrc.height;
+        item.src = item.originalSrc.url;
       }
+      return item;
     });
+
+    const photoSwipe = new PhotoSwipe(photoSwipeElement, PhotoSwipeUI_Default, preloadItems, photoSwipeOptions);
 
     photoSwipe.listen('destroy', () => {
       onClose();

--- a/assets/src/blocks/components/Lightbox/setupLightboxForImages.js
+++ b/assets/src/blocks/components/Lightbox/setupLightboxForImages.js
@@ -1,17 +1,74 @@
 import {Lightbox} from './Lightbox';
 import {createRoot} from 'react-dom/client';
 
+/**
+ * Extracts the WordPress image ID from an element's class list.
+ *
+ * @param {HTMLElement} el - The DOM element to inspect.
+ * @return {number|null} The image ID if found, otherwise null.
+ */
+const getImageIdFromClass = el => {
+  for (const cls of el.classList) {
+    const match = cls.match(/^wp-image-(\d+)$/);
+    if (match) {
+      return parseInt(match[1], 10);
+    }
+  }
+  return null;
+};
+
+/**
+ * Fetches metadata for a WordPress image by its DOM element.
+ *
+ * @param {HTMLImageElement} imgEl - The image element.
+ * @return {Promise<{url: string, width: number|null, height: number|null}|null>}
+ *   An object containing the image URL and dimensions, or null if not found.
+ */
+const getImageMeta = async imgEl => {
+  const imgId = getImageIdFromClass(imgEl);
+  if (!imgId) { return null; }
+
+  try {
+    const response = await fetch(`/wp-json/wp/v2/media/${imgId}`);
+    if (!response.ok) { throw new Error('Failed to fetch media info'); }
+
+    const data = await response.json();
+
+    const url =
+      data?.media_details?.sizes?.full?.source_url ?? // try full size
+      data?.media_details?.sizes?.large?.source_url ?? // fallback to large
+      data?.source_url; // fallback to original
+
+    const width = data?.media_details?.width ?? null;
+    const height = data?.media_details?.height ?? null;
+
+    return {url, width, height};
+  } catch (err) {
+    return null;
+  }
+};
+
+/**
+ * Prepares a single image block for the lightbox.
+ *
+ * @param {HTMLElement} lightBoxNode           - The container node for the lightbox portal.
+ * @param {string}      [imageSelector='img']  - Selector for the image inside the block.
+ * @param {string|null} [captionSelector=null] - Selector for the caption inside the block.
+ * @return {function(HTMLElement, number): Promise<void>} Callback for `forEach` over image blocks.
+ */
 const setupImageAndCaption = (lightBoxNode, imageSelector = 'img', captionSelector = null) => {
-  // Returns the callback for `forEach`
-  return (imageBlock, index) => {
+  return async (imageBlock, index) => {
     const image = imageBlock.querySelector(imageSelector);
 
     if (!image) {
       return;
     }
 
+    const imgSrc = image.src ?? image.dataset.src;
+
     const item = {
-      src: image.src ? image.src : image.dataset.src,
+      src: imgSrc,
+      originalSrc: await getImageMeta(image) ?? imgSrc,
       w: 0,
       h: 0,
     };
@@ -26,7 +83,10 @@ const setupImageAndCaption = (lightBoxNode, imageSelector = 'img', captionSelect
   };
 };
 
-export const setupLightboxForImages = function() {
+/**
+ * Initializes the lightbox for images on the page.
+ */
+export const setupLightboxForImages = function () {
   // We can't use `createPortal` outside `render()`,
   // `React.render()` needs a node, even if it ends up being empty.
   // See: https://github.com/facebook/react/issues/12653#issuecomment-382851495

--- a/assets/src/blocks/components/Lightbox/setupLightboxForImages.js
+++ b/assets/src/blocks/components/Lightbox/setupLightboxForImages.js
@@ -28,24 +28,29 @@ const getImageMeta = async imgEl => {
   const imgId = getImageIdFromClass(imgEl);
   if (!imgId) { return null; }
 
-  try {
-    const response = await fetch(`/wp-json/wp/v2/media/${imgId}`);
-    if (!response.ok) { throw new Error('Failed to fetch media info'); }
-
-    const data = await response.json();
-
-    const url =
-      data?.media_details?.sizes?.full?.source_url ?? // try full size
-      data?.media_details?.sizes?.large?.source_url ?? // fallback to large
-      data?.source_url; // fallback to original
-
-    const width = data?.media_details?.width ?? null;
-    const height = data?.media_details?.height ?? null;
-
-    return {url, width, height};
-  } catch (err) {
+  const response = await fetch(`/wp-json/wp/v2/media/${imgId}`);
+  if (!response.ok) {
+    // eslint-disable-next-line no-console
+    console.log('Failed to fetch media info');
     return null;
   }
+
+  const data = await response.json();
+
+  if (data.media_details) {
+    const url =
+        data.media_details.sizes?.full?.source_url || // try full size
+        data.media_details.sizes?.large?.source_url || // fallback to large
+        data.source_url; // fallback to original
+
+    const width = data.media_details.width || null;
+    const height = data.media_details.height || null;
+
+    return {url, width, height};
+  }
+
+  // fallback if no media_details
+  return {url: data.source_url, width: null, height: null};
 };
 
 /**

--- a/assets/src/blocks/components/Lightbox/setupLightboxForImages.js
+++ b/assets/src/blocks/components/Lightbox/setupLightboxForImages.js
@@ -69,13 +69,11 @@ const setupImageAndCaption = (lightBoxNode, imageSelector = 'img', captionSelect
       return;
     }
 
-    const imgSrc = image.src ?? image.dataset.src;
+    const src = image.src ?? image.dataset.src;
 
     const item = {
-      src: imgSrc,
-      originalSrc: await getImageMeta(image) ?? imgSrc,
-      w: 0,
-      h: 0,
+      src,
+      originalSrc: await getImageMeta(image) ?? src,
     };
 
     const caption = imageBlock.querySelector(captionSelector);


### PR DESCRIPTION
### Summary

This PR fixes the images of the Image block not using their largest size when expanded by the lightbox, but the one selected by the editor.

---

Ref: https://greenpeace-planet4.atlassian.net/browse/PLANET-7649

### Testing

1. In a post or page, add the following blocks: Image (with caption), Image (without caption), Media Text, and Paragraph.
2. Add images to all the blocks mentioned in step 1. In the case of the Paragraph block, add an inline image.
3. Change the size of the image and use one different to of "full" or "original".
4. In the front, click on every image. The lightbox should be fired, and the image should expand to full size regardless of the size chosen on step 3.
