### PR TITLE
PLANET-8116 Implement new Timeline block year navigation

### DIFF
--- a/assets/src/blocks/Timeline/NewTimelineFrontend.js
+++ b/assets/src/blocks/Timeline/NewTimelineFrontend.js
@@ -1,3 +1,5 @@
+import {YearsNavigation} from './YearsNavigation';
+
 const {useState, useEffect} = wp.element;
 const {__, sprintf} = wp.i18n;
 
@@ -229,9 +231,10 @@ export const NewTimelineFrontend = ({attributes}) => {
           <p className="page-section-description text-center" dangerouslySetInnerHTML={{__html: description}} />
         }
 
+        <YearsNavigation years={processedSheetData.map(({year}) => year)} />
         <fieldset className="timeline-group">
           {processedSheetData.map(({year, list}) => (
-            <div key={year}>
+            <div id={year} key={year}>
               <p className="timeline-block-year">{year}</p>
               <ul className="timeline-block-events">
                 {list.map((event, index) => (

--- a/assets/src/blocks/Timeline/NewTimelineFrontend.js
+++ b/assets/src/blocks/Timeline/NewTimelineFrontend.js
@@ -234,7 +234,7 @@ export const NewTimelineFrontend = ({attributes}) => {
         <YearsNavigation years={processedSheetData.map(({year}) => year)} />
         <fieldset className="timeline-group">
           {processedSheetData.map(({year, list}) => (
-            <div id={year} key={year}>
+            <div className="timeline-block-year-group" id={year} key={year}>
               <p className="timeline-block-year">{year}</p>
               <ul className="timeline-block-events">
                 {list.map((event, index) => (

--- a/assets/src/blocks/Timeline/YearsNavigation.js
+++ b/assets/src/blocks/Timeline/YearsNavigation.js
@@ -46,7 +46,7 @@ export const YearsNavigation = ({years}) => {
     const observerOptions = {
       root: null,
       rootMargin: '0px',
-      threshold: 1.0,
+      threshold: 0.1,
     };
 
     const observerCallback = entries => {

--- a/assets/src/blocks/Timeline/YearsNavigation.js
+++ b/assets/src/blocks/Timeline/YearsNavigation.js
@@ -32,7 +32,8 @@ export const YearsNavigation = ({years}) => {
     const firstElement = yearDiv.querySelector('.timeline-block-event');
     firstElement.focus();
 
-    setTimeout(() => isClicking.current = false, 500);
+    // Update isClicking after the scroll to div is over.
+    addEventListener('scrollend', () => isClicking.current = false, {once: true});
   };
 
   const scrollNav = direction => {

--- a/assets/src/blocks/Timeline/YearsNavigation.js
+++ b/assets/src/blocks/Timeline/YearsNavigation.js
@@ -156,7 +156,7 @@ export const YearsNavigation = ({years}) => {
       className="years-navigation d-flex justify-content-center"
       aria-label={sprintf(
       /* translators: 1: amount of years in the timeline */
-        __('Timeline navigation, list with %1$d items', 'planet4-blocks'),
+        __('Timeline, list with %1$d items', 'planet4-blocks'),
         years.length
       )}
     >

--- a/assets/src/blocks/Timeline/YearsNavigation.js
+++ b/assets/src/blocks/Timeline/YearsNavigation.js
@@ -1,4 +1,5 @@
 import {useState, useEffect, useRef} from '@wordpress/element';
+const {sprintf, __} = wp.i18n;
 
 export const YearsNavigation = ({years}) => {
   const [showLeftArrow, setShowLeftArrow] = useState(false);
@@ -147,7 +148,14 @@ export const YearsNavigation = ({years}) => {
   }, [isRTL]);
 
   return (
-    <div className="years-navigation d-flex justify-content-center">
+    <nav
+      className="years-navigation d-flex justify-content-center"
+      aria-label={sprintf(
+      /* translators: 1: amount of years in the timeline */
+        __('Timeline navigation, list with %1$d items', 'planet4-blocks'),
+        years.length
+      )}
+    >
       {showLeftArrow && (
         <button className="nav-arrow left" onClick={() => scrollNav('left')}/>
       )}
@@ -168,6 +176,6 @@ export const YearsNavigation = ({years}) => {
       {showRightArrow && (
         <button className="nav-arrow right" onClick={() => scrollNav('right')}/>
       )}
-    </div>
+    </nav>
   );
 };

--- a/assets/src/blocks/Timeline/YearsNavigation.js
+++ b/assets/src/blocks/Timeline/YearsNavigation.js
@@ -27,6 +27,11 @@ export const YearsNavigation = ({years}) => {
     isClicking.current = true;
     setActiveYear(year);
 
+    // Move focus to first element in the list for that year.
+    const yearDiv = document.getElementById(year);
+    const firstElement = yearDiv.querySelector('.timeline-block-event');
+    firstElement.focus();
+
     setTimeout(() => isClicking.current = false, 500);
   };
 

--- a/assets/src/blocks/Timeline/YearsNavigation.js
+++ b/assets/src/blocks/Timeline/YearsNavigation.js
@@ -147,7 +147,7 @@ export const YearsNavigation = ({years}) => {
   }, [isRTL]);
 
   return (
-    <div className="years-navigation d-flex">
+    <div className="years-navigation d-flex justify-content-center">
       {showLeftArrow && (
         <button className="nav-arrow left" onClick={() => scrollNav('left')}/>
       )}

--- a/assets/src/blocks/Timeline/YearsNavigation.js
+++ b/assets/src/blocks/Timeline/YearsNavigation.js
@@ -1,0 +1,173 @@
+import {useState, useEffect, useRef} from '@wordpress/element';
+
+export const YearsNavigation = ({years}) => {
+  const [showLeftArrow, setShowLeftArrow] = useState(false);
+  const [showRightArrow, setShowRightArrow] = useState(false);
+  const [activeYear, setActiveYear] = useState('');
+  const yearsListRef = useRef(null);
+  const isManualScroll = useRef(false);
+  const isClicking = useRef(false);
+  const visibleRef = useRef([]);
+
+  const isRTL = document.dir === 'rtl';
+
+  const handleClick = year => {
+    const isFirefox = navigator.userAgent.toLowerCase().includes('firefox');
+
+    if (isFirefox) {
+      const target = document.getElementById(year);
+      if (target) {
+        target.scrollIntoView({behavior: 'smooth', block: 'start'});
+      }
+      // Ensures dropdown is updated with current year
+      window.history.replaceState(null, null, `#${year}`);
+    }
+
+    isClicking.current = true;
+    setActiveYear(year);
+
+    setTimeout(() => isClicking.current = false, 500);
+  };
+
+  const scrollNav = direction => {
+    isManualScroll.current = true;
+
+    const distance = 150;
+
+    const scrollBy = direction === 'right' ? distance : -distance;
+
+    yearsListRef.current?.scrollBy({left: scrollBy, behavior: 'smooth'});
+
+    setTimeout(() => isManualScroll.current = false, 500);
+  };
+
+  // This runs to auto update the URL and active year class, works on scroll
+  useEffect(() => {
+    const observerOptions = {
+      root: null,
+      rootMargin: '0px',
+      threshold: 1.0,
+    };
+
+    const observerCallback = entries => {
+      if (isClicking.current || isManualScroll.current) {return;}
+
+      // Update ref based on visible years/entries
+      entries.forEach(entry => {
+        if (entry.isIntersecting) {
+          if (!visibleRef.current.includes(entry.target)) {
+            visibleRef.current.push(entry.target);
+          }
+        } else {
+          visibleRef.current = visibleRef.current.filter(el => el !== entry.target);
+        }
+      });
+
+      // Using this so we update just before the next 'repaint'
+      // This prevents flicker between year elements
+      requestAnimationFrame(() => {
+        if (visibleRef.current.length === 0) {return;}
+
+        // Pick the closest visible year to the top
+        const currentHeaderElement = visibleRef.current.reduce((closest, el) => {
+          const rect = el.getBoundingClientRect();
+          if (!closest) {return {el, top: rect.top};}
+          return rect.top < closest.top ? {el, top: rect.top} : closest;
+        }, null);
+
+        if (currentHeaderElement && currentHeaderElement.el.id !== activeYear) {
+          setActiveYear(currentHeaderElement.el.id);
+          window.history.replaceState(null, null, `#${currentHeaderElement.el.id}`);
+
+          // Make active year element visible
+          setTimeout(() => {
+            const navItem = document.querySelector('.years-navigation-items a.active');
+            navItem?.scrollIntoView({
+              behavior: 'smooth',
+              inline: 'center',
+              block: 'nearest',
+            });
+          }, 0);
+        }
+      });
+    };
+
+    const observer = new IntersectionObserver(observerCallback, observerOptions);
+
+    years.forEach(year => {
+      const link = document.getElementById(year);
+      if (link) {observer.observe(link);}
+    });
+
+    return () => observer.disconnect();
+  }, [activeYear, years]);
+
+  // Make sure that the body has overflow set to "visible", otherwise the "sticky"
+  // position of the navigation won't work.
+  useEffect(() => document.body.classList.add('overflow-visible'), []);
+
+  // This adds arrows to the container to indicate more elements available
+  // It also works for RTL sites
+  useEffect(() => {
+    const navEl = yearsListRef.current;
+    if (!navEl) {return;}
+
+    const items = navEl.querySelectorAll('li');
+    if (!items.length) {return;}
+
+    const firstItem = items[0];
+    const lastItem = items[items.length - 1];
+
+    const observer = new IntersectionObserver(
+      entries => {
+        for (const entry of entries) {
+          if (entry.target === firstItem) {
+            if (isRTL) {
+              setShowRightArrow(!entry.isIntersecting);
+            } else {
+              setShowLeftArrow(!entry.isIntersecting);
+            }
+          }
+          if (entry.target === lastItem) {
+            if (isRTL) {
+              setShowLeftArrow(!entry.isIntersecting);
+            } else {
+              setShowRightArrow(!entry.isIntersecting);
+            }
+          }
+        }
+      },
+      {root: navEl, threshold: 1.0}
+    );
+
+    observer.observe(firstItem);
+    observer.observe(lastItem);
+
+    return () => observer.disconnect();
+  }, [isRTL]);
+
+  return (
+    <div className="years-navigation d-flex">
+      {showLeftArrow && (
+        <button className="nav-arrow left" onClick={() => scrollNav('left')}/>
+      )}
+      <ul className="years-navigation-items d-flex" ref={yearsListRef}>
+        {years.map(year => (
+          <li key={year}>
+            <a
+              href={`#${year}`}
+              onClick={() => handleClick(year)}
+              data-target={year}
+              className={`${activeYear === year ? 'active': ''}`}
+            >
+              {year}
+            </a>
+          </li>
+        ))}
+      </ul>
+      {showRightArrow && (
+        <button className="nav-arrow right" onClick={() => scrollNav('right')}/>
+      )}
+    </div>
+  );
+};

--- a/assets/src/blocks/Timeline/YearsNavigation.js
+++ b/assets/src/blocks/Timeline/YearsNavigation.js
@@ -165,7 +165,10 @@ export const YearsNavigation = ({years}) => {
       {showLeftArrow && (
         <button className="nav-arrow left" onClick={() => scrollNav('left')}/>
       )}
-      <ul className="years-navigation-items d-flex" ref={yearsListRef}>
+      <ul
+        className={`years-navigation-items d-flex ${showLeftArrow || showRightArrow ? 'with-gradient' : ''}`}
+        ref={yearsListRef}
+      >
         {years.map(year => (
           <li key={year}>
             <a

--- a/assets/src/blocks/Timeline/YearsNavigation.js
+++ b/assets/src/blocks/Timeline/YearsNavigation.js
@@ -20,8 +20,6 @@ export const YearsNavigation = ({years}) => {
       if (target) {
         target.scrollIntoView({behavior: 'smooth', block: 'start'});
       }
-      // Ensures dropdown is updated with current year
-      window.history.replaceState(null, null, `#${year}`);
     }
 
     isClicking.current = true;

--- a/assets/src/scss/blocks/SecondaryNavigation/SecondaryNavigationStyle.scss
+++ b/assets/src/scss/blocks/SecondaryNavigation/SecondaryNavigationStyle.scss
@@ -71,39 +71,35 @@
     border: none;
     color: var(--white);
     font-size: var(--font-size-m--font-family-primary);
+    background-image: none;
+    mask-image: url("../../images/chevron.svg");
+    mask-size: contain;
+    mask-repeat: no-repeat;
+    mask-position: center;
+    background-color: var(--white);
+    height: 15px;
+    width: 15px;
 
     @include large-and-less {
       top: 10px;
     }
-  }
-}
 
-.nav-arrow.left,
-.nav-arrow.right {
-  background-image: none;
-  mask-image: url("../../images/chevron.svg");
-  mask-size: contain;
-  mask-repeat: no-repeat;
-  mask-position: center;
-  background-color: var(--white);
-  height: 15px;
-  width: 15px;
-}
+    &.left {
+      left: -20px;
+      transform: rotate(180deg);
 
-.nav-arrow.left {
-  left: -20px;
-  transform: rotate(180deg);
+      @include large-and-less {
+        left: -15px;
+      }
+    }
 
-  @include large-and-less {
-    left: -15px;
-  }
-}
+    &.right {
+      right: -20px;
 
-.nav-arrow.right {
-  right: -20px;
-
-  @include large-and-less {
-    right: -15px;
+      @include large-and-less {
+        right: -15px;
+      }
+    }
   }
 }
 

--- a/assets/src/scss/blocks/Timeline/TimelineStyle.scss
+++ b/assets/src/scss/blocks/Timeline/TimelineStyle.scss
@@ -630,9 +630,12 @@
 
   .years-navigation-items {
     list-style: none;
-    padding: 0;
+    padding: 0 $sp-2;
     margin: 0;
     overflow: scroll;
+    mask-image: linear-gradient(to right, transparent 0, black 30px, black calc(100% - 30px), transparent 100%);
+    mask-repeat: no-repeat;
+    mask-size: 100% 100%;
 
     /* Hide scrollbar for Chrome, Safari and Opera */
     &::-webkit-scrollbar {

--- a/assets/src/scss/blocks/Timeline/TimelineStyle.scss
+++ b/assets/src/scss/blocks/Timeline/TimelineStyle.scss
@@ -357,6 +357,10 @@
     z-index: 1;
   }
 
+  .timeline-block-year-group {
+    scroll-margin-top: 100px;
+  }
+
   .timeline-block-event-day,
   .timeline-block-event-description,
   .timeline-description-toggle,

--- a/assets/src/scss/blocks/Timeline/TimelineStyle.scss
+++ b/assets/src/scss/blocks/Timeline/TimelineStyle.scss
@@ -596,7 +596,8 @@
     z-index: 999;
     padding: $sp-1x 0;
     top: 68px;
-    margin-bottom: $sp-2;
+    max-width: 340px;
+    margin: 0 auto $sp-2 auto;
 
     body.admin-bar & {
       top: 100px;
@@ -617,6 +618,14 @@
         top: 156px;
       }
     }
+
+    @include large-and-up {
+      max-width: 916px;
+    }
+
+    @include x-large-and-up {
+      max-width: 986px;
+    }
   }
 
   .years-navigation-items {
@@ -635,7 +644,7 @@
     scrollbar-width: none;  /* Firefox */
 
     li {
-      margin: $sp-x $sp-2x;
+      margin: $sp-x $sp-2;
 
       a {
         font-family: var(--font-family-tertiary);
@@ -684,6 +693,10 @@
       &.right {
         right: -$sp-3x;
       }
+    }
+
+    @include x-large-and-up {
+      top: 24px;
     }
   }
 }

--- a/assets/src/scss/blocks/Timeline/TimelineStyle.scss
+++ b/assets/src/scss/blocks/Timeline/TimelineStyle.scss
@@ -630,7 +630,7 @@
     scrollbar-width: none;  /* Firefox */
 
     li {
-      margin: $sp-x $sp-2;
+      margin: $sp-x $sp-2x;
 
       a {
         font-family: var(--font-family-tertiary);

--- a/assets/src/scss/blocks/Timeline/TimelineStyle.scss
+++ b/assets/src/scss/blocks/Timeline/TimelineStyle.scss
@@ -637,9 +637,12 @@
     padding: 0 $sp-2;
     margin: 0;
     overflow-x: auto;
-    mask-image: linear-gradient(to right, transparent 0, black 30px, black calc(100% - 30px), transparent 100%);
-    mask-repeat: no-repeat;
-    mask-size: 100% 100%;
+
+    &.with-gradient {
+      mask-image: linear-gradient(to right, transparent 0, black 30px, black calc(100% - 30px), transparent 100%);
+      mask-repeat: no-repeat;
+      mask-size: 100% 100%;
+    }
 
     /* Hide scrollbar for Chrome, Safari and Opera */
     &::-webkit-scrollbar {

--- a/assets/src/scss/blocks/Timeline/TimelineStyle.scss
+++ b/assets/src/scss/blocks/Timeline/TimelineStyle.scss
@@ -626,6 +626,10 @@
     @include x-large-and-up {
       max-width: 986px;
     }
+
+    @include xx-large-and-up {
+      max-width: 1096px;
+    }
   }
 
   .years-navigation-items {

--- a/assets/src/scss/blocks/Timeline/TimelineStyle.scss
+++ b/assets/src/scss/blocks/Timeline/TimelineStyle.scss
@@ -596,7 +596,6 @@
     z-index: 999;
     padding: $sp-1x 0;
     top: 68px;
-    max-width: 340px;
     margin: 0 auto $sp-2 auto;
 
     body.admin-bar & {
@@ -656,6 +655,14 @@
     li {
       margin: $sp-x $sp-2;
 
+      &:first-child {
+        margin-inline-start: 0;
+      }
+
+      &:last-child {
+        margin-inline-end: 0;
+      }
+
       a {
         font-family: var(--font-family-tertiary);
         color: var(--grey-600);
@@ -688,12 +695,12 @@
     width: 48px;
 
     &.left {
-      left: -42px;
+      left: -24px;
       transform: rotate(180deg);
     }
 
     &.right {
-      right: -42px;
+      right: -24px;
     }
 
     @include medium-and-up {

--- a/assets/src/scss/blocks/Timeline/TimelineStyle.scss
+++ b/assets/src/scss/blocks/Timeline/TimelineStyle.scss
@@ -632,7 +632,7 @@
 
   .years-navigation-items {
     list-style: none;
-    padding: 0 $sp-2;
+    padding: 0 $sp-3x;
     margin: 0;
     overflow-x: auto;
 
@@ -695,21 +695,21 @@
     width: 48px;
 
     &.left {
-      left: -24px;
+      left: -$sp-3;
       transform: rotate(180deg);
     }
 
     &.right {
-      right: -24px;
+      right: -$sp-3;
     }
 
     @include medium-and-up {
       &.left {
-        left: -52px;
+        left: -$sp-4;
       }
 
       &.right {
-        right: -52px;
+        right: -$sp-4;
       }
     }
 

--- a/assets/src/scss/blocks/Timeline/TimelineStyle.scss
+++ b/assets/src/scss/blocks/Timeline/TimelineStyle.scss
@@ -585,4 +585,91 @@
       }
     }
   }
+
+  .years-navigation {
+    position: sticky;
+    background-color: var(--beige-100);
+    z-index: 999;
+    padding: $sp-1x 0;
+    top: 68px;
+
+    body.admin-bar & {
+      top: 100px;
+    }
+
+    @include medium-and-less {
+      top: 60px;
+
+      body.admin-bar & {
+        top: 104px;
+      }
+
+      body.stuck-open & {
+        top: 110px;
+      }
+
+      body.admin-bar.stuck-open & {
+        top: 156px;
+      }
+    }
+  }
+
+  .years-navigation-items {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    overflow: scroll;
+
+    li {
+      margin: $sp-x $sp-2;
+
+      a {
+        font-family: var(--font-family-tertiary);
+        color: var(--grey-600);
+        font-weight: 600;
+
+        &:hover,
+        &.active {
+          text-decoration: none;
+          @include shared-link-styles;
+        }
+      }
+    }
+  }
+
+  .nav-arrow {
+    position: absolute;
+    top: 20px;
+    background: none;
+    border: none;
+    color: var(--white);
+    font-size: var(--font-size-m--font-family-primary);
+    background-image: none;
+    mask-image: url("../../images/chevron.svg");
+    mask-size: contain;
+    mask-repeat: no-repeat;
+    mask-position: center;
+    background-color: var(--grey-600);
+    height: 15px;
+    width: 15px;
+
+    &.left {
+      left: -$sp-2x;
+      transform: rotate(180deg);
+    }
+
+    &.right {
+      right: -$sp-2x;
+    }
+
+    @include medium-and-up {
+      &.left {
+        left: -$sp-3x;
+      }
+
+      &.right {
+        right: -$sp-3x;
+      }
+    }
+  }
 }

--- a/assets/src/scss/blocks/Timeline/TimelineStyle.scss
+++ b/assets/src/scss/blocks/Timeline/TimelineStyle.scss
@@ -636,7 +636,7 @@
     list-style: none;
     padding: 0 $sp-2;
     margin: 0;
-    overflow: scroll;
+    overflow-x: auto;
     mask-image: linear-gradient(to right, transparent 0, black 30px, black calc(100% - 30px), transparent 100%);
     mask-repeat: no-repeat;
     mask-size: 100% 100%;

--- a/assets/src/scss/blocks/Timeline/TimelineStyle.scss
+++ b/assets/src/scss/blocks/Timeline/TimelineStyle.scss
@@ -374,7 +374,6 @@
 
   .timeline-block-event {
     list-style: none;
-
     border: 1px solid var(--grey-300);
     max-width: 340px;
     margin: 0 auto $sp-3 auto;
@@ -667,6 +666,7 @@
         font-family: var(--font-family-tertiary);
         color: var(--grey-600);
         font-weight: 600;
+        font-size: 17px;
 
         &:hover,
         &.active {

--- a/assets/src/scss/blocks/Timeline/TimelineStyle.scss
+++ b/assets/src/scss/blocks/Timeline/TimelineStyle.scss
@@ -657,7 +657,8 @@
         &:hover,
         &.active {
           text-decoration: none;
-          @include shared-link-styles;
+          border-bottom: 3px solid var(--gp-green-500);
+          color: var(--grey-900);
         }
       }
     }

--- a/assets/src/scss/blocks/Timeline/TimelineStyle.scss
+++ b/assets/src/scss/blocks/Timeline/TimelineStyle.scss
@@ -596,6 +596,7 @@
     z-index: 999;
     padding: $sp-1x 0;
     top: 68px;
+    margin-bottom: $sp-2;
 
     body.admin-bar & {
       top: 100px;

--- a/assets/src/scss/blocks/Timeline/TimelineStyle.scss
+++ b/assets/src/scss/blocks/Timeline/TimelineStyle.scss
@@ -620,6 +620,15 @@
     margin: 0;
     overflow: scroll;
 
+    /* Hide scrollbar for Chrome, Safari and Opera */
+    &::-webkit-scrollbar {
+      display: none;
+    }
+
+    /* Hide scrollbar for IE, Edge and Firefox */
+    -ms-overflow-style: none;  /* IE and Edge */
+    scrollbar-width: none;  /* Firefox */
+
     li {
       margin: $sp-x $sp-2;
 

--- a/assets/src/scss/blocks/Timeline/TimelineStyle.scss
+++ b/assets/src/scss/blocks/Timeline/TimelineStyle.scss
@@ -665,41 +665,41 @@
 
   .nav-arrow {
     position: absolute;
-    top: 20px;
+    top: 4px;
     background: none;
     border: none;
     color: var(--white);
     font-size: var(--font-size-m--font-family-primary);
     background-image: none;
     mask-image: url("../../images/chevron.svg");
-    mask-size: contain;
+    mask-size: 15px 15px;
     mask-repeat: no-repeat;
     mask-position: center;
     background-color: var(--grey-600);
-    height: 15px;
-    width: 15px;
+    height: 48px;
+    width: 48px;
 
     &.left {
-      left: -$sp-2x;
+      left: -42px;
       transform: rotate(180deg);
     }
 
     &.right {
-      right: -$sp-2x;
+      right: -42px;
     }
 
     @include medium-and-up {
       &.left {
-        left: -$sp-3x;
+        left: -52px;
       }
 
       &.right {
-        right: -$sp-3x;
+        right: -52px;
       }
     }
 
     @include x-large-and-up {
-      top: 24px;
+      top: 8px;
     }
   }
 }


### PR DESCRIPTION
### Summary

Ref: [PLANET-8116](https://greenpeace-planet4.atlassian.net/browse/PLANET-8116)

**Requirements**
- Follow the [mockups](https://www.figma.com/design/9NtbY8n3at8uOEJTsLrETb/P4-Design-System?node-id=9010-18014) on implementing the years sub-navigation at the top of the block.
- We should only show the years that have at least one item.
- If the amount of years is more that can fit on the screen it should be scrollable horizontally.
- We should use the nav component as the one in the Secondary navigation block.
- Clicking on a year should scroll on the respective year first item.

**Note**: SonarCloud is complaining about duplicated code, which there is a lot of with the Secondary Navigation block. I think it's fine for now but we should try in the future to refactor these 2 so that there isn't so much duplication.

### Testing

You can use this [page](https://www-dev.greenpeace.org/test-phobos/timelineee) I made for UAT.

[PLANET-8116]: https://greenpeace-planet4.atlassian.net/browse/PLANET-8116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ