### PR TITLE
PLANET-7902: Fix type error in enqueue_share_buttons function

### DIFF
--- a/templates/blocks/share_buttons.twig
+++ b/templates/blocks/share_buttons.twig
@@ -1,4 +1,7 @@
-{% do action('enqueue_share_buttons_script', social) %}
+{% if social is defined and social is iterable and social|length > 0 %}
+  {% do action('enqueue_share_buttons_script', social) %}
+{% endif %}
+
 {% set socialLink = (share_url ?? social.link) ~ '?utm_medium=' ~ utm_medium ~ utm_content_param ~ utm_campaign_param %}
 <div class="share-buttons">
     <!-- Whatsapp -->


### PR DESCRIPTION
### Summary

This PR fixes the `TypeError` reported by Sentry: `P4\MasterTheme\EnqueueController::enqueue_share_buttons(): Argument #1 ($social_data) must be of type array, null given, called in /app/source/public/wp-includes/class-wp-hook.php on line 326` 

To do so, the `share_buttons.twig` file, before calling the `enqueue_share_buttons_script` function, checks:
- If the `social` variable exists (is defined).
- If the `social` variable is an array (is iterable).
- If the `social` variable is not empty (length > 0).

---

Ref 1: https://greenpeace-planet4.atlassian.net/browse/PLANET-7902
Ref 2: https://greenpeace-international.sentry.io/issues/6361837634

### Testing

1. Run this branch in your local instance.
2. Clear the Timber cache: `npx wp-env run cli wp timber clear_cache` 
3. Load a post that uses the social share feature and check if the `/assets/build/shareButtons.js` is enqueued.
4. Turn `null` the social variable. You can do it by adding this at the top of the `templates/blocks/share_buttons.twig` file: `{% set social = null %}` 
5. Clear the Timber cache: `npx wp-env run cli wp timber clear_cache` 
6. Load a post that uses the social share feature and check if the `/assets/build/shareButtons.js` is NOT enqueued.
