### PR TITLE
PLANET-7630: render special chars when post is shared 

### DIFF
--- a/src/Post.php
+++ b/src/Post.php
@@ -257,7 +257,12 @@ class Post extends \Timber\Post
      */
     public function get_og_title(): string
     {
-        return get_post_meta($this->id, 'p4_og_title', true);
+        $og_title = get_post_meta($this->id, 'p4_og_title', true);
+
+        if (empty($og_title)) {
+            $og_title = wp_title('', false) ?? '';
+        }
+        return html_entity_decode($og_title, ENT_QUOTES, 'UTF-8');
     }
 
     /**

--- a/templates/blocks/meta_fields.twig
+++ b/templates/blocks/meta_fields.twig
@@ -30,7 +30,7 @@
         {% set title = site.name %}
     {% endif %}
 
-    {% set title = title|replace({'`': "'"}) %}
+    {% set title = title|replace({'`': "'"})|raw %}
 
     <meta name="title" content="{{ title }}"/>
     <meta property="og:title" content="{{ title }}" />

--- a/templates/blocks/meta_fields.twig
+++ b/templates/blocks/meta_fields.twig
@@ -30,8 +30,8 @@
         {% set title = site.name %}
     {% endif %}
 
-    <meta name="title" content="{{ title|e('html_attr')|raw }}"/>
-    <meta property="og:title" content="{{ title|e('html_attr')|raw }}" />
+    <meta name="title" content="{{ title|raw }}"/>
+    <meta property="og:title" content="{{ title|raw }}" />
     <meta property="og:url" content="{{ current_url }}" />
     {% if (og_type) %}
         <meta property="og:type" content="{{ og_type }}" />
@@ -56,7 +56,7 @@
 
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:site" content="{{ site.name }}" />
-    <meta name="twitter:title" content="{{ title|e('html_attr')|raw }}">
+    <meta name="twitter:title" content="{{ title|raw }}">
     {% if (og_description) %}
         <meta name="twitter:description" content="{{ og_description|e('html_attr')|raw }}">
     {% endif %}

--- a/templates/blocks/meta_fields.twig
+++ b/templates/blocks/meta_fields.twig
@@ -22,8 +22,6 @@
 
     <meta name="description" content="{{ meta_description }}">
 
-
-    {# og_title (before): {{og_title}} #}
     {% if og_title %}
         {% set title = og_title %}
     {% else %}

--- a/templates/blocks/meta_fields.twig
+++ b/templates/blocks/meta_fields.twig
@@ -30,8 +30,10 @@
         {% set title = site.name %}
     {% endif %}
 
-    <meta name="title" content="{{ title|raw }}"/>
-    <meta property="og:title" content="{{ title|raw }}" />
+    {% set title = title|replace({'`': "'"}) %}
+
+    <meta name="title" content="{{ title }}"/>
+    <meta property="og:title" content="{{ title }}" />
     <meta property="og:url" content="{{ current_url }}" />
     {% if (og_type) %}
         <meta property="og:type" content="{{ og_type }}" />
@@ -56,7 +58,7 @@
 
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:site" content="{{ site.name }}" />
-    <meta name="twitter:title" content="{{ title|raw }}">
+    <meta name="twitter:title" content="{{ title }}">
     {% if (og_description) %}
         <meta name="twitter:description" content="{{ og_description|e('html_attr')|raw }}">
     {% endif %}

--- a/templates/blocks/meta_fields.twig
+++ b/templates/blocks/meta_fields.twig
@@ -22,18 +22,16 @@
 
     <meta name="description" content="{{ meta_description }}">
 
+
+    {# og_title (before): {{og_title}} #}
     {% if og_title %}
-        {% set title = og_title|raw~' - '~site.name %}
-    {% elseif wp_title %}
-        {% set title = wp_title|raw~' - '~site.name %}
+        {% set title = og_title %}
     {% else %}
         {% set title = site.name %}
     {% endif %}
 
-    {% set title = title|replace({'`': "'"})|raw %}
-
-    <meta name="title" content="{{ title }}"/>
-    <meta property="og:title" content="{{ title }}" />
+    <meta name="title" content="{{ title|raw }}"/>
+    <meta property="og:title" content="{{ title|raw }}" />
     <meta property="og:url" content="{{ current_url }}" />
     {% if (og_type) %}
         <meta property="og:type" content="{{ og_type }}" />
@@ -58,7 +56,7 @@
 
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:site" content="{{ site.name }}" />
-    <meta name="twitter:title" content="{{ title }}">
+    <meta name="twitter:title" content="{{ title|raw }}">
     {% if (og_description) %}
         <meta name="twitter:description" content="{{ og_description|e('html_attr')|raw }}">
     {% endif %}


### PR DESCRIPTION
### Summary
Render just raw the content and prevent XSS atacks. 

Please check the reported issue on Slack https://greenpeace.slack.com/archives/C0151L0KKNX/p1770909176985789

After
<img width="1550" height="839" alt="Screenshot 2026-02-18 at 11 57 15 AM" src="https://github.com/user-attachments/assets/59f5fba3-116e-4a8b-964f-8d2e17617117" />


<!-- Please provide a brief summary of the change introduced in this Pull Request. -->

---

<!-- Please add a reference link to the ticket, if one exists. -->
Ref: https://greenpeace-planet4.atlassian.net/browse/PLANET-7630



### Testing

<!-- Please add the steps required to test the changes in this Pull Request. -->
1. Create a new post using the title of https://bsky.app/profile/greenpeace.eu/post/3meoaaow4p22t
2. BlueSky account it's required 🙏 
