### PR TITLE
PLANET-7930 Add e2e test for Counter block

### DIFF
--- a/tests/e2e/blocks/counter.spec.js
+++ b/tests/e2e/blocks/counter.spec.js
@@ -1,0 +1,51 @@
+import {test, expect} from '../tools/lib/test-utils.js';
+import {publishPostAndVisit, createPostWithFeaturedImage} from '../tools/lib/post.js';
+import {searchAndInsertBlock} from '../tools/lib/editor.js';
+
+const COUNTER_URL = 'https://counter.greenpeace.org/signups?id=testcounter';
+const COUNTER_GOAL = 10000;
+const COUNTER_TITLE = 'Counter Block';
+const COUNTER_DESCRIPTION = 'Counter description';
+
+test.useAdminLoggedIn();
+
+test('Test Counter block', async ({page, admin, editor, request}) => {
+  await createPostWithFeaturedImage({page, admin, editor}, {title: 'Test Counter', postType: 'page'});
+
+  // Add Counter block.
+  await searchAndInsertBlock({page}, 'Counter');
+
+  // Pick the "Progress Bar" style.
+  const stylePicker = page.locator('.block-editor-block-styles__variants');
+  await stylePicker.locator('button[aria-label="Progress Bar"]').click();
+
+  // Change the block settings.
+  await page.getByLabel('API URL for Goal Reached').fill(COUNTER_URL);
+  await page.getByLabel('Goal', {exact: true}).fill(`${COUNTER_GOAL}`);
+  await page.getByPlaceholder('e.g. "signatures collected of').fill('Signatures collected: %completed% from %target%. (%remaining% remaining)');
+
+  // Change block title and description.
+  await page.getByRole('textbox', {name: 'Enter title'}).fill(COUNTER_TITLE);
+  await page.getByRole('textbox', {name: 'Enter description'}).fill(COUNTER_DESCRIPTION);
+
+  // Publish page.
+  await publishPostAndVisit({page, editor});
+
+  // Test that the block is displayed as expected in the frontend:
+  // Title and description.
+  await expect(page.locator('.page-section-header')).toHaveText(COUNTER_TITLE);
+  await expect(page.locator('.page-section-description')).toHaveText(COUNTER_DESCRIPTION);
+
+  // Counter text with correct values.
+  const apiResponse = await request.get(COUNTER_URL);
+  const {unique_count: completed} = await apiResponse.json();
+  const counterTextNumbers = page.locator('.counter-target');
+  await expect(counterTextNumbers.nth(0)).toHaveText(`${completed}`);
+  await expect(counterTextNumbers.nth(1)).toHaveText(`${COUNTER_GOAL}`);
+  await expect(counterTextNumbers.nth(2)).toHaveText(`${COUNTER_GOAL - completed}`);
+
+  // Counter progress bar with correct percentage.
+  const completedPercentage = Math.round((completed / COUNTER_GOAL) * 100);
+  await expect(page.locator('.progress-bar')).toHaveAttribute('style', `width: calc(${completedPercentage}% + 20px);`);
+});
+


### PR DESCRIPTION
### Summary

**Test Steps:**
1. Login to the Admin Panel.
2. Create a new Page.
3. Add a Counter block:
  - Pick the “Progress Bar” style
  - Change the API URL to “https://counter.greenpeace.org/signups?id=testcounter”
  - Change block goal to “10000”
  - Change block template to “signatures collected: %completed% from %target%. (%remaining% remaining)”
  - Change block title to "Counter Block"
  - Change block description to “Counter description”
4. Publish the page.
5. Navigate to the frontend view of that Page and verify that all of the above properties are working as expected:
  - Block title
  - Block description
  - The counter text matches the template
  - The progress bar is there and its width is determined by the completed signatures percentage

Ref: [PLANET-7930](https://greenpeace-planet4.atlassian.net/browse/PLANET-7930)

### Testing

On local you can run it using `npx playwright test tests/e2e/blocks/counter.spec.js`.


[PLANET-7930]: https://greenpeace-planet4.atlassian.net/browse/PLANET-7930?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ