### PR TITLE
Hide ElasticPress version notice

### DIFF
--- a/admin/css/options.css
+++ b/admin/css/options.css
@@ -76,3 +76,8 @@
     font-weight: bold;
   }
 }
+
+/* Temporarily hide ElasticPress version mismatch notice */
+[data-ep-notice] {
+  display: none !important;
+}


### PR DESCRIPTION
### Summary

As we are planning on using a newer version of ElasticSearch, this hides the version notice to avoid confusion for admins.

Used the data selector, as the css classes have very generic names.

---

### Testing

<!-- Please add the steps required to test the changes in this Pull Request. -->
1. Test any dev to see the notice that is visible on admin panel by Elasticpress
2. In this branch, the notice should no longer be visible
