### PR TITLE
PLANET-8003: Enhance CarouselHeader focus interaction

### DIFF
--- a/assets/src/blocks/CarouselHeader/CarouselControls.js
+++ b/assets/src/blocks/CarouselHeader/CarouselControls.js
@@ -70,4 +70,4 @@ export const CarouselControls = forwardRef(({
       </div>
     </div>
   </>
-), [currentSlide, disableControls, autoplay, slides, goToPrevSlide, goToNextSlide, goToSlide, handleAutoplay]));
+), [currentSlide, disableControls, autoplay, slides, ref, goToPrevSlide, goToNextSlide, goToSlide, handleAutoplay]));

--- a/assets/src/blocks/CarouselHeader/CarouselControls.js
+++ b/assets/src/blocks/CarouselHeader/CarouselControls.js
@@ -1,7 +1,7 @@
-const {useMemo} = wp.element;
+const {useMemo, forwardRef} = wp.element;
 const {__, sprintf} = wp.i18n;
 
-export const CarouselControls = ({
+export const CarouselControls = forwardRef(({
   goToPrevSlide = () => {},
   goToNextSlide = () => {},
   goToSlide = () => {},
@@ -10,7 +10,7 @@ export const CarouselControls = ({
   slides = null,
   autoplay,
   disableControls,
-}) => useMemo(() => (
+}, ref) => useMemo(() => (
   <>
     {/* Arrows */}
     <nav aria-label={__('Greenpeace highlights carousel controls', 'planet4-master-theme')}>
@@ -26,36 +26,33 @@ export const CarouselControls = ({
     {/* Indicators */}
     <div className="carousel-indicators-wrapper">
       <div className="container">
-        <ol className="carousel-indicators" tabIndex={-1}>
-          {
-            slides.map((_, index) =>
-              <li
-                key={index}
-                {...(index === currentSlide) ? {
-                  className: 'active',
-                } : {}}
-              >
-                <button
-                  onClick={() => {
-                    if (index !== currentSlide) {
-                      goToSlide(index);
-                    }
-                  }}
-                  tabIndex={0}
-                  onKeyDown={e => {
-                    if ((e.key === 'Enter' || e.key === ' ') && index !== currentSlide) {
-                      e.preventDefault();
-                      goToSlide(index);
-                    }
-                  }}
-                  // translators: %s: slide index
-                  aria-label={sprintf(__('Go to slide %s', 'planet4-master-theme'), index + 1)}
-                  aria-current={index === currentSlide ? 'true' : undefined}
-                />
-              </li>
-            )
-          }
+        <ol className="carousel-indicators" tabIndex={-1} ref={ref}>
+          {slides.map((_, index) => (
+            <li
+              key={index}
+              {...(index === currentSlide ? {className: 'active'} : {})}
+            >
+              <button
+                onClick={() => {
+                  if (index !== currentSlide) {
+                    goToSlide(index);
+                  }
+                }}
+                tabIndex={0}
+                onKeyDown={e => {
+                  if ((e.key === 'Enter' || e.key === ' ') && index !== currentSlide) {
+                    e.preventDefault();
+                    goToSlide(index);
+                  }
+                }}
+                // translators: %s: slide header
+                aria-label={sprintf(__('Go to %s slide', 'planet4-master-theme'), slides[index].header)}
+                aria-current={index === currentSlide ? 'true' : undefined}
+              />
+            </li>
+          ))}
         </ol>
+
         {disableControls && (
           <>
             <button
@@ -73,4 +70,4 @@ export const CarouselControls = ({
       </div>
     </div>
   </>
-), [currentSlide, disableControls, autoplay, slides, goToPrevSlide, goToNextSlide, goToSlide, handleAutoplay]);
+), [currentSlide, disableControls, autoplay, slides, goToPrevSlide, goToNextSlide, goToSlide, handleAutoplay]));

--- a/assets/src/blocks/CarouselHeader/CarouselHeaderFrontend.js
+++ b/assets/src/blocks/CarouselHeader/CarouselHeaderFrontend.js
@@ -10,6 +10,8 @@ const {__} = wp.i18n;
 export const CarouselHeaderFrontend = ({slides, carousel_autoplay, className, decoding}) => {
   const slidesRef = useRef([]);
   const containerRef = useRef(null);
+  const headingsRef = useRef([]);
+  const indicatorsRef = useRef();
   const {
     currentSlide,
     goToSlide,
@@ -18,7 +20,7 @@ export const CarouselHeaderFrontend = ({slides, carousel_autoplay, className, de
     handleAutoplay,
     setAutoplay,
     autoplay,
-  } = useSlides(slidesRef, slides.length, containerRef, carousel_autoplay);
+  } = useSlides(slidesRef, slides.length, containerRef, carousel_autoplay, headingsRef, indicatorsRef);
 
   return useMemo(() => (
     <section
@@ -36,7 +38,7 @@ export const CarouselHeaderFrontend = ({slides, carousel_autoplay, className, de
             ref={element => slidesRef ? slidesRef.current[index] = element : null}
           >
             <SlideBackground decoding={decoding} slide={slide} />
-            <StaticCaption slide={slide} focusable={currentSlide === index} />
+            <StaticCaption slide={slide} focusable={currentSlide === index} ref={el => (headingsRef.current[index] = el)} />
           </Slide>)
           }
         </ul>
@@ -57,6 +59,7 @@ export const CarouselHeaderFrontend = ({slides, carousel_autoplay, className, de
           currentSlide={currentSlide}
           autoplay={autoplay}
           disableControls={carousel_autoplay}
+          ref={indicatorsRef}
         />
       )}
     </section>

--- a/assets/src/blocks/CarouselHeader/Slide.js
+++ b/assets/src/blocks/CarouselHeader/Slide.js
@@ -8,6 +8,8 @@ export const SlideWithRef = ({
   <li
     className={`carousel-item ${active ? 'active' : ''}`}
     tabIndex={focusable ? 0 : -1}
+    // eslint-disable-next-line react/no-unknown-property
+    area-hidden={focusable ? 'false' : 'true'}
     ref={ref}
     role="tabpanel"
     alt=""

--- a/assets/src/blocks/CarouselHeader/StaticCaption.js
+++ b/assets/src/blocks/CarouselHeader/StaticCaption.js
@@ -1,21 +1,21 @@
-const {useMemo} = wp.element;
+const {useMemo, forwardRef} = wp.element;
 
 const htmlDecode = input => {
   const doc = new DOMParser().parseFromString(input, 'text/html');
   return doc.documentElement.textContent;
 };
 
-export const StaticCaption = ({slide, focusable}) => useMemo(() => (
+export const StaticCaption = forwardRef(({slide, focusable}, ref) => useMemo(() => (
   <div className="carousel-caption">
     <div className="caption-overlay"></div>
     <div className="container main-header">
       <div className="carousel-captions-wrapper">
-        <h2>
+        <h2 ref={ref} tabIndex={focusable ? 0 : -1}>
           {htmlDecode(slide.header)}
         </h2>
         <p dangerouslySetInnerHTML={{__html: slide.description}} />
       </div>
-      {slide.link_url &&
+      {slide.link_url && (
         <div className="col-xs-12 col-sm-8 col-md-4 action-button">
           <a
             href={slide.link_url}
@@ -23,15 +23,13 @@ export const StaticCaption = ({slide, focusable}) => useMemo(() => (
             data-ga-category="Carousel Header"
             data-ga-action="Call to Action"
             data-ga-label={slide.index}
-            {...slide.link_url_new_tab && {rel: 'noreferrer noopener', target: '_blank'}}
+            {...(slide.link_url_new_tab && {rel: 'noreferrer noopener', target: '_blank'})}
             tabIndex={focusable ? 0 : -1}
           >
-            <span>
-              {slide.link_text}
-            </span>
+            <span>{slide.link_text}</span>
           </a>
         </div>
-      }
+      )}
     </div>
   </div>
-), [slide, focusable]);
+), [slide, focusable, ref]));

--- a/assets/src/blocks/CarouselHeader/StaticCaption.js
+++ b/assets/src/blocks/CarouselHeader/StaticCaption.js
@@ -10,6 +10,7 @@ export const StaticCaption = forwardRef(({slide, focusable}, ref) => useMemo(() 
     <div className="caption-overlay"></div>
     <div className="container main-header">
       <div className="carousel-captions-wrapper">
+        {/* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex */}
         <h2 ref={ref} tabIndex={focusable ? 0 : -1}>
           {htmlDecode(slide.header)}
         </h2>

--- a/assets/src/blocks/CarouselHeader/useSlides.js
+++ b/assets/src/blocks/CarouselHeader/useSlides.js
@@ -29,7 +29,15 @@ export const useSlides = (
   carousel_autoplay,
   headingsRef,
   indicatorsRef,
-  options = {
+  options
+) => {
+  const [autoplay, setAutoplay] = useState(carousel_autoplay);
+  const [currentSlide, setCurrentSlide] = useState(0);
+  const [sliding, setSliding] = useState(false);
+  // Set up the autoplay for the slides
+  const timerRef = useRef(null);
+
+  options = options || {
     // Following Bootstrap's approach for RTL:
     // https://getbootstrap.com/docs/5.0/getting-started/rtl/#approach
     // Note: in non-directional transitions (e.g.: fade out),
@@ -42,12 +50,7 @@ export const useSlides = (
       next: 'exit-to-start',
       prev: 'exit-to-end',
     },
-  }) => {
-  const [autoplay, setAutoplay] = useState(carousel_autoplay);
-  const [currentSlide, setCurrentSlide] = useState(0);
-  const [sliding, setSliding] = useState(false);
-  // Set up the autoplay for the slides
-  const timerRef = useRef(null);
+  };
 
   const handleAutoplay = useCallback(() => {
     setAutoplay(!autoplay);
@@ -174,7 +177,7 @@ export const useSlides = (
   }, [totalSlides, autoplay, timerRef, goToNextSlide]);
 
   useEffect(() => {
-    if(!headingsRef || !headingsRef.current || !indicatorsRef || !indicatorsRef.current) {
+    if(!headingsRef?.current || !indicatorsRef?.current) {
       return;
     }
 

--- a/assets/src/blocks/CarouselHeader/useSlides.js
+++ b/assets/src/blocks/CarouselHeader/useSlides.js
@@ -16,23 +16,33 @@ const activeClass = 'active';
  * @param {*}       totalSlides
  * @param {*}       containerRef
  * @param {boolean} carousel_autoplay
+ * @param {*}       headingsRef
+ * @param {*}       indicatorsRef
  * @param {Object}  options
  * @return {*} functions for the carousel header slides
  */
-export const useSlides = (slidesRef, totalSlides, containerRef, carousel_autoplay, options = {
-  // Following Bootstrap's approach for RTL:
-  // https://getbootstrap.com/docs/5.0/getting-started/rtl/#approach
-  // Note: in non-directional transitions (e.g.: fade out),
-  // these could have the same class for both directions.
-  enterTransitionClasses: {
-    next: 'enter-from-end',
-    prev: 'enter-from-start',
-  },
-  exitTransitionClasses: {
-    next: 'exit-to-start',
-    prev: 'exit-to-end',
-  },
-}) => {
+
+export const useSlides = (
+  slidesRef,
+  totalSlides,
+  containerRef,
+  carousel_autoplay,
+  headingsRef,
+  indicatorsRef,
+  options = {
+    // Following Bootstrap's approach for RTL:
+    // https://getbootstrap.com/docs/5.0/getting-started/rtl/#approach
+    // Note: in non-directional transitions (e.g.: fade out),
+    // these could have the same class for both directions.
+    enterTransitionClasses: {
+      next: 'enter-from-end',
+      prev: 'enter-from-start',
+    },
+    exitTransitionClasses: {
+      next: 'exit-to-start',
+      prev: 'exit-to-end',
+    },
+  }) => {
   const [autoplay, setAutoplay] = useState(carousel_autoplay);
   const [currentSlide, setCurrentSlide] = useState(0);
   const [sliding, setSliding] = useState(false);
@@ -97,6 +107,12 @@ export const useSlides = (slidesRef, totalSlides, containerRef, carousel_autopla
       activeElement.classList.add(exitTransitionClass);
       nextElement.classList.add(enterTransitionClass);
 
+      // // Force to focus heading
+      const heading = nextElement.querySelector('h2');
+      if(heading) {
+        heading.focus();
+      }
+
       const unsetTransitionClasses = () => {
         activeElement.removeEventListener('transitionend', unsetTransitionClasses);
         activeElement.classList.remove(exitTransitionClass);
@@ -157,6 +173,20 @@ export const useSlides = (slidesRef, totalSlides, containerRef, carousel_autopla
     }
   }, [totalSlides, autoplay, timerRef, goToNextSlide]);
 
+  useEffect(() => {
+    if(!headingsRef || !headingsRef.current || !indicatorsRef || !indicatorsRef.current) {
+      return;
+    }
+
+    const totalIndicators = indicatorsRef.current.children.length;
+    for (const heading of headingsRef.current) {
+      heading.addEventListener('focusout', () => {
+        const nextIndicator = (currentSlide + 1) < totalIndicators ? (currentSlide + 1) : 0;
+        indicatorsRef.current.children[nextIndicator].querySelector('button').focus();
+      });
+    }
+  }, [headingsRef, indicatorsRef, currentSlide]);
+
   return {
     totalSlides,
     currentSlide,
@@ -168,5 +198,7 @@ export const useSlides = (slidesRef, totalSlides, containerRef, carousel_autopla
     setAutoplay,
     setCarouselHeight,
     autoplay,
+    headingsRef,
+    indicatorsRef,
   };
 };

--- a/assets/src/scss/blocks/CarouselHeader/CarouselHeaderStyle.scss
+++ b/assets/src/scss/blocks/CarouselHeader/CarouselHeaderStyle.scss
@@ -425,6 +425,10 @@ $medium-image-height: 600px;
         max-width: 100%;
         width: 100%;
       }
+
+      &:focus {
+        @include focus-styles();
+      }
     }
 
     p {


### PR DESCRIPTION
### Summary

When the user is positioned in any indicator from Caroseul Header and press Enter (or Click) the next slider's text focus should be focused. In addition, when the user is still "Tabing" he might be focused to the next next indicator and so on.

---

<!-- Please add a reference link to the ticket, if one exists. -->
Ref: https://greenpeace-planet4.atlassian.net/browse/PLANET-8003

### Testing

<!-- Please add the steps required to test the changes in this Pull Request. -->
1. Try to use a screen reader
2. Go to Homepage which always includes a CarouselHeader block. 
3. Try it out by tabing.
4. Also make sure that the indicator announces the related slide's text.
