### PR TITLE
Experimentation Day: reduce and optimize database queries

### DIFF
--- a/src/ActionPage.php
+++ b/src/ActionPage.php
@@ -30,12 +30,15 @@ class ActionPage
         'p4_department',
     ];
 
+    public mixed $terms;
+
     /**
      * The constructor.
      */
     public function __construct()
     {
         $this->hooks();
+        $this->terms = wp_get_object_terms(get_queried_object_id(), self::TAXONOMY);
     }
 
     /**
@@ -521,7 +524,7 @@ class ActionPage
 
         // Check if Action has a action type term assigned to it and if none assigned,
         // assign the default p4 action type term.
-        $terms = wp_get_object_terms($post->ID, self::TAXONOMY);
+        $terms = $this->terms;
         if (is_wp_error($terms)) {
             return;
         }
@@ -666,7 +669,7 @@ class ActionPage
         }
 
         // Get action's taxonomy terms.
-        $terms = wp_get_object_terms($post->ID, self::TAXONOMY);
+        $terms = $this->terms;
 
         if (! is_wp_error($terms) && ! empty($terms) && is_object($terms[0])) {
             $taxonomy_slug = $terms[0]->slug;

--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -500,6 +500,8 @@ class MasterSite extends \Timber\Site
     {
         global $wp;
 
+        $this->add_nav_menus_to_context($context);
+
         $context['cookies'] = [
             'text' => planet4_get_option('cookies_field'),
             'enable_analytical_cookies' => planet4_get_option('enable_analytical_cookies'),
@@ -524,29 +526,6 @@ class MasterSite extends \Timber\Site
         ];
         $context['domain'] = 'planet4-master-theme';
         $context['foo'] = 'bar'; // For unit test purposes.
-
-        if (has_nav_menu('navigation-bar-menu')) {
-            $menu = Timber::get_menu('navigation-bar-menu');
-            $menu_items = $menu->get_items();
-            $context['navbar_menu'] = $menu;
-            $context['navbar_menu_items'] = array_filter(
-                $menu_items,
-                function ($item) {
-                    return !in_array('wpml-ls-item', $item->classes ?? [], true);
-                }
-            );
-        }
-
-        // Check if the menu has been created.
-        if (has_nav_menu('donate-menu')) {
-            $donate_menu = Timber::get_menu('donate-menu');
-
-            // Check if it has at least 1 item added into the menu.
-            if (!empty($donate_menu->get_items())) {
-                $context['donate_menu_items'] = $donate_menu->get_items();
-            }
-        }
-
 
         $languages = function_exists('icl_get_languages') ? icl_get_languages() : [];
         $context['site_languages'] = $languages;
@@ -612,27 +591,6 @@ class MasterSite extends \Timber\Site
         $context['copyright_text_line1'] = $options['copyright_line1'] ?? '';
         $context['copyright_text_line2'] = $options['copyright_line2'] ?? '';
 
-        if (has_nav_menu('footer-social-menu')) {
-            $footer_social_menu = Timber::get_menu('footer-social-menu');
-            $context['footer_social_menu'] = wp_get_nav_menu_items($footer_social_menu->id);
-        } else {
-            $context['footer_social_menu'] = wp_get_nav_menu_items('Footer Social');
-        }
-
-        if (has_nav_menu('footer-primary-menu')) {
-            $footer_primary_menu = Timber::get_menu('footer-primary-menu');
-            $context['footer_primary_menu'] = wp_get_nav_menu_items($footer_primary_menu->id);
-        } else {
-            $context['footer_primary_menu'] = wp_get_nav_menu_items('Footer Primary');
-        }
-
-        if (has_nav_menu('footer-secondary-menu')) {
-            $footer_secondary_menu = Timber::get_menu('footer-secondary-menu');
-            $context['footer_secondary_menu'] = wp_get_nav_menu_items($footer_secondary_menu->id);
-        } else {
-            $context['footer_secondary_menu'] = wp_get_nav_menu_items('Footer Secondary');
-        }
-
         // Default depth level set to 1 if not selected from admin.
         $context['p4_comments_depth'] = get_option('thread_comments_depth') ?? 1;
 
@@ -669,6 +627,43 @@ class MasterSite extends \Timber\Site
         }
 
         return $context;
+    }
+
+    private function add_nav_menus_to_context(&$context)
+    {
+        if (has_nav_menu('navigation-bar-menu')) {
+            $menu = Timber::get_menu('navigation-bar-menu');
+            $menu_items = $menu->get_items();
+            $context['navbar_menu'] = $menu;
+            $context['navbar_menu_items'] = array_filter(
+                $menu_items,
+                function ($item) {
+                    return !in_array('wpml-ls-item', $item->classes ?? [], true);
+                }
+            );
+        }
+
+        $nav_locations = get_nav_menu_locations();
+
+        $context['donate_menu_items'] =
+            array_key_exists('donate-menu', $nav_locations) ?
+            Timber::get_menu('donate-menu')->get_items() :
+            Timber::get_menu('Donate Menu')->get_items();
+
+        $context['footer_primary_menu'] =
+            array_key_exists('footer-primary-menu', $nav_locations) ?
+            Timber::get_menu('footer-primary-menu')->get_items() :
+            Timber::get_menu('Footer Primary')->get_items();
+
+        $context['footer_secondary_menu'] =
+            array_key_exists('footer-secondary-menu', $nav_locations) ?
+            Timber::get_menu('footer-secondary-menu')->get_items() :
+            Timber::get_menu('Footer Secondary')->get_items();
+
+        $context['footer_social_menu'] =
+            array_key_exists('footer-social-menu', $nav_locations) ?
+            Timber::get_menu('footer-social-menu')->get_items() :
+            Timber::get_menu('Footer Social')->get_items();
     }
 
     /**

--- a/src/Post.php
+++ b/src/Post.php
@@ -44,9 +44,12 @@ class Post extends \Timber\Post
      */
     public array $data_layer;
 
+    public array $post_meta = [];
+
     public static function build(\WP_Post $wp_post): self
     {
         $post = parent::build($wp_post);
+        $post->post_meta = get_post_meta($wp_post->ID);
         $post->set_page_types();
         $post->set_author();
 
@@ -257,7 +260,7 @@ class Post extends \Timber\Post
      */
     public function get_og_title(): string
     {
-        return get_post_meta($this->id, 'p4_og_title', true);
+        return $this->post_meta['p4_og_title'][0] ?? '';
     }
 
     /**
@@ -266,7 +269,7 @@ class Post extends \Timber\Post
      */
     public function get_og_description(): string
     {
-        $og_desc = get_post_meta($this->id, 'p4_og_description', true);
+        $og_desc = array_key_exists('p4_og_description', $this->post_meta) ? $this->post_meta['p4_og_description'][0] : '';
 
         if ('' === $og_desc) {
             return $this->post_excerpt;
@@ -281,7 +284,7 @@ class Post extends \Timber\Post
      */
     public function get_og_image(): array
     {
-        $meta = get_post_meta($this->id);
+        $meta = $this->post_meta;
         $image_id = null;
         $image_metas = ['p4_og_image_id', '_thumbnail_id', 'background_image_id'];
         foreach ($image_metas as $image_meta) {
@@ -313,8 +316,9 @@ class Post extends \Timber\Post
      */
     public function share_meta(): array
     {
-        $og_title = get_post_meta($this->id, 'p4_og_title', true);
-        $og_description = get_post_meta($this->id, 'p4_og_description', true);
+        $og_title = $this->post_meta['p4_og_title'][0];
+        $og_description = $this->post_meta['p4_og_description'][0];
+
         $link = get_permalink($this->id);
 
         if (('' === $og_title) && '' !== $this->post_title) {
@@ -352,7 +356,8 @@ class Post extends \Timber\Post
      */
     public function get_author_override(): bool
     {
-        return !empty(get_post_meta($this->id, 'p4_author_override', true));
+        $author_override = $this->post_meta['p4_author_override'][0];
+        return !empty($author_override);
     }
 
     /**
@@ -360,7 +365,8 @@ class Post extends \Timber\Post
      */
     public function set_author(): void
     {
-        $author_override = get_post_meta($this->id, 'p4_author_override', true);
+        $author_override = array_key_exists('p4_author_override', $this->post_meta) ? $this->post_meta['p4_author_override'][0] : '';
+
         if ('' !== $author_override) {
             $fake_user = Timber::get_user(false); // Create fake User.
             $fake_user->display_name = $author_override;


### PR DESCRIPTION
### Summary

As part of the Experimentation Day, this PR attempts to reduce and optimize some of the most time-consuming database queries on our websites, according to the information provided by the Query Monitor plugin.

---

### Results

By reducing the calls to the functions `get_post_meta`, `wp_get_nav_menu_items`, `wp_get_object_terms`, and `get_terms`, the number of query calls made by the master theme was reduced from 59 to 48 on the homepage and from 55 to 44 on a single post (about 20% in both cases).

The most time-consuming queries, by far, are the ones related to functions used to get menu items in the `MasterSite` class (for example: `$menu = Timber::get_menu('navigation-bar-menu');`). I tried to reduce the number of calls for these functions, without success.

Homepage Before:
<img width="1544" height="753" alt="home-before" src="https://github.com/user-attachments/assets/ddc15f6c-808f-4294-be1d-391b248d325f" />

Homepage After:
<img width="1544" height="753" alt="home-after" src="https://github.com/user-attachments/assets/edbe4cbd-eaf7-4a12-befc-059cc7d22ef5" />

Single Post Before:
<img width="1544" height="753" alt="post-before" src="https://github.com/user-attachments/assets/b23227d9-1c42-4bfc-8d6d-0b5f233afe95" />

Single Post After:
<img width="1544" height="753" alt="post-after" src="https://github.com/user-attachments/assets/cd98134e-4b13-46f5-a428-43f9c8bff7cb" />
