### PR TITLE
PLANET-7899: Add integrity Sub-Resource to 3rd party libraries

### DIFF
--- a/src/Blocks/CarouselHeader.php
+++ b/src/Blocks/CarouselHeader.php
@@ -123,6 +123,11 @@ class CarouselHeader extends BaseBlock
                 '2.0.8',
                 true
             );
+            wp_script_add_data(
+                'hammer',
+                'integrity',
+                'sha512-UXumZrZNiOwnTcZSHLOfcTs0aos2MzBWHXOHOuB0J/R44QB0dwY5JgfbvljXcklVf65Gc4El6RjZ+lnwd2az2g=='
+            );
         }
         parent::enqueue_frontend_assets();
     }

--- a/src/Blocks/Gallery.php
+++ b/src/Blocks/Gallery.php
@@ -133,6 +133,11 @@ class Gallery extends BaseBlock
                 '2.0.8',
                 true
             );
+            wp_script_add_data(
+                'hammer',
+                'integrity',
+                'sha512-UXumZrZNiOwnTcZSHLOfcTs0aos2MzBWHXOHOuB0J/R44QB0dwY5JgfbvljXcklVf65Gc4El6RjZ+lnwd2az2g=='
+            );
         }
         parent::enqueue_frontend_assets();
     }

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -69,6 +69,11 @@ final class Loader
                     '1.12.1',
                     true
                 );
+                wp_script_add_data(
+                    'rellax',
+                    'integrity',
+                    'sha512-f5HTYZYTDZelxS7LEQYv8ppMHTZ6JJWglzeQmr0CVTS70vJgaJiIO15ALqI7bhsracojbXkezUIL+35UXwwGrQ=='
+                );
             }
         );
     }

--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -1031,6 +1031,11 @@ class MasterSite extends TimberSite
             '3.3.1',
             true
         );
+        wp_script_add_data(
+            'jquery-3',
+            'integrity',
+            'sha512-+NqPlbbtM1QqiK8ZAo4Yrj2c4lNQoGv8P79DPtKzj++l5jnN39rHA/xsqn8zE9l0uSoxaCdrOgFs6yjyfbBxSg=='
+        );
     }
 
     /**


### PR DESCRIPTION
- It is applied to CDN libraries as a base64-encoded SHA-512 hash
- Jquery, Hammer and rellax are the spotted libraries

### Summary

<!-- Please provide a brief summary of the change introduced in this Pull Request. -->

---

<!-- Please add a reference link to the ticket, if one exists. -->
Ref: https://greenpeace-planet4.atlassian.net/browse/PLANET-7899

### Testing

<!-- Please add the steps required to test the changes in this Pull Request. -->
1. 
2. 
3. 
