### PR TITLE
Install a bundle analyzer

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "start": "wp-scripts start --config webpack.config.js --mode=development",
     "build": "wp-scripts build --config webpack.config.js --mode=production",
+    "analyze": "wp-scripts build --config webpack.config.js --mode=production --env analyze",
     "lint:css": "npx stylelint 'assets/src/scss/**/*.scss'",
     "lint:js": "npx eslint 'assets/src/**/*.js' 'tests/e2e/**/*.js' 'admin/js/**/*.js'",
     "lint": "npm run lint:js && npm run lint:css",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,6 +17,7 @@ const mediaQueryAliases = {
 
 module.exports = (env, argv) => {
   const isProduction = argv.mode === 'production';
+  const analyze = env && env.analyze;
 
   return {
     //stats: 'verbose',
@@ -156,13 +157,15 @@ module.exports = (env, argv) => {
       new SpriteLoaderPlugin({
         plainSprite: true,
       }),
-      new BundleAnalyzerPlugin(
-        {
-          analyzerMode: 'server',
-          analyzerPort: 8888,
-          openAnalyzer: true,
-        }
-      ),
+      ...(analyze ?
+        [
+          new BundleAnalyzerPlugin({
+            analyzerMode: 'server',
+            analyzerPort: 8888,
+            openAnalyzer: true,
+          }),
+        ] :
+        []),
     ],
     optimization: {
       concatenateModules: isProduction,


### PR DESCRIPTION
### Summary

As part of the Experimentation Day, this PR installs the Webpack Bundle Analyzer tool to help us visualize the size of our JS bundles. As can be seen from the graphic below, our biggest elements are:

- editorIndex.js (180.54 KB)
- GalleryEditorScript.js (123.4 KB)
- index.js (113.58 KB)
- CarouselHeaderEditorScript.js (86.1 KB)
- SpreadsheetEditorScript.js (76.5 KB)
- CounterEditorScript.js (75.18 KB)
- frontendIndex.js (64.34 KB)
- GalleryScript.js (50 KB)

<img width="1544" height="753" alt="planet4-master-theme-12-Sep-2025-at-10-13-" src="https://github.com/user-attachments/assets/391a1d85-be43-486e-b26c-1161bd255880" />

---

### Testing

1. In your local environment, install the Webpack Bundle Analyzer by running `npm install`
2. Build the project and analyze it by running `npm run analyze` 
3. The results should be shown automatically on your browser, using the localhost port `8888`