### PR TITLE
PLANET-8149: Posts show wrong publish date in certain timezones

### DIFF
--- a/templates/single-attachment.twig
+++ b/templates/single-attachment.twig
@@ -16,7 +16,7 @@
                         </address>
                     {% endif %}
                     <span class="single-post-meta-bullet" aria-hidden="true">&#8226;</span>
-                    <time class="single-post-time" pubdate>{{ post.post_date|date }}</time>
+                    <time class="single-post-time" pubdate>{{ post.post_date_gmt|date }}</time>
                 </div>
                 {% include "blocks/share_buttons.twig" with {
                     social:post.share_meta,

--- a/templates/single.twig
+++ b/templates/single.twig
@@ -61,7 +61,7 @@
                                 {% endif %}
                             </address>
                         {% endif %}
-                        <time class="single-post-time" pubdate>{{ post.post_date|date }}</time>
+                        <time class="single-post-time" pubdate>{{ post.post_date_gmt|date }}</time>
                         {% set reading_time = post.reading_time_for_display %}
                         {% if reading_time %}
                             <span class="single-post-meta-bullet" aria-hidden="true">&#8226;</span>

--- a/templates/tease-search.twig
+++ b/templates/tease-search.twig
@@ -143,7 +143,7 @@
 
             {% if ( 'page' != post.post_type ) %}
                 <div class="search-result-item-info">
-                    <span class="search-result-item-date">{{ post.post_date|date('d/m/Y') }}</span>
+                    <span class="search-result-item-date">{{ post.post_date_gmt|date('d/m/Y') }}</span>
                 </div>
             {% endif %}
 


### PR DESCRIPTION
### Summary

This PR fixes the posts showing a wrong publish date in certain time zones by replacing the variable `post.post_date` with `post.post_date_gmt` in our Timber files. 

In [a previous attempt](https://github.com/greenpeace/planet4-master-theme/pull/2942/), the variable `post.post_date` had been replaced with `post.date`. However, that approach [produced errors in some scenarios](https://greenpeace.slack.com/archives/C014UMRC4AJ/p1775661491347849), so the changes were reverted.

Finally, and differently from [this PR](https://github.com/greenpeace/planet4-master-theme/pull/2942/), I decided not to replace the date in the files `tease-author.twig`, `tease-taxonomy-action.twig`, and `tease-taxonomy-post.twig` as I couldn't find a way to test them.

---

Ref: https://greenpeace-planet4.atlassian.net/browse/PLANET-8149

### Testing

1. Log in to the website admin panel.
2. Go to Settings > General and change the Timezone to “Auckland“.
3. Create or edit a post. Change its publication time to 12:30 PM and save the changes.
4. Upload a media file. Change its upload time to 12:30 PM and save the changes.
5. Switch to the `main` branch.
6. Clear the Timber cache by running `npx wp-env run cli wp timber clear_cache`
7. Go to the front and check the date of the post created in step 3. Compare it with the real publication date in the post editor. The date in the front should be the following day.
8. Search for the post created in step 3 in the Search Results page and check its date. Compare it with the real publication date in the post editor. The date in the front should be the following day.
9. Open the attachment page of the media uploaded in step 4 and check its date. Compare it with the real publication date in the post editor. The date in the front should be the following day.
10. Switch to this PR branch. 
11. Clear the Timber cache by running `npx wp-env run cli wp timber clear_cache`
12. Repeat steps 7, 8, and 9. Compare the dates with the real publication date in the post editor. Both dates should be the same.
13. Repeat the previous steps using different timezones and posts' dates and times.
