### PR TITLE
PLANET-8052: Replace SCSS @import related to mixins

### DIFF
--- a/assets/src/scss/base/_body.scss
+++ b/assets/src/scss/base/_body.scss
@@ -1,3 +1,5 @@
+@use "../base/mixins" as mixins;
+
 html,
 body {
   overflow-x: hidden;
@@ -17,7 +19,7 @@ body {
     clear: initial;
   }
 
-  @include medium-and-less {
+  @include mixins.medium-and-less {
     &.with-mobile-tabs {
       .page-header {
         padding-top: 140px;

--- a/assets/src/scss/base/_icons.scss
+++ b/assets/src/scss/base/_icons.scss
@@ -1,3 +1,5 @@
+@use "../base/mixins" as mixins;
+
 .icon {
   position: relative;
   top: .125em;
@@ -9,7 +11,7 @@
 }
 
 a.standalone-link {
-  @include shared-link-styles;
+  @include mixins.shared-link-styles;
 
   display: inline-block;
   width: fit-content;

--- a/assets/src/scss/base/_index.scss
+++ b/assets/src/scss/base/_index.scss
@@ -1,2 +1,3 @@
 @forward "tokens";
 @forward "social-media-colors";
+@forward "mixins";

--- a/assets/src/scss/base/_rtl.scss
+++ b/assets/src/scss/base/_rtl.scss
@@ -1,3 +1,5 @@
+@use "../base/mixins" as mixins;
+
 html[dir="rtl"] body {
   text-transform: lowercase;
   text-align: right;
@@ -7,7 +9,7 @@ html[dir="rtl"] body {
     text-transform: lowercase;
   }
 
-  @include large-and-up {
+  @include mixins.large-and-up {
     .offset-lg-1 {
       margin-left: 0;
       margin-right: 8.333333%;

--- a/assets/src/scss/base/_typography.scss
+++ b/assets/src/scss/base/_typography.scss
@@ -1,3 +1,5 @@
+@use "../base/mixins" as mixins;
+
 html {
   text-rendering: optimizelegibility;
   -webkit-font-smoothing: antialiased;
@@ -10,7 +12,7 @@ li {
   font-size: var(--font-size-m--font-family-secondary);
   line-height: var(--line-height-m--font-family-secondary);
 
-  @include x-large-and-up {
+  @include mixins.x-large-and-up {
     font-size: var(--font-size-xl--font-family-secondary);
     line-height: var(--line-height-xl--font-family-secondary);
   }
@@ -45,11 +47,11 @@ h1 {
   font-size: $font-size-xxl;
   margin-bottom: 30px;
 
-  @include medium-and-up {
+  @include mixins.medium-and-up {
     font-size: $font-size-xxxxl;
   }
 
-  @include large-and-up {
+  @include mixins.large-and-up {
     margin-bottom: 48px;
   }
 }
@@ -59,11 +61,11 @@ h2 {
   font-size: $font-size-xl;
   margin-bottom: 5px;
 
-  @include medium-and-up {
+  @include mixins.medium-and-up {
     font-size: $font-size-xxl;
   }
 
-  @include x-large-and-up {
+  @include mixins.x-large-and-up {
     margin-bottom: 24px;
   }
 }
@@ -71,7 +73,7 @@ h2 {
 h3 {
   font-size: $font-size-lg;
 
-  @include medium-and-up {
+  @include mixins.medium-and-up {
     font-size: $font-size-xl;
   }
 }
@@ -79,7 +81,7 @@ h3 {
 h4 {
   font-size: $font-size-md;
 
-  @include medium-and-up {
+  @include mixins.medium-and-up {
     font-size: $font-size-lg;
   }
 }
@@ -87,7 +89,7 @@ h4 {
 h5 {
   font-size: $font-size-sm;
 
-  @include medium-and-up {
+  @include mixins.medium-and-up {
     font-size: $font-size-md;
   }
 }
@@ -101,7 +103,7 @@ h6 {
 }
 
 a:focus {
-  @include focus-styles;
+  @include mixins.focus-styles;
 
   &:not(:focus-visible) {
     outline: 0;
@@ -124,7 +126,7 @@ figcaption {
   min-height: 24px; // This is needed in case there's a link in the caption, for our styles
 
   a {
-    @include shared-link-styles;
+    @include mixins.shared-link-styles;
   }
 }
 

--- a/assets/src/scss/blocks.scss
+++ b/assets/src/scss/blocks.scss
@@ -32,26 +32,3 @@
 
 // Other
 @import "blocks/WideBlocks";
-
-.is-style-space-evenly {
-  gap: 24px !important;
-
-  & > * {
-    flex-grow: 1;
-    flex-basis: 100%;
-    align-self: stretch;
-
-    @include medium-and-up {
-      flex-grow: 0;
-      flex-basis: calc(50% - 12px);
-    }
-
-    @include large-and-up {
-      flex-basis: calc(25% - 18px);
-    }
-  }
-}
-
-.is-style-reset-margin {
-  margin: 0 !important;
-}

--- a/assets/src/scss/blocks/Accordion/AccordionEditorStyle.scss
+++ b/assets/src/scss/blocks/Accordion/AccordionEditorStyle.scss
@@ -1,3 +1,5 @@
+@use "../../base/mixins" as mixins;
+
 .add-button {
   cursor: pointer;
   font-weight: var(--font-weight-regular);
@@ -47,11 +49,11 @@
     }
   }
 
-  @include medium-and-up {
+  @include mixins.medium-and-up {
     width: 40%;
   }
 
-  @include large-and-up {
+  @include mixins.large-and-up {
     width: 25%;
   }
 }

--- a/assets/src/scss/blocks/Accordion/AccordionStyle.scss
+++ b/assets/src/scss/blocks/Accordion/AccordionStyle.scss
@@ -1,3 +1,5 @@
+@use "../../base/mixins" as mixins;
+
 @mixin headline {
   border-color: transparent;
   background: var(--p4-dark-green-800);
@@ -52,7 +54,7 @@
     }
   }
 
-  @include medium-and-up {
+  @include mixins.medium-and-up {
     padding-inline-start: $sp-3;
     font-size: var(--font-size-m--font-family-primary);
     margin-bottom: $sp-3;
@@ -100,10 +102,10 @@
   margin: $sp-3 0 0 !important;
   width: 80%;
 
-  @include medium-and-up {
+  @include mixins.medium-and-up {
     width: 40%;
   }
-  @include large-and-up {
+  @include mixins.large-and-up {
     width: 25%;
   }
 }
@@ -114,7 +116,7 @@
   overflow: hidden;
   transition: display 1s, opacity 1s, height 1s ease-in-out;
 
-  @include medium-and-up {
+  @include mixins.medium-and-up {
     padding: 0 $sp-3 $sp-5 $sp-3;
   }
 }

--- a/assets/src/scss/blocks/ActionsList/ActionsListEditorStyle.scss
+++ b/assets/src/scss/blocks/ActionsList/ActionsListEditorStyle.scss
@@ -1,3 +1,5 @@
+@use "../../base/mixins" as mixins;
+
 .actions-list {
   .wp-block-post-excerpt__more-link {
     display: none;
@@ -7,7 +9,7 @@
     display: none !important;
   }
 
-  @include large-and-up {
+  @include mixins.large-and-up {
     .wp-block-post {
       flex-basis: calc((100% / 3) - $sp-2);
     }

--- a/assets/src/scss/blocks/ActionsList/ActionsListStyle.scss
+++ b/assets/src/scss/blocks/ActionsList/ActionsListStyle.scss
@@ -1,3 +1,5 @@
+@use "../../base/mixins" as mixins;
+
 .actions-list {
   margin-bottom: $sp-4;
 
@@ -10,13 +12,13 @@
   }
 
   &.is-custom-layout-carousel {
-    @include medium-and-less {
+    @include mixins.medium-and-less {
       .wp-block-post {
         width: 354px;
       }
     }
 
-    @include large-and-up {
+    @include mixins.large-and-up {
       .carousel-item-wrapper {
         grid-template-columns: repeat(3, 1fr);
         padding: $sp-1x $sp-1;
@@ -40,7 +42,7 @@
       // This padding-top is added only when the figure is not being rendered
       padding-top: calc(196px + $sp-3);
 
-      @include large-and-up {
+      @include mixins.large-and-up {
         padding-top: calc(220px + $sp-3);
       }
     }
@@ -121,7 +123,7 @@
     margin-bottom: $sp-1;
 
     a {
-      @include clamp-text(2);
+      @include mixins.clamp-text(2);
     }
   }
 
@@ -129,9 +131,9 @@
     font-family: var(--font-family-tertiary);
     font-size: var(--font-size-xxs--font-family-primary);
     line-height: var(--line-height-m--font-family-tertiary);
-    @include clamp-text(3);
+    @include mixins.clamp-text(3);
 
-    @include large-and-up {
+    @include mixins.large-and-up {
       line-height: var(--line-height-m--font-family-tertiary);
     }
   }
@@ -140,7 +142,7 @@
     height: 196px;
     object-fit: cover;
 
-    @include large-and-up {
+    @include mixins.large-and-up {
       height: 220px;
     }
   }
@@ -154,7 +156,7 @@
       font-weight: var(--font-weight-bold);
       font-family: var(--font-family-tertiary);
       line-height: var(--line-height-s--font-family-tertiary);
-      @include clamp-text(1);
+      @include mixins.clamp-text(1);
     }
   }
 
@@ -165,28 +167,28 @@
       display: grid;
       gap: $sp-2;
 
-      @include medium-and-up {
+      @include mixins.medium-and-up {
         grid-template-columns: repeat(2, minmax(0, 1fr));
       }
 
-      @include large-and-up {
+      @include mixins.large-and-up {
         grid-template-columns: repeat(3, minmax(0, 1fr));
       }
     }
 
-    @include mobile-only {
+    @include mixins.mobile-only {
       .wp-block-post:nth-child(n+4) {
         display: none;
       }
     }
 
-    @include medium-and-less {
+    @include mixins.medium-and-less {
       .wp-block-post:nth-child(n+5) {
         display: none;
       }
     }
 
-    @include large-and-up {
+    @include mixins.large-and-up {
       .wp-block-post:nth-child(n+7) {
         display: none;
       }

--- a/assets/src/scss/blocks/CarouselHeader/CarouselHeaderEditorStyle.scss
+++ b/assets/src/scss/blocks/CarouselHeader/CarouselHeaderEditorStyle.scss
@@ -1,4 +1,4 @@
-@import "./SidebarSlidesEditor.scss";
+@use "../../base/mixins" as mixins;
 
 // Fix for the block being inside of a wrapper element.
 // We can remove this fix once this block starts using the v2 block registration API.
@@ -9,7 +9,7 @@ div[data-type="planet4-blocks/carousel-header"] {
 .carousel-header .carousel-caption .carousel-captions-wrapper {
   h2,
   p {
-    @include clamp-text(none);
+    @include mixins.clamp-text(none);
   }
 }
 
@@ -118,7 +118,7 @@ div[data-type="planet4-blocks/carousel-header"] {
   }
 }
 
-@include x-large-and-up {
+@include mixins.x-large-and-up {
   .carousel-header .carousel-item .carousel-caption .main-header .row {
     padding-inline-start: 110px;
   }
@@ -127,4 +127,142 @@ div[data-type="planet4-blocks/carousel-header"] {
 // Fix Safari issue with forced min-width:1px in editor
 .carousel-header .carousel-item .carousel-caption .main-header .action-button div.btn {
   overflow: initial;
+}
+
+.sidebar-slides {
+  position: relative;
+}
+
+.sidebar-slide {
+  pointer-events: none;
+
+  .components-panel__arrow {
+    display: none;
+  }
+
+  .components-panel__body-toggle {
+    pointer-events: none;
+    padding-right: 16px;
+    padding-left: 9px;
+  }
+}
+
+.cloned-slide {
+  transition: top 500ms ease;
+  position: absolute;
+  width: 100%;
+  opacity: 1;
+}
+
+.dragged-slide {
+  opacity: .25;
+}
+
+.opened-slide {
+  pointer-events: auto;
+
+  .slide-item-draggable-button {
+    pointer-events: none;
+  }
+
+  .arrow-button[data-type="up"],
+  .arrow-button[data-type="down"] {
+    pointer-events: none;
+  }
+
+  .arrow-button[data-type="toggle"] {
+    transform: rotate(-90deg);
+  }
+}
+
+.slide-item-wrapper {
+  flex-direction: row;
+  display: flex;
+  align-items: center;
+  overflow: hidden;
+  width: 100%;
+
+  * {
+    display: inline-block;
+  }
+}
+
+.slide-item-draggable-button {
+  pointer-events: auto;
+  flex-basis: 8px;
+  flex-shrink: 0;
+  height: 14px;
+  margin-right: 10px;
+  cursor: grab;
+  display: inline-flex;
+}
+
+.slide-item-order-arrows {
+  flex-direction: column;
+  display: inline-flex;
+  align-items: center;
+  flex-grow: 0;
+  justify-content: center;
+  margin-right: 12px;
+
+  > * {
+    &:not(:last-child) {
+      margin-bottom: 6px;
+    }
+  }
+}
+
+.arrow-button {
+  position: relative;
+  overflow: hidden;
+  flex-shrink: 0;
+  width: 15px;
+  height: 15px;
+  pointer-events: auto;
+
+  &::before {
+    content: "";
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    background-size: 9px 9px;
+    background-image: url("../../images/chevron.svg");
+    background-repeat: no-repeat;
+    background-position: center;
+    transform-origin: center;
+  }
+
+  &[data-type="up"] {
+    transform: rotate(-90deg);
+  }
+
+  &[data-type="toggle"] {
+    transition: rotate 250ms ease;
+  }
+
+  &[data-type="down"], &[data-type="toggle"] {
+    transform: rotate(90deg);
+  }
+
+  &.disabled {
+    opacity: .5;
+    pointer-events: none;
+  }
+}
+
+.slide-item-image {
+  background-color: var(--grey-200);
+  flex: 0 0 50px;
+  width: 50px;
+  // Overriden from block-editor__container img
+  height: 50px !important;
+  margin-right: 12px;
+}
+
+.slide-item-text {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis "...";
+  width: 100%;
+  margin-right: 14px;
 }

--- a/assets/src/scss/blocks/CarouselHeader/CarouselHeaderStyle.scss
+++ b/assets/src/scss/blocks/CarouselHeader/CarouselHeaderStyle.scss
@@ -1,4 +1,5 @@
 @use "../../base/tokens" as tokens;
+@use "../../base/mixins" as mixins;
 
 // $slide-transition-speed should match SLIDE_TRANSITION_SPEED in carousel-header.js
 $slide-transition-speed: .2s;
@@ -83,19 +84,19 @@ $medium-image-height: 600px;
     padding-bottom: 0;
     padding-inline-start: 0;
 
-    @include medium-and-up {
+    @include mixins.medium-and-up {
       height: 960px;
     }
 
-    @include large-and-up {
+    @include mixins.large-and-up {
       height: 620px;
     }
 
     .backgrounds-holder {
-      @include fill-container;
+      @include mixins.fill-container;
 
       div {
-        @include fill-container;
+        @include mixins.fill-container;
         z-index: 500;
         display: none;
       }
@@ -115,11 +116,11 @@ $medium-image-height: 600px;
       margin-right: auto;
     }
 
-    @include medium-and-up {
+    @include mixins.medium-and-up {
       height: $medium-image-height;
     }
 
-    @include large-and-up {
+    @include mixins.large-and-up {
       height: 100%;
     }
 
@@ -174,21 +175,21 @@ $medium-image-height: 600px;
         width: 100vw;
       }
 
-      @include medium-and-up {
+      @include mixins.medium-and-up {
         height: $medium-image-height;
       }
 
-      @include large-and-up {
+      @include mixins.large-and-up {
         height: 100%;
       }
 
       // Darken background
       &::after {
-        @include fill-container;
+        @include mixins.fill-container;
         content: "";
         background: none;
 
-        @include large-and-up {
+        @include mixins.large-and-up {
           background: rgba(30, 30, 30, 0.45);
         }
       }
@@ -325,11 +326,11 @@ $medium-image-height: 600px;
       right: 0;
     }
 
-    @include medium-and-up {
+    @include mixins.medium-and-up {
       padding-top: $sp-4;
     }
 
-    @include large-and-up {
+    @include mixins.large-and-up {
       display: block;
       padding: 0;
       background: none;
@@ -340,20 +341,20 @@ $medium-image-height: 600px;
     .carousel-captions-wrapper {
       overflow: hidden;
 
-      @include medium-and-up {
+      @include mixins.medium-and-up {
         width: #{460 + ($text-slide-offset * 2)};
       }
 
-      @include large-and-up {
+      @include mixins.large-and-up {
         width: #{320 + ($text-slide-offset * 2)};
 
         h2,
         p {
-          @include clamp-text(3);
+          @include mixins.clamp-text(3);
         }
       }
 
-      @include x-large-and-up {
+      @include mixins.x-large-and-up {
         width: #{480 + ($text-slide-offset * 2)};
       }
     }
@@ -373,12 +374,12 @@ $medium-image-height: 600px;
         background-position: bottom left;
       }
 
-      @include large-and-up {
+      @include mixins.large-and-up {
         display: block;
         opacity: 1;
       }
 
-      @include x-large-and-up {
+      @include mixins.x-large-and-up {
         width: 580px;
       }
     }
@@ -390,7 +391,7 @@ $medium-image-height: 600px;
     height: 100%;
     width: 100%;
 
-    @include large-and-up {
+    @include mixins.large-and-up {
       padding-top: 180px;
       padding-bottom: 32px;
       margin-inline-start: 80px;
@@ -406,12 +407,12 @@ $medium-image-height: 600px;
         text-align: right;
       }
 
-      @include medium-and-up {
+      @include mixins.medium-and-up {
         font-size: var(--font-size-xl--font-family-primary);
         line-height: var(--line-height-xl--font-family-primary);
       }
 
-      @include large-and-up {
+      @include mixins.large-and-up {
         max-width: 100%;
         width: 100%;
         color: var(--white);
@@ -420,7 +421,7 @@ $medium-image-height: 600px;
         font-size: $font-size-xxl;
       }
 
-      @include x-large-and-up {
+      @include mixins.x-large-and-up {
         font-size: $font-size-xxxl;
         max-width: 100%;
         width: 100%;
@@ -448,23 +449,23 @@ $medium-image-height: 600px;
 
       transform: translateX($text-slide-offset);
 
-      @include small-and-up {
+      @include mixins.small-and-up {
         font-size: var(--font-size-m--font-family-secondary);
       }
 
-      @include medium-and-up {
+      @include mixins.medium-and-up {
         font-size: var(--font-size-m--font-family-secondary);
         line-height: var(--line-height-m--font-family-secondary);
         margin-bottom: 24px;
       }
 
-      @include large-and-up {
+      @include mixins.large-and-up {
         font-size: var(--font-size-xl--font-family-secondary);
         margin-bottom: 36px;
         color: var(--white);
       }
 
-      @include x-large-and-up {
+      @include mixins.x-large-and-up {
         font-size: var(--font-size-xl--font-family-secondary);
         line-height: var(--line-height-xl--font-family-secondary);
       }
@@ -482,13 +483,13 @@ $medium-image-height: 600px;
       padding-left: 0;
       padding-right: 0;
 
-      @include small-and-up {
+      @include mixins.small-and-up {
         width: auto;
         bottom: inherit;
         position: relative;
       }
 
-      @include medium-and-up {
+      @include mixins.medium-and-up {
         text-align: left;
         position: inherit;
         margin-top: 0;
@@ -509,7 +510,7 @@ $medium-image-height: 600px;
         text-overflow: ellipsis;
         margin-bottom: 0;
 
-        @include large-and-up {
+        @include mixins.large-and-up {
           min-width: 240px;
           max-width: 100%;
         }
@@ -522,7 +523,7 @@ $medium-image-height: 600px;
     z-index: 4000;
     margin-inline-start: 0;
 
-    @include large-and-up {
+    @include mixins.large-and-up {
       display: flex;
       top: 50%;
       margin-top: -46px;
@@ -552,7 +553,7 @@ $medium-image-height: 600px;
     background-color: var(--white);
     transform: rotate(180deg);
 
-    @include large-and-up {
+    @include mixins.large-and-up {
       display: block;
       margin: auto;
     }
@@ -567,7 +568,7 @@ $medium-image-height: 600px;
     margin-inline-end: 0;
     z-index: 4000;
 
-    @include large-and-up {
+    @include mixins.large-and-up {
       top: 50%;
       display: flex;
       margin-top: -46px;
@@ -597,7 +598,7 @@ $medium-image-height: 600px;
     mask-size: cover;
     background-color: var(--white);
 
-    @include large-and-up {
+    @include mixins.large-and-up {
       display: block;
       margin: auto;
     }
@@ -609,11 +610,11 @@ $medium-image-height: 600px;
 
   .carousel-control-prev, .carousel-control-next {
     &:focus {
-      @include focus-styles(4px);
+      @include mixins.focus-styles(4px);
     }
 
     &:focus-visible {
-      @include focus-styles(4px);
+      @include mixins.focus-styles(4px);
     }
 
     &:focus:not(:focus-visible) {
@@ -632,12 +633,12 @@ $medium-image-height: 600px;
       justify-content: center;
       height: 24px;
 
-      @include medium-and-up {
+      @include mixins.medium-and-up {
         justify-content: flex-end;
         margin-bottom: $sp-2x;
         padding: 0;
       }
-      @include large-and-up {
+      @include mixins.large-and-up {
         justify-content: flex-start;
         padding-inline-start: $sp-1x;
       }
@@ -661,17 +662,17 @@ $medium-image-height: 600px;
           content: "";
           background-color: var(--grey-900);
 
-          @include large-and-up {
+          @include mixins.large-and-up {
             background-color: var(--white);
           }
         }
 
         &:focus {
-          @include focus-styles(4px);
+          @include mixins.focus-styles(4px);
         }
 
         &:focus-visible {
-          @include focus-styles(4px);
+          @include mixins.focus-styles(4px);
         }
 
         &:focus:not(:focus-visible) {
@@ -705,7 +706,7 @@ $medium-image-height: 600px;
       justify-content: flex-end;
     }
 
-    @include large-and-up {
+    @include mixins.large-and-up {
       position: absolute;
       bottom: $sp-2x;
       left: 0;
@@ -716,7 +717,7 @@ $medium-image-height: 600px;
       }
     }
 
-    @include x-large-and-up {
+    @include mixins.x-large-and-up {
       > .container {
         margin-inline-start: auto;
       }
@@ -729,7 +730,7 @@ $medium-image-height: 600px;
     margin: 0;
     text-align: center;
 
-    @include medium-and-up {
+    @include mixins.medium-and-up {
       text-align: right;
       width: auto;
 
@@ -738,7 +739,7 @@ $medium-image-height: 600px;
       }
     }
 
-    @include large-and-up {
+    @include mixins.large-and-up {
       text-align: left;
 
       html[dir="rtl"] & {
@@ -761,11 +762,11 @@ $medium-image-height: 600px;
         border: none;
 
         &:focus {
-          @include focus-styles(4px);
+          @include mixins.focus-styles(4px);
         }
 
         &:focus-visible {
-          @include focus-styles(4px);
+          @include mixins.focus-styles(4px);
         }
 
         &:focus:not(:focus-visible) {
@@ -774,7 +775,7 @@ $medium-image-height: 600px;
         }
       }
 
-      @include large-and-less {
+      @include mixins.large-and-less {
         button {
           background-color: rgba(tokens.$grey-900, .15);
         }
@@ -784,7 +785,7 @@ $medium-image-height: 600px;
         }
       }
 
-      @include large-and-up {
+      @include mixins.large-and-up {
         button {
           background-color: rgba(tokens.$white, 0.4);
         }

--- a/assets/src/scss/blocks/Columns/ColumnsStyle.scss
+++ b/assets/src/scss/blocks/Columns/ColumnsStyle.scss
@@ -1,3 +1,5 @@
+@use "../../base/mixins" as mixins;
+
 .columns-block {
   a {
     &:not(.btn) {
@@ -5,7 +7,7 @@
     }
 
     &.btn-secondary {
-      @include large-and-up {
+      @include mixins.large-and-up {
         width: 100%;
       }
     }
@@ -22,11 +24,11 @@
       margin-bottom: .5rem;
       text-transform: none;
 
-      @include medium-and-up {
+      @include mixins.medium-and-up {
         font-size: 1.5rem;
       }
 
-      @include large-and-up {
+      @include mixins.large-and-up {
         font-size: 1.5rem;
       }
     }
@@ -37,7 +39,7 @@
     .row {
       margin-top: -$sp-6;
 
-      @include large-and-up {
+      @include mixins.large-and-up {
         margin-top: 0;
       }
     }
@@ -48,7 +50,7 @@
       justify-content: space-between;
       margin-top: $sp-6;
 
-      @include large-and-up {
+      @include mixins.large-and-up {
         margin-top: 0;
       }
 
@@ -63,7 +65,7 @@
           margin-bottom: 0;
         }
 
-        @include medium-and-up {
+        @include mixins.medium-and-up {
           width: auto;
           margin-bottom: $sp-4;
         }
@@ -82,7 +84,7 @@
       // Compensate for last row margin
       margin-bottom: -$sp-4;
 
-      @include large-and-up {
+      @include mixins.large-and-up {
         margin-bottom: 0;
       }
     }
@@ -93,7 +95,7 @@
       justify-content: space-between;
       margin-bottom: $sp-6;
 
-      @include large-and-up {
+      @include mixins.large-and-up {
         margin-bottom: 0;
       }
 
@@ -101,7 +103,7 @@
       .icon-container {
         text-align: center;
 
-        @include medium-and-up {
+        @include mixins.medium-and-up {
           text-align: inherit;
         }
       }
@@ -109,7 +111,7 @@
       p {
         flex-grow: 1;
 
-        @include medium-and-up {
+        @include mixins.medium-and-up {
           margin-bottom: $sp-4;
         }
 
@@ -130,7 +132,7 @@
         text-align: center;
         margin-bottom: $sp-2;
 
-        @include medium-and-up {
+        @include mixins.medium-and-up {
           text-align: inherit;
         }
       }
@@ -140,11 +142,11 @@
         width: 102px;
         height: 102px;
 
-        @include medium-and-up {
+        @include mixins.medium-and-up {
           text-align: inherit;
         }
 
-        @include x-large-and-up {
+        @include mixins.x-large-and-up {
           margin-bottom: 24px;
         }
       }
@@ -156,8 +158,8 @@
     .can-do-steps {
       position: relative;
 
-      @include x-large-and-up {
-        @include clearfix;
+      @include mixins.x-large-and-up {
+        @include mixins.clearfix;
       }
 
       .step-number {
@@ -204,7 +206,7 @@
         p {
           font-family: var(--font-family-tertiary);
 
-          @include x-large-and-up {
+          @include mixins.x-large-and-up {
             font-size: $font-size-sm;
           }
         }
@@ -216,7 +218,7 @@
           object-position: 10% 10%;
           margin-bottom: $sp-4;
 
-          @include x-large-and-up {
+          @include mixins.x-large-and-up {
             height: 250px;
           }
         }
@@ -298,15 +300,15 @@
             object-position: 10% 10%;
             margin-top: $sp-4;
 
-            @include small-and-up {
+            @include mixins.small-and-up {
               width: 100%;
             }
 
-            @include medium-and-up {
+            @include mixins.medium-and-up {
               height: 220px;
             }
 
-            @include large-and-up {
+            @include mixins.large-and-up {
               width: 50%;
             }
           }
@@ -355,7 +357,7 @@
         font-family: var(--font-family-heading);
         font-weight: 700;
 
-        @include large-and-up {
+        @include mixins.large-and-up {
           font-size: 1.5rem;
         }
       }
@@ -369,7 +371,7 @@
       flex-direction: column;
       margin-bottom: $sp-4;
 
-      @include large-and-up {
+      @include mixins.large-and-up {
         margin-bottom: 0;
       }
 
@@ -377,7 +379,7 @@
       .icon-container {
         text-align: center;
 
-        @include medium-and-up {
+        @include mixins.medium-and-up {
           text-align: inherit;
         }
       }
@@ -385,7 +387,7 @@
       p {
         flex-grow: 1;
 
-        @include medium-and-up {
+        @include mixins.medium-and-up {
           margin-bottom: $sp-4;
         }
 
@@ -406,7 +408,7 @@
         text-align: center;
         margin-bottom: $sp-2;
 
-        @include medium-and-up {
+        @include mixins.medium-and-up {
           text-align: inherit;
         }
       }

--- a/assets/src/scss/blocks/Cookies/CookiesStyle.scss
+++ b/assets/src/scss/blocks/Cookies/CookiesStyle.scss
@@ -1,10 +1,12 @@
+@use "../../base/mixins" as mixins;
+
 .cookies-block {
   .custom-control-description,
   .custom-control input[type="checkbox"] ~ .custom-control-description {
     font-size: var(--font-size-xl--font-family-primary);
     font-family: var(--font-family-primary);
 
-    @include x-large-and-up {
+    @include mixins.x-large-and-up {
       font-size: var(--font-size-2xl--font-family-primary);
     }
   }

--- a/assets/src/scss/blocks/Gallery/styles/GalleryCarousel.scss
+++ b/assets/src/scss/blocks/Gallery/styles/GalleryCarousel.scss
@@ -1,3 +1,5 @@
+@use "../../../base/mixins" as mixins;
+
 .carousel-wrap {
   overflow: hidden;
 
@@ -16,12 +18,12 @@
       text-align: right;
     }
 
-    @include large-and-up {
+    @include mixins.large-and-up {
       font-size: $font-size-xl;
       margin-bottom: 20px;
     }
 
-    @include x-large-and-up {
+    @include mixins.x-large-and-up {
       font-size: 1.875rem;
       margin-bottom: 22px;
     }
@@ -29,27 +31,27 @@
 
   .carousel-item {
 
-    @include mobile-only {
+    @include mixins.mobile-only {
       height: 265px;
     }
 
-    @include small-and-up {
+    @include mixins.small-and-up {
       height: 365px;
     }
 
-    @include medium-and-up {
+    @include mixins.medium-and-up {
       height: 465px;
     }
 
-    @include large-and-up {
+    @include mixins.large-and-up {
       height: 565px;
     }
 
-    @include x-large-and-up {
+    @include mixins.x-large-and-up {
       height: 665px;
     }
 
-    @include xx-large-and-up {
+    @include mixins.xx-large-and-up {
       height: 765px;
     }
 
@@ -68,27 +70,27 @@
       object-fit: cover;
       cursor: pointer;
 
-      @include mobile-only {
+      @include mixins.mobile-only {
         height: 200px;
       }
 
-      @include small-and-up {
+      @include mixins.small-and-up {
         height: 300px;
       }
 
-      @include medium-and-up {
+      @include mixins.medium-and-up {
         height: 400px;
       }
 
-      @include large-and-up {
+      @include mixins.large-and-up {
         height: 500px;
       }
 
-      @include x-large-and-up {
+      @include mixins.x-large-and-up {
         height: 600px;
       }
 
-      @include xx-large-and-up {
+      @include mixins.xx-large-and-up {
         height: 700px;
       }
     }
@@ -118,7 +120,7 @@
       font-family: var(--font-family-paragraph-secondary);
       line-height: 1.4;
       margin-bottom: 0;
-      @include clamp-text(3);
+      @include mixins.clamp-text(3);
     }
   }
 
@@ -126,19 +128,19 @@
     top: 180px;
     list-style: none;
 
-    @include medium-and-up {
+    @include mixins.medium-and-up {
       top: 380px;
     }
 
-    @include large-and-up {
+    @include mixins.large-and-up {
       top: 480px;
     }
 
-    @include x-large-and-up {
+    @include mixins.x-large-and-up {
       top: 580px;
     }
 
-    @include xx-large-and-up {
+    @include mixins.xx-large-and-up {
       top: 680px;
     }
 
@@ -168,7 +170,7 @@
     opacity: 1;
 
     &:focus {
-      @include focus-styles(50%);
+      @include mixins.focus-styles(50%);
     }
 
     &:hover {
@@ -176,20 +178,20 @@
       padding-inline-start: 0;
     }
 
-    @include medium-and-up {
+    @include mixins.medium-and-up {
       display: block;
       top: 180px;
     }
 
-    @include large-and-up {
+    @include mixins.large-and-up {
       top: 240px;
     }
 
-    @include x-large-and-up {
+    @include mixins.x-large-and-up {
       top: 290px;
     }
 
-    @include xx-large-and-up {
+    @include mixins.xx-large-and-up {
       top: 340px;
     }
   }

--- a/assets/src/scss/blocks/Gallery/styles/GalleryGrid.scss
+++ b/assets/src/scss/blocks/Gallery/styles/GalleryGrid.scss
@@ -1,3 +1,5 @@
+@use "../../../base/mixins" as mixins;
+
 // use the padding-top trick to get fixed aspect ratio
 @mixin aspect-ratio-column($ratio, $columns) {
   width: 100% / $columns;
@@ -23,7 +25,7 @@
           width: 100%;
           height: 210px;
 
-          @include x-large-and-up {
+          @include mixins.x-large-and-up {
             height: 250px;
           }
         }
@@ -38,11 +40,11 @@
       grid-column-gap: $sp-1x;
       grid-row-gap: $sp-1x;
 
-      @include medium-and-up {
+      @include mixins.medium-and-up {
         grid-template-columns: repeat(3, 1fr);
       }
 
-      @include large-and-up {
+      @include mixins.large-and-up {
         grid-template-columns: repeat(4, 1fr);
 
         .post-content & {

--- a/assets/src/scss/blocks/Gallery/styles/GalleryThreeColumns.scss
+++ b/assets/src/scss/blocks/Gallery/styles/GalleryThreeColumns.scss
@@ -1,3 +1,5 @@
+@use "../../../base/mixins" as mixins;
+
 .split-three-column {
   .three-column-images {
     min-height: 184px;
@@ -6,13 +8,13 @@
     max-width: 100%;
     margin: auto;
 
-    @include medium-and-up {
+    @include mixins.medium-and-up {
       min-height: 330px;
       margin-left: 0;
       margin-right: 0;
     }
 
-    @include x-large-and-up {
+    @include mixins.x-large-and-up {
       min-height: 430px;
     }
   }
@@ -36,37 +38,37 @@
       object-fit: cover;
       cursor: pointer;
 
-      @include mobile-only {
+      @include mixins.mobile-only {
         width: 260px;
       }
 
-      @include medium-and-up {
+      @include mixins.medium-and-up {
         height: 330px;
         width: 400px;
       }
 
-      @include large-and-up {
+      @include mixins.large-and-up {
         left: -25%;
       }
 
-      @include x-large-and-up {
+      @include mixins.x-large-and-up {
         left: -30%;
         height: 430px;
         width: 530px;
       }
 
-      @include xx-large-and-up {
+      @include mixins.xx-large-and-up {
         width: 620px;
       }
 
       html[dir="rtl"] & {
         right: -25%;
 
-        @include large-and-up {
+        @include mixins.large-and-up {
           right: -15%;
         }
 
-        @include x-large-and-up {
+        @include mixins.x-large-and-up {
           right: -20%;
           height: 430px;
         }
@@ -96,7 +98,7 @@
 
       img {
         transform: skew(25deg);
-        @include mobile-only {
+        @include mixins.mobile-only {
           right: -50px;
         }
       }
@@ -126,22 +128,22 @@
       width: 660px;
       transform: skew(-25deg);
 
-      @include mobile-only {
+      @include mixins.mobile-only {
         width: 280px;
         left: -50px;
       }
 
-      @include small-and-up {
+      @include mixins.small-and-up {
         left: -180px;
       }
 
-      @include medium-and-up {
+      @include mixins.medium-and-up {
         left: -100px;
       }
     }
 
     .img_post {
-      @include small-and-up {
+      @include mixins.small-and-up {
         width: 500px;
         left: -150px;
       }

--- a/assets/src/scss/blocks/HappyPoint/HappyPointEditorStyle.scss
+++ b/assets/src/scss/blocks/HappyPoint/HappyPointEditorStyle.scss
@@ -1,3 +1,5 @@
+@use "../../base/mixins" as mixins;
+
 .wp-block-master-theme-happypoint__FocalPointPicker .components-focal-point-picker_position-display-container {
   display: none;
 }
@@ -7,7 +9,7 @@
 }
 
 .happy-point-block-wrap .happy-point iframe {
-  @include medium-and-up {
+  @include mixins.medium-and-up {
     width: 100%;
   }
 }

--- a/assets/src/scss/blocks/HappyPoint/HappyPointStyle.scss
+++ b/assets/src/scss/blocks/HappyPoint/HappyPointStyle.scss
@@ -1,5 +1,7 @@
+@use "../../base/mixins" as mixins;
+
 .happy-point-block-wrap {
-  @include background-before-opacity($beige-100);
+  @include mixins.background-before-opacity($beige-100);
   width: 100vw;
   height: 444px;
   overflow: hidden;
@@ -10,30 +12,30 @@
     width: 100%;
   }
 
-  @include mobile-only {
+  @include mixins.mobile-only {
     height: auto;
     min-height: 544px;
   }
 
-  @include medium-and-up {
+  @include mixins.medium-and-up {
     max-height: 480px;
   }
 
-  @include large-and-up {
+  @include mixins.large-and-up {
     max-height: 500px;
   }
 
-  @include x-large-and-up {
+  @include mixins.x-large-and-up {
     height: 620px;
     width: 100vw;
-    @include background-before-opacity($beige-100);
+    @include mixins.background-before-opacity($beige-100);
   }
 
   .container {
     height: inherit;
     width: 100%;
 
-    @include medium-and-up {
+    @include mixins.medium-and-up {
       max-width: none;
     }
 
@@ -45,7 +47,7 @@
   .happy-point {
     height: inherit;
 
-    @include medium-and-up {
+    @include mixins.medium-and-up {
       text-align: center;
       padding-left: 0;
       padding-right: 0;
@@ -58,18 +60,18 @@
       margin-top: calc(var(--iframe-height) / 2 * -1);
       top: 50%;
 
-      @include mobile-only {
+      @include mixins.mobile-only {
         position: absolute;
         width: 100vw;
         bottom: 0;
         --iframe-height: 490px;
       }
 
-      @include medium-and-up {
+      @include mixins.medium-and-up {
         width: 80vw;
       }
 
-      @include large-and-up {
+      @include mixins.large-and-up {
         width: 100%;
       }
     }
@@ -81,18 +83,18 @@
     line-height: 32px;
     margin-bottom: 24px;
 
-    @include medium-and-up {
+    @include mixins.medium-and-up {
       font-size: $font-size-xl;
       line-height: 34px;
       margin-bottom: 20px;
     }
 
-    @include large-and-up {
+    @include mixins.large-and-up {
       font-size: 2.125rem;
       margin-bottom: 30px;
     }
 
-    @include x-large-and-up {
+    @include mixins.x-large-and-up {
       font-size: 2.25rem;
       margin-bottom: 42px;
     }
@@ -102,12 +104,12 @@
     font-size: $font-size-sm;
     line-height: 24px;
 
-    @include medium-and-up {
+    @include mixins.medium-and-up {
       font-size: 1.125rem;
       line-height: 28px;
     }
 
-    @include large-and-up {
+    @include mixins.large-and-up {
       line-height: 24px;
     }
   }
@@ -119,11 +121,11 @@
     color: var(--grey-800);
     text-align: left;
 
-    @include medium-and-up {
+    @include mixins.medium-and-up {
       text-align: center;
     }
 
-    @include large-and-up {
+    @include mixins.large-and-up {
       text-align: left;
     }
   }
@@ -139,7 +141,7 @@
         & {
           height: 500px;
 
-          @include mobile-only {
+          @include mixins.mobile-only {
             height: 544px;
           }
         }
@@ -154,7 +156,7 @@
       border-color: transparent;
       margin-bottom: 16px;
 
-      @include medium-and-up {
+      @include mixins.medium-and-up {
         margin-bottom: inherit;
       }
     }
@@ -171,17 +173,17 @@
       background-color: var(--gp-green-500);
     }
 
-    @include medium-and-up {
+    @include mixins.medium-and-up {
       margin-top: 16px;
     }
 
-    @include large-and-up {
+    @include mixins.large-and-up {
       margin-top: 0;
       height: 42px;
       line-height: 42px;
     }
 
-    @include x-large-and-up {
+    @include mixins.x-large-and-up {
       margin-bottom: 8px;
     }
   }

--- a/assets/src/scss/blocks/PageHeader.scss
+++ b/assets/src/scss/blocks/PageHeader.scss
@@ -1,3 +1,5 @@
+@use "../base/mixins" as mixins;
+
 $title-width-l: 660px;
 $text-column-width-l: 320px;
 $text-column-width-xl: 380px;
@@ -8,11 +10,11 @@ $text-column-padding-in: 24px;
   grid-template-columns: 100%;
   width: 100vw;
 
-  @include medium-and-up {
+  @include mixins.medium-and-up {
     padding-bottom: $sp-5;
   }
 
-  @include large-and-up {
+  @include mixins.large-and-up {
     padding: $sp-7 0;
   }
 
@@ -33,7 +35,7 @@ $text-column-padding-in: 24px;
     padding-inline-start: 0;
     z-index: 1;
 
-    @include medium-and-less {
+    @include mixins.medium-and-less {
       padding-inline-end: 0;
 
       html[dir="rtl"] & {
@@ -49,7 +51,7 @@ $text-column-padding-in: 24px;
         width: auto;
       }
 
-      @include medium-and-less {
+      @include mixins.medium-and-less {
         html[dir="rtl"] & {
           margin-left: auto;
         }
@@ -58,19 +60,19 @@ $text-column-padding-in: 24px;
   }
 
   .wp-block-group:first-child {
-    @include clamp-text(5);
+    @include mixins.clamp-text(5);
     overflow: hidden;
     font-size: $font-size-xxl;
     font-weight: 700;
     line-height: initial;
 
-    @include medium-and-less {
+    @include mixins.medium-and-less {
       padding: 0 $sp-1;
       margin: 0 (-$sp-1);
     }
 
-    @include medium-and-up {
-      @include clamp-text(3);
+    @include mixins.medium-and-up {
+      @include mixins.clamp-text(3);
     }
   }
 
@@ -84,12 +86,12 @@ $text-column-padding-in: 24px;
   }
 
   p {
-    @include clamp-text(8);
+    @include mixins.clamp-text(8);
     margin-bottom: $sp-4;
     padding-top: $sp-2;
   }
 
-  @include medium-and-up {
+  @include mixins.medium-and-up {
     .wp-block-media-text__media img {
       max-height: 432px;
     }
@@ -107,7 +109,7 @@ $text-column-padding-in: 24px;
     }
   }
 
-  @include large-and-up {
+  @include mixins.large-and-up {
     width: calc(100% + (100vw - 100%) / 2);
 
     .wp-block-media-text__media img {
@@ -134,7 +136,7 @@ $text-column-padding-in: 24px;
     }
   }
 
-  @include x-large-and-up {
+  @include mixins.x-large-and-up {
     .wp-block-media-text__content {
       > *:nth-child(n+2) {
         max-width: calc(#{$text-column-width-xl} - #{$text-column-padding-in});
@@ -146,7 +148,7 @@ $text-column-padding-in: 24px;
     }
   }
 
-  @include xx-large-and-up {
+  @include mixins.xx-large-and-up {
     .wp-block-media-text__content {
       > *:nth-child(n+2) {
         max-width: calc(#{$text-column-width-xxl} - #{$text-column-padding-in});
@@ -156,7 +158,7 @@ $text-column-padding-in: 24px;
 }
 
 .wp-block-media-text.alignfull.is-pattern-p4-page-header.has-media-on-the-right {
-  @include large-and-up {
+  @include mixins.large-and-up {
     grid-template-columns: $text-column-width-l auto;
     margin-left: 0;
 
@@ -177,7 +179,7 @@ $text-column-padding-in: 24px;
     }
   }
 
-  @include x-large-and-up {
+  @include mixins.x-large-and-up {
     grid-template-columns: $text-column-width-xl auto;
 
     .wp-block-group:first-child {
@@ -187,13 +189,13 @@ $text-column-padding-in: 24px;
     }
   }
 
-  @include xx-large-and-up {
+  @include mixins.xx-large-and-up {
     grid-template-columns: $text-column-width-xxl auto;
   }
 }
 
 .wp-block-media-text.alignfull.is-pattern-p4-page-header:not(.has-media-on-the-right) {
-  @include large-and-up {
+  @include mixins.large-and-up {
     grid-template-columns: auto $text-column-width-l;
 
     html[dir="rtl"] & {
@@ -222,7 +224,7 @@ $text-column-padding-in: 24px;
     }
   }
 
-  @include x-large-and-up {
+  @include mixins.x-large-and-up {
     grid-template-columns: auto $text-column-width-xl;
 
     .wp-block-group:first-child {
@@ -230,7 +232,7 @@ $text-column-padding-in: 24px;
     }
   }
 
-  @include xx-large-and-up {
+  @include mixins.xx-large-and-up {
     grid-template-columns: auto $text-column-width-xxl;
 
     .wp-block-group:first-child {

--- a/assets/src/scss/blocks/PostsList/PostsListEditorStyle.scss
+++ b/assets/src/scss/blocks/PostsList/PostsListEditorStyle.scss
@@ -1,3 +1,5 @@
+@use "../../base/mixins" as mixins;
+
 .posts-list {
   .carousel-controls {
     display: none !important;
@@ -26,7 +28,7 @@
     margin-bottom: $sp-3;
   }
 
-  @include large-and-up {
+  @include mixins.large-and-up {
     .wp-block-post {
       flex-basis: calc(25% - $sp-2);
     }

--- a/assets/src/scss/blocks/PostsList/PostsListStyle.scss
+++ b/assets/src/scss/blocks/PostsList/PostsListStyle.scss
@@ -1,3 +1,5 @@
+@use "../../base/mixins" as mixins;
+
 .posts-list {
   margin-bottom: $sp-4;
 
@@ -10,7 +12,7 @@
     list-style: none;
 
     a {
-      @include shared-link-styles;
+      @include mixins.shared-link-styles;
       display: inline-block;
       font-family: var(--font-family-heading);
       font-size: 16px;
@@ -35,7 +37,7 @@
       }
     }
 
-    @include medium-and-less {
+    @include mixins.medium-and-less {
       margin-top: $sp-4;
     }
   }
@@ -48,7 +50,7 @@
   }
 
   .taxonomy-post_tag {
-    @include render-bullet();
+    @include mixins.render-bullet();
     margin-inline-start: $sp-1x;
 
     &:before {
@@ -91,11 +93,11 @@
       width: 100% !important;
       object-fit: cover;
 
-      @include medium-and-up {
+      @include mixins.medium-and-up {
         height: 180px;
       }
 
-      @include large-and-up {
+      @include mixins.large-and-up {
         height: 210px;
       }
     }
@@ -107,7 +109,7 @@
     margin-bottom: calc($sp-1x - 2px);
 
     a {
-      @include clamp-text(2);
+      @include mixins.clamp-text(2);
 
       &:hover {
         text-decoration: underline;
@@ -115,11 +117,11 @@
       }
     }
 
-    @include large-and-up {
+    @include mixins.large-and-up {
       font-size: 20px;
     }
 
-    @include x-large-and-up {
+    @include mixins.x-large-and-up {
       margin-bottom: $sp-3;
     }
   }
@@ -149,7 +151,7 @@
       margin-bottom: 0;
     }
 
-    @include medium-and-less {
+    @include mixins.medium-and-less {
       .wp-block-post {
         width: 250px;
       }
@@ -159,13 +161,13 @@
       }
     }
 
-    @include medium-and-up {
+    @include mixins.medium-and-up {
       .wp-block-post {
         width: 276px;
       }
     }
 
-    @include large-and-up {
+    @include mixins.large-and-up {
       .carousel-indicators {
         margin-top: -$sp-3;
       }
@@ -197,10 +199,10 @@
       width: 100%;
       margin-bottom: $sp-1;
       font-size: var(--font-size-m--font-family-secondary);
-      @include clamp-text(3);
+      @include mixins.clamp-text(3);
       word-break: break-word;
 
-      @include large-and-up {
+      @include mixins.large-and-up {
         line-height: 1.5;
       }
     }
@@ -290,11 +292,11 @@
       display: grid;
       gap: $sp-3;
 
-      @include medium-and-up {
+      @include mixins.medium-and-up {
         grid-template-columns: repeat(2, minmax(0, 1fr));
       }
 
-      @include large-and-up {
+      @include mixins.large-and-up {
         grid-template-columns: repeat(4, minmax(0, 1fr));
       }
     }
@@ -303,7 +305,7 @@
   &.is-custom-layout-grid,
   &.is-custom-layout-carousel {
     .wp-block-post-terms a {
-      @include clamp-text(1);
+      @include mixins.clamp-text(1);
 
       overflow-wrap: break-word;
       word-break: break-word;
@@ -316,10 +318,10 @@
     line-height: var(--line-height-xs--font-family-tertiary);
 
     .article-list-item-author {
-      @include clamp-text(1);
+      @include mixins.clamp-text(1);
 
       &:focus-within {
-        @include focus-styles();
+        @include mixins.focus-styles();
       }
 
       a:focus {

--- a/assets/src/scss/blocks/SecondaryNavigation/SecondaryNavigationStyle.scss
+++ b/assets/src/scss/blocks/SecondaryNavigation/SecondaryNavigationStyle.scss
@@ -1,3 +1,5 @@
+@use "../../base/mixins" as mixins;
+
 .secondary-navigation-block {
   margin-left: calc(-50vw + 50%);
   width: 100vw;
@@ -6,7 +8,7 @@
   background: var(--p4-dark-green-800);
   position: relative;
 
-  @include medium-and-less {
+  @include mixins.medium-and-less {
     > .container {
       max-width: 100%;
     }
@@ -33,7 +35,7 @@
     top: 84px !important;
   }
 
-  @include medium-and-less {
+  @include mixins.medium-and-less {
     top: 60px;
 
     body.admin-bar & {
@@ -72,7 +74,7 @@
     color: var(--white);
     font-size: var(--font-size-m--font-family-primary);
 
-    @include large-and-less {
+    @include mixins.large-and-less {
       top: 10px;
     }
   }
@@ -94,7 +96,7 @@
   left: -20px;
   transform: rotate(180deg);
 
-  @include large-and-less {
+  @include mixins.large-and-less {
     left: -15px;
   }
 }
@@ -102,13 +104,13 @@
 .nav-arrow.right {
   right: -20px;
 
-  @include large-and-less {
+  @include mixins.large-and-less {
     right: -15px;
   }
 }
 
 .secondary-nav-scroll-wrapper {
-  @include large-and-up {
+  @include mixins.large-and-up {
     mask-image: linear-gradient(to right, transparent 0, black 30px, black calc(100% - 30px), transparent 100%);
     mask-repeat: no-repeat;
     mask-size: 100% 100%;
@@ -138,14 +140,14 @@
   margin-bottom: -$sp-1;
   cursor: pointer;
 
-  @include large-and-up {
+  @include mixins.large-and-up {
     display: none;
   }
 
   &:focus,
   &:focus-within,
   &:focus-visible {
-    @include focus-styles;
+    @include mixins.focus-styles;
   }
 }
 
@@ -178,7 +180,7 @@
   margin-top: 2px;
   padding-inline-end: $sp-3;
 
-  @include large-and-less {
+  @include mixins.large-and-less {
     margin-top: $sp-x;
   }
 
@@ -215,7 +217,7 @@
     display: none;
   }
 
-  @include medium-and-less {
+  @include mixins.medium-and-less {
     flex-direction: column;
     height: auto;
     overflow: hidden;
@@ -274,7 +276,7 @@
 }
 
 .secondary-navigation-link {
-  @include medium-and-less {
+  @include mixins.medium-and-less {
     color: var(--grey-700) !important;
     font-weight: var(--font-weight-regular);
     font-size: var(--font-size-s--font-family-tertiary);
@@ -302,7 +304,7 @@
 }
 
 .page-content > h2:first-of-type {
-  @include medium-and-less {
+  @include mixins.medium-and-less {
     margin-top: 30px !important;
   }
 }

--- a/assets/src/scss/blocks/Spreadsheet.scss
+++ b/assets/src/scss/blocks/Spreadsheet.scss
@@ -1,9 +1,11 @@
+@use "../base/mixins" as mixins;
+
 .block-spreadsheet {
   display: inline-block;
   margin-top: $sp-1;
   margin-bottom: $sp-2;
 
-  @include large-and-up {
+  @include mixins.large-and-up {
     margin-top: $sp-2;
     margin-bottom: $sp-4;
   }
@@ -15,12 +17,12 @@
   max-height: 320px;
   margin-top: $sp-3;
 
-  @include medium-and-up {
+  @include mixins.medium-and-up {
     max-height: 520px;
     margin-top: $sp-2;
   }
 
-  @include large-and-up {
+  @include mixins.large-and-up {
     max-height: 575px;
   }
 }
@@ -29,7 +31,7 @@ table.spreadsheet-table {
   min-width: 100%;
   margin-bottom: 0;
 
-  @include mobile-only {
+  @include mixins.mobile-only {
     overflow: visible;
   }
 
@@ -46,7 +48,7 @@ table.spreadsheet-table {
       font-size: var(--font-size-s--font-family-tertiary);
       white-space: pre-wrap;
 
-      @include x-large-and-up {
+      @include mixins.x-large-and-up {
         font-size: var(--font-size-s--font-family-tertiary);
       }
 
@@ -146,7 +148,7 @@ table.spreadsheet-table.is-color-gp-green {
   font-size: var(--font-size-s--font-family-primary);
   line-height: 1.375rem;
 
-  @include medium-and-up {
+  @include mixins.medium-and-up {
     font-size: var(--font-size-m--font-family-primary);
     line-height: var(--line-height-m--font-family-primary);
     margin: 0 0 $sp-3 0;

--- a/assets/src/scss/blocks/TableOfContents/TableOfContentsStyle.scss
+++ b/assets/src/scss/blocks/TableOfContents/TableOfContentsStyle.scss
@@ -1,3 +1,5 @@
+@use "../../base/mixins" as mixins;
+
 // On outer element as otherwise it will not be clickable when floating on the right.
 div[data-render="planet4-blocks/submenu"] {
   z-index: 4;
@@ -25,7 +27,7 @@ div[data-render="planet4-blocks/submenu"] {
     ul.table-of-contents-item {
       flex-basis: 100%;
 
-      @include large-and-up {
+      @include mixins.large-and-up {
         flex-basis: 50%;
       }
     }
@@ -64,7 +66,7 @@ div[data-render="planet4-blocks/submenu"] {
 
   &.table-of-contents-short {
     .table-of-contents-menu {
-      @include medium-and-up {
+      @include mixins.medium-and-up {
         ul.table-of-contents-item {
           flex-basis: 100%;
           column-count: 3;
@@ -83,7 +85,7 @@ div[data-render="planet4-blocks/submenu"] {
         flex-basis: 100%;
         column-count: 1;
 
-        @include medium-and-up {
+        @include mixins.medium-and-up {
           column-count: 2;
         }
       }
@@ -93,7 +95,7 @@ div[data-render="planet4-blocks/submenu"] {
   &.table-of-contents-sidebar {
     z-index: 4;
 
-    @include medium-and-up {
+    @include mixins.medium-and-up {
       float: right;
       max-width: 350px;
       margin-bottom: $sp-2;
@@ -108,7 +110,7 @@ div[data-render="planet4-blocks/submenu"] {
       ul.table-of-contents-item {
         flex-basis: 100%;
 
-        @include large-and-up {
+        @include mixins.large-and-up {
           flex-basis: 100%;
         }
       }

--- a/assets/src/scss/blocks/TakeActionBoxout/TakeActionBoxoutStyle.scss
+++ b/assets/src/scss/blocks/TakeActionBoxout/TakeActionBoxoutStyle.scss
@@ -1,3 +1,5 @@
+@use "../../base/mixins" as mixins;
+
 @mixin boxout-half-and-half {
   height: 222px;
 
@@ -30,7 +32,7 @@
 @mixin boxout-heading-font-size($mobile, $desktop) {
   font-size: $mobile;
 
-  @include large-and-up {
+  @include mixins.large-and-up {
     font-size: $desktop;
   }
 }
@@ -87,7 +89,7 @@
     color: var(--color-text-body);
     margin-bottom: $sp-1;
     word-break: break-word;
-    @include clamp-text(2);
+    @include mixins.clamp-text(2);
     // Medium font size is the default.
     @include boxout-heading-font-size(
       var(--font-size-s--font-family-primary),
@@ -127,11 +129,11 @@
     line-height: var(--line-height-m--font-family-tertiary);
     color: var(--color-text-body);
     margin: 0;
-    @include clamp-text(2);
+    @include mixins.clamp-text(2);
   }
 
   &:not(.sticky-bottom-mobile) {
-    @include small-and-less {
+    @include mixins.small-and-less {
       flex-direction: column-reverse;
 
       .boxout-content {
@@ -151,13 +153,13 @@
       }
     }
 
-    @include medium-and-up {
+    @include mixins.medium-and-up {
       @include boxout-half-and-half;
     }
   }
 
   &.sticky-bottom-mobile {
-    @include medium-and-less {
+    @include mixins.medium-and-less {
       z-index: 9999;
       position: fixed;
       bottom: 0;
@@ -213,14 +215,14 @@
         }
       }
 
-      @include mobile-only {
+      @include mixins.mobile-only {
         .boxout-heading {
           margin-inline-end: $sp-3;
         }
       }
     }
 
-    @include large-and-up {
+    @include mixins.large-and-up {
       @include boxout-half-and-half;
     }
   }

--- a/assets/src/scss/blocks/core-overrides/BlockSpacing.scss
+++ b/assets/src/scss/blocks/core-overrides/BlockSpacing.scss
@@ -1,3 +1,5 @@
+@use "../../base/mixins" as mixins;
+
 .wp-block-quote,
 .wp-block-file,
 .wp-block-button,
@@ -17,7 +19,7 @@
   margin-top: $sp-1;
   margin-bottom: $sp-2;
 
-  @include large-and-up {
+  @include mixins.large-and-up {
     margin-top: $sp-2;
     margin-bottom: $sp-4;
   }
@@ -30,7 +32,7 @@
   margin-top: $sp-1;
   margin-bottom: $sp-1;
 
-  @include large-and-up {
+  @include mixins.large-and-up {
     margin-top: $sp-2;
     margin-bottom: $sp-2;
   }

--- a/assets/src/scss/blocks/core-overrides/Columns.scss
+++ b/assets/src/scss/blocks/core-overrides/Columns.scss
@@ -1,3 +1,5 @@
+@use "../../base/mixins" as mixins;
+
 @mixin apply-item-width($gap, $items-count) {
   $gap: 0;
   $total-gap: calc($gap * $items-count);
@@ -11,7 +13,7 @@
 }
 
 .wp-block-columns.is-not-stacked-on-mobile.is-style-mobile-carousel {
-  @include large-and-less {
+  @include mixins.large-and-less {
     flex-wrap: nowrap;
     overflow-x: auto;
     scrollbar-width: none;
@@ -28,8 +30,8 @@
 
   // These styles will be applied to the Quick Links Block only
   &.quick-links {
-    @include mobile-only {
-      @include wide-block;
+    @include mixins.mobile-only {
+      @include mixins.wide-block;
       @include apply-item-width(0, 3);
 
       padding-left: $sp-1x;
@@ -45,7 +47,7 @@
     }
   }
 
-  @include small-and-less {
+  @include mixins.small-and-less {
     gap: $sp-2;
   }
 }

--- a/assets/src/scss/blocks/core-overrides/Embed.scss
+++ b/assets/src/scss/blocks/core-overrides/Embed.scss
@@ -1,3 +1,5 @@
+@use "../../base/mixins" as mixins;
+
 // This combination of height: 0, and padding-bottom: 56.25%
 // is to force the aspect ratio of the video to 16:9, based
 // on the width. See: https://css-tricks.com/fluid-width-video/
@@ -14,13 +16,13 @@
   margin-top: $sp-1;
   margin-bottom: $sp-2;
 
-  @include large-and-up {
+  @include mixins.large-and-up {
     margin-top: $sp-2;
     margin-bottom: $sp-4;
   }
 
   iframe {
-    @include absolute-position;
+    @include mixins.absolute-position;
   }
 
   .wp-block-embed__wrapper {
@@ -32,17 +34,17 @@
   margin-top: $sp-1;
   margin-bottom: $sp-2;
 
-  @include medium-and-up {
+  @include mixins.medium-and-up {
     width: 510px;
   }
 
-  @include large-and-up {
+  @include mixins.large-and-up {
     margin-top: $sp-2;
     margin-bottom: $sp-4;
     width: 610px;
   }
 
-  @include x-large-and-up {
+  @include mixins.x-large-and-up {
     width: 630px;
   }
 
@@ -77,7 +79,7 @@ lite-youtube,
   @include embed-wrapper;
 
   iframe {
-    @include absolute-position;
+    @include mixins.absolute-position;
   }
 }
 

--- a/assets/src/scss/blocks/core-overrides/Heading.scss
+++ b/assets/src/scss/blocks/core-overrides/Heading.scss
@@ -1,3 +1,5 @@
+@use "../../base/mixins" as mixins;
+
 .wp-block-heading {
   &.is-style-chevron::after {
     content: "";
@@ -19,6 +21,6 @@
   }
 
   > a {
-    @include shared-link-styles;
+    @include mixins.shared-link-styles;
   }
 }

--- a/assets/src/scss/blocks/core-overrides/Image.scss
+++ b/assets/src/scss/blocks/core-overrides/Image.scss
@@ -1,3 +1,5 @@
+@use "../../base/mixins" as mixins;
+
 @mixin rounded-image-size($size) {
   figure,
   img {
@@ -32,11 +34,11 @@
   margin-bottom: $sp-2;
 
   &.is-style-rounded-180 {
-    @include rounded-image-size(180px);
+    @include mixins.rounded-image-size(180px);
   }
 
   &.is-style-rounded-90 {
-    @include rounded-image-size(90px);
+    @include mixins.rounded-image-size(90px);
   }
 
   &:not(.force-no-lightbox) img {
@@ -48,14 +50,14 @@
   }
 
   &.square-40 {
-    @include square-image-size(40px);
+    @include mixins.square-image-size(40px);
   }
 
   &.square-80 {
-    @include square-image-size(80px);
+    @include mixins.square-image-size(80px);
   }
 
-  @include large-and-up {
+  @include mixins.large-and-up {
     margin-top: $sp-2;
     margin-bottom: $sp-4;
   }
@@ -79,7 +81,7 @@
     margin-right: auto;
   }
 
-  @include medium-and-up {
+  @include mixins.medium-and-up {
     .image-credit {
       position: absolute;
       text-align: right;

--- a/assets/src/scss/blocks/core-overrides/MediaText.scss
+++ b/assets/src/scss/blocks/core-overrides/MediaText.scss
@@ -1,5 +1,7 @@
+@use "../../base/mixins" as mixins;
+
 .wp-block-media-text {
-  @include mobile-only {
+  @include mixins.mobile-only {
     .wp-block-media-text__content {
       margin-top: $sp-3;
     }
@@ -25,11 +27,11 @@
     max-width: 440px;
     width: 100%;
 
-    @include x-large-and-up {
+    @include mixins.x-large-and-up {
       max-width: 522px;
     }
 
-    @include xx-large-and-up {
+    @include mixins.xx-large-and-up {
       max-width: 612px;
     }
   }
@@ -43,7 +45,7 @@
     width: 100%;
   }
 
-  @include x-large-and-up {
+  @include mixins.x-large-and-up {
     &.has-media-on-the-right .wp-block-media-text__content {
       padding-inline-end: $sp-6;
     }

--- a/assets/src/scss/blocks/core-overrides/Quote.scss
+++ b/assets/src/scss/blocks/core-overrides/Quote.scss
@@ -1,3 +1,5 @@
+@use "../../base/mixins" as mixins;
+
 .wp-block-quote {
   font-style: italic;
   quotes: auto;
@@ -22,11 +24,11 @@
       margin-inline-start: $sp-x;
     }
 
-    @include medium-and-up {
+    @include mixins.medium-and-up {
       font-size: var(--font-size-xl--font-family-primary);
     }
 
-    @include x-large-and-up {
+    @include mixins.x-large-and-up {
       font-size: var(--font-size-xl--font-family-primary);
     }
   }
@@ -35,7 +37,7 @@
     font-style: normal;
 
     a {
-      @include shared-link-styles;
+      @include mixins.shared-link-styles;
     }
   }
 }

--- a/assets/src/scss/blocks/core-overrides/Separator.scss
+++ b/assets/src/scss/blocks/core-overrides/Separator.scss
@@ -1,3 +1,4 @@
+@use "../../base/mixins" as mixins;
 
 .wp-block-separator {
   border: none;
@@ -7,7 +8,7 @@
   margin-top: $sp-1;
   margin-bottom: $sp-2;
 
-  @include large-and-up {
+  @include mixins.large-and-up {
     margin-top: $sp-2;
     margin-bottom: $sp-4;
   }

--- a/assets/src/scss/blocks/core-overrides/Table.scss
+++ b/assets/src/scss/blocks/core-overrides/Table.scss
@@ -1,8 +1,9 @@
+@use "../../base/mixins" as mixins;
 
 // Table background colors (header, footer, odd/even rows)
 .wp-block-table {
   a {
-    @include shared-link-styles;
+    @include mixins.shared-link-styles;
   }
 
   table {

--- a/assets/src/scss/components/_buttons.scss
+++ b/assets/src/scss/components/_buttons.scss
@@ -1,3 +1,5 @@
+@use "../base/mixins" as mixins;
+
 .btn,
 .wp-block-button a,
 .wp-block-button button,
@@ -16,7 +18,7 @@
   transition-timing-function: linear;
 
   &:focus {
-    @include focus-styles;
+    @include mixins.focus-styles;
   }
 
   display: inline-block;
@@ -197,7 +199,7 @@
     color: var(--color-text-button--donate--visited);
   }
 
-  @include large-and-up {
+  @include mixins.large-and-up {
     font-size: $font-size-md;
   }
 

--- a/assets/src/scss/components/_tweet-block.scss
+++ b/assets/src/scss/components/_tweet-block.scss
@@ -1,10 +1,12 @@
+@use "../base/mixins" as mixins;
+
 blockquote.twitter-tweet {
   margin: $sp-7x 0;
   padding-left: 30px;
   border-left: 4px solid var(--grey-500);
   display: inline-block;
 
-  @include medium-and-up {
+  @include mixins.medium-and-up {
     padding-left: 70px;
   }
 

--- a/assets/src/scss/editorOverrides.scss
+++ b/assets/src/scss/editorOverrides.scss
@@ -1,4 +1,5 @@
-@import "./base/tokens";
+@use "./base/mixins" as mixins;
+@use "./base/tokens" as tokens;
 
 // Moved from another repo, for history please see https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/blame/f5c532ed5704738136224cde305e9a0ffe614ceb/assets/src/styles/editorOverrides.scss
 .editor-post-title__block textarea.editor-post-title__input {
@@ -7,11 +8,11 @@
   line-height: 1.225;
   margin-bottom: 30px;
 
-  @include large-and-up {
+  @include mixins.large-and-up {
     font-size: $font-size-xxl;
     margin-bottom: 48px;
   }
-  @include x-large-and-up {
+  @include mixins.x-large-and-up {
     font-size: $font-size-xxxl;
   }
 }
@@ -109,20 +110,20 @@
     font-size: var(--font-size-m--font-family-secondary);
     line-height: var(--line-height-m--font-family-secondary);
 
-    @include x-large-and-up {
+    @include mixins.x-large-and-up {
       font-size: var(--font-size-xl--font-family-secondary);
       line-height: var(--line-height-xl--font-family-secondary);
     }
 
     > a {
-      @include shared-link-styles;
+      @include mixins.shared-link-styles;
     }
   }
 
   .wp-block-list a,
   > ul li a,
   > ol li a {
-    @include shared-link-styles;
+    @include mixins.shared-link-styles;
   }
 }
 
@@ -407,7 +408,7 @@ input.describe[type=text][data-setting=caption] {
     }
   }
 
-  @include large-and-up {
+  @include mixins.large-and-up {
     .wp-block-post:not(:last-child) {
       margin-inline-end: $sp-3;
     }
@@ -433,5 +434,53 @@ html[dir="rtl"] {
       direction: rtl;
       unicode-bidi: embed;
     }
+  }
+}
+
+.block-editor-block-list__layout.is-root-container > * {
+  margin-top: $sp-1;
+  margin-bottom: $sp-2;
+
+  @include mixins.large-and-up {
+    margin-top: $sp-2;
+    margin-bottom: $sp-4;
+  }
+}
+
+.block-edit-mode-warning {
+  padding: $sp-2;
+  margin: 0;
+}
+
+.EmptyMessage {
+  font-family: var(--font-family-primary);
+  padding: $sp-4;
+  background: var(--gp-green-200);
+}
+
+.HTMLSidebarHelp {
+  padding-top: $sp-1;
+  padding-bottom: $sp-2;
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+// Prevent links being clickable in editor
+.secondary-navigation-link {
+  pointer-events: none;
+  cursor: default;
+}
+
+.secondary-navigation-block:has(.EmptyMessage) {
+  height: unset;
+  padding: unset;
+}
+
+.secondary-navigation-items {
+  width: 90%;
+  margin-inline-start: 7%;
+
+  li:first-child {
+    margin-left: 115px;
   }
 }

--- a/assets/src/scss/editorStyle.scss
+++ b/assets/src/scss/editorStyle.scss
@@ -8,7 +8,6 @@
 @import "base/variables";
 @import "base/palette";
 @import "base/functions";
-@import "base/mixins";
 @import "base/fonts";
 
 @import "base/icons";
@@ -49,51 +48,3 @@
 
 // Variations
 @import "variations/stretched-link/edit";
-
-.block-editor-block-list__layout.is-root-container > * {
-  margin-top: $sp-1;
-  margin-bottom: $sp-2;
-
-  @include large-and-up {
-    margin-top: $sp-2;
-    margin-bottom: $sp-4;
-  }
-}
-
-.block-edit-mode-warning {
-  padding: $sp-2;
-  margin: 0;
-}
-
-.EmptyMessage {
-  font-family: var(--font-family-primary);
-  padding: $sp-4;
-  background: var(--gp-green-200);
-}
-
-.HTMLSidebarHelp {
-  padding-top: $sp-1;
-  padding-bottom: $sp-2;
-  font-size: 13px;
-  line-height: 1.5;
-}
-
-// Prevent links being clickable in editor
-.secondary-navigation-link {
-  pointer-events: none;
-  cursor: default;
-}
-
-.secondary-navigation-block:has(.EmptyMessage) {
-  height: unset;
-  padding: unset;
-}
-
-.secondary-navigation-items {
-  width: 90%;
-  margin-inline-start: 7%;
-
-  li:first-child {
-    margin-left: 115px;
-  }
-}

--- a/assets/src/scss/layout/_blocks.scss
+++ b/assets/src/scss/layout/_blocks.scss
@@ -1,10 +1,12 @@
+@use "../base/mixins" as mixins;
+
 .block {
   display: inline-block;
   width: 100%;
   margin-top: $sp-1;
   margin-bottom: $sp-2;
 
-  @include large-and-up {
+  @include mixins.large-and-up {
     margin-top: $sp-2;
     margin-bottom: $sp-4;
   }
@@ -14,7 +16,7 @@
   margin-top: 0;
   margin-bottom: $sp-2;
 
-  @include large-and-up {
+  @include mixins.large-and-up {
     margin-bottom: $sp-4;
   }
 }
@@ -23,7 +25,7 @@
   margin-top: $sp-1;
   margin-bottom: 0;
 
-  @include large-and-up {
+  @include mixins.large-and-up {
     margin-top: $sp-2;
   }
 }

--- a/assets/src/scss/layout/_cookies-settings.scss
+++ b/assets/src/scss/layout/_cookies-settings.scss
@@ -1,3 +1,5 @@
+@use "../base/mixins" as mixins;
+
 .cookies-settings {
   position: relative;
 
@@ -7,11 +9,11 @@
     line-height: var(--line-height-s--font-family-tertiary);
   }
 
-  @include medium-and-up {
+  @include mixins.medium-and-up {
     width: 434px;
   }
 
-  @include large-and-up {
+  @include mixins.large-and-up {
     p {
       font-size: var(--font-size-xs--font-family-tertiary);
     }
@@ -38,7 +40,7 @@
     left: -$sp-1;
   }
 
-  @include medium-and-up {
+  @include mixins.medium-and-up {
     right: -$sp-2;
 
     html[dir="rtl"] & {
@@ -59,7 +61,7 @@
   font-family: var(--font-family-paragraph-secondary);
   font-size: 16px;
 
-  @include large-and-up {
+  @include mixins.large-and-up {
     font-size: 20px;
   }
 }
@@ -81,7 +83,7 @@
     margin-bottom: $sp-2;
   }
 
-  @include medium-and-up {
+  @include mixins.medium-and-up {
     max-height: 300px;
     width: calc(100% + 2 * #{$sp-4});
     margin-inline-start: -$sp-4;
@@ -109,7 +111,7 @@
     width: calc(50% - 8px);
     font-size: 14px;
 
-    @include medium-and-up {
+    @include mixins.medium-and-up {
       width: auto;
     }
   }
@@ -122,7 +124,7 @@
       margin-top: $sp-2;
     }
 
-    @include medium-and-up {
+    @include mixins.medium-and-up {
       justify-content: flex-start;
       flex-wrap: nowrap;
 

--- a/assets/src/scss/layout/_cookies.scss
+++ b/assets/src/scss/layout/_cookies.scss
@@ -1,3 +1,5 @@
+@use "../base/mixins" as mixins;
+
 .cookie-notice {
   font-family: var(--font-family-paragraph-secondary);
   color: var(--grey-900);
@@ -19,7 +21,7 @@
     visibility: visible;
   }
 
-  @include medium-and-up {
+  @include mixins.medium-and-up {
     width: auto;
     bottom: $sp-2;
     right: $sp-2;
@@ -34,7 +36,7 @@
     }
   }
 
-  @include large-and-up {
+  @include mixins.large-and-up {
     bottom: $sp-3;
     right: $sp-3;
 
@@ -45,7 +47,7 @@
 }
 
 .cookies-intro {
-  @include medium-and-up {
+  @include mixins.medium-and-up {
     width: 308px;
   }
 }
@@ -61,7 +63,7 @@
 .cookies-text,
 .cookies-settings-details {
   a {
-    @include shared-link-styles;
+    @include mixins.shared-link-styles;
     transition-timing-function: cubic-bezier(0.5, 0, 0, 0.5);
   }
 }
@@ -76,7 +78,7 @@
     margin-top: $sp-2;
   }
 
-  @include medium-and-up {
+  @include mixins.medium-and-up {
     display: flex;
     justify-content: space-between;
 

--- a/assets/src/scss/layout/_country-selector.scss
+++ b/assets/src/scss/layout/_country-selector.scss
@@ -1,4 +1,5 @@
 @use "../base/tokens" as tokens;
+@use "../base/mixins" as mixins;
 
 #country-selector {
   color: inherit;
@@ -16,7 +17,7 @@
   }
 
   button:focus {
-    @include focus-styles;
+    @include mixins.focus-styles;
   }
 
   button:focus:not(:focus-visible) {
@@ -97,7 +98,7 @@
 .countries-list .container {
   padding: 24px 24px $sp-4 16px;
 
-  @include medium-and-up {
+  @include mixins.medium-and-up {
     padding: 24px 0 $sp-4;
   }
 }
@@ -108,7 +109,7 @@
   margin: 0;
   padding-inline-start: $sp-4;
 
-  @include medium-and-up {
+  @include mixins.medium-and-up {
     column-count: 3;
   }
 
@@ -127,7 +128,7 @@
     list-style: none;
     padding: $sp-x 0 0 0;
 
-    @include medium-and-up {
+    @include mixins.medium-and-up {
       margin-inline-end: $sp-4;
     }
   }

--- a/assets/src/scss/layout/_featured-action.scss
+++ b/assets/src/scss/layout/_featured-action.scss
@@ -1,3 +1,5 @@
+@use "../base/mixins" as mixins;
+
 .featured-action-section {
   position: relative;
   margin-top: $sp-6x;
@@ -45,7 +47,7 @@
 
 .featured-action-section__content h5,
 .featured-action-section__content p {
-  @include clamp-text(2);
+  @include mixins.clamp-text(2);
 }
 
 .featured-action-section__content p {

--- a/assets/src/scss/layout/_featured-posts.scss
+++ b/assets/src/scss/layout/_featured-posts.scss
@@ -1,3 +1,5 @@
+@use "../base/mixins" as mixins;
+
 #featured-posts {
   background-color: var(--beige-100);
   margin-inline-start: calc(-50vw + 50%);
@@ -16,7 +18,7 @@
     padding: 0;
   }
 
-  @include mobile-only {
+  @include mixins.mobile-only {
     .container {
       padding-left: 0;
       padding-right: 0;
@@ -56,7 +58,7 @@
     }
   }
 
-  @include small-and-up {
+  @include mixins.small-and-up {
     .wp-block-post {
       &:first-child {
         flex-direction: column;
@@ -77,7 +79,7 @@
     }
   }
 
-  @include x-large-and-up {
+  @include mixins.x-large-and-up {
     .wp-block-post-template {
       display: grid;
       grid-template-columns: 1fr 1fr;

--- a/assets/src/scss/layout/_footer-social-media.scss
+++ b/assets/src/scss/layout/_footer-social-media.scss
@@ -1,17 +1,18 @@
 @use "../base/tokens" as tokens;
+@use "../base/mixins" as mixins;
 
 .footer-social-media {
   text-align: left;
   margin-bottom: 24px;
 
-  @include medium-and-up {
+  @include mixins.medium-and-up {
     margin-bottom: 0;
   }
 
   span {
     display: none;
 
-    @include large-and-up {
+    @include mixins.large-and-up {
       margin-bottom: 24px;
       display: block;
       line-height: 1;
@@ -27,7 +28,7 @@
     padding-bottom: 9px;
     border-bottom: 1px solid rgba(tokens.$white, 0.5);
 
-    @include large-and-up {
+    @include mixins.large-and-up {
       border-bottom: none;
       flex-wrap: nowrap;
     }
@@ -68,7 +69,7 @@
     margin-bottom: 0;
     padding-bottom: 0;
 
-    @include x-large-and-up {
+    @include mixins.x-large-and-up {
       justify-content: center;
     }
   }
@@ -77,7 +78,7 @@
     margin-bottom: 0;
   }
 
-  @include medium-and-up {
+  @include mixins.medium-and-up {
     margin-bottom: 24px;
   }
 }

--- a/assets/src/scss/layout/_footer.scss
+++ b/assets/src/scss/layout/_footer.scss
@@ -1,3 +1,5 @@
+@use "../base/mixins" as mixins;
+
 .site-footer {
   font-family: var(--font-family-paragraph-secondary);
   background: var(--color-background-footer);
@@ -49,12 +51,12 @@
     text-align: start;
     column-count: 1;
 
-    @include medium-and-up {
+    @include mixins.medium-and-up {
       font-size: $font-size-md;
       column-count: 3;
     }
 
-    @include large-and-up {
+    @include mixins.large-and-up {
       column-count: 2;
     }
   }
@@ -107,7 +109,7 @@
       margin-bottom: 0;
     }
 
-    @include x-large-and-up {
+    @include mixins.x-large-and-up {
       margin-bottom: 0;
 
       &:not(:last-of-type):after {
@@ -121,7 +123,7 @@
 
 .site-footer--minimal {
   .copyright .container {
-    @include large-and-up {
+    @include mixins.large-and-up {
       justify-content: center;
     }
   }

--- a/assets/src/scss/layout/_forms.scss
+++ b/assets/src/scss/layout/_forms.scss
@@ -1,6 +1,8 @@
+@use "../base/mixins" as mixins;
+
 .custom-control {
   &:has(> input[type="checkbox"]) {
-    @include custom-checkbox;
+    @include mixins.custom-checkbox;
   }
 
   input[type="radio"] {
@@ -10,7 +12,7 @@
 
     &:focus:focus-visible ~ label:before,
     &:focus:focus-visible ~ .custom-control-description:before {
-      @include focus-styles;
+      @include mixins.focus-styles;
     }
 
     &:not(:disabled) ~ .custom-control-description:hover:before,
@@ -101,11 +103,11 @@
 
 .ginput_container {
   &:has(> input[type="checkbox"]) {
-    @include custom-checkbox;
+    @include mixins.custom-checkbox;
   }
 
   &.ginput_container_fileupload input:focus {
-    @include focus-styles;
+    @include mixins.focus-styles;
   }
 }
 

--- a/assets/src/scss/layout/_gravity-forms.scss
+++ b/assets/src/scss/layout/_gravity-forms.scss
@@ -1,6 +1,7 @@
+@use "../base/mixins";
+
 @import "../base/tokens";
 @import "../base/variables";
-@import "../base/mixins";
 @import "../base/fonts";
 @import "../base/typography";
 

--- a/assets/src/scss/layout/_page-header.scss
+++ b/assets/src/scss/layout/_page-header.scss
@@ -1,3 +1,5 @@
+@use "../base/mixins" as mixins;
+
 .breadcrumbs {
   padding-top: 40px;
 
@@ -30,16 +32,16 @@
   margin-bottom: $sp-2;
   position: relative;
 
-  @include medium-and-up {
+  @include mixins.medium-and-up {
     padding-top: 104px;
   }
 
-  @include large-and-up {
+  @include mixins.large-and-up {
     padding-top: 144px;
     margin-bottom: $sp-4;
   }
 
-  @include x-large-and-up {
+  @include mixins.x-large-and-up {
     padding-top: 144px;
   }
 
@@ -49,19 +51,19 @@
   }
 
   .container > *:not(.row) {
-    @include medium-and-up {
+    @include mixins.medium-and-up {
       max-width: 581px;
     }
 
-    @include large-and-up {
+    @include mixins.large-and-up {
       max-width: 696px;
     }
 
-    @include x-large-and-up {
+    @include mixins.x-large-and-up {
       max-width: 736px;
     }
 
-    @include xx-large-and-up {
+    @include mixins.xx-large-and-up {
       max-width: 856px;
     }
   }
@@ -69,15 +71,15 @@
   h3 {
     margin-bottom: 20px;
 
-    @include medium-and-up {
+    @include mixins.medium-and-up {
       line-height: 1.2;
     }
 
-    @include large-and-up {
+    @include mixins.large-and-up {
       width: 696px;
     }
 
-    @include x-large-and-up {
+    @include mixins.x-large-and-up {
       margin-bottom: 30px;
       line-height: 1.1;
     }
@@ -85,7 +87,7 @@
 
   .tag & {
     p a {
-      @include shared-link-styles;
+      @include mixins.shared-link-styles;
     }
   }
 }
@@ -115,7 +117,7 @@
     height: 100%;
     width: 100%;
 
-    @include mobile-only {
+    @include mixins.mobile-only {
       height: 100%;
     }
   }
@@ -135,15 +137,15 @@
   max-width: 80%;
   margin-bottom: 10px;
 
-  @include medium-and-up {
+  @include mixins.medium-and-up {
     margin-bottom: 12px;
   }
 
-  @include large-and-up {
+  @include mixins.large-and-up {
     margin-bottom: 20px;
   }
 
-  @include x-large-and-up {
+  @include mixins.x-large-and-up {
     line-height: 1.1;
     margin-bottom: 20px;
   }
@@ -164,7 +166,7 @@ div.page-header {
   max-width: 80%;
   margin: 0;
 
-  @include medium-and-up {
+  @include mixins.medium-and-up {
     margin: 0 0 22px 0;
   }
 }
@@ -177,17 +179,17 @@ div.page-header {
   overflow: hidden;
   text-overflow: ellipsis;
 
-  @include medium-and-up {
+  @include mixins.medium-and-up {
     margin-top: 24px;
     width: auto;
     min-width: 300px;
   }
 
-  @include large-and-up {
+  @include mixins.large-and-up {
     margin-top: 24px;
   }
 
-  @include x-large-and-up {
+  @include mixins.x-large-and-up {
     margin-top: 36px;
   }
 }

--- a/assets/src/scss/layout/_page-section.scss
+++ b/assets/src/scss/layout/_page-section.scss
@@ -1,3 +1,5 @@
+@use "../base/mixins" as mixins;
+
 .page-section-header {
   text-transform: none;
   color: inherit;
@@ -6,7 +8,7 @@
   font-size: var(--font-size-xl--font-family-primary);
   margin-bottom: $sp-2;
 
-  @include x-large-and-up {
+  @include mixins.x-large-and-up {
     font-size: var(--font-size-2xl--font-family-primary);
   }
 }
@@ -14,11 +16,11 @@
 .page-section-description {
   margin-bottom: $sp-6;
 
-  @include medium-and-up {
+  @include mixins.medium-and-up {
     width: 100%;
   }
 
-  @include x-large-and-up {
+  @include mixins.x-large-and-up {
     .row & {
       margin-top: 0;
     }

--- a/assets/src/scss/layout/_query-loop-overrides.scss
+++ b/assets/src/scss/layout/_query-loop-overrides.scss
@@ -1,4 +1,5 @@
 @use "../base/tokens" as tokens;
+@use "../base/mixins" as mixins;
 
 .p4-query-loop {
   & > .wp-block-group {
@@ -19,7 +20,7 @@
       margin-bottom: 0;
     }
 
-    @include medium-and-less {
+    @include mixins.medium-and-less {
       .carousel {
         overflow: hidden;
         padding: $sp-x $sp-x $sp-x 0;
@@ -48,7 +49,7 @@
       }
     }
 
-    @include large-and-up {
+    @include mixins.large-and-up {
       .carousel-item {
         width: 100%;
       }
@@ -111,7 +112,7 @@
       }
     }
 
-    @include xx-large-and-up {
+    @include mixins.xx-large-and-up {
       .carousel-controls {
         width: calc(100% + calc($sp-8 * 2));
       }

--- a/assets/src/scss/layout/_tables.scss
+++ b/assets/src/scss/layout/_tables.scss
@@ -1,3 +1,5 @@
+@use "../base/mixins" as mixins;
+
 @mixin table {
   .wp-block-table {
     margin-top: $sp-1;
@@ -9,7 +11,7 @@
       }
     }
 
-    @include large-and-up {
+    @include mixins.large-and-up {
       margin-top: $sp-2;
       margin-bottom: $sp-4;
     }
@@ -20,7 +22,7 @@
     margin-bottom: 15px;
     width: 100%;
 
-    @include mobile-only {
+    @include mixins.mobile-only {
       display: block;
       overflow: auto;
     }
@@ -38,7 +40,7 @@
       font-size: $font-size-xs;
       padding: 6px $sp-2x;
       box-sizing: border-box;
-      @include x-large-and-up {
+      @include mixins.x-large-and-up {
         font-size: $font-size-md;
       }
     }
@@ -50,11 +52,11 @@
       vertical-align: top;
       color: var(--color-text-body);
 
-      @include mobile-only {
+      @include mixins.mobile-only {
         min-width: 300px;
       }
 
-      @include x-large-and-up {
+      @include mixins.x-large-and-up {
         font-size: $font-size-md;
       }
     }

--- a/assets/src/scss/layout/_wide-blocks.scss
+++ b/assets/src/scss/layout/_wide-blocks.scss
@@ -1,7 +1,9 @@
+@use "../base/mixins" as mixins;
+
 // .block-wide kept for BC of existing content.
 // Can be removed once no content uses it anymore.
 .alignfull, .block-wide {
-  @include wide-block;
+  @include mixins.wide-block;
 
   .block-editor & {
     width: 100%;

--- a/assets/src/scss/layout/navbar/_burger-menu.scss
+++ b/assets/src/scss/layout/navbar/_burger-menu.scss
@@ -1,3 +1,5 @@
+@use "../../base/mixins" as mixins;
+
 $transition-duration: .2s;
 
 @mixin slide-from-start() {
@@ -47,7 +49,7 @@ $transition-duration: .2s;
   }
 
   .admin-bar & {
-    @include medium-and-less {
+    @include mixins.medium-and-less {
       top: 46px;
       height: calc(100% - 46px);
     }
@@ -58,11 +60,11 @@ $transition-duration: .2s;
     }
   }
 
-  @include small-and-less {
+  @include mixins.small-and-less {
     width: 100vw;
   }
 
-  @include small-and-up {
+  @include mixins.small-and-up {
     width: 400px;
   }
 }
@@ -107,7 +109,7 @@ $transition-duration: .2s;
     padding: $sp-1x $sp-x 0;
   }
 
-  @include scrollbar-layout;
+  @include mixins.scrollbar-layout;
 }
 
 .burger-menu-footer {
@@ -210,7 +212,7 @@ $transition-duration: .2s;
   &:focus,
   &:focus-within,
   &:focus-visible {
-    @include focus-styles;
+    @include mixins.focus-styles;
   }
 }
 
@@ -233,7 +235,7 @@ $transition-duration: .2s;
 
   &:focus,
   &:focus-visible {
-    @include focus-styles;
+    @include mixins.focus-styles;
   }
 
   @supports not (inset-inline-end: $sp-3) {

--- a/assets/src/scss/layout/navbar/_desktop-menu.scss
+++ b/assets/src/scss/layout/navbar/_desktop-menu.scss
@@ -1,5 +1,7 @@
+@use "../../base/mixins" as mixins;
+
 #nav-main-desktop {
-  @include large-and-up {
+  @include mixins.large-and-up {
     flex-grow: 1;
     width: auto;
   }

--- a/assets/src/scss/layout/navbar/_languages.scss
+++ b/assets/src/scss/layout/navbar/_languages.scss
@@ -1,4 +1,5 @@
 @use "../../base/tokens" as tokens;
+@use "../../base/mixins" as mixins;
 
 .nav-languages-toggle {
   background: transparent;
@@ -9,7 +10,7 @@
   font-weight: 700;
   padding: 0 $sp-2;
 
-  @include large-and-up {
+  @include mixins.large-and-up {
     border-inline-start: var(--top-navigation--separation);
     display: inline-block;
     line-height: var(--navbar-menu-height);
@@ -89,7 +90,7 @@
     display: none;
   }
 
-  @include large-and-up {
+  @include mixins.large-and-up {
     inset-inline-end: 0;
     min-width: 140px;
     position: absolute;

--- a/assets/src/scss/layout/navbar/_search.scss
+++ b/assets/src/scss/layout/navbar/_search.scss
@@ -1,4 +1,5 @@
 @use "../../base/tokens" as tokens;
+@use "../../base/mixins" as mixins;
 
 .nav-search-form {
   background-color: inherit;
@@ -21,7 +22,7 @@
       top: calc(var(--navbar-menu-height--small) + 32px);
     }
 
-    @include large-and-up {
+    @include mixins.large-and-up {
       top: calc(var(--navbar-menu-height) + 32px);
     }
   }
@@ -29,7 +30,7 @@
   &.open {
     display: flex;
 
-    @include medium-and-less {
+    @include mixins.medium-and-less {
       @supports not (inset-inline-start: 0) {
         left: 100%;
         margin: auto;
@@ -46,7 +47,7 @@
       }
     }
 
-    @include small-and-less {
+    @include mixins.small-and-less {
       @supports not (inset-inline-start: 0) {
         left: 100vw;
 
@@ -57,11 +58,11 @@
     }
   }
 
-  @include large-and-up {
+  @include mixins.large-and-up {
     top: var(--navbar-menu-height);
   }
 
-  @include x-large-and-up {
+  @include mixins.x-large-and-up {
     border-inline-start: var(--top-navigation--separation);
     border-top: none;
     box-shadow: none;
@@ -88,7 +89,7 @@
   padding-inline: 12px 8px;
   width: auto;
 
-  @include small-and-less {
+  @include mixins.small-and-less {
     @supports not (padding-inline: 12px 8px) {
       padding-right: 12px;
       padding-left: 8px;
@@ -100,7 +101,7 @@
     }
   }
 
-  @include x-large-and-up {
+  @include mixins.x-large-and-up {
     color: inherit;
     width: calc(100% - 48px);
   }
@@ -141,17 +142,17 @@
     float: right;
   }
 
-  @include x-large-and-up {
+  @include mixins.x-large-and-up {
     display: inline-block;
   }
 
   &:focus {
-    @include focus-styles;
+    @include mixins.focus-styles;
   }
 }
 
 .nav-search-clear {
-  @include clear-input-styles;
+  @include mixins.clear-input-styles;
   float: right;
   margin-inline-end: 36px;
 
@@ -159,11 +160,11 @@
     float: left;
   }
 
-  @include small-and-less {
+  @include mixins.small-and-less {
     margin-inline-end: 16px;
   }
 
-  @include x-large-and-up {
+  @include mixins.x-large-and-up {
     display: inline-block;
   }
 }
@@ -180,7 +181,7 @@
   position: relative;
 
   &:focus {
-    @include focus-styles(50%);
+    @include mixins.focus-styles(50%);
   }
 
   &.open --top-navigation--search-toggle-- {
@@ -190,12 +191,12 @@
   &.medium-and-less {
     display: inline-block;
 
-    @include large-and-up {
+    @include mixins.large-and-up {
       display: none;
     }
   }
 
-  @include large-and-up {
+  @include mixins.large-and-up {
     display: inline-block;
 
     &:before {
@@ -214,7 +215,7 @@
     }
   }
 
-  @include x-large-and-up {
+  @include mixins.x-large-and-up {
     display: none;
   }
 }

--- a/assets/src/scss/layout/navbar/_site-logo.scss
+++ b/assets/src/scss/layout/navbar/_site-logo.scss
@@ -1,3 +1,5 @@
+@use "../../base/mixins" as mixins;
+
 .site-logo {
   line-height: var(--navbar-menu-height--small);
 
@@ -5,17 +7,17 @@
     height: 26px;
   }
 
-  @include large-and-up {
+  @include mixins.large-and-up {
     margin-inline-start: calc((100vw - 960px) / 2);
     line-height: var(--navbar-menu-height--large);
     padding-left: $sp-1x;
   }
 
-  @include x-large-and-up {
+  @include mixins.x-large-and-up {
     margin-inline-start: calc((100vw - 1140px) / 2);
   }
 
-  @include xx-large-and-up {
+  @include mixins.xx-large-and-up {
     margin-inline-start: calc((100vw - 1320px) / 2);
   }
 
@@ -26,7 +28,7 @@
       height: 18px;
     }
 
-    @include large-and-up {
+    @include mixins.large-and-up {
       margin-inline-start: 36px;
     }
   }

--- a/assets/src/scss/layout/navbar/mobile.scss
+++ b/assets/src/scss/layout/navbar/mobile.scss
@@ -1,3 +1,5 @@
+@use "../../base/mixins" as mixins;
+
 #nav-mobile {
   display: flex;
   flex: 1 1 100%;
@@ -9,7 +11,7 @@
   transition: height 0.2s linear;
   height: 50px;
 
-  @include large-and-up {
+  @include mixins.large-and-up {
     display: none;
   }
 

--- a/assets/src/scss/pages/_404.scss
+++ b/assets/src/scss/pages/_404.scss
@@ -1,3 +1,5 @@
+@use "../base/mixins" as mixins;
+
 .page-404-page {
   .page-header {
     min-height: 100vh;
@@ -5,15 +7,15 @@
     .page-header-subtitle {
       margin-top: 150px;
 
-      @include small-and-up {
+      @include mixins.small-and-up {
         margin-top: 30px;
       }
 
-      @include medium-and-up {
+      @include mixins.medium-and-up {
         margin-top: -10px;
       }
 
-      @include large-and-up {
+      @include mixins.large-and-up {
         margin-top: -30px;
       }
     }
@@ -38,7 +40,7 @@
     }
 
     .container > *:not(.row) {
-      @include x-large-and-up {
+      @include mixins.x-large-and-up {
         max-width: 65%;
       }
     }
@@ -52,10 +54,10 @@
     margin-bottom: 30px;
 
     a {
-      @include shared-link-styles;
+      @include mixins.shared-link-styles;
     }
 
-    @include medium-and-up {
+    @include mixins.medium-and-up {
       width: 600px;
     }
   }

--- a/assets/src/scss/pages/_author.scss
+++ b/assets/src/scss/pages/_author.scss
@@ -1,3 +1,5 @@
+@use "../base/mixins" as mixins;
+
 .author {
   .page-header {
     display: flex;
@@ -5,7 +7,7 @@
     gap: 40px;
     flex-wrap: wrap;
 
-    @include medium-and-up {
+    @include mixins.medium-and-up {
       flex-wrap: nowrap;
     }
   }
@@ -19,7 +21,7 @@
     object-fit: cover;
   }
 
-  @include mobile-only {
+  @include mixins.mobile-only {
     h1 {
       text-align: center;
     }
@@ -51,7 +53,7 @@
   justify-content: center;
 
   a {
-    @include shared-link-styles;
+    @include mixins.shared-link-styles;
   }
 }
 
@@ -59,11 +61,11 @@
   flex-shrink: 0;
   max-width: 50%;
 
-  @include small-and-up {
+  @include mixins.small-and-up {
     width: 300px;
   }
 
-  @include mobile-only {
+  @include mixins.mobile-only {
     margin: 0 auto;
   }
 

--- a/assets/src/scss/pages/_evergreen.scss
+++ b/assets/src/scss/pages/_evergreen.scss
@@ -1,3 +1,5 @@
+@use "../base/mixins" as mixins;
+
 .page-template-evergreen {
   .page-header {
     .page-header-title {
@@ -19,20 +21,20 @@
       p, blockquote,
       h1, h2, h3, h4, h5, h6,
       ul, ol {
-        @include large-and-up {
+        @include mixins.large-and-up {
           max-width: 65%;
         }
       }
 
       hr.is-style-wide, hr.is-style-dots {
-        @include large-and-up {
+        @include mixins.large-and-up {
           max-width: 65%;
           margin-left: 0;
         }
       }
 
       hr:not(.is-style-wide):not(.is-style-dots) {
-        @include large-and-up {
+        @include mixins.large-and-up {
           margin-left: calc((65% - 100px) / 2);
         }
       }

--- a/assets/src/scss/pages/_listing-page.scss
+++ b/assets/src/scss/pages/_listing-page.scss
@@ -1,3 +1,5 @@
+@use "../base/mixins" as mixins;
+
 .query-list-item-image {
   flex-basis: 30%;
 
@@ -12,11 +14,11 @@
       object-fit: cover;
       object-position: 50% 50%;
 
-      @include medium-and-up {
+      @include mixins.medium-and-up {
         height: 200px;
       }
 
-      @include large-and-up {
+      @include mixins.large-and-up {
         height: 210px;
       }
     }
@@ -47,7 +49,7 @@
 
   a {
     color: inherit;
-    @include clamp-text(1);
+    @include mixins.clamp-text(1);
     overflow-wrap: break-word;
     word-break: break-word;
     hyphens: auto;
@@ -68,7 +70,7 @@
 
   .wrapper-post-tag {
     display: flex;
-    @include render-bullet;
+    @include mixins.render-bullet;
 
     .taxonomy-post_tag a {
       margin-inline-end: $sp-x;
@@ -93,14 +95,14 @@
   font-size: $font-size-sm;
   margin-bottom: $sp-1;
   line-height: var(--line-height-m--font-family-secondary);
-  @include clamp-text(4);
+  @include mixins.clamp-text(4);
 }
 
 .query-list-item-headline.wp-block-post-title {
   font-size: $font-size-lg;
 
   a {
-    @include clamp-text(2);
+    @include mixins.clamp-text(2);
   }
 }
 
@@ -115,10 +117,10 @@
 
   .article-list-item-author {
     font-weight: var(--font-weight-semibold);
-    @include clamp-text(1);
+    @include mixins.clamp-text(1);
 
     &:focus-within {
-      @include focus-styles();
+      @include mixins.focus-styles();
     }
   }
 
@@ -132,7 +134,7 @@
 
   .article-list-item-readtime {
     display: flex;
-    @include render-bullet($sp-x);
+    @include mixins.render-bullet($sp-x);
     margin-inline-start: 5px;
   }
 
@@ -162,24 +164,24 @@
       justify-content: space-between;
       margin-top: $sp-4;
 
-      @include medium-and-up {
+      @include mixins.medium-and-up {
         flex-direction: row;
       }
     }
 
     .query-list-item-body {
-      @include medium-and-up {
+      @include mixins.medium-and-up {
         padding-inline-start: $sp-2x;
       }
     }
 
     .query-list-item-content p {
-      @include medium-and-up {
-        @include clamp-text(2);
+      @include mixins.medium-and-up {
+        @include mixins.clamp-text(2);
       }
 
-      @include large-and-up {
-        @include clamp-text(3);
+      @include mixins.large-and-up {
+        @include mixins.clamp-text(3);
       }
     }
   }
@@ -193,23 +195,23 @@
       gap: 1.25em;
 
       li {
-        @include small-and-up {
+        @include mixins.small-and-up {
           width: calc((100% / 2) - 1.25em + (1.25em / 2)) !important;
         }
 
-        @include large-and-up {
+        @include mixins.large-and-up {
           width: calc((100% / 3) - 1.25em + (1.25em / 3)) !important;
         }
 
-        @include x-large-and-up {
+        @include mixins.x-large-and-up {
           width: calc((100% / 4) - 1.25em + (1.25em / 4)) !important;
         }
       }
     }
 
     .query-list-item-headline.wp-block-post-title a {
-      @include large-and-up {
-        @include clamp-text(2);
+      @include mixins.large-and-up {
+        @include mixins.clamp-text(2);
       }
     }
 
@@ -249,7 +251,7 @@
   width: 100%;
   margin-bottom: $sp-6;
 
-  @include large-and-up {
+  @include mixins.large-and-up {
     justify-content: center;
   }
 }
@@ -307,7 +309,7 @@
     border-color: var(--grey-900);
   }
 
-  @include large-and-up {
+  @include mixins.large-and-up {
     margin: 0 $sp-5 0 !important;
   }
 }
@@ -317,7 +319,7 @@
   border-bottom-color: var(--color-border-separator);
   margin: $sp-3 0;
 
-  @include medium-and-up {
+  @include mixins.medium-and-up {
     margin: $sp-5 0;
     padding-bottom: $sp-4;
   }
@@ -330,7 +332,7 @@
     margin-bottom: 0;
   }
 
-  @include medium-and-up {
+  @include mixins.medium-and-up {
     margin-bottom: $sp-7;
   }
 }
@@ -338,7 +340,7 @@
 .layout-button-ctn {
   display: none;
 
-  @include medium-and-up {
+  @include mixins.medium-and-up {
     border-radius: 50%;
     display: inline-block;
     width: 40px;
@@ -350,7 +352,7 @@
 
     &:focus-within {
       background-color: var(--grey-200);
-      @include focus-styles(50%);
+      @include mixins.focus-styles(50%);
     }
   }
 }
@@ -384,7 +386,7 @@
       overflow: hidden;
       text-overflow: ellipsis;
 
-      @include medium-and-up {
+      @include mixins.medium-and-up {
         margin-bottom: 0;
       }
     }
@@ -394,7 +396,7 @@
     width: 100%;
   }
 
-  @include medium-and-up {
+  @include mixins.medium-and-up {
     display: flex;
 
     .listing-page-select {
@@ -407,7 +409,7 @@
     }
   }
 
-  @include small-and-less {
+  @include mixins.small-and-less {
     width: 100%;
   }
 }
@@ -424,7 +426,7 @@
   margin-bottom: $sp-1;
   color: var(--grey-600);
 
-  @include medium-and-up {
+  @include mixins.medium-and-up {
     position: absolute;
     top: -$sp-4;
     left: 0;

--- a/assets/src/scss/pages/_page.scss
+++ b/assets/src/scss/pages/_page.scss
@@ -1,3 +1,5 @@
+@use "../base/mixins" as mixins;
+
 .page-content {
   > * {
     position: relative;
@@ -18,32 +20,32 @@
   .wp-block-list a,
   > ul li a,
   > ol li a {
-    @include shared-link-styles;
+    @include mixins.shared-link-styles;
   }
 
   &.no-page-title {
     padding-top: var(--navbar-menu-height--small);
 
-    @include large-and-up {
+    @include mixins.large-and-up {
       padding-top: var(--navbar-menu-height--large);
     }
 
     & > p:first-child {
       padding-top: $sp-1;
 
-      @include small-and-up {
+      @include mixins.small-and-up {
         padding-top: $sp-1x;
       }
 
-      @include medium-and-up {
+      @include mixins.medium-and-up {
         padding-top: $sp-2;
       }
 
-      @include large-and-up {
+      @include mixins.large-and-up {
         padding-top: $sp-4;
       }
 
-      @include x-large-and-up {
+      @include mixins.x-large-and-up {
         padding-top: $sp-6;
       }
     }
@@ -102,7 +104,7 @@
     padding: 15px 14px 8px;
     width: 100%;
 
-    @include medium-and-up {
+    @include mixins.medium-and-up {
       max-width: 400px;
     }
   }
@@ -165,7 +167,7 @@
     text-overflow: ellipsis;
   }
 
-  @include large-and-up {
+  @include mixins.large-and-up {
     height: 116px;
     font-size: var(--font-size-s--font-family-primary);
   }

--- a/assets/src/scss/pages/_sitemap.scss
+++ b/assets/src/scss/pages/_sitemap.scss
@@ -1,3 +1,5 @@
+@use "../base/mixins" as mixins;
+
 .page-sitemap {
   margin-bottom: 100px;
 
@@ -23,7 +25,7 @@
   ul {
     list-style: none;
     padding-inline-start: 0;
-    @include small-and-less {
+    @include mixins.small-and-less {
       margin-bottom: 0;
     }
 

--- a/assets/src/scss/pages/post/_article-content.scss
+++ b/assets/src/scss/pages/post/_article-content.scss
@@ -1,12 +1,14 @@
+@use "../../base/mixins" as mixins;
+
 .post-content {
   margin: 24px 0;
   z-index: 3;
 
-  @include large-and-up {
+  @include mixins.large-and-up {
     max-width: 776px;
   }
 
-  @include x-large-and-up {
+  @include mixins.x-large-and-up {
     max-width: 736px;
   }
 
@@ -23,7 +25,7 @@
       font-family: var(--font-family-heading);
     }
 
-    @include medium-and-up {
+    @include mixins.medium-and-up {
       min-height: 365px;
       width: 290px;
       float: right;
@@ -34,11 +36,11 @@
       }
     }
 
-    @include large-and-up {
+    @include mixins.large-and-up {
       margin-left: 0;
     }
 
-    @include x-large-and-up {
+    @include mixins.x-large-and-up {
       width: 330px;
       min-height: 415px;
     }
@@ -48,15 +50,15 @@
     margin-bottom: 15px;
     padding-top: 8px;
 
-    @include medium-and-up {
+    @include mixins.medium-and-up {
       padding-top: 10px;
     }
 
-    @include large-and-up {
+    @include mixins.large-and-up {
       margin-bottom: 20px;
     }
 
-    @include x-large-and-up {
+    @include mixins.x-large-and-up {
       padding-top: 20px;
       margin-bottom: 20px;
     }
@@ -67,7 +69,7 @@
     overflow-wrap: break-word;
     word-wrap: break-word;
 
-    @include medium-and-up {
+    @include mixins.medium-and-up {
       margin: 0 0 $sp-2x 0;
     }
 
@@ -80,20 +82,20 @@
       border: none;
       overflow: hidden;
 
-      @include small-and-up {
+      @include mixins.small-and-up {
         height: 290px;
       }
 
-      @include medium-and-up {
+      @include mixins.medium-and-up {
         height: 390px;
         padding: 0;
       }
 
-      @include large-and-up {
+      @include mixins.large-and-up {
         height: 350px;
       }
 
-      @include x-large-and-up {
+      @include mixins.x-large-and-up {
         height: 410px;
       }
     }
@@ -107,7 +109,7 @@
       margin-top: $sp-2;
       margin-bottom: $sp-6;
 
-      @include large-and-up {
+      @include mixins.large-and-up {
         margin-top: $sp-4;
         margin-bottom: $sp-8;
       }
@@ -160,7 +162,7 @@
       float: left;
       margin-top: 0;
 
-      @include mobile-only {
+      @include mixins.mobile-only {
         width: calc(50% - 10px);
       }
 
@@ -206,19 +208,19 @@
       font-family: var(--font-family-heading);
       padding-top: 0;
       padding-bottom: 0;
-      @include clamp-text(2);
+      @include mixins.clamp-text(2);
     }
 
     .article-list-item-content {
       width: 100%;
-      @include clamp-text(3);
+      @include mixins.clamp-text(3);
 
-      @include medium-and-up {
-        @include clamp-text(2);
+      @include mixins.medium-and-up {
+        @include mixins.clamp-text(2);
       }
 
-      @include large-and-up {
-        @include clamp-text(3);
+      @include mixins.large-and-up {
+        @include mixins.clamp-text(3);
       }
     }
 
@@ -228,11 +230,11 @@
     }
 
     .article-list-item-image img {
-      @include medium-and-up {
+      @include mixins.medium-and-up {
         height: 180px;
       }
 
-      @include large-and-up {
+      @include mixins.large-and-up {
         height: 210px;
       }
     }
@@ -263,7 +265,7 @@
   .wp-block-list a,
   > ul li a,
   > ol li a {
-    @include shared-link-styles;
+    @include mixins.shared-link-styles;
   }
 }
 
@@ -278,7 +280,7 @@
     margin-bottom: $sp-6;
     margin-top: $sp-2;
 
-    @include large-and-up {
+    @include mixins.large-and-up {
       margin-bottom: $sp-8;
       margin-top: $sp-4;
     }
@@ -289,7 +291,7 @@
     height: auto;
   }
 
-  @include medium-and-up {
+  @include mixins.medium-and-up {
     .image-credit {
       position: absolute;
       text-align: right;

--- a/assets/src/scss/pages/post/_author-block.scss
+++ b/assets/src/scss/pages/post/_author-block.scss
@@ -1,3 +1,5 @@
+@use "../../base/mixins" as mixins;
+
 .author-block {
   background: var(--color-background-author_block);
   overflow: hidden;
@@ -5,7 +7,7 @@
   border-radius: 4px;
   margin-bottom: 24px;
 
-  @include medium-and-up {
+  @include mixins.medium-and-up {
     display: flex;
     padding: 24px;
 
@@ -16,11 +18,11 @@
     }
   }
 
-  @include large-and-up {
+  @include mixins.large-and-up {
     max-width: 776px;
   }
 
-  @include x-large-and-up {
+  @include mixins.x-large-and-up {
     max-width: 736px;
   }
 }
@@ -42,7 +44,7 @@
     object-fit: cover;
   }
 
-  @include small-and-less {
+  @include mixins.small-and-less {
     margin: auto;
   }
 }
@@ -57,7 +59,7 @@
 
 .author-block-info-name,
 .author-block-info-title {
-  @include medium-and-up {
+  @include mixins.medium-and-up {
     text-align: inherit;
     margin: 8px 0;
   }
@@ -76,7 +78,7 @@
   }
 
   a {
-    @include shared-link-styles;
+    @include mixins.shared-link-styles;
   }
 }
 
@@ -112,7 +114,7 @@
   }
 
   &:focus {
-    @include focus-styles;
+    @include mixins.focus-styles;
   }
 
   &:after {

--- a/assets/src/scss/pages/post/_comments-block.scss
+++ b/assets/src/scss/pages/post/_comments-block.scss
@@ -1,5 +1,7 @@
+@use "../../base/mixins" as mixins;
+
 // Adds nesting on comments
-@include comment-level;
+@include mixins.comment-level;
 
 .comments-block {
   h3 {
@@ -25,7 +27,7 @@
   overflow-wrap: break-word;
 
   a {
-    @include shared-link-styles;
+    @include mixins.shared-link-styles;
   }
 }
 
@@ -51,11 +53,11 @@
     font-size: 14px;
     margin-top: $sp-2;
     width: fit-content;
-    @include shared-link-styles;
+    @include mixins.shared-link-styles;
   }
 }
 
-@include medium-and-up {
+@include mixins.medium-and-up {
   .single-comment-meta {
     .comment-reply-link {
       font-family: var(--font-family-primary);
@@ -70,13 +72,13 @@
   }
 }
 
-@include large-and-up {
+@include mixins.large-and-up {
   .comments-block {
     max-width: 696px;
   }
 }
 
-@include x-large-and-up {
+@include mixins.x-large-and-up {
   .comments-block {
     max-width: 736px;
   }

--- a/assets/src/scss/pages/post/_comments-form.scss
+++ b/assets/src/scss/pages/post/_comments-form.scss
@@ -1,3 +1,5 @@
+@use "../../base/mixins" as mixins;
+
 .comments-block {
   font-family: var(--font-family-paragraph-secondary);
 
@@ -28,7 +30,7 @@
       margin-bottom: 0;
     }
 
-    @include medium-and-up {
+    @include mixins.medium-and-up {
       .comment-author,
       .comment-email {
         width: calc(50% - $sp-1);
@@ -88,7 +90,7 @@
   }
 }
 
-@include medium-and-up {
+@include mixins.medium-and-up {
   .comments-block .form-section .comment-respond {
     padding: $sp-4;
   }

--- a/assets/src/scss/pages/post/_post.scss
+++ b/assets/src/scss/pages/post/_post.scss
@@ -1,4 +1,6 @@
-@include large-and-up {
+@use "../../base/mixins" as mixins;
+
+@include mixins.large-and-up {
   .narrow-container {
     margin-left: auto;
     margin-right: auto;
@@ -7,7 +9,7 @@
   }
 }
 
-@include x-large-and-up {
+@include mixins.x-large-and-up {
   .narrow-container {
     max-width: 736px;
   }
@@ -95,7 +97,7 @@
       margin-top: $sp-3;
     }
 
-    @include medium-and-up {
+    @include mixins.medium-and-up {
       padding-top: $sp-3;
     }
   }
@@ -110,7 +112,7 @@
   padding: $sp-3;
   margin-top: $sp-3;
 
-  @include medium-and-up {
+  @include mixins.medium-and-up {
     padding: $sp-3 $sp-8;
   }
 

--- a/assets/src/scss/pages/search/_filter-modal.scss
+++ b/assets/src/scss/pages/search/_filter-modal.scss
@@ -1,3 +1,5 @@
+@use "../../base/mixins" as mixins;
+
 .filter-modal {
   .modal-dialog {
     max-width: 90%;
@@ -6,7 +8,7 @@
   .modal-body {
     padding: $sp-4 15px;
 
-    @include small-and-up {
+    @include mixins.small-and-up {
       padding: $sp-6x;
     }
   }
@@ -15,7 +17,7 @@
     font-size: 1.625rem;
     margin-bottom: 24px;
 
-    @include small-and-up {
+    @include mixins.small-and-up {
       font-size: 2.125rem;
     }
   }

--- a/assets/src/scss/pages/search/_filter-sidebar.scss
+++ b/assets/src/scss/pages/search/_filter-sidebar.scss
@@ -1,3 +1,5 @@
+@use "../../base/mixins" as mixins;
+
 .filter-sidebar {
   position: relative;
 
@@ -25,13 +27,13 @@
       font-size: $font-size-sm;
       margin-bottom: 24px;
 
-      @include small-and-up {
+      @include mixins.small-and-up {
         padding: 13px $sp-4;
         font-size: 1.125rem;
         margin-bottom: 32px;
       }
 
-      @include large-and-up {
+      @include mixins.large-and-up {
         padding: 11px $sp-4;
         font-size: $font-size-md;
       }
@@ -115,7 +117,7 @@
       left: auto;
     }
 
-    @include small-and-up {
+    @include mixins.small-and-up {
       margin-top: -14px;
     }
 
@@ -135,7 +137,7 @@
         margin-right: 20px;
       }
 
-      @include small-and-up {
+      @include mixins.small-and-up {
         font-size: $font-size-sm;
         height: 48px;
         width: 150px;

--- a/assets/src/scss/pages/search/_filtered-tags.scss
+++ b/assets/src/scss/pages/search/_filtered-tags.scss
@@ -1,3 +1,5 @@
+@use "../../base/mixins" as mixins;
+
 .search-info {
   font-size: $font-size-xxs;
   margin-bottom: 0;
@@ -6,15 +8,15 @@
   color: var(--grey-800);
   line-height: normal;
 
-  @include medium-and-up {
+  @include mixins.medium-and-up {
     font-size: 1.125rem;
   }
 
-  @include large-and-up {
+  @include mixins.large-and-up {
     font-size: $font-size-xl;
   }
 
-  @include x-large-and-up {
+  @include mixins.x-large-and-up {
     font-size: 2rem;
   }
 }

--- a/assets/src/scss/pages/search/_search-bar.scss
+++ b/assets/src/scss/pages/search/_search-bar.scss
@@ -1,4 +1,5 @@
 @use "../../base/tokens" as tokens;
+@use "../../base/mixins" as mixins;
 
 .search-bar {
   width: 100%;
@@ -7,7 +8,7 @@
   border-radius: 4px;
   border: 1px solid var(--grey-300);
 
-  @include small-and-up {
+  @include mixins.small-and-up {
     padding: 32px;
   }
 
@@ -33,7 +34,7 @@
       visibility: hidden;
     }
 
-    @include large-and-up {
+    @include mixins.large-and-up {
       font-size: 1.125rem;
       line-height: 3;
     }
@@ -45,7 +46,7 @@
   }
 
   .clear-search {
-    @include clear-input-styles;
+    @include mixins.clear-input-styles;
     position: absolute;
     right: $sp-3;
     top: 0;
@@ -67,7 +68,7 @@
       margin-top: -3px;
     }
 
-    @include medium-and-up {
+    @include mixins.medium-and-up {
       margin-inline-start: $sp-3;
     }
 
@@ -77,7 +78,7 @@
       float: left;
       margin-top: 22px;
 
-      @include large-and-up {
+      @include mixins.large-and-up {
         margin-top: 27px;
       }
     }

--- a/assets/src/scss/pages/search/_search-results.scss
+++ b/assets/src/scss/pages/search/_search-results.scss
@@ -1,15 +1,17 @@
+@use "../../base/mixins" as mixins;
+
 .search-result-list {
   height: 150px;
 
-  @include small-and-up {
+  @include mixins.small-and-up {
     height: 120px;
   }
 
-  @include large-and-up {
+  @include mixins.large-and-up {
     height: 235px;
   }
 
-  @include x-large-and-up {
+  @include mixins.x-large-and-up {
     height: 208px;
   }
 }
@@ -22,7 +24,7 @@
   height: 100%;
   padding-top: 100px;
 
-  @include small-and-up {
+  @include mixins.small-and-up {
     padding-top: 32px;
   }
 
@@ -43,7 +45,7 @@
           width: 100%;
         }
 
-        @include small-and-up {
+        @include mixins.small-and-up {
           width: 25%;
           min-width: 25%;
           margin-inline-end: 32px;
@@ -60,7 +62,7 @@
   .more-btn {
     margin-top: 25px;
 
-    @include large-and-up {
+    @include mixins.large-and-up {
       margin-top: 35px;
     }
   }
@@ -74,7 +76,7 @@
       width: 100%;
     }
 
-    @include medium-and-up {
+    @include mixins.medium-and-up {
       display: flex;
     }
   }
@@ -83,7 +85,7 @@
     margin-top: $sp-3;
     width: 100%;
 
-    @include medium-and-up {
+    @include mixins.medium-and-up {
       width: auto;
     }
 
@@ -91,7 +93,7 @@
       margin-bottom: $sp-3;
       white-space: nowrap;
 
-      @include medium-and-up {
+      @include mixins.medium-and-up {
         padding: 0 $sp-2;
         margin-left: $sp-2;
         margin-top: 0;
@@ -119,12 +121,12 @@
       line-height: $sp-4;
       margin-bottom: 10px;
 
-      @include medium-and-up {
+      @include mixins.medium-and-up {
         display: none;
       }
     }
 
-    @include medium-and-up {
+    @include mixins.medium-and-up {
       padding: 0 $sp-3;
       display: block;
       width: auto;
@@ -149,7 +151,7 @@
   width: 100%;
   float: left;
 
-  @include small-and-up {
+  @include mixins.small-and-up {
     position: absolute;
     right: 0;
     top: 0;
@@ -162,7 +164,7 @@
   margin-bottom: 10px;
   font-size: $font-size-xxs;
 
-  @include large-and-up {
+  @include mixins.large-and-up {
     font-size: $font-size-xs;
   }
 }
@@ -173,7 +175,7 @@
   line-height: 1.6;
   margin-bottom: $sp-1;
 
-  @include large-and-up {
+  @include mixins.large-and-up {
     font-size: 1.125rem;
   }
 }
@@ -205,7 +207,7 @@
   }
 
   .tags {
-    @include mobile-only {
+    @include mixins.mobile-only {
       margin-top: 5px;
     }
   }

--- a/assets/src/scss/pages/search/_search.scss
+++ b/assets/src/scss/pages/search/_search.scss
@@ -1,3 +1,5 @@
+@use "../../base/mixins" as mixins;
+
 .search {
   .multiple-search-result .more-btn {
     width: auto;
@@ -8,7 +10,7 @@
 .search-block {
   padding-top: 56px;
 
-  @include small-and-up {
+  @include mixins.small-and-up {
     padding-top: 64px;
   }
 }
@@ -18,15 +20,15 @@
   margin-bottom: 8px;
   line-height: 1.2;
 
-  @include small-and-up {
+  @include mixins.small-and-up {
     font-size: $font-size-xxxl;
   }
 
-  @include large-and-up {
+  @include mixins.large-and-up {
     font-size: 3.5rem;
   }
 
-  @include x-large-and-up {
+  @include mixins.x-large-and-up {
     font-size: 4.125rem;
   }
 }
@@ -35,7 +37,7 @@
 .search-result {
   margin-top: 94px;
 
-  @include x-large-and-up {
+  @include mixins.x-large-and-up {
     margin-top: 120px;
   }
 
@@ -46,18 +48,18 @@
     color: var(--grey-800);
     line-height: 1.8;
 
-    @include small-and-up {
+    @include mixins.small-and-up {
       font-size: 1.125rem;
       margin-bottom: 32px;
       padding-left: 20px;
     }
 
-    @include large-and-up {
+    @include mixins.large-and-up {
       margin-bottom: 45px;
       padding-left: 30px;
     }
 
-    @include x-large-and-up {
+    @include mixins.x-large-and-up {
       font-size: $font-size-lg;
       margin-bottom: 40px;
       padding-left: 50px;

--- a/assets/src/scss/pages/search/_sort-filter.scss
+++ b/assets/src/scss/pages/search/_sort-filter.scss
@@ -1,12 +1,14 @@
+@use "../../base/mixins" as mixins;
+
 div.search-filter-results {
   margin-top: 48px;
   z-index: auto;
 
-  @include small-and-up {
+  @include mixins.small-and-up {
     margin-top: 75px;
   }
 
-  @include large-and-up {
+  @include mixins.large-and-up {
     margin-top: 100px;
   }
 }
@@ -21,7 +23,7 @@ div.search-filter-results {
     text-align: left;
   }
 
-  @include small-and-up {
+  @include mixins.small-and-up {
     width: 100%;
     float: none;
 
@@ -33,7 +35,7 @@ div.search-filter-results {
   .select-container {
     margin-top: -7px;
 
-    @include small-and-up {
+    @include mixins.small-and-up {
       margin-top: -14px;
     }
   }
@@ -43,15 +45,15 @@ div.search-filter-results {
     margin-inline-end: 90px;
     font-weight: bold;
 
-    @include small-and-up {
+    @include mixins.small-and-up {
       margin-inline-end: 0.5rem;
     }
 
-    @include large-and-up {
+    @include mixins.large-and-up {
       font-size: 1.625rem;
     }
 
-    @include large-and-up {
+    @include mixins.large-and-up {
       font-size: $font-size-xl;
     }
   }
@@ -60,15 +62,15 @@ div.search-filter-results {
     width: 151px;
     display: inline-block;
 
-    @include small-and-up {
+    @include mixins.small-and-up {
       width: 210px;
     }
 
-    @include large-and-up {
+    @include mixins.large-and-up {
       width: 224px;
     }
 
-    @include large-and-up {
+    @include mixins.large-and-up {
       width: 270px;
     }
   }

--- a/assets/src/scss/pages/search/_suggested-terms.scss
+++ b/assets/src/scss/pages/search/_suggested-terms.scss
@@ -1,4 +1,5 @@
 @use "../../base/tokens" as tokens;
+@use "../../base/mixins" as mixins;
 
 .suggested-search-terms {
   margin: $sp-6x 0 104px;
@@ -7,11 +8,11 @@
     font-size: 1.625rem;
     margin-bottom: 16px;
 
-    @include small-and-up {
+    @include mixins.small-and-up {
       font-size: 2.125rem;
     }
 
-    @include large-and-up {
+    @include mixins.large-and-up {
       font-size: 2.25rem;
     }
   }
@@ -29,7 +30,7 @@
   li {
     text-align: center;
 
-    @include medium-and-up {
+    @include mixins.medium-and-up {
       text-align: left;
     }
 
@@ -38,15 +39,15 @@
       font-size: 1.125rem;
       line-height: 2.3;
 
-      @include medium-and-up {
+      @include mixins.medium-and-up {
         font-size: $font-size-lg;
       }
 
-      @include large-and-up {
+      @include mixins.large-and-up {
         font-size: 1.125rem;
       }
 
-      @include x-large-and-up {
+      @include mixins.x-large-and-up {
         font-size: $font-size-lg;
       }
     }

--- a/assets/src/scss/post.scss
+++ b/assets/src/scss/post.scss
@@ -2,7 +2,6 @@
 @import "base/variables";
 @import "base/fonts";
 @import "base/functions";
-@import "base/mixins";
 
 // Posts
 @import "pages/post/post";

--- a/assets/src/scss/style.scss
+++ b/assets/src/scss/style.scss
@@ -15,7 +15,6 @@ Text Domain: planet4-master-theme
 @import "base/variables";
 @import "base/palette";
 @import "base/functions";
-@import "base/mixins";
 @import "base/fonts";
 @import "base/typography";
 @import "base/icons";
@@ -95,7 +94,7 @@ Text Domain: planet4-master-theme
 
 // Override Navbar styles for Homepage only
 body.transparent-nav {
-  @include x-large-and-up {
+  @include mixins.x-large-and-up {
     .page-content {
       padding-top: 0;
     }
@@ -171,6 +170,29 @@ body.transparent-nav {
 .wp-block-button.carousel-control-next,
 .wp-block-button.carousel-control-prev {
   &:focus-within {
-    @include focus-styles();
+    @include mixins.focus-styles();
   }
+}
+
+.is-style-space-evenly {
+  gap: 24px !important;
+
+  & > * {
+    flex-grow: 1;
+    flex-basis: 100%;
+    align-self: stretch;
+
+    @include mixins.medium-and-up {
+      flex-grow: 0;
+      flex-basis: calc(50% - 12px);
+    }
+
+    @include mixins.large-and-up {
+      flex-basis: calc(25% - 18px);
+    }
+  }
+}
+
+.is-style-reset-margin {
+  margin: 0 !important;
 }

--- a/assets/src/scss/vendors/_usabilla.scss
+++ b/assets/src/scss/vendors/_usabilla.scss
@@ -1,5 +1,7 @@
+@use "../base/mixins" as mixins;
+
 body div.usabilla_live_button_container {
-  @include medium-and-up {
+  @include mixins.medium-and-up {
     top: auto !important;
     bottom: 25% !important;
   }


### PR DESCRIPTION
### Summary

In [Dart Sass](https://sass-lang.com/dart-sass/), `@import` [is deprecated](https://sass-lang.com/documentation/breaking-changes/import/) and will eventually be removed.
The module system (`@use` and `@forward` rules) should be used as a replacement.
Considering that, this PR replaces `@import` with the module system in all SCSS files related to **mixins**.
In the following PRs, the rest of the SCSS files will be replaced as well.

---

Ref: 
- https://greenpeace-planet4.atlassian.net/browse/PLANET-8052
- https://github.com/greenpeace/planet4-master-theme/pull/2421
- https://github.com/greenpeace/planet4-master-theme/pull/2868
- https://github.com/greenpeace/planet4-master-theme/pull/2915

### Testing

1. Review the website.
2. Check that all the elements affected by the changed styles look as they should (unaffected).
