### PR TITLE
PLANET-7460: Hide GF notification checkbox for attachments

### DIFF
--- a/admin/css/gravity-forms-admin.css
+++ b/admin/css/gravity-forms-admin.css
@@ -1,0 +1,3 @@
+#gform_setting_enableAttachments {
+  display: none !important;
+}

--- a/src/GravityFormsExtensions.php
+++ b/src/GravityFormsExtensions.php
@@ -124,6 +124,28 @@ class GravityFormsExtensions
         add_action('gform_stripe_fulfillment', [ $this, 'record_fulfillment_entry' ], 10, 2);
         add_action('gform_post_payment_action', [ $this, 'check_stripe_payment_status' ], 10, 2);
         add_action('gform_pre_render', [$this, 'enqueue_share_buttons'], 10, 2);
+        add_action('admin_enqueue_scripts', [$this, 'enqueue_admin_styles']);
+    }
+
+    /**
+     * Enqueues styles for the GF admin pages.
+     *
+     */
+    public function enqueue_admin_styles(): void
+    {
+        $page = isset($_GET['page']) && $_GET['page'] === 'gf_edit_forms';
+        $subview = isset($_GET['subview']) && $_GET['subview'] === 'notification';
+
+        if (!$page || !$subview) {
+            return;
+        }
+
+        wp_enqueue_style(
+            'gravity-forms-admin',
+            get_stylesheet_directory_uri() . '/admin/css/gravity-forms-admin.css',
+            [],
+            Loader::theme_file_ver('admin/css/gravity-forms-admin.css')
+        );
     }
 
     /**


### PR DESCRIPTION
### Summary

This PR hides the "Attachments" option (see below) in the Gravity Form's notification settings.
As it was mentioned [here](https://greenpeace-planet4.atlassian.net/browse/PLANET-7460?focusedCommentId=25642), there's an incompatibility between that option and the WP-Stateless plugin, so the decision to remove the option was made. 
I could not find any filter to properly remove it, so the change applied to this PR relies on CSS.

<img width="1544" height="753" alt="New-Notification-‹-Notifications-‹-Form-title-goes-here-‹-Forms-Gravity-Forms-‹-Greenpeace-—-WordPress" src="https://github.com/user-attachments/assets/994281aa-11b5-4949-bcae-fdd354b22c71" />

---

Ref: https://greenpeace-planet4.atlassian.net/browse/PLANET-7460

### Testing

1. Go to Gravity Form's notification settings.
2. Check that the "Attachments" option is no longer visible.
