### PR TITLE
Force the usage of a custom folder in WP Stateless

### DIFF
--- a/src/AttachmentsController.php
+++ b/src/AttachmentsController.php
@@ -55,6 +55,10 @@ class AttachmentsController
         add_filter('wp_stateless_get_setting_root_dir', function () {
             return date('Y') . "/" . date('m');
         });
+
+        add_filter('wp_stateless_get_setting_mode', function () {
+            return 'disabled';
+        });
     }
 
     /**

--- a/src/AttachmentsController.php
+++ b/src/AttachmentsController.php
@@ -53,7 +53,7 @@ class AttachmentsController
          * @return string The new folder structure
          */
         add_filter('wp_stateless_get_setting_root_dir', function () {
-            return date('Y') . "/" . date('m');
+            return 'test/pedro';
         });
     }
 

--- a/src/AttachmentsController.php
+++ b/src/AttachmentsController.php
@@ -45,6 +45,16 @@ class AttachmentsController
             100,
             2
         );
+
+        /**
+         * Overrides the "root_dir" WP-Stateless setting, changing the upload folder structure.
+         *
+         * @link https://stateless.udx.io/docs/changelog/ (check v4.0.0 notes)
+         * @return string The new folder structure
+         */
+        add_filter('wp_stateless_get_setting_root_dir', function () {
+            return date('Y') . "/" . date('m');
+        });
     }
 
     /**

--- a/src/AttachmentsController.php
+++ b/src/AttachmentsController.php
@@ -55,10 +55,6 @@ class AttachmentsController
         add_filter('wp_stateless_get_setting_root_dir', function () {
             return date('Y') . "/" . date('m');
         });
-
-        add_filter('wp_stateless_get_setting_mode', function () {
-            return 'disabled';
-        });
     }
 
     /**

--- a/src/AttachmentsController.php
+++ b/src/AttachmentsController.php
@@ -53,7 +53,7 @@ class AttachmentsController
          * @return string The new folder structure
          */
         add_filter('wp_stateless_get_setting_root_dir', function () {
-            return 'test/pedro';
+            return date('Y') . "/" . date('m');
         });
     }
 


### PR DESCRIPTION
### Summary

This PR overrides the folder structure used by the WP Stateless plugin as an attempt to solve the problem that still persists on the GP Aoatearoa website.

---

### Notes

As this is a custom solution for only one website, it could be moved to the corresponding child theme.

---

Ref: https://greenpeace-gpi.slack.com/archives/C0160MX64AG/p1759304244505969 

### Testing

1. Visit the [WP Stateless settings page](https://www-dev.greenpeace.org/test-nix/wp-admin/upload.php?page=stateless-settings). The folder structure should be `/2025/10/` (or the corresponding year/month).
2. [Upload](https://www-dev.greenpeace.org/test-nix/wp-admin/media-new.php) a new file.
3. Check that the new file was stored accordingly to the folder structure.