### PR TITLE
PLANET-8147: Carousel Header fix heading focus when it's autoplayed

### DIFF
--- a/assets/src/blocks/CarouselHeader/CarouselControls.js
+++ b/assets/src/blocks/CarouselHeader/CarouselControls.js
@@ -1,4 +1,4 @@
-const {useMemo, forwardRef} = wp.element;
+const {useMemo, forwardRef, useRef} = wp.element;
 const {__, sprintf} = wp.i18n;
 
 export const CarouselControls = forwardRef(({
@@ -10,67 +10,79 @@ export const CarouselControls = forwardRef(({
   slides = null,
   autoplay,
   disableControls,
-}, ref) => useMemo(() => (
-  <>
-    {/* Indicators */}
-    <div className="carousel-indicators-wrapper">
-      <div className="container">
-        {disableControls && (
-          <>
-            <button
-              aria-label={__('Autoplay', 'planet4-master-theme')}
-              className={`carousel-autoplay-control ${autoplay ? 'stop' : 'play'}`}
-              onClick={handleAutoplay}
-              aria-pressed={autoplay ? 'true' : 'false'}
-            />
-            {/* This is for screen readers to announce the state of the autoplay */}
-            <div className="visually-hidden" aria-live="polite">
-              {autoplay ? __('Slide resumed', 'planet4-master-theme') : __('Slide paused', 'planet4-master-theme')}
-            </div>
-          </>
-        )}
-        <ol className="carousel-indicators" tabIndex={-1} ref={ref}>
-          {
-            slides.map((_, index) =>
-              <li
-                key={index}
-                {...(index === currentSlide) ? {
-                  className: 'active',
-                } : {}}
-              >
-                <button
-                  onClick={() => {
-                    if (index !== currentSlide) {
-                      goToSlide({newSlide: index});
-                    }
-                  }}
-                  tabIndex={0}
-                  onKeyDown={e => {
-                    if ((e.key === 'Enter' || e.key === ' ') && index !== currentSlide) {
-                      e.preventDefault();
-                      goToSlide({newSlide: index});
-                    }
-                  }}
-                  // translators: %s: slide header
-                  aria-label={sprintf(__('Go to %s slide', 'planet4-master-theme'), slides[index].header)}
-                  aria-current={index === currentSlide ? 'true' : undefined}
-                />
-              </li>
-            )
-          }
-        </ol>
+}, ref) => {
+  const controlsRef = useRef();
+
+  return useMemo(() => (
+    <>
+      {/* Indicators */}
+      <div className="carousel-indicators-wrapper">
+        <div className="container">
+          {disableControls && (
+            <>
+              <button
+                aria-label={__('Autoplay', 'planet4-master-theme')}
+                className={`carousel-autoplay-control ${autoplay ? 'stop' : 'play'}`}
+                onClick={handleAutoplay}
+                aria-pressed={autoplay ? 'true' : 'false'}
+              />
+              {/* This is for screen readers to announce the state of the autoplay */}
+              <div className="visually-hidden" aria-live="polite">
+                {autoplay ? __('Slide resumed', 'planet4-master-theme') : __('Slide paused', 'planet4-master-theme')}
+              </div>
+            </>
+          )}
+          <ol className="carousel-indicators" tabIndex={-1} ref={ref}>
+            {
+              slides.map((_, index) =>
+                <li
+                  key={index}
+                  {...(index === currentSlide) ? {
+                    className: 'active',
+                  } : {}}
+                >
+                  <button
+                    onClick={() => {
+                      if (index !== currentSlide) {
+                        goToSlide({newSlide: index, fromClick: true});
+                      }
+                    }}
+                    tabIndex={0}
+                    onKeyDown={e => {
+                      if ((e.key === 'Enter' || e.key === ' ') && index !== currentSlide) {
+                        e.preventDefault();
+                        goToSlide({newSlide: index, fromClick: true});
+                      }
+                    }}
+                    // translators: %s: slide header
+                    aria-label={sprintf(__('Go to %s slide', 'planet4-master-theme'), slides[index].header)}
+                    aria-current={index === currentSlide ? 'true' : undefined}
+                  />
+                </li>
+              )
+            }
+          </ol>
+        </div>
       </div>
-    </div>
-    {/* Arrows */}
-    <nav aria-label={__('Greenpeace highlights carousel controls', 'planet4-master-theme')}>
-      <button className="carousel-control-prev" onClick={goToPrevSlide} aria-label={__('Go to previous slide', 'planet4-master-theme')}>
-        <span className="carousel-control-prev-icon" aria-hidden="true"><i></i></span>
-        <span className="visually-hidden">{__('Previous', 'planet4-master-theme')}</span>
-      </button>
-      <button className="carousel-control-next" onClick={goToNextSlide} aria-label={__('Go to next slide', 'planet4-master-theme')}>
-        <span className="carousel-control-next-icon" aria-hidden="true"><i></i></span>
-        <span className="visually-hidden">{__('Next', 'planet4-master-theme')}</span>
-      </button>
-    </nav>
-  </>
-), [currentSlide, disableControls, autoplay, slides, ref, goToPrevSlide, goToNextSlide, goToSlide, handleAutoplay]));
+      {/* Arrows */}
+      <nav aria-label={__('Greenpeace highlights carousel controls', 'planet4-master-theme')} ref={controlsRef}>
+
+        <button className="carousel-control-prev" onClick={goToPrevSlide}
+          // translators: %s: slide header
+          aria-label={sprintf(__('Go to previous slide %s', 'planet4-master-theme'), slides[currentSlide - 1] && slides[currentSlide - 1].header ? slides[currentSlide - 1].header : slides[slides.length - 1].header)}
+        >
+          <span className="carousel-control-prev-icon" aria-hidden="true"><i></i></span>
+          <span className="visually-hidden">{__('Previous', 'planet4-master-theme')}</span>
+        </button>
+        <button className="carousel-control-next" onClick={goToNextSlide}
+          // translators: %s: slide header
+          aria-label={sprintf(__('Go to next slide %s', 'planet4-master-theme'), slides[currentSlide + 1] && slides[currentSlide + 1].header ? slides[currentSlide + 1].header : slides[0].header)}
+        >
+          <span className="carousel-control-next-icon" aria-hidden="true"><i></i></span>
+          <span className="visually-hidden">{__('Next', 'planet4-master-theme')}</span>
+        </button>
+      </nav>
+
+    </>
+  ), [currentSlide, disableControls, autoplay, slides, ref, controlsRef, goToPrevSlide, goToNextSlide, goToSlide, handleAutoplay]);
+});

--- a/assets/src/blocks/CarouselHeader/CarouselControls.js
+++ b/assets/src/blocks/CarouselHeader/CarouselControls.js
@@ -29,7 +29,7 @@ export const CarouselControls = forwardRef(({
             </div>
           </>
         )}
-        <ol className="carousel-indicators" tabIndex={-1}>
+        <ol className="carousel-indicators" tabIndex={-1} ref={ref}>
           {
             slides.map((_, index) =>
               <li
@@ -41,18 +41,18 @@ export const CarouselControls = forwardRef(({
                 <button
                   onClick={() => {
                     if (index !== currentSlide) {
-                      goToSlide(index);
+                      goToSlide({newSlide: index});
                     }
                   }}
                   tabIndex={0}
                   onKeyDown={e => {
                     if ((e.key === 'Enter' || e.key === ' ') && index !== currentSlide) {
                       e.preventDefault();
-                      goToSlide(index);
+                      goToSlide({newSlide: index});
                     }
                   }}
-                  // translators: %s: slide index
-                  aria-label={sprintf(__('Go to slide %s', 'planet4-master-theme'), index + 1)}
+                  // translators: %s: slide header
+                  aria-label={sprintf(__('Go to %s slide', 'planet4-master-theme'), slides[index].header)}
                   aria-current={index === currentSlide ? 'true' : undefined}
                 />
               </li>

--- a/assets/src/blocks/CarouselHeader/CarouselControls.js
+++ b/assets/src/blocks/CarouselHeader/CarouselControls.js
@@ -1,7 +1,7 @@
-const {useMemo} = wp.element;
+const {useMemo, forwardRef} = wp.element;
 const {__, sprintf} = wp.i18n;
 
-export const CarouselControls = ({
+export const CarouselControls = forwardRef(({
   goToPrevSlide = () => {},
   goToNextSlide = () => {},
   goToSlide = () => {},
@@ -10,7 +10,7 @@ export const CarouselControls = ({
   slides = null,
   autoplay,
   disableControls,
-}) => useMemo(() => (
+}, ref) => useMemo(() => (
   <>
     {/* Indicators */}
     <div className="carousel-indicators-wrapper">
@@ -73,4 +73,4 @@ export const CarouselControls = ({
       </button>
     </nav>
   </>
-), [currentSlide, disableControls, autoplay, slides, goToPrevSlide, goToNextSlide, goToSlide, handleAutoplay]);
+), [currentSlide, disableControls, autoplay, slides, ref, goToPrevSlide, goToNextSlide, goToSlide, handleAutoplay]));

--- a/assets/src/blocks/CarouselHeader/CarouselHeaderEditor.js
+++ b/assets/src/blocks/CarouselHeader/CarouselHeaderEditor.js
@@ -53,7 +53,7 @@ export const CarouselHeaderEditor = ({setAttributes, attributes}) => {
     setAttributes({slides: newSlides});
     const lastSlide = newSlides.length - 1;
     // There is no callback to setAttributes so we use timeout instead
-    setTimeout(() => goToSlide(lastSlide), 0);
+    setTimeout(() => goToSlide({newSlide: lastSlide}), 0);
   }, [slides, setAttributes, goToSlide]);
 
   const removeSlide = useCallback(() => {
@@ -63,7 +63,7 @@ export const CarouselHeaderEditor = ({setAttributes, attributes}) => {
     ];
     const lastSlide = newSlides.length - 1;
     setAttributes({slides: newSlides});
-    goToSlide(currentSlide > lastSlide ? 0 : currentSlide, true);
+    goToSlide({newSlide: currentSlide > lastSlide ? 0 : currentSlide, forceCurrentSlide: true});
   }, [currentSlide, goToSlide, setAttributes, slides]);
 
   const needsMigration = slides.some(slide => !!slide.image && !slide.image_srcset);

--- a/assets/src/blocks/CarouselHeader/CarouselHeaderFrontend.js
+++ b/assets/src/blocks/CarouselHeader/CarouselHeaderFrontend.js
@@ -10,6 +10,8 @@ const {__} = wp.i18n;
 export const CarouselHeaderFrontend = ({slides, carousel_autoplay, className, decoding}) => {
   const slidesRef = useRef([]);
   const containerRef = useRef(null);
+  const headingsRef = useRef([]);
+  const indicatorsRef = useRef();
   const {
     currentSlide,
     goToSlide,
@@ -18,7 +20,7 @@ export const CarouselHeaderFrontend = ({slides, carousel_autoplay, className, de
     handleAutoplay,
     setAutoplay,
     autoplay,
-  } = useSlides(slidesRef, slides.length, containerRef, carousel_autoplay);
+  } = useSlides(slidesRef, slides.length, containerRef, carousel_autoplay, headingsRef, indicatorsRef);
 
   return useMemo(() => (
     <section
@@ -43,6 +45,7 @@ export const CarouselHeaderFrontend = ({slides, carousel_autoplay, className, de
           currentSlide={currentSlide}
           autoplay={autoplay}
           disableControls={carousel_autoplay}
+          ref={indicatorsRef}
         />
       )}
       <div className="carousel-wrapper-header">

--- a/assets/src/blocks/CarouselHeader/CarouselHeaderFrontend.js
+++ b/assets/src/blocks/CarouselHeader/CarouselHeaderFrontend.js
@@ -32,12 +32,16 @@ export const CarouselHeaderFrontend = ({slides, carousel_autoplay, className, de
       {(slides.length > 1) && (
         <CarouselControls
           goToPrevSlide={() => {
-            setAutoplay(false);
-            goToPrevSlide();
+            setAutoplay(() => {
+              goToPrevSlide(true);
+              return false;
+            });
           }}
           goToNextSlide={() => {
-            setAutoplay(false);
-            goToNextSlide();
+            setAutoplay(() => {
+              goToNextSlide(true);
+              return false;
+            });
           }}
           goToSlide={goToSlide}
           handleAutoplay={handleAutoplay}
@@ -69,11 +73,11 @@ export const CarouselHeaderFrontend = ({slides, carousel_autoplay, className, de
     decoding,
     autoplay,
     slides,
-    goToSlide,
     setAutoplay,
+    carousel_autoplay,
     handleAutoplay,
+    goToSlide,
     goToPrevSlide,
     goToNextSlide,
-    carousel_autoplay,
   ]);
 };

--- a/assets/src/blocks/CarouselHeader/CarouselHeaderFrontend.js
+++ b/assets/src/blocks/CarouselHeader/CarouselHeaderFrontend.js
@@ -29,7 +29,7 @@ export const CarouselHeaderFrontend = ({slides, carousel_autoplay, className, de
       aria-label={__('Greenpeace highlights', 'planet4-blocks')}
       aria-roledescription="carousel"
     >
-      {(slides.length > 1) && (
+      {(slides.length > 1) ? (
         <CarouselControls
           goToPrevSlide={() => {
             setAutoplay(() => {
@@ -51,7 +51,7 @@ export const CarouselHeaderFrontend = ({slides, carousel_autoplay, className, de
           disableControls={carousel_autoplay}
           ref={indicatorsRef}
         />
-      )}
+      ) : null}
       <div className="carousel-wrapper-header">
         <ul className="carousel-inner" role="listbox">
           {slides.map((slide, index) => <Slide

--- a/assets/src/blocks/CarouselHeader/Slide.js
+++ b/assets/src/blocks/CarouselHeader/Slide.js
@@ -8,6 +8,8 @@ export const SlideWithRef = ({
   <li
     className={`carousel-item ${active ? 'active' : ''}`}
     tabIndex={focusable ? 0 : -1}
+    // eslint-disable-next-line react/no-unknown-property
+    area-hidden={focusable ? 'false' : 'true'}
     ref={ref}
     role="tabpanel"
     alt=""

--- a/assets/src/blocks/CarouselHeader/StaticCaption.js
+++ b/assets/src/blocks/CarouselHeader/StaticCaption.js
@@ -1,21 +1,22 @@
-const {useMemo} = wp.element;
+const {useMemo, forwardRef} = wp.element;
 
 const htmlDecode = input => {
   const doc = new DOMParser().parseFromString(input, 'text/html');
   return doc.documentElement.textContent;
 };
 
-export const StaticCaption = ({slide, focusable}) => useMemo(() => (
+export const StaticCaption = forwardRef(({slide, focusable}, ref) => useMemo(() => (
   <div className="carousel-caption">
     <div className="caption-overlay"></div>
     <div className="container main-header">
       <div className="carousel-captions-wrapper">
-        <h2>
+        {/* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex */}
+        <h2 ref={ref} tabIndex={focusable ? 0 : -1}>
           {htmlDecode(slide.header)}
         </h2>
         <p dangerouslySetInnerHTML={{__html: slide.description}} />
       </div>
-      {slide.link_url &&
+      {slide.link_url && (
         <div className="col-xs-12 col-sm-8 col-md-4 action-button">
           <a
             href={slide.link_url}
@@ -23,15 +24,13 @@ export const StaticCaption = ({slide, focusable}) => useMemo(() => (
             data-ga-category="Carousel Header"
             data-ga-action="Call to Action"
             data-ga-label={slide.index}
-            {...slide.link_url_new_tab && {rel: 'noreferrer noopener', target: '_blank'}}
+            {...(slide.link_url_new_tab && {rel: 'noreferrer noopener', target: '_blank'})}
             tabIndex={focusable ? 0 : -1}
           >
-            <span>
-              {slide.link_text}
-            </span>
+            <span>{slide.link_text}</span>
           </a>
         </div>
-      }
+      )}
     </div>
   </div>
-), [slide, focusable]);
+), [slide, focusable, ref]));

--- a/assets/src/blocks/CarouselHeader/useSlides.js
+++ b/assets/src/blocks/CarouselHeader/useSlides.js
@@ -108,18 +108,18 @@ export const useSlides = (
    * If the heading exists and the CTA too, then focus the CTA
    */
   const onkeyboardHandler = useCallback(event => {
-    // Only handle tab without shift key
     if (event.key !== 'Tab' || event.shiftKey) {
       return;
     }
 
+    const carouselItem = event.target.closest('.carousel-item');
     // Only applied to the carousel item
-    if(!event.target.closest('.carousel-item')) {
+    if(!carouselItem) {
       return;
     }
 
     const headingFocused = event.target.tagName === 'H2';
-    const cta = event.target.closest('.carousel-item').querySelector('.action-button a');
+    const cta = carouselItem.querySelector('.action-button a');
 
     if(headingFocused && cta) {
       return;
@@ -138,7 +138,7 @@ export const useSlides = (
 
     // Remove listener after first successful use
     document.removeEventListener('keydown', onkeyboardHandler);
-  }, [indicatorsRef, event]);
+  }, [indicatorsRef]);
 
   const goToSlide = useCallback(({newSlide, forceCurrentSlide = false, fromClick = false}) => {
     if (!slidesRef.current) {

--- a/assets/src/blocks/CarouselHeader/useSlides.js
+++ b/assets/src/blocks/CarouselHeader/useSlides.js
@@ -102,7 +102,38 @@ export const useSlides = (
     }
   }, [containerRef]);
 
-  const goToSlide = useCallback(({newSlide, forceCurrentSlide = false, fromClick = false}) => { // newSlide, forceCurrentSlide = false)
+  /**
+   * Handle the key press event when navigating through the carousel with keyboard.
+   */
+  const onkeyboardHandler = useCallback(event => {
+    // Only handle tab without shift key
+    if (event.key !== 'Tab' || event.shiftKey) {
+      return;
+    }
+
+    // Check if focus is currently on a CTA button
+    const cta = event.target.closest('.carousel-item.active .action-button a');
+
+    if (!cta) {
+      return;
+    }
+
+    // Find the active indicator
+    const activeIndicator = indicatorsRef.current.querySelector('li.active button');
+    if (!activeIndicator) {
+      return;
+    }
+
+    event.preventDefault();
+
+    // Move focus to the active indicator
+    activeIndicator.focus();
+
+    // Remove listener after first successful use
+    document.removeEventListener('keydown', onkeyboardHandler);
+  }, [indicatorsRef]);
+
+  const goToSlide = useCallback(({newSlide, forceCurrentSlide = false, fromClick = false}) => {
     if (!slidesRef.current) {
       return;
     }
@@ -123,10 +154,12 @@ export const useSlides = (
       nextElement.classList.add(enterTransitionClass);
 
       if(fromClick) {
-        // Force to focus heading
         const heading = nextElement.querySelector('h2');
+
         if(heading) {
           heading.focus();
+
+          document.addEventListener('keydown', onkeyboardHandler);
         }
       }
 
@@ -151,7 +184,7 @@ export const useSlides = (
         unsetTransitionClasses();
       }
     }
-  }, [currentSlide, getOrder, options, sliding, setCarouselHeight, slidesRef]);
+  }, [currentSlide, getOrder, options, sliding, setCarouselHeight, slidesRef, onkeyboardHandler]);
 
   const goToPrevSlide = useCallback((fromClick = false) => {
     goToSlide({newSlide: (currentSlide - 1 < 0) ? totalSlides - 1 : currentSlide - 1, fromClick});
@@ -189,20 +222,6 @@ export const useSlides = (
       clearTimeout(timerRef.current);
     }
   }, [totalSlides, autoplay, timerRef, goToNextSlide]);
-
-  useEffect(() => {
-    if(!headingsRef?.current || !indicatorsRef?.current) {
-      return;
-    }
-
-    const totalIndicators = indicatorsRef.current.children.length;
-    for (const heading of headingsRef.current) {
-      heading.addEventListener('focusout', () => {
-        const nextIndicator = (currentSlide + 1) < totalIndicators ? (currentSlide + 1) : 0;
-        indicatorsRef.current.children[nextIndicator].querySelector('button').focus();
-      });
-    }
-  }, [headingsRef, indicatorsRef, currentSlide]);
 
   useEffect(() => {
     if(carousel_autoplay) {

--- a/assets/src/blocks/CarouselHeader/useSlides.js
+++ b/assets/src/blocks/CarouselHeader/useSlides.js
@@ -52,6 +52,18 @@ export const useSlides = (
     },
   };
 
+  const onScrollHandler = useCallback(() => {
+    if (!containerRef || !containerRef.current) {
+      return;
+    }
+
+    const {top, height} = containerRef.current.getBoundingClientRect();
+
+    if(top < (height * -1) || top > window.innerHeight) {
+      setAutoplay(false);
+    }
+  }, [setAutoplay, containerRef]);
+
   const handleAutoplay = useCallback(() => {
     setAutoplay(!autoplay);
   }, [autoplay]);
@@ -141,12 +153,12 @@ export const useSlides = (
     }
   }, [currentSlide, getOrder, options, sliding, setCarouselHeight, slidesRef]);
 
-  const goToPrevSlide = useCallback(() => {
-    goToSlide({newSlide: (currentSlide - 1 < 0) ? totalSlides - 1 : currentSlide - 1, fromClick: true});
+  const goToPrevSlide = useCallback((fromClick = false) => {
+    goToSlide({newSlide: (currentSlide - 1 < 0) ? totalSlides - 1 : currentSlide - 1, fromClick});
   }, [currentSlide, totalSlides, goToSlide]);
 
-  const goToNextSlide = useCallback(() => {
-    goToSlide({newSlide: (currentSlide + 1 >= totalSlides) ? 0 : currentSlide + 1, fromClick: true});
+  const goToNextSlide = useCallback((fromClick = false) => {
+    goToSlide({newSlide: (currentSlide + 1 >= totalSlides) ? 0 : currentSlide + 1, fromClick});
   }, [currentSlide, totalSlides, goToSlide]);
 
   useHammerSwipe(containerRef, goToNextSlide, goToPrevSlide);
@@ -191,6 +203,16 @@ export const useSlides = (
       });
     }
   }, [headingsRef, indicatorsRef, currentSlide]);
+
+  useEffect(() => {
+    if(carousel_autoplay) {
+      window.addEventListener('scroll', onScrollHandler);
+
+      return () => {
+        window.removeEventListener('scroll', onScrollHandler);
+      };
+    }
+  }, [carousel_autoplay, onScrollHandler]);
 
   return {
     totalSlides,

--- a/assets/src/blocks/CarouselHeader/useSlides.js
+++ b/assets/src/blocks/CarouselHeader/useSlides.js
@@ -52,18 +52,6 @@ export const useSlides = (
     },
   };
 
-  const onScrollHandler = useCallback(() => {
-    if (!containerRef?.current) {
-      return;
-    }
-
-    const {top, height} = containerRef.current.getBoundingClientRect();
-
-    if(top < (height * -1) || top > window.innerHeight) {
-      setAutoplay(false);
-    }
-  }, [setAutoplay, containerRef]);
-
   const handleAutoplay = useCallback(() => {
     setAutoplay(!autoplay);
   }, [autoplay]);
@@ -231,14 +219,26 @@ export const useSlides = (
   }, [totalSlides, autoplay, timerRef, goToNextSlide]);
 
   useEffect(() => {
-    if(carousel_autoplay) {
-      window.addEventListener('scroll', onScrollHandler);
-
-      return () => {
-        window.removeEventListener('scroll', onScrollHandler);
-      };
+    if (!containerRef?.current || !carousel_autoplay) {
+      return;
     }
-  }, [carousel_autoplay, onScrollHandler]);
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        setAutoplay(entry.isIntersecting);
+      },
+      {
+        root: null,
+        threshold: 0.10,
+      }
+    );
+
+    observer.observe(containerRef.current);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [carousel_autoplay, containerRef, autoplay]);
 
   return {
     totalSlides,

--- a/assets/src/blocks/CarouselHeader/useSlides.js
+++ b/assets/src/blocks/CarouselHeader/useSlides.js
@@ -104,6 +104,8 @@ export const useSlides = (
 
   /**
    * Handle the key press event when navigating through the carousel with keyboard.
+   * If the heading exists but not the CTA then focus the current indicator
+   * If the heading exists and the CTA too, then focus the CTA
    */
   const onkeyboardHandler = useCallback(event => {
     // Only handle tab without shift key
@@ -111,10 +113,15 @@ export const useSlides = (
       return;
     }
 
-    // Check if focus is currently on a CTA button
-    const cta = event.target.closest('.carousel-item.active .action-button a');
+    // Only applied to the carousel item
+    if(!event.target.closest('.carousel-item')) {
+      return;
+    }
 
-    if (!cta) {
+    const headingFocused = event.target.tagName === 'H2';
+    const cta = event.target.closest('.carousel-item').querySelector('.action-button a');
+
+    if(headingFocused && cta) {
       return;
     }
 
@@ -131,7 +138,7 @@ export const useSlides = (
 
     // Remove listener after first successful use
     document.removeEventListener('keydown', onkeyboardHandler);
-  }, [indicatorsRef]);
+  }, [indicatorsRef, event]);
 
   const goToSlide = useCallback(({newSlide, forceCurrentSlide = false, fromClick = false}) => {
     if (!slidesRef.current) {

--- a/assets/src/blocks/CarouselHeader/useSlides.js
+++ b/assets/src/blocks/CarouselHeader/useSlides.js
@@ -53,7 +53,7 @@ export const useSlides = (
   };
 
   const onScrollHandler = useCallback(() => {
-    if (!containerRef || !containerRef.current) {
+    if (!containerRef?.current) {
       return;
     }
 

--- a/assets/src/blocks/CarouselHeader/useSlides.js
+++ b/assets/src/blocks/CarouselHeader/useSlides.js
@@ -16,28 +16,41 @@ const activeClass = 'active';
  * @param {*}       totalSlides
  * @param {*}       containerRef
  * @param {boolean} carousel_autoplay
+ * @param {*}       headingsRef
+ * @param {*}       indicatorsRef
  * @param {Object}  options
  * @return {*} functions for the carousel header slides
  */
-export const useSlides = (slidesRef, totalSlides, containerRef, carousel_autoplay, options = {
-  // Following Bootstrap's approach for RTL:
-  // https://getbootstrap.com/docs/5.0/getting-started/rtl/#approach
-  // Note: in non-directional transitions (e.g.: fade out),
-  // these could have the same class for both directions.
-  enterTransitionClasses: {
-    next: 'enter-from-end',
-    prev: 'enter-from-start',
-  },
-  exitTransitionClasses: {
-    next: 'exit-to-start',
-    prev: 'exit-to-end',
-  },
-}) => {
+
+export const useSlides = (
+  slidesRef,
+  totalSlides,
+  containerRef,
+  carousel_autoplay,
+  headingsRef,
+  indicatorsRef,
+  options
+) => {
   const [autoplay, setAutoplay] = useState(carousel_autoplay);
   const [currentSlide, setCurrentSlide] = useState(0);
   const [sliding, setSliding] = useState(false);
   // Set up the autoplay for the slides
   const timerRef = useRef(null);
+
+  options = options || {
+    // Following Bootstrap's approach for RTL:
+    // https://getbootstrap.com/docs/5.0/getting-started/rtl/#approach
+    // Note: in non-directional transitions (e.g.: fade out),
+    // these could have the same class for both directions.
+    enterTransitionClasses: {
+      next: 'enter-from-end',
+      prev: 'enter-from-start',
+    },
+    exitTransitionClasses: {
+      next: 'exit-to-start',
+      prev: 'exit-to-end',
+    },
+  };
 
   const handleAutoplay = useCallback(() => {
     setAutoplay(!autoplay);
@@ -77,7 +90,7 @@ export const useSlides = (slidesRef, totalSlides, containerRef, carousel_autopla
     }
   }, [containerRef]);
 
-  const goToSlide = useCallback((newSlide, forceCurrentSlide = false) => {
+  const goToSlide = useCallback(({newSlide, forceCurrentSlide = false, fromClick = false}) => { // newSlide, forceCurrentSlide = false)
     if (!slidesRef.current) {
       return;
     }
@@ -96,6 +109,14 @@ export const useSlides = (slidesRef, totalSlides, containerRef, carousel_autopla
 
       activeElement.classList.add(exitTransitionClass);
       nextElement.classList.add(enterTransitionClass);
+
+      if(fromClick) {
+        // Force to focus heading
+        const heading = nextElement.querySelector('h2');
+        if(heading) {
+          heading.focus();
+        }
+      }
 
       const unsetTransitionClasses = () => {
         activeElement.removeEventListener('transitionend', unsetTransitionClasses);
@@ -121,11 +142,11 @@ export const useSlides = (slidesRef, totalSlides, containerRef, carousel_autopla
   }, [currentSlide, getOrder, options, sliding, setCarouselHeight, slidesRef]);
 
   const goToPrevSlide = useCallback(() => {
-    goToSlide(currentSlide === 0 ? totalSlides - 1 : currentSlide - 1);
+    goToSlide({newSlide: (currentSlide - 1 < 0) ? totalSlides - 1 : currentSlide - 1, fromClick: true});
   }, [currentSlide, totalSlides, goToSlide]);
 
   const goToNextSlide = useCallback(() => {
-    goToSlide((currentSlide + 1 >= totalSlides) ? 0 : currentSlide + 1);
+    goToSlide({newSlide: (currentSlide + 1 >= totalSlides) ? 0 : currentSlide + 1, fromClick: true});
   }, [currentSlide, totalSlides, goToSlide]);
 
   useHammerSwipe(containerRef, goToNextSlide, goToPrevSlide);
@@ -157,6 +178,20 @@ export const useSlides = (slidesRef, totalSlides, containerRef, carousel_autopla
     }
   }, [totalSlides, autoplay, timerRef, goToNextSlide]);
 
+  useEffect(() => {
+    if(!headingsRef?.current || !indicatorsRef?.current) {
+      return;
+    }
+
+    const totalIndicators = indicatorsRef.current.children.length;
+    for (const heading of headingsRef.current) {
+      heading.addEventListener('focusout', () => {
+        const nextIndicator = (currentSlide + 1) < totalIndicators ? (currentSlide + 1) : 0;
+        indicatorsRef.current.children[nextIndicator].querySelector('button').focus();
+      });
+    }
+  }, [headingsRef, indicatorsRef, currentSlide]);
+
   return {
     totalSlides,
     currentSlide,
@@ -168,5 +203,7 @@ export const useSlides = (slidesRef, totalSlides, containerRef, carousel_autopla
     setAutoplay,
     setCarouselHeight,
     autoplay,
+    headingsRef,
+    indicatorsRef,
   };
 };

--- a/assets/src/blocks/Gallery/GalleryCarousel.js
+++ b/assets/src/blocks/Gallery/GalleryCarousel.js
@@ -3,7 +3,7 @@ import {getCaptionWithCredits} from './getCaptionWithCredits.js';
 import {useHammerSwipe} from '../components/HammerSwipe/HammerSwipe.js';
 
 const {__} = wp.i18n;
-const {useState, useEffect, useRef} = wp.element;
+const {useState, useEffect, useRef, useCallback} = wp.element;
 
 // This will trigger the browser to synchronously calculate the style and layout
 // You can find a list of examples here: https://gist.github.com/paulirish/5d52fb081b3570c81e3a
@@ -17,7 +17,7 @@ export const GalleryCarousel = ({images, onImageClick, isEditing}) => {
   const slidesRef = useRef([]);
   const containerRef = useRef(null);
 
-  const getOrder = newSlide => {
+  const getOrder = useCallback(newSlide => {
     let order = newSlide < currentSlide ? 'prev' : 'next';
     if (newSlide === lastSlide && currentSlide === 0 && order !== 'prev') {
       order = 'prev';
@@ -25,9 +25,9 @@ export const GalleryCarousel = ({images, onImageClick, isEditing}) => {
       order = 'next';
     }
     return order;
-  };
+  }, [currentSlide, lastSlide]);
 
-  const goToSlide = newSlide => {
+  const goToSlide = useCallback(newSlide => {
     const nextElement = slidesRef.current[newSlide];
     const activeElement = slidesRef.current[currentSlide];
     if (newSlide !== currentSlide && nextElement && activeElement && !sliding) {
@@ -51,10 +51,10 @@ export const GalleryCarousel = ({images, onImageClick, isEditing}) => {
         setCurrentSlide(newSlide);
       }, 600);
     }
-  };
+  }, [currentSlide, getOrder, sliding]);
 
-  const goToNextSlide = () => goToSlide(currentSlide === lastSlide ? 0 : currentSlide + 1);
-  const goToPrevSlide = () => goToSlide(currentSlide === 0 ? lastSlide : currentSlide - 1);
+  const goToNextSlide = useCallback(() => goToSlide({newSlide: (currentSlide + 1 > lastSlide) ? 0 : currentSlide + 1}), [currentSlide, lastSlide, goToSlide])  ;
+  const goToPrevSlide = useCallback(() => goToSlide({newSlide: currentSlide === 0 ? lastSlide : currentSlide - 1}), [currentSlide, lastSlide, goToSlide]);
 
   // Set up the autoplay for the slides
   useEffect(() => {
@@ -65,7 +65,7 @@ export const GalleryCarousel = ({images, onImageClick, isEditing}) => {
       timerRef.current = setTimeout(goToNextSlide, 10000);
       return () => clearTimeout(timerRef.current);
     }
-  }, [currentSlide, images]);
+  }, [currentSlide, images, goToNextSlide]);
 
   // Set up swiping on mobile
   useHammerSwipe(containerRef, goToNextSlide, goToPrevSlide, isEditing);
@@ -78,7 +78,7 @@ export const GalleryCarousel = ({images, onImageClick, isEditing}) => {
             {images.map((image, index) =>
               <li
                 key={`indicator-${index}`}
-                onClick={() => goToSlide(index)}
+                onClick={() => goToSlide({newSlide: index})}
                 className={index === currentSlide ? 'active' : ''}
                 role="presentation"
               />

--- a/assets/src/scss/blocks/CarouselHeader/CarouselHeaderStyle.scss
+++ b/assets/src/scss/blocks/CarouselHeader/CarouselHeaderStyle.scss
@@ -425,6 +425,10 @@ $medium-image-height: 600px;
         max-width: 100%;
         width: 100%;
       }
+
+      &:focus {
+        @include focus-styles();
+      }
     }
 
     p {


### PR DESCRIPTION
### Summary
This PR includes the code of #2926 (but reverted [4ad07c13802](https://github.com/greenpeace/planet4-master-theme/commit/a7f6ad3ced73b7f71c164498f666e4ad07c13802)). 

Also implemented:
- The possibility to receive as param whenever the user click on arrows or interactions.
- Automatically stop sliding when this block is not visible on viewport
- Follow up the keyboard navigfation in block accesability-wise

Demo page https://www-dev.greenpeace.org/test-mars/carousel-demo-page/

---

<!-- Please add a reference link to the ticket, if one exists. -->
Ref: [PLANET-8147](https://greenpeace-planet4.atlassian.net/browse/PLANET-8147) and [PLANET-8003](https://greenpeace-planet4.atlassian.net/browse/PLANET-8003)

### Testing
<!-- Please add the steps required to test the changes in this Pull Request. -->
1. Navigate through the home of the assigned instance
2. The slide's heading NOT BE focused if the carousel is autoplayed.
3. The slide's heading MIGHT BE focused if the user click on arrows and/or indicators.
4. The slide's heading NOT BE focused if the carousel is autoplayed and the user scroll down into page.
5. After the focus tab on current slide, the next focus when tabbing should be the assigned indicator.


[PLANET-8147]: https://greenpeace-planet4.atlassian.net/browse/PLANET-8147?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[PLANET-8003]: https://greenpeace-planet4.atlassian.net/browse/PLANET-8003?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ