### PR TITLE
PLANET-8013: News & Stories accessibility

### DIFF
--- a/templates/listing-page.twig
+++ b/templates/listing-page.twig
@@ -9,6 +9,7 @@
     <div class="wp-block-separator is-style-wide listing-page-separator"></div>
     <div class="d-flex align-items-center justify-content-between listing-page-title">
         {% if fn('is_home') %}
+            <h2 tabindex="0" class="visually-hidden">{{__( 'Filter posts', 'planet4-master-theme' ) }}</h2>
             {% include 'listing-page-filters.twig' %}
         {% else %}
             <h2>{{ listing_page_title ?? __( 'All articles', 'planet4-master-theme' ) }}</h2>


### PR DESCRIPTION
### Summary

This PR adds a screen-reader-only `H2` element with the text "Filter posts" before the filter controls on the News & Stories page.

NOTE: I decided to add the `H2` to the `listing-page.twig` file instead of the `listing-page-filters.twig` file to keep the consistency with the accessibility changes introduced [here](https://github.com/greenpeace/planet4-master-theme/pull/2887).

---

Ref: https://greenpeace-planet4.atlassian.net/browse/PLANET-8013

### Testing

1. Go to the News & Stories page and move the focus right before the filter controls by tabbing.
2. Check that the screen reader announces the hidden "Filter posts" element.