### PR TITLE
PLANET-7976 Remove Actions List featured image link

### DIFF
--- a/assets/src/blocks/ActionsList/index.js
+++ b/assets/src/blocks/ActionsList/index.js
@@ -60,7 +60,7 @@ export const getActionsListBlockTemplate = (title = __('', 'planet4-master-theme
     ['core/paragraph', {content: __('No posts found. (This default text can be edited)', 'planet4-master-theme-backend')}],
   ]],
   ['core/post-template', {lock: {move: true, remove: true}}, [
-    ['core/post-featured-image', {isLink: true}],
+    ['core/post-featured-image'],
     ['core/group', {}, [
       [TAX_BREADCRUMB_BLOCK_NAME, {
         taxonomy: LISTS_BREADCRUMBS[0].value,

--- a/assets/src/js/actions_list_clickable_cards.js
+++ b/assets/src/js/actions_list_clickable_cards.js
@@ -28,10 +28,9 @@ export const setupClickableActionsListCards = () => {
     li.appendChild(anchor);
 
     // Remove keyboard access for the image, tag, title, and the card itself.
-    const imageLink = li.querySelector('.wp-block-post-featured-image > a');
     const tagLink = li.querySelector('.taxonomy-post_tag > a');
     const postTerms = li.querySelector('.wp-block-post-terms > a');
-    const NO_KEYBOARD_ACCESS_ELEMENTS = [titleLink, imageLink, tagLink, li, postTerms];
+    const NO_KEYBOARD_ACCESS_ELEMENTS = [titleLink, tagLink, li, postTerms];
 
     NO_KEYBOARD_ACCESS_ELEMENTS.forEach(element => element?.setAttribute('tabindex', -1));
   });

--- a/src/Migrations/M062RemoveActionsListImageLink.php
+++ b/src/Migrations/M062RemoveActionsListImageLink.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace P4\MasterTheme\Migrations;
+
+use P4\MasterTheme\MigrationRecord;
+use P4\MasterTheme\MigrationScript;
+
+/**
+ * Remove links in the Actions List blocks, since we have an overlay they don't make sense.
+ * For the featured image and the category.
+ */
+class M062RemoveActionsListImageLink extends MigrationScript
+{
+    /**
+     * Perform the actual migration.
+     *
+     * @param MigrationRecord $record Information on the execution, can be used to add logs.
+     * phpcs:disable SlevomatCodingStandard.Functions.UnusedParameter -- interface implementation
+     */
+    public static function execute(MigrationRecord $record): void
+    {
+        $check_is_valid_block = function ($block) {
+            return self::check_is_valid_block($block);
+        };
+
+        $transform_block = function ($block) {
+            return self::transform_block($block);
+        };
+
+        Utils\Functions::execute_block_migration(
+            Utils\Constants::BLOCK_QUERY,
+            $check_is_valid_block,
+            $transform_block,
+        );
+    }
+    // phpcs:enable SlevomatCodingStandard.Functions.UnusedParameter
+
+    /**
+     * Check whether a block is an Actions List block with a featured image link.
+     *
+     * @param array $block - A block data array.
+     */
+    private static function check_is_valid_block(array $block): bool
+    {
+        // Check if the block is an array, has a 'blockName' key and a namespace.
+        if (!is_array($block) || !isset($block['blockName']) || !isset($block['attrs']['namespace'])) {
+            return false;
+        }
+
+        // Check if the block is an Actions List block.
+        if (
+            $block['blockName'] !== Utils\Constants::BLOCK_QUERY ||
+            $block['attrs']['namespace'] !== Utils\Constants::BLOCK_ACTIONS_LIST
+        ) {
+            return false;
+        }
+
+        // Check if the block's featured image exists and is a link.
+        // First we find the post template block, in its inner blocks we can find the featured image.
+        $post_template = array_find($block['innerBlocks'], function ($innerBlock) {
+            return $innerBlock['blockName'] === Utils\Constants::BLOCK_POST_TEMPLATE;
+        });
+
+        if (!$post_template || !$post_template['innerBlocks']) {
+            return false;
+        }
+
+        $featured_image = array_find($post_template['innerBlocks'], function ($innerBlock) {
+            return $innerBlock['blockName'] === Utils\Constants::BLOCK_FEAT_IMAGE;
+        });
+
+        return $featured_image && isset($featured_image['attrs']['isLink'])
+            && $featured_image['attrs']['isLink'] === true;
+    }
+
+    /**
+     * Remove link in the Actions List featured image.
+     *
+     * @param array $block - A block data array.
+     * @return array - The transformed block.
+     */
+    private static function transform_block(array &$block): array
+    {
+        self::remove_featured_image_link($block['innerBlocks']);
+
+        return $block;
+    }
+
+    /**
+     * Remove link from featured image.
+     *
+     * @param array $blocks - array of blocks.
+     */
+    private static function remove_featured_image_link(array &$blocks): void
+    {
+        foreach ($blocks as &$block) {
+            if (isset($block['blockName']) && $block['blockName'] === Utils\Constants::BLOCK_POST_TEMPLATE) {
+                if (!empty($block['innerBlocks'])) {
+                    foreach ($block['innerBlocks'] as &$innerBlock) {
+                        if (
+                            !isset($innerBlock['blockName']) ||
+                            $innerBlock['blockName'] !== Utils\Constants::BLOCK_FEAT_IMAGE
+                        ) {
+                            continue;
+                        }
+                        unset($innerBlock['attrs']['isLink']);
+                    }
+                }
+            }
+
+            self::remove_featured_image_link($block['innerBlocks']);
+        }
+    }
+}

--- a/src/Migrator.php
+++ b/src/Migrator.php
@@ -62,6 +62,7 @@ use P4\MasterTheme\Migrations\M058ReplaceTagsRedirections;
 use P4\MasterTheme\Migrations\M059AddMissingTypeToButtons;
 use P4\MasterTheme\Migrations\M060RemoveCountrySelectorText;
 use P4\MasterTheme\Migrations\M061RemovePlanet4BlocksFeature;
+use P4\MasterTheme\Migrations\M062RemoveActionsListImageLink;
 
 /**
  * Run any new migration scripts and record results in the log.
@@ -141,6 +142,7 @@ class Migrator
             M059AddMissingTypeToButtons::class,
             M060RemoveCountrySelectorText::class,
             M061RemovePlanet4BlocksFeature::class,
+            M062RemoveActionsListImageLink::class,
         ];
 
         // Loop migrations and run those that haven't run yet.


### PR DESCRIPTION
### Summary

This is for new blocks but also includes a migration for existing ones. This PR is only for one of the 2 tickets requirements, removing the featured image link. I think it's easier both for review and implementation to separate the two!

Ref: [PLANET-7976](https://greenpeace-planet4.atlassian.net/browse/PLANET-7976)

### Testing

1. Add an Actions List block to a page and make sure that the featured images are not links anymore.
2. Run the migration script on local `npx wp-env run cli wp p4-run-activator` and make sure that existing blocks are updated (you can for example check the [Take Action](http://www.planet4.test/take-action/) page).

<img width="258" height="212" alt="Screenshot 2026-03-26 at 15 51 09" src="https://github.com/user-attachments/assets/6e17a00a-0a06-45ad-b685-0dcd8dab80ca" />


[PLANET-7976]: https://greenpeace-planet4.atlassian.net/browse/PLANET-7976?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ