### PR TITLE
PLANET-8119: Prevent p4 vars error log

### DIFF
--- a/assets/src/js/app.js
+++ b/assets/src/js/app.js
@@ -1,6 +1,5 @@
 import 'bootstrap';
 
-import {setupCookies} from './cookies';
 import {setupHeader} from './header';
 import {setupPDFIcon} from './pdf_icon';
 import {setupExternalLinks} from './external_links';
@@ -16,7 +15,11 @@ function requireAll(r) {
 requireAll(require.context('../images/icons/', true, /\.svg$/));
 
 document.addEventListener('DOMContentLoaded', () => {
-  setupCookies();
+  if (window.p4_vars && typeof window.p4_vars !== 'undefined') {
+    import('./cookies').then(({setupCookies}) => {
+      setupCookies();
+    });
+  }
   setupHeader();
   setupPDFIcon();
   setupExternalLinks();


### PR DESCRIPTION
### Summary
The issue happens when p4 blocks feature is disabled

Currently 
<img width="727" height="239" alt="Screenshot 2026-02-12 at 8 53 33 AM" src="https://github.com/user-attachments/assets/3d05d16b-c5dd-4b56-bb7e-d7df99f9e565" />


---

<!-- Please add a reference link to the ticket, if one exists. -->
Ref: https://greenpeace-planet4.atlassian.net/browse/PLANET-8119

### Testing

<!-- Please add the steps required to test the changes in this Pull Request. -->
1. Disable/Enable Planet 4 Blocks from Admin. In both cases, no errors related to cookies should be displayed
<img width="803" height="209" alt="Screenshot 2026-02-12 at 9 12 22 AM" src="https://github.com/user-attachments/assets/3d811872-9c98-40ba-95aa-63848a9e9b53" />
