### PR TITLE
PLANET-7927: Change the Manual Override feature limits

### DIFF
--- a/assets/src/block-editor/QueryLoopBlockExtension/index.js
+++ b/assets/src/block-editor/QueryLoopBlockExtension/index.js
@@ -213,6 +213,12 @@ export const setupQueryLoopBlockExtension = () => {
           wp.data.select('core/block-editor').getSelectedBlock(),
         ]);
 
+        // Set the max length of items for the Manual Override feature based on the layout.
+        const maxLength = useMemo(
+          () => { return (attributes.layout.type === 'flex') ? 12 : 100; },
+          [attributes.layout.type]
+        );
+
         return useMemo(() => (
           <>
             <InspectorControls>
@@ -239,7 +245,7 @@ export const setupQueryLoopBlockExtension = () => {
                     postType={query.postType || 'post'}
                     postParent={query?.postParent || null}
                     placeholder={__('Select articles', 'planet4-blocks-backend')}
-                    maxLength={10}
+                    maxLength={maxLength}
                     maxSuggestions={20}
                   />
                 </PanelBody>


### PR DESCRIPTION
### Summary

This PR sets the max length of items for the Manual Override feature based on the layout: 12 items for the Carousel layout and 100 items for the rest.

---

Ref: 
- https://greenpeace-planet4.atlassian.net/browse/PLANET-7927
- https://greenpeace-gpi.slack.com/archives/G015K63081W/p1757325074167009 

### Testing

1. On any post or page, add a Post List block.
2. Switch to the Carousel layout for that block. The maximum length of items for the Manual Override should be 12. 
3. Switch to another layout. The maximum length of items for the Manual Override should be 100.
4. Repeat the previous steps now using the Actions List block. 
