### PR TITLE
PLANET-7975: Improve Actions List carousel accessibility

### DIFF
--- a/assets/src/blocks/ActionsList/index.js
+++ b/assets/src/blocks/ActionsList/index.js
@@ -35,7 +35,7 @@ const carouselButtons = [
           'core/button',
           {
             className: 'carousel-control-prev',
-            text: __('Previous Carousel Slide', 'planet4-master-theme-backend'),
+            text: __('Previous carousel slide', 'planet4-master-theme-backend'),
             tagName: 'button',
           },
         ],
@@ -43,7 +43,7 @@ const carouselButtons = [
           'core/button',
           {
             className: 'carousel-control-next',
-            text: __('Next Carousel Slide', 'planet4-master-theme-backend'),
+            text: __('Next carousel slide', 'planet4-master-theme-backend'),
             tagName: 'button',
           },
         ],

--- a/assets/src/blocks/ActionsList/index.js
+++ b/assets/src/blocks/ActionsList/index.js
@@ -1,4 +1,4 @@
-import {LISTS_BREADCRUMBS, carouselButtons} from '../PostsList';
+import {LISTS_BREADCRUMBS} from '../PostsList';
 import {TAX_BREADCRUMB_BLOCK_NAME} from '../../block-editor/setupTaxonomyBreadcrumbBlock';
 
 export const ACTIONS_LIST_BLOCK_NAME = 'planet4-blocks/actions-list';
@@ -15,6 +15,42 @@ const IS_NEW_IA = window.p4_vars.options.new_ia;
 const ACT_PAGE = window.p4_vars.options.take_action_page || -1;
 
 const queryPostType = IS_NEW_IA ? 'p4_action' : 'page';
+
+const carouselButtons = [
+  'core/group',
+  {
+    tagName: 'nav',
+    className: 'carousel-controls',
+    ariaLabel: __('Actions List carousel controls', 'planet4-master-theme-backend'),
+  },
+  [
+    [
+      'core/buttons',
+      {
+        lock: {move: true},
+        layout: {type: 'flex', justifyContent: 'space-between', orientation: 'horizontal', flexWrap: 'nowrap'},
+      },
+      [
+        [
+          'core/button',
+          {
+            className: 'carousel-control-prev',
+            text: __('Previous Carousel Slide', 'planet4-master-theme-backend'),
+            tagName: 'button',
+          },
+        ],
+        [
+          'core/button',
+          {
+            className: 'carousel-control-next',
+            text: __('Next Carousel Slide', 'planet4-master-theme-backend'),
+            tagName: 'button',
+          },
+        ],
+      ],
+    ],
+  ],
+];
 
 export const ACTIONS_LIST_BLOCK_ATTRIBUTES = {
   namespace: ACTIONS_LIST_BLOCK_NAME,

--- a/assets/src/blocks/PostsList/index.js
+++ b/assets/src/blocks/PostsList/index.js
@@ -22,7 +22,7 @@ const seeAllLink = ['core/navigation-link', {...!newsPageLink ? {className: 'd-n
   className: 'see-all-link',
 }}];
 
-export const carouselButtons = ['core/buttons', {
+const carouselButtons = ['core/buttons', {
   className: 'carousel-controls',
   lock: {move: true},
   layout: {type: 'flex', justifyContent: 'space-between', orientation: 'horizontal', flexWrap: 'nowrap'},

--- a/assets/src/js/query_loop_carousel.js
+++ b/assets/src/js/query_loop_carousel.js
@@ -149,22 +149,32 @@ export const setupQueryLoopCarousel = () => {
 
         const carouselButtons = layout.querySelectorAll(`${BUTTONS_CLASS} ${CONTROLS_CLASS}-next, ${BUTTONS_CLASS} ${CONTROLS_CLASS}-prev`);
 
-        // This resets the focus to the ghost element so users can tab over the new slide.
+        // Moves the focus to the next slide when the carousel arrows are hit.
         carouselButtons.forEach(button => {
           button.addEventListener('click', () => {
-            setTimeout(() => {
-              const resetFocusLink = layout.querySelector('.carousel-ghost-link');
-              const currentSlide = layout.querySelector('.carousel-item.active');
-              if (resetFocusLink) {
-                const match = currentSlide.className.match(/carousel-slide-(\d+)/);
-                const slideIndex = match ? parseInt(match[1], 10) : null;
 
-                // This adds a voice over so the screen reader reads out which Slide you are on.
-                resetFocusLink.removeAttribute('aria-hidden');
-                resetFocusLink.setAttribute('aria-label', `Slide ${slideIndex}`);
-                resetFocusLink.focus();
+            const observer = new MutationObserver(() => {
+              const currentSlide = layout.querySelector('.carousel-item.active');
+
+              if (!currentSlide) {return;}
+
+              const focusTarget = currentSlide.querySelector('a');
+
+              if (focusTarget) {
+                focusTarget.focus();
+              } else {
+                currentSlide.setAttribute('tabindex', '-1');
+                currentSlide.focus();
               }
-            }, 600);
+
+              observer.disconnect();
+            });
+
+            observer.observe(layout, {
+              subtree: true,
+              attributes: true,
+              attributeFilter: ['class'],
+            });
           });
         });
       });

--- a/assets/src/js/query_loop_carousel.js
+++ b/assets/src/js/query_loop_carousel.js
@@ -10,6 +10,10 @@ const LAYOUTS = {
 };
 const BUTTONS_CLASS = '.wp-block-buttons';
 const CONTROLS_CLASS = `.${LAYOUTS.carousel}-control`;
+const BLOCK_CLASSNAMES = {
+  actionsList: 'actions-list',
+  postsList: 'posts-list',
+};
 
 /**
  * This function removes the arrows, in one of these two cases:
@@ -149,34 +153,57 @@ export const setupQueryLoopCarousel = () => {
 
         const carouselButtons = layout.querySelectorAll(`${BUTTONS_CLASS} ${CONTROLS_CLASS}-next, ${BUTTONS_CLASS} ${CONTROLS_CLASS}-prev`);
 
-        // Moves the focus to the next slide when the carousel arrows are hit.
-        carouselButtons.forEach(button => {
-          button.addEventListener('click', () => {
+        if (layout.className.includes(BLOCK_CLASSNAMES.postsList)) {
+          // This resets the focus to the ghost element so users can tab over the new slide.
+          carouselButtons.forEach(button => {
+            button.addEventListener('click', () => {
+              setTimeout(() => {
+                const resetFocusLink = layout.querySelector('.carousel-ghost-link');
+                const currentSlide = layout.querySelector('.carousel-item.active');
+                if (resetFocusLink) {
+                  const match = currentSlide.className.match(/carousel-slide-(\d+)/);
+                  const slideIndex = match ? parseInt(match[1], 10) : null;
 
-            const observer = new MutationObserver(() => {
-              const currentSlide = layout.querySelector('.carousel-item.active');
-
-              if (!currentSlide) {return;}
-
-              const focusTarget = currentSlide.querySelector('a');
-
-              if (focusTarget) {
-                focusTarget.focus();
-              } else {
-                currentSlide.setAttribute('tabindex', '-1');
-                currentSlide.focus();
-              }
-
-              observer.disconnect();
-            });
-
-            observer.observe(layout, {
-              subtree: true,
-              attributes: true,
-              attributeFilter: ['class'],
+                  // This adds a voice over so the screen reader reads out which Slide you are on.
+                  resetFocusLink.removeAttribute('aria-hidden');
+                  resetFocusLink.setAttribute('aria-label', `Slide ${slideIndex}`);
+                  resetFocusLink.focus();
+                }
+              }, 600);
             });
           });
-        });
+        }
+
+        if (layout.className.includes(BLOCK_CLASSNAMES.actionsList)) {
+          // Moves the focus to the next slide when the carousel arrows are hit.
+          carouselButtons.forEach(button => {
+            button.addEventListener('click', () => {
+
+              const observer = new MutationObserver(() => {
+                const currentSlide = layout.querySelector('.carousel-item.active');
+
+                if (!currentSlide) {return;}
+
+                const focusTarget = currentSlide.querySelector('a');
+
+                if (focusTarget) {
+                  focusTarget.focus();
+                } else {
+                  currentSlide.setAttribute('tabindex', '-1');
+                  currentSlide.focus();
+                }
+
+                observer.disconnect();
+              });
+
+              observer.observe(layout, {
+                subtree: true,
+                attributes: true,
+                attributeFilter: ['class'],
+              });
+            });
+          });
+        }
       });
     } else {
       // This is for the grid or list layouts, we need to remove the arrows.

--- a/src/Migrations/M063ActionsListCarouselAccessibility.php
+++ b/src/Migrations/M063ActionsListCarouselAccessibility.php
@@ -83,10 +83,10 @@ class M063ActionsListCarouselAccessibility extends MigrationScript
             unset($current['attrs']['className']);
 
             $current['innerHTML'] =
-                self::remove_class_from_html($current['innerHTML'], 'carousel-controls');
+                Utils\Functions::remove_class_from_html($current['innerHTML'], 'carousel-controls');
 
             $current['innerContent'][0] =
-                self::remove_class_from_html($current['innerContent'][0], 'carousel-controls');
+                Utils\Functions::remove_class_from_html($current['innerContent'][0], 'carousel-controls');
 
             $block['innerBlocks'][$i] = Utils\Functions::create_group_block(
                 [$current],
@@ -96,31 +96,5 @@ class M063ActionsListCarouselAccessibility extends MigrationScript
         }
 
         return $block;
-    }
-
-    /**
-     * Removes a class from a piece of html.
-     *
-     * @param string $html - The HTML.
-     * @param string $classToRemove - The class to be removed.
-     * @return string.
-     */
-    private static function remove_class_from_html(string $html, string $classToRemove): string
-    {
-        return preg_replace_callback(
-            '/class="([^"]*)"/',
-            function ($matches) use ($classToRemove) {
-                $classes = preg_split('/\s+/', trim($matches[1]));
-
-                $classes = array_filter($classes, fn($c) => $c !== $classToRemove);
-
-                if (empty($classes)) {
-                    return '';
-                }
-
-                return 'class="' . implode(' ', $classes) . '"';
-            },
-            $html
-        );
     }
 }

--- a/src/Migrations/M063ActionsListCarouselAccessibility.php
+++ b/src/Migrations/M063ActionsListCarouselAccessibility.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace P4\MasterTheme\Migrations;
+
+use P4\MasterTheme\MigrationRecord;
+use P4\MasterTheme\MigrationScript;
+
+/**
+ * Refactor Actions List blocks to wrap the carousel arrows within a "nav" tag.
+ */
+class M063ActionsListCarouselAccessibility extends MigrationScript
+{
+    /**
+     * Perform the actual migration.
+     *
+     * @param MigrationRecord $record Information on the execution, can be used to add logs.
+     * phpcs:disable SlevomatCodingStandard.Functions.UnusedParameter -- interface implementation
+     */
+    public static function execute(MigrationRecord $record): void
+    {
+        $check_is_valid_block = function ($block) {
+            return self::check_is_valid_block($block);
+        };
+
+        $transform_block = function ($block) {
+            return self::transform_block($block);
+        };
+
+        Utils\Functions::execute_block_migration(
+            Utils\Constants::BLOCK_QUERY,
+            $check_is_valid_block,
+            $transform_block,
+        );
+    }
+    // phpcs:enable SlevomatCodingStandard.Functions.UnusedParameter
+
+    /**
+     * Check whether a block is an Actions List block.
+     *
+     * @param array $block - A block data array.
+     */
+    private static function check_is_valid_block(array $block): bool
+    {
+        if (!is_array($block)) {
+            return false;
+        }
+
+        if (!isset($block['blockName']) || !isset($block['attrs']['namespace'])) {
+            return false;
+        }
+
+        return
+            $block['blockName'] === Utils\Constants::BLOCK_QUERY &&
+            $block['attrs']['namespace'] === Utils\Constants::BLOCK_ACTIONS_LIST;
+    }
+
+    /**
+     * Wrap the "carousel-controls" buttons within a nav-type group block.
+     *
+     * @param array $block - A block data array.
+     * @return array - The transformed block.
+     */
+    private static function transform_block(array $block): array
+    {
+        if (empty($block['innerBlocks']) || !is_array($block['innerBlocks'])) {
+            return $block;
+        }
+
+        foreach ($block['innerBlocks'] as $i => $current) {
+            $is_block_buttons = ($current['blockName'] ?? null) === Utils\Constants::BLOCK_BUTTONS;
+            $has_classname = !empty($current['attrs']['className'] ?? '');
+
+            if (!$is_block_buttons || !$has_classname) {
+                continue;
+            }
+
+            $classes = preg_split('/\s+/', trim($current['attrs']['className']));
+
+            if (!in_array('carousel-controls', $classes, true)) {
+                continue;
+            }
+
+            unset($current['attrs']['className']);
+
+            $current['innerHTML'] =
+                self::remove_class_from_html($current['innerHTML'], 'carousel-controls');
+
+            $current['innerContent'][0] =
+                self::remove_class_from_html($current['innerContent'][0], 'carousel-controls');
+
+            $block['innerBlocks'][$i] = Utils\Functions::create_group_block(
+                [$current],
+                ['tagName' => 'nav', 'className' => 'carousel-controls'],
+                'Actions List carousel controls',
+            );
+        }
+
+        return $block;
+    }
+
+    /**
+     * Removes a class from a piece of html.
+     *
+     * @param string $html - The HTML.
+     * @param string $classToRemove - The class to be removed.
+     * @return string.
+     */
+    private static function remove_class_from_html(string $html, string $classToRemove): string
+    {
+        return preg_replace_callback(
+            '/class="([^"]*)"/',
+            function ($matches) use ($classToRemove) {
+                $classes = preg_split('/\s+/', trim($matches[1]));
+
+                $classes = array_filter($classes, fn($c) => $c !== $classToRemove);
+
+                if (empty($classes)) {
+                    return '';
+                }
+
+                return 'class="' . implode(' ', $classes) . '"';
+            },
+            $html
+        );
+    }
+}

--- a/src/Migrations/Utils/Functions.php
+++ b/src/Migrations/Utils/Functions.php
@@ -644,9 +644,11 @@ class Functions
 
         $tagname = isset($attrs['tagName']) ? $attrs['tagName'] : 'div';
 
+        $aria_label_attr = $aria_label !== '' ? ' aria-label="' . $aria_label . '"' : '';
+
         // IMPORTANT: DO NOT MODIFY THIS FORMAT!
         $inner_html =
-        '<' . $tagname . ' class="' . $classname . '" aria-label="' . $aria_label . '">
+        '<' . $tagname . ' class="' . $classname . '"' . $aria_label_attr . '>
 
 
 
@@ -657,7 +659,7 @@ class Functions
         // IMPORTANT: DO NOT MODIFY THIS FORMAT!
         $inner_content = array (
             0 => '
-        <' . $tagname . ' class="' . $classname . '" aria-label="' . $aria_label . '">',
+        <' . $tagname . ' class="' . $classname . '"' . $aria_label_attr . '>',
             1 => null,
             2 => '
         ',

--- a/src/Migrations/Utils/Functions.php
+++ b/src/Migrations/Utils/Functions.php
@@ -631,30 +631,33 @@ class Functions
      *
      * @param array $inner_blocks - The block's inner blocks.
      * @param array $attrs - The block's attributes.
+     * @param string $aria_label - The block's ARIA label.
      *
      * @return array - The new Group block.
      */
-    public static function create_group_block(array $inner_blocks, array $attrs): array
+    public static function create_group_block(array $inner_blocks, array $attrs, string $aria_label = ''): array
     {
         $classname =
             isset($attrs['className']) ?
             'wp-block-group ' . $attrs['className'] :
             'wp-block-group';
 
+        $tagname = isset($attrs['tagName']) ? $attrs['tagName'] : 'div';
+
         // IMPORTANT: DO NOT MODIFY THIS FORMAT!
         $inner_html =
-        '<div class="' . $classname . '">
+        '<' . $tagname . ' class="' . $classname . '" aria-label="' . $aria_label . '">
 
 
 
 
 
-        </div>';
+        </' . $tagname . '>';
 
         // IMPORTANT: DO NOT MODIFY THIS FORMAT!
         $inner_content = array (
             0 => '
-        <div class="' . $classname . '">',
+        <' . $tagname . ' class="' . $classname . '" aria-label="' . $aria_label . '">',
             1 => null,
             2 => '
         ',
@@ -665,7 +668,7 @@ class Functions
             6 => '
         ',
             7 => null,
-            8 => '</div>
+            8 => '</' . $tagname . '>
         ',
         );
 

--- a/src/Migrations/Utils/Functions.php
+++ b/src/Migrations/Utils/Functions.php
@@ -736,4 +736,30 @@ class Functions
             $content,
         );
     }
+
+    /**
+     * Removes a class from a piece of html.
+     *
+     * @param string $html - The HTML.
+     * @param string $classToRemove - The class to be removed.
+     * @return string
+     */
+    public static function remove_class_from_html(string $html, string $classToRemove): string
+    {
+        return preg_replace_callback(
+            '/class="([^"]*)"/',
+            function ($matches) use ($classToRemove) {
+                $classes = preg_split('/\s+/', trim($matches[1]));
+
+                $classes = array_filter($classes, fn($c) => $c !== $classToRemove);
+
+                if (empty($classes)) {
+                    return '';
+                }
+
+                return 'class="' . implode(' ', $classes) . '"';
+            },
+            $html
+        );
+    }
 }

--- a/src/Migrations/Utils/Functions.php
+++ b/src/Migrations/Utils/Functions.php
@@ -744,7 +744,6 @@ class Functions
      *
      * @param string $html - The HTML.
      * @param string $classToRemove - The class to be removed.
-     * @return string
      */
     public static function remove_class_from_html(string $html, string $classToRemove): string
     {

--- a/src/Migrator.php
+++ b/src/Migrator.php
@@ -63,6 +63,7 @@ use P4\MasterTheme\Migrations\M059AddMissingTypeToButtons;
 use P4\MasterTheme\Migrations\M060RemoveCountrySelectorText;
 use P4\MasterTheme\Migrations\M061RemovePlanet4BlocksFeature;
 use P4\MasterTheme\Migrations\M062ActionsListStretchedLinkRefactor;
+use P4\MasterTheme\Migrations\M063ActionsListCarouselAccessibility;
 
 /**
  * Run any new migration scripts and record results in the log.
@@ -143,6 +144,7 @@ class Migrator
             M060RemoveCountrySelectorText::class,
             M061RemovePlanet4BlocksFeature::class,
             M062ActionsListStretchedLinkRefactor::class,
+            M063ActionsListCarouselAccessibility::class,
         ];
 
         // Loop migrations and run those that haven't run yet.

--- a/tests/e2e/blocks/secondary-navigation.spec.js
+++ b/tests/e2e/blocks/secondary-navigation.spec.js
@@ -26,7 +26,7 @@ const HEADINGS = [
 
 test.useAdminLoggedIn();
 
-test('Test Secondary Navigation block', async ({page, admin, editor}) => {
+test.slow('Test Secondary Navigation block', async ({page, admin, editor}) => {
   await createPostWithFeaturedImage({page, admin, editor}, {title: 'Test Secondary Navigation', postType: 'page'});
 
   // Add Page Header block.


### PR DESCRIPTION
### Summary

This PR fulfills the following requirements:
- Wrap the Previous/Next controls in a navigation landmark so they are easy to find.
- Add a label name "Actions List carousel controls".
- When activating an arrow, the focus moves to the next slide container. 

---

Ref: https://greenpeace-planet4.atlassian.net/browse/PLANET-7975

### Testing

1. Launch the website locally.
2. Add a new Actions List block with a carousel layout to any page.
3. Check that the carousel arrows are wrapped in a navigation landmark.
4. Check that the navigation landmark contains an ARIA label with the value "Actions List carousel controls".
5. Check that the focus is moved from the arrows to the first carousel item when an arrow is hit.
6. Now check a previously existing Actions List block. Points 3 and 4 should not be fulfilled.
7. Reset the database by running `npm run db:reset` 
8. Run the migration: `npx wp-env run cli wp p4-run-activator` 
9. Check again a previously existing Actions List block. 
10. Points 3, 4, and 5 should be fulfilled now.
