### PR TITLE
PLANET-7766: Purge Cloudflare cache on file replacement

### DIFF
--- a/src/CloudflarePurger.php
+++ b/src/CloudflarePurger.php
@@ -8,7 +8,6 @@ use CF\Integration\DefaultLogger;
 use CF\WordPress\DataStore;
 use CF\WordPress\WordPressAPI;
 use CF\WordPress\WordPressClientAPI;
-use CF\API\Request;
 use Generator;
 
 /**
@@ -38,7 +37,7 @@ class CloudflarePurger
         $integration = new DefaultIntegration($config, $integration_api, $data_store, $logger);
 
         $this->api = new WordPressClientAPI($integration);
-        $this->zone_id = $this->api->getZoneTag('greenpeace.org');
+        $this->zone_id = $this->api->getZoneTag(get_option('cloudflare_cached_domain_name'));
     }
 
     /**
@@ -61,20 +60,6 @@ class CloudflarePurger
                 $chunk,
             ];
         }
-    }
-
-    /**
-     * Query API to purge given URLs list.
-     * It's similar to the "purge" function, but this one returns the full response, and not only bool + chunk.
-     *
-     * @param string[] $files URLs list.
-     * @return mixed response.
-     */
-    public function zone_purge_files(array $files)
-    {
-        $request = new Request('DELETE', 'zones/' . $this->zone_id . '/purge_cache', array(), array('files' => $files));
-        $response = $this->api->callAPI($request);
-        return $response;
     }
 
     /**

--- a/src/MediaReplacer.php
+++ b/src/MediaReplacer.php
@@ -553,17 +553,7 @@ class MediaReplacer
     private function success_handler(string $message, string $file_name): void
     {
         $stateless_url = $this->gc_storage_url . $this->bucket_name . "/" . $file_name;
-        $purge_result = $this->cf->zone_purge_files([$stateless_url]);
-
-        //phpcs:disable Squiz.PHP.DiscouragedFunctions.Discouraged
-        $json_purge_result = json_encode($purge_result, JSON_PRETTY_PRINT);
-
-        error_log('Cloudflare Response: ' . $json_purge_result);
-
-        if (function_exists('\Sentry\captureMessage')) {
-            \Sentry\captureMessage('Cloudflare Response: ' . $json_purge_result);
-        }
-        //phpcs:enable Squiz.PHP.DiscouragedFunctions.Discouraged
+        $this->cf->purge([$stateless_url]);
 
         array_push($this->replacement_status['success'], $message);
         $this->transient_handler(self::TRANSIENT['file'], $this->replacement_status);


### PR DESCRIPTION
### Summary

This PR purges Cloudflare's cache when a file is replaced by the `MediaReplacer` class, following the instructions mentioned [here](https://greenpeace-gpi.slack.com/archives/C0160MX64AG/p1756471909745629?thread_ts=1756471873.651339&cid=C0160MX64AG).

---

Ref: https://greenpeace-planet4.atlassian.net/browse/PLANET-7766

### Testing

**Locally:**
1. Configure "WP-Stateless" from `wp-admin > Media > Stateless settings` using the same data as the Gutenberg instance.
2. Edit line 40 of the `src/CloudflarePurger.php` file and replace `get_option('cloudflare_cached_domain_name')` with `'greenpeace.org'`
3. Go to the Media Library and add a new file.
4. Replace the previous file by using the "Replace Media" button.
5. Once the page reloads, you should see the new file.
6. To double-check that the file was actually replaced, open the file in a new tab and force the cache refresh by adding extra parameters to the URL. You should see the new file.

**Dev instance:**
1. Log in to the Nix instance: https://www-dev.greenpeace.org/test-nix/wp-admin/
2. Go to the Media Library and replace a file by using the "Replace Media" button.
3. Once the page reloads, you should see the new file.
4. To double-check that the file was actually replaced, open the file in a new tab and force the cache refresh by adding extra parameters to the URL. You should see the new file.