### PR TITLE
Remove transparent navigation in screens smaller than large

### DIFF
--- a/assets/src/scss/style.scss
+++ b/assets/src/scss/style.scss
@@ -97,7 +97,7 @@ Text Domain: planet4-master-theme
 
 // Override Navbar styles for Homepage only
 body.transparent-nav {
-  @include large-and-up {
+  @include x-large-and-up {
     .page-content {
       padding-top: 0;
     }


### PR DESCRIPTION
### Summary

Otherwise the search input also has a transparent background and it's not user friendly

Ref: [Slack thread](https://greenpeace-gpi.slack.com/archives/G015K63081W/p1758621515810969)

### Testing

The transparent navigation should no longer be applied when the screen width is lower than 1200px.
