### PR TITLE
PLANET-7990: Fix "skip to content" link in the Search Results page

### DIFF
--- a/templates/search.twig
+++ b/templates/search.twig
@@ -8,7 +8,7 @@
     {% set search_label = __( 'Search by name, keyword, or topic', 'planet4-master-theme' ) %}
 
     <div class="search-block">
-        <div class="container">
+        <div id="content" class="container">
             <div class="without-search-result row clearfix">
                 <div class="col-md-12">
                     <h1 class="result-statement">{{ page_title|e('wp_kses_post')|raw }}</h1>


### PR DESCRIPTION
### Summary

This PR fixes the "skip to content" link so that it works and moves focus correctly.

---

Ref: https://greenpeace-planet4.atlassian.net/browse/PLANET-7990

### Testing

1. On your local instance or the [test instance](https://www-dev.greenpeace.org/test-mars/), perform a search.
2. Wait for the Search Results page to load.
3. Tab until the "Skip to Content" button is reached.
4. Press enter, the screen should scroll until the beginning of the page content.
5. Press tab again, and the focus should go directly to the content.
6. Compare this functionality with an unfixed search page (e.g., [this one](https://www.greenpeace.org/international/?s=oceans&orderby=_score#content))