### PR TITLE
PLANET-7594 Fix sitemap page query for new IA

### DIFF
--- a/page-templates/sitemap.php
+++ b/page-templates/sitemap.php
@@ -36,6 +36,8 @@ if (!empty(planet4_get_option('new_ia'))) {
             'numberposts' => -1,
         ]);
     }
+    $sitemap = new Sitemap();
+    $context['no_cat_pages'] = $sitemap->get_top_level_pages_without_category();
 } else {
     $sitemap = new Sitemap();
 

--- a/src/Sitemap.php
+++ b/src/Sitemap.php
@@ -157,4 +157,44 @@ class Sitemap
 
         return $article_types_data;
     }
+
+    /**
+     * Retrieves all top-level pages that do not have any category assigned,
+     * and attaches their direct child pages to each parent.
+     *
+     * @return WP_Post[] Array of top-level page objects.
+     *                   Each object includes a 'children' property (array of WP_Post).
+     */
+    public function get_top_level_pages_without_category(): array
+    {
+        $args = [
+            'post_type' => 'page',
+            'posts_per_page' => -1,
+            'post_parent' => 0,
+            'orderby' => 'title',
+            'order' => 'ASC',
+            'tax_query' => [
+                [
+                    'taxonomy' => 'category',
+                    'operator' => 'NOT EXISTS',
+                ],
+            ],
+        ];
+
+        $parents = get_posts($args);
+
+        // Attach children for each parent
+        foreach ($parents as $p_index => $parent) {
+            $children = get_posts([
+                'post_type' => 'page',
+                'posts_per_page' => -1,
+                'post_parent' => $parent->ID,
+                'orderby' => 'title',
+                'order' => 'ASC',
+            ]);
+            $parents[$p_index]->children = $children;
+        }
+
+        return $parents;
+    }
 }

--- a/templates/sitemap.twig
+++ b/templates/sitemap.twig
@@ -63,6 +63,31 @@
                     {% endif %}
                     {% endfor %}
                 {% endif %}
+                {% if no_cat_pages  %}
+                    {% for no_cat_page in no_cat_pages %}
+                        {% if no_cat_page.children is not empty %}
+                            <div class="col-md-5 order-md-2 order-lg-3 col-lg-3">
+                                <h5 class="mb-3 mt-5 mt-lg-0">
+                                    <a href="{{ function('get_permalink', no_cat_page.ID) }}">{{ no_cat_page.post_title|e('wp_kses_post')|raw }}</a>
+                                </h5>
+                                <ul>
+                                    {% for post in no_cat_page.children %}
+                                        <li><a href="{{ function('get_permalink', post.ID) }}">{{ post.post_title|e('wp_kses_post')|raw }}</a></li>
+                                    {% endfor %}
+                                </ul>
+                            </div>
+                        {% endif %}
+                    {% endfor %}
+                    <div class="col-md-5 order-md-2 order-lg-3 col-lg-3">
+                        <ul>
+                            {% for post in no_cat_pages %}
+                                {% if post.children is empty %}
+                                <li><a href="{{ function('get_permalink', post.ID) }}">{{ post.post_title|e('wp_kses_post')|raw }}</a></li>
+                                {% endif %}
+                            {% endfor %}
+                        </ul>
+                    </div>
+                {% endif %}
             </div>
         </div>
     </div>


### PR DESCRIPTION
Show all pages for categories on sitemap page

### Summary

Earlier, The sitemap was showing a maximum of 5 pages per category, but we fixed it to show all pages.

eg. https://www-dev.greenpeace.org/test-titan/sitemap/

Ref. : [PLANET-7594](https://greenpeace-planet4.atlassian.net/browse/PLANET-7594)

[PLANET-7594]: https://greenpeace-planet4.atlassian.net/browse/PLANET-7594?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ