### PR TITLE
Planet 8081 fix translations loaded too early

### DIFF
--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -98,15 +98,17 @@ class MasterSite extends \Timber\Site
         add_filter('wp_dropdown_users_args', [$this, 'filter_authors'], 10, 1);
         add_filter('http_request_timeout', fn () => 10);
 
-        register_nav_menus(
-            [
-                'navigation-bar-menu' => __('Navigation Bar Menu', 'planet4-master-theme-backend'),
-                'donate-menu' => __('Donate Button', 'planet4-master-theme-backend'),
-                'footer-primary-menu' => __('Footer Primary Menu', 'planet4-master-theme-backend'),
-                'footer-secondary-menu' => __('Footer Secondary Menu', 'planet4-master-theme-backend'),
-                'footer-social-menu' => __('Footer Social Menu', 'planet4-master-theme-backend'),
-            ]
-        );
+        add_action('after_setup_theme', function (): void {
+            register_nav_menus(
+                [
+                    'navigation-bar-menu' => __('Navigation Bar Menu', 'planet4-master-theme-backend'),
+                    'donate-menu' => __('Donate Button', 'planet4-master-theme-backend'),
+                    'footer-primary-menu' => __('Footer Primary Menu', 'planet4-master-theme-backend'),
+                    'footer-secondary-menu' => __('Footer Secondary Menu', 'planet4-master-theme-backend'),
+                    'footer-social-menu' => __('Footer Social Menu', 'planet4-master-theme-backend'),
+                ]
+            );
+        }, 0);
 
         add_filter(
             'editable_roles',


### PR DESCRIPTION
### Summary

- When switching the language to pt_BR, the following notice is triggered:

`Notice: A função _load_textdomain_just_in_time foi chamada <strong>incorretamente</strong>. O carregamento da tradução para o domínio <code>planet4-master-theme-backend</code> foi ativado muito cedo. Isso geralmente é um indicador de que algum código no plugin ou tema está sendo executado muito cedo. As traduções devem ser carregadas na ação <code>init</code> ou mais tarde. Leia como <a href="https://developer.wordpress.org/advanced-administration/debug/debug-wordpress/ ">Depurar o WordPress</a> para mais informações. (Esta mensagem foi adicionada na versão 6.7.0.) in /var/www/html/wp-includes/functions.php on line 6121`

- The notice occurs because translation functions such as __() are being executed before the text domain translations are loaded.

- The issue is caused by the [MasterSite](https://github.com/greenpeace/planet4-master-theme/blob/main/src/Loader.php#L80) and [MediaReplacer](https://github.com/greenpeace/planet4-master-theme/blob/main/src/Loader.php#L109) classes calling the __() function too early in the lifecycle.

---

<!-- Please add a reference link to the ticket, if one exists. -->
Ref: 
https://greenpeace-planet4.atlassian.net/browse/PLANET-8081
### Testing

- In the local development environment, install the pt_BR language and activate it
```
npx wp-env run cli wp language core install pt_BR
npx wp-env run cli wp language core activate pt_BR
```
- Check for the above mentioned notice
- With this PR applied, the notice should be fixed and no longer appear