### PR TITLE
Fix search e2e test

### DIFF
--- a/tests/e2e/search.spec.js
+++ b/tests/e2e/search.spec.js
@@ -6,7 +6,6 @@ test.useAdminLoggedIn();
 test('check search works', async ({page, requestUtils}) => {
   const testId = `testsearch-${Math.floor(Math.random() * 10000)}`; //NOSONAR
   const tagName = `Tag ${testId}`;
-  const tagPageTitle = `#Tag ${testId}`;
   const postTitle = `Test Post ${testId}`;
 
   const tag = await requestUtils.rest({
@@ -44,7 +43,6 @@ test('check search works', async ({page, requestUtils}) => {
     const searchTags = await page.locator('.search-result-item-tag').allInnerTexts();
 
     expect(searchResult).toContain(testId);
-    expect(searchPage).toContain(tagPageTitle);
     expect(searchPage).toContain(postTitle);
     expect(searchTags).toContain(`#${tagName}`);
   };


### PR DESCRIPTION
### Summary

Search test is failing even now that Elasticsearch is back on test instances (see screenshot from the report below). Looking at the test code, it looks like we are testing for the tag name twice, but the first time we are looking at the wrong place.

Not sure why it used to work before. Maybe something changed because if [this commit](https://github.com/greenpeace/planet4-master-theme/commit/56f4f2834a185fc80f428fef089e7db3ed315975#diff-3a54bde3f5a7b056c7bb6cfd1a84b704e2412d26ae66ea39e0de84e7f6783737)? 

<img width="536" height="128" alt="Screenshot 2025-09-19 at 12 05 30" src="https://github.com/user-attachments/assets/80c7af7a-f479-4468-bca5-a81c7d05b2ef" />

