### PR TITLE
PLANET-8055 Write an e2e test for the Posts List block (grid layout)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,7 +188,7 @@ jobs:
   e2e-tests:
     working_directory: /usr/app/
     docker:
-      - image: mcr.microsoft.com/playwright:v1.49.1
+      - image: mcr.microsoft.com/playwright:v1.59.1
         auth:
           <<: *docker_auth
     steps:
@@ -199,7 +199,7 @@ jobs:
       - run:
           name: Install dependencies
           command: |
-            npm install @playwright/test@1.49.1 @wordpress/e2e-test-utils-playwright@1.16.0 dotenv
+            npm install @playwright/test@1.59.1 @wordpress/e2e-test-utils-playwright@1.16.0 dotenv
             npx playwright install --with-deps
       - run:
           name: End-to-end tests

--- a/tests/e2e/blocks/posts-list.spec.js
+++ b/tests/e2e/blocks/posts-list.spec.js
@@ -1,48 +1,34 @@
-import {test, expect} from '../tools/lib/test-utils.js';
+import {test} from '../tools/lib/test-utils.js';
 import {publishPostAndVisit, createPostWithFeaturedImage} from '../tools/lib/post.js';
-import {searchAndInsertBlock} from '../tools/lib/editor';
-
-const TEST_TITLE = 'Related Stories';
-const TEST_CATEGORY = 'Energy';
+import {addPostsListBlock, checkPostsListBlock} from '../tools/lib/posts-list.js';
 
 test.useAdminLoggedIn();
 
 test.describe('Test Posts List block', () => {
   // This is the default layout, so we don't need to select it manually.
   test('Test the List layout', async ({page, admin, editor}) => {
-    await createPostWithFeaturedImage({page, admin, editor}, {title: 'Test Posts List List Layout', postType: 'page'});
+    await createPostWithFeaturedImage({page, admin, editor}, {title: 'Test Posts List, List Layout', postType: 'page'});
 
-    // Add Posts List block.
-    await searchAndInsertBlock({page}, 'Posts List');
+    // Add a Posts List block with the wanted attributes.
+    await addPostsListBlock(page);
 
-    // Change amount of posts from 3 to 4.
-    await page.getByRole('spinbutton', {name: 'Items per page'}).fill('4');
+    // Publish page.
+    await publishPostAndVisit({page, editor});
 
-    // Filter by "Energy" category.
-    const editorSettings = page.getByRole('region', {name: 'Editor settings'});
-    await editorSettings.getByRole('button', {name: 'Filters options'}).click();
-    await page.getByLabel('Show Taxonomies').click();
-    await editorSettings.getByLabel('Categories').fill(TEST_CATEGORY);
-    await editorSettings.locator(
-      '.components-form-token-field__suggestion', {hasText: TEST_CATEGORY}
-    ).click();
-    await expect(editorSettings.locator(
-      '.components-form-token-field__token-text', {hasText: TEST_CATEGORY})
-    ).toBeVisible();
+    // Check that the block displays correctly in the frontend.
+    await checkPostsListBlock(page, 'list');
+  });
 
-    // Change the title.
-    await page.getByRole('document', {name: 'Block: Heading'}).fill(TEST_TITLE);
+  test('Test the Grid layout', async ({page, admin, editor}) => {
+    await createPostWithFeaturedImage({page, admin, editor}, {title: 'Test Posts List, Grid Layout', postType: 'page'});
+
+    // Add a Posts List block with the wanted attributes.
+    await addPostsListBlock(page, 'Grid');
 
     // Publish page.
     await publishPostAndVisit({page, editor});
 
     // Test that the block is displayed as expected in the frontend.
-    const block = page.locator('.p4-query-loop');
-    await expect(block).toHaveClass(/is-custom-layout-list/);
-    await expect(block.locator('h2.wp-block-heading')).toHaveText(TEST_TITLE);
-    await expect(block.locator('.wp-block-post')).toHaveCount(4);
-    for (const category of await block.locator('.wp-block-post-terms:not(.taxonomy-post_tag)').all()) {
-      await expect(category).toHaveText(TEST_CATEGORY);
-    }
+    await checkPostsListBlock(page, 'grid');
   });
 });

--- a/tests/e2e/tools/lib/posts-list.js
+++ b/tests/e2e/tools/lib/posts-list.js
@@ -1,0 +1,46 @@
+import {searchAndInsertBlock} from './editor.js';
+import {expect} from './test-utils.js';
+
+const TEST_TITLE = 'Related Stories';
+const TEST_CATEGORY = 'Energy';
+
+async function addPostsListBlock(page, layout) {
+  // Add Posts List block.
+  await searchAndInsertBlock({page}, 'Posts List');
+
+  // Select wanted layout. If none is provided it means we are using the default one which is List.
+  if (layout) {
+    await page.getByRole('radio', {name: layout}).check();
+  }
+
+  // Change amount of posts from 3 to 4.
+  await page.getByRole('spinbutton', {name: 'Items per page'}).fill('4');
+
+  // Filter by "Energy" category.
+  const editorSettings = page.getByRole('region', {name: 'Editor settings'});
+  await editorSettings.getByRole('button', {name: 'Filters options'}).click();
+  await page.getByLabel('Show Taxonomies').click();
+  await editorSettings.getByLabel('Categories').fill(TEST_CATEGORY);
+  await editorSettings.locator(
+    '.components-form-token-field__suggestion', {hasText: TEST_CATEGORY}
+  ).click();
+  await expect(editorSettings.locator(
+    '.components-form-token-field__token-text', {hasText: TEST_CATEGORY})
+  ).toBeVisible();
+
+  // Change the title.
+  await page.getByRole('document', {name: 'Block: Heading'}).fill(TEST_TITLE);
+}
+
+async function checkPostsListBlock(page, layout) {
+  // Test that the block is displayed as expected in the frontend.
+  const block = page.locator('.p4-query-loop');
+  await expect(block).toContainClass(`is-custom-layout-${layout}`);
+  await expect(block.locator('h2.wp-block-heading')).toHaveText(TEST_TITLE);
+  await expect(block.locator('.wp-block-post')).toHaveCount(4);
+  for (const category of await block.locator('.wp-block-post-terms:not(.taxonomy-post_tag)').all()) {
+    await expect(category).toHaveText(TEST_CATEGORY);
+  }
+}
+
+export {addPostsListBlock, checkPostsListBlock};


### PR DESCRIPTION
### Summary

Ref: [PLANET-8055](https://greenpeace-planet4.atlassian.net/browse/PLANET-8055)

This commit also refactors the tests for this specific block to avoid code duplication. SonarCloud still complains about duplicated code with the Actions List tests, but I think this is fine for now, we can look into refactoring later when we add more tests for the Actions List as well.

**Test Steps**
1. Login to the Admin Panel.
2. Create a new Page.
3. Add a Posts List block:
  - Pick the Grid layout
  - Increase the Posts per page value to 4
  - Filter posts by category "Energy"
  - Change block title to "Related Stories"
4. Publish the page.
5. Navigate to the frontend view of that Page and verify that all of the above properties are working as expected:
  - Block title
  - All posts are from the "Energy" category
  - Assess grid layout
  - There are 4 posts displayed

**NOTE:** we first need to upgrade Playwright to latest version, to be able to use the new `toContainClass` assertion. There is already an [open PR](https://github.com/greenpeace/planet4-master-theme/pull/2949) for this, and in this PR we update it in CI as well.

### Testing

On local you can run `npx playwright test tests/e2e/blocks/posts-list.spec.js`

[PLANET-8055]: https://greenpeace-planet4.atlassian.net/browse/PLANET-8055?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ