### PR TITLE
PLANET-8139 Add data attributes to Posts List block

### DIFF
--- a/src/Blocks/QueryLoopExtension.php
+++ b/src/Blocks/QueryLoopExtension.php
@@ -250,7 +250,7 @@ class QueryLoopExtension
             $block_name === 'core/post-terms' && ($attrs['term'] ?? '') === 'post_tag' => 'Navigation Tag',
             $block_name === 'p4/taxonomy-breadcrumb' => 'Post Type Tag',
             $block_name === 'core/navigation-link'
-                && str_contains($attrs['className'] ?? '', 'see-all-link') => 'Load More Button',
+                && str_contains($attrs['className'] ?? '', 'see-all-link') => 'See More Link',
             default => null,
         };
 

--- a/src/Blocks/QueryLoopExtension.php
+++ b/src/Blocks/QueryLoopExtension.php
@@ -17,6 +17,14 @@ class QueryLoopExtension
     public const POSTS_LIST_BLOCK = 'planet4-blocks/posts-list';
 
     /**
+     * Tracks whether we are currently rendering inside a Posts List block.
+     * Inner blocks (core/post-title etc.) do not carry query context, so a
+     * static flag set before the outer core/query renders is the reliable way
+     * to know we are inside a posts-list.
+     */
+    private static bool $in_posts_list = false;
+
+    /**
      * Register all necessary filters for both REST API and frontend query handling.
      */
     public static function registerHooks(): void
@@ -25,6 +33,8 @@ class QueryLoopExtension
         add_filter('rest_page_query', [self::class, 'registerEditorQuery'], 10, 2);
         add_filter('rest_p4_action_query', [self::class, 'registerEditorQuery'], 10, 2);
         add_filter('query_loop_block_query_vars', [self::class, 'registerFrontendQuery'], 10, 2);
+        add_filter('render_block_data', [self::class, 'trackPostsListContext'], 10, 1);
+        add_filter('render_block', [self::class, 'addDataAttributes'], 10, 2);
     }
 
     /**
@@ -185,5 +195,74 @@ class QueryLoopExtension
         ];
 
         return $query;
+    }
+
+    /**
+     * Sets the static flag when a Posts List core/query block is about to render,
+     * so that inner block renders (which lack query context) can detect it.
+     *
+     * @param array $parsed_block The parsed block data.
+     *
+     * @return array Unmodified parsed block data.
+     */
+    public static function trackPostsListContext(array $parsed_block): array
+    {
+        if (($parsed_block['blockName'] ?? '') === 'core/query') {
+            $namespace = $parsed_block['attrs']['namespace'] ?? '';
+            if ($namespace === self::POSTS_LIST_BLOCK) {
+                self::$in_posts_list = true;
+            }
+        }
+
+        return $parsed_block;
+    }
+
+    /**
+     * Injects GA/Mixpanel tracking data attributes into Posts List block inner block links.
+     *
+     * @param string $content      The rendered block output.
+     * @param array  $parsed_block The parsed block data.
+     *
+     * @return string Modified block output.
+     */
+    public static function addDataAttributes(string $content, array $parsed_block): string
+    {
+        $block_name = $parsed_block['blockName'] ?? '';
+        $attrs = $parsed_block['attrs'] ?? [];
+
+        // Clear the flag once the outer core/query finishes rendering.
+        if (
+            $block_name === 'core/query'
+            && ($attrs['namespace'] ?? '') === self::POSTS_LIST_BLOCK
+        ) {
+            self::$in_posts_list = false;
+            return $content;
+        }
+
+        if (!self::$in_posts_list) {
+            return $content;
+        }
+
+        $ga_action = match (true) {
+            $block_name === 'core/post-title' => 'Title',
+            $block_name === 'core/post-featured-image' => 'Image',
+            $block_name === 'core/post-author-name' => 'Author',
+            $block_name === 'core/post-terms' && ($attrs['term'] ?? '') === 'post_tag' => 'Navigation Tag',
+            $block_name === 'p4/taxonomy-breadcrumb' => 'Post Type Tag',
+            $block_name === 'core/navigation-link'
+                && str_contains($attrs['className'] ?? '', 'see-all-link') => 'Load More Button',
+            default => null,
+        };
+
+        if (null === $ga_action) {
+            return $content;
+        }
+
+        $data_attrs = sprintf(
+            'data-ga-category="Post List" data-ga-action="%s" data-ga-label="n/a"',
+            esc_attr($ga_action)
+        );
+
+        return (string) preg_replace('/<a\b/', '<a ' . $data_attrs, $content);
     }
 }

--- a/src/Blocks/QueryLoopExtension.php
+++ b/src/Blocks/QueryLoopExtension.php
@@ -259,7 +259,7 @@ class QueryLoopExtension
         }
 
         $data_attrs = sprintf(
-            'data-ga-category="Post List" data-ga-action="%s" data-ga-label="n/a"',
+            'data-ga-category="Posts List" data-ga-action="%s" data-ga-label="n/a"',
             esc_attr($ga_action)
         );
 

--- a/src/Blocks/QueryLoopExtension.php
+++ b/src/Blocks/QueryLoopExtension.php
@@ -263,6 +263,14 @@ class QueryLoopExtension
             esc_attr($ga_action)
         );
 
+        if ($block_name === 'core/post-featured-image') {
+            return (string) preg_replace('/<img\b/', '<img ' . $data_attrs, $content);
+        }
+
+        if ($block_name === 'core/navigation-link') {
+            return (string) preg_replace('/<span\b/', '<span ' . $data_attrs, $content);
+        }
+
         return (string) preg_replace('/<a\b/', '<a ' . $data_attrs, $content);
     }
 }

--- a/src/Blocks/QueryLoopExtension.php
+++ b/src/Blocks/QueryLoopExtension.php
@@ -20,21 +20,21 @@ class QueryLoopExtension
      * Tracks whether we are currently rendering inside a Posts List block.
      * Inner blocks (core/post-title etc.) do not carry query context, so a
      * static flag set before the outer core/query renders is the reliable way
-     * to know we are inside a posts-list.
+     * to know we are inside a Posts List.
      */
-    private static bool $in_posts_list = false;
+    private static bool $inPostsList = false;
 
     /**
      * Register all necessary filters for both REST API and frontend query handling.
      */
-    public static function registerHooks(): void
+    public static function register_hooks(): void
     {
-        add_filter('rest_post_query', [self::class, 'registerEditorQuery'], 10, 2);
-        add_filter('rest_page_query', [self::class, 'registerEditorQuery'], 10, 2);
-        add_filter('rest_p4_action_query', [self::class, 'registerEditorQuery'], 10, 2);
-        add_filter('query_loop_block_query_vars', [self::class, 'registerFrontendQuery'], 10, 2);
-        add_filter('render_block_data', [self::class, 'trackPostsListContext'], 10, 1);
-        add_filter('render_block', [self::class, 'addDataAttributes'], 10, 2);
+        add_filter('rest_post_query', [self::class, 'register_editor_query'], 10, 2);
+        add_filter('rest_page_query', [self::class, 'register_editor_query'], 10, 2);
+        add_filter('rest_p4_action_query', [self::class, 'register_editor_query'], 10, 2);
+        add_filter('query_loop_block_query_vars', [self::class, 'register_frontend_query'], 10, 2);
+        add_filter('render_block_data', [self::class, 'track_posts_list_context'], 10, 1);
+        add_filter('render_block', [self::class, 'add_data_attributes'], 10, 2);
     }
 
     /**
@@ -45,14 +45,14 @@ class QueryLoopExtension
      *
      * @return array Modified query arguments.
      */
-    public static function registerEditorQuery(array $args, \WP_REST_Request $request): array
+    public static function register_editor_query(array $args, \WP_REST_Request $request): array
     {
         $params = [
             'postIn' => $request->get_param('postIn'),
             'block_name' => $request->get_param('block_name'),
             'exclude' => $request->get_param('exclude'),
         ];
-        return self::applyCommonQueryModifiers($args, $params);
+        return self::apply_common_query_modifiers($args, $params);
     }
 
     /**
@@ -63,10 +63,10 @@ class QueryLoopExtension
      *
      * @return array Modified query arguments.
      */
-    public static function registerFrontendQuery(array $query, WP_Block $block): array
+    public static function register_frontend_query(array $query, WP_Block $block): array
     {
         $params = $block->context['query'] ?? [];
-        return self::applyCommonQueryModifiers($query, $params);
+        return self::apply_common_query_modifiers($query, $params);
     }
 
     /**
@@ -77,7 +77,7 @@ class QueryLoopExtension
      *
      * @return array Modified query arguments.
      */
-    private static function applyCommonQueryModifiers(array $query, array $params): array
+    private static function apply_common_query_modifiers(array $query, array $params): array
     {
         // Ensure only published items without password are queried
         $query['post_status'] = 'publish';
@@ -86,7 +86,7 @@ class QueryLoopExtension
         // If the type of block can be identified:
         if (!empty($params['block_name'])) {
             if ($params['block_name'] === self::ACTIONS_LIST_BLOCK) {
-                $query = self::buildActionListQuery($query);
+                $query = self::build_action_list_query($query);
             }
 
             if ($params['block_name'] === self::POSTS_LIST_BLOCK) {
@@ -124,14 +124,14 @@ class QueryLoopExtension
      *
      * @return array Modified query arguments.
      */
-    private static function buildActionListQuery(array $query): array
+    private static function build_action_list_query(array $query): array
     {
         $is_new_ia = !empty(planet4_get_option('new_ia'));
 
         if (!$is_new_ia) {
-            $query = self::buildOldIaActionListQuery($query);
+            $query = self::build_old_ia_action_list_query($query);
         } else {
-            $query = self::buildNewIaActionListQuery($query);
+            $query = self::build_new_ia_action_list_query($query);
         }
         return $query;
     }
@@ -143,7 +143,7 @@ class QueryLoopExtension
      *
      * @return array Modified query arguments.
      */
-    private static function buildOldIaActionListQuery(array $query): array
+    private static function build_old_ia_action_list_query(array $query): array
     {
         $query['post_type'] = ['page'];
         $query['post_parent'] = !empty(planet4_get_option('act_page'))
@@ -160,7 +160,7 @@ class QueryLoopExtension
      *
      * @return array Modified query arguments.
      */
-    private static function buildNewIaActionListQuery(array $query): array
+    private static function build_new_ia_action_list_query(array $query): array
     {
         global $wpdb;
 
@@ -205,13 +205,13 @@ class QueryLoopExtension
      *
      * @return array Unmodified parsed block data.
      */
-    public static function trackPostsListContext(array $parsed_block): array
+    public static function track_posts_list_context(array $parsed_block): array
     {
-        if (($parsed_block['blockName'] ?? '') === 'core/query') {
-            $namespace = $parsed_block['attrs']['namespace'] ?? '';
-            if ($namespace === self::POSTS_LIST_BLOCK) {
-                self::$in_posts_list = true;
-            }
+        if (
+            ($parsed_block['blockName'] ?? '') === 'core/query'
+            && ($parsed_block['attrs']['namespace'] ?? '') === self::POSTS_LIST_BLOCK
+        ) {
+            self::$inPostsList = true;
         }
 
         return $parsed_block;
@@ -225,7 +225,7 @@ class QueryLoopExtension
      *
      * @return string Modified block output.
      */
-    public static function addDataAttributes(string $content, array $parsed_block): string
+    public static function add_data_attributes(string $content, array $parsed_block): string
     {
         $block_name = $parsed_block['blockName'] ?? '';
         $attrs = $parsed_block['attrs'] ?? [];
@@ -235,11 +235,11 @@ class QueryLoopExtension
             $block_name === 'core/query'
             && ($attrs['namespace'] ?? '') === self::POSTS_LIST_BLOCK
         ) {
-            self::$in_posts_list = false;
+            self::$inPostsList = false;
             return $content;
         }
 
-        if (!self::$in_posts_list) {
+        if (!self::$inPostsList) {
             return $content;
         }
 

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -219,7 +219,7 @@ final class Loader
 
         new Blocks\ActionButtonText();//NOSONAR
 
-        Blocks\QueryLoopExtension::registerHooks();
+        Blocks\QueryLoopExtension::register_hooks();
         add_filter(
             'allowed_block_types_all',
             function ($allowed_block_types) {


### PR DESCRIPTION
Ref. https://greenpeace-planet4.atlassian.net/browse/PLANET-8139

### Summary

<!-- Please provide a brief summary of the change introduced in this Pull Request. -->

---

### Testing

- Checkout `PLANET-8139_Post-List-block-data-attribute` branch on local dev env or test it on [sinope](https://www-dev.greenpeace.org/test-sinope/story/1766/test-post-list-block-data-attributes/) test instance for Post List block data attributes
- The data attributes should be:

**data-ga-category**="Post**s** List” 
**data-ga-action**="Title”, “Image”, “Author”, “Navigation Tag”, “Post Type Tag”, “Load More Button” 
**data-ga-label** = “n/a”