### PR TITLE
Enabled the Secondary Navigation Block

### DIFF
--- a/assets/src/blocks/SecondaryNavigation/SecondaryNavigationBlock.js
+++ b/assets/src/blocks/SecondaryNavigation/SecondaryNavigationBlock.js
@@ -11,7 +11,7 @@ export const registerSecondaryNavigationBlock = () => {
     title: 'Secondary Navigation Menu',
     description: __('Inserts a secondary navigation menu to the page that leads to different sections of the same page.', 'planet4-blocks-backend'),
     icon: 'menu-alt3',
-    category: 'planet4-blocks-beta',
+    category: 'planet4-blocks',
     attributes: {
       levels: {
         type: 'array',

--- a/assets/src/blocks/SecondaryNavigation/SecondaryNavigationEditor.js
+++ b/assets/src/blocks/SecondaryNavigation/SecondaryNavigationEditor.js
@@ -1,23 +1,22 @@
 import {getHeadingsFromBlocks} from '../../functions/getHeadingsFromBlocks';
 
 const {useSelect} = wp.data;
-// const {InspectorControls} = wp.blockEditor;
-// const {PanelBody} = wp.components;
+const {InspectorControls} = wp.blockEditor;
+const {PanelBody} = wp.components;
 const {__} = wp.i18n;
 
-// const renderEdit = () =>  (
-//   // TODO: Update with correct link
-//   // <InspectorControls>
-//   //   <PanelBody title={__('Learn more about this block', 'planet4-blocks-backend')} initialOpen={false}>
-//   //     <p className="components-base-control__help">
-//   //       <a target="_blank" href="https://planet4.greenpeace.org/content/blocks/table-of-contents/" rel="noreferrer">
-//   //           P4 Handbook - P4 Secondary Navigation Menu
-//   //       </a>
-//   //       {' '} &#128203;
-//   //     </p>
-//   //   </PanelBody>
-//   // </InspectorControls>
-// );
+const renderEdit = () =>  (
+  <InspectorControls>
+    <PanelBody title={__('Learn more about this block', 'planet4-blocks-backend')} initialOpen={false}>
+      <p className="components-base-control__help">
+        <a target="_blank" href="https://planet4.greenpeace.org/content/blocks/secondary-navigation/" rel="noreferrer">
+            P4 Handbook - P4 Secondary Navigation Menu
+        </a>
+        {' '} &#128203;
+      </p>
+    </PanelBody>
+  </InspectorControls>
+);
 
 const renderView = ({levels}) => {
   const blocks = useSelect(select => select('core/block-editor').getBlocks(), []);
@@ -51,7 +50,7 @@ const renderView = ({levels}) => {
 // eslint-disable-next-line no-unused-vars
 export const SecondaryNavigationEditor = ({attributes, isSelected}) => (
   <>
-    {/* {isSelected && renderEdit()} */}
+    {isSelected && renderEdit()}
     {renderView(attributes)}
   </>
 );

--- a/assets/src/editorIndex.js
+++ b/assets/src/editorIndex.js
@@ -34,14 +34,10 @@ wp.domReady(() => {
   registerTopicLinkBlock();
   registerActionButtonTextBlock();
   registerActionsListBlock();
+  registerSecondaryNavigationBlock();
 
   // Block Templates
   registerBlockTemplates();
-
-  // Beta blocks
-  if (window.p4_vars.features.beta_blocks === 'on') {
-    registerSecondaryNavigationBlock();
-  }
 
   // Custom block styles
   registerBlockStyles();


### PR DESCRIPTION
### Summary

<!-- Please provide a brief summary of the change introduced in this Pull Request. -->

---

<!-- Please add a reference link to the ticket, if one exists. -->
Ref: https://greenpeace-gpi.slack.com/archives/C0160MX64AG/p1759326083077969?thread_ts=1759320876.591019&cid=C0160MX64AG

### Testing

<!-- Please add the steps required to test the changes in this Pull Request. -->
Secondary Navigation block is now enabled by default under `planet4-blocks` category. Also updated the Block description in the editor.
