### PR TITLE
PLANET-7649: Fix lightbox not using largest image

### DIFF
--- a/assets/src/blocks/components/Lightbox/setupLightboxForImages.js
+++ b/assets/src/blocks/components/Lightbox/setupLightboxForImages.js
@@ -10,8 +10,12 @@ const setupImageAndCaption = (lightBoxNode, imageSelector = 'img', captionSelect
       return;
     }
 
+    // Derive full/original image URL by removing size suffix
+    let fullSrc = image.src ? image.src : image.dataset.src;
+    fullSrc = image.src.replace(/-\d+x\d+(?=\.\w+$)/, '');
+
     const item = {
-      src: image.src ? image.src : image.dataset.src,
+      src: fullSrc,
       w: 0,
       h: 0,
     };


### PR DESCRIPTION
### Summary

This PR fixes the images not using their largest size when expanded by the lightbox, but the one selected by the editor.

---

Ref: https://greenpeace-planet4.atlassian.net/browse/PLANET-7649

### Testing

1. In a post or page, add the following blocks: Image (with caption), Image (without caption), Media Text, and Paragraph (or you can also use [this page](https://www-dev.greenpeace.org/test-atlas/test-page/)).
2. Add images to all the blocks mentioned in step 1. In the case of the Paragraph block, add an inline image.
3. Change the size of the image and use one different to of "full" or "original".
4. In the front, click on every image. The lightbox should be fired, and the image should expand to full size regardless of the size chosen on step 3.
5. Also check that the Gallery blocks keep working alright and unchanged.