### PR TITLE
PLANET-8078 Enable keyboard accessibility for language selector

### DIFF
--- a/assets/src/js/header/setupAccessibleNavMenu.js
+++ b/assets/src/js/header/setupAccessibleNavMenu.js
@@ -123,6 +123,7 @@ export const setupAccessibleNavMenu = () => {
     handleAccessibleNavLink();
     handleNavMenuSub();
     handleNavMenuSubItems();
+    makeLanguageMenuAccessible();
   }
 
   if (mobileNav) {
@@ -274,3 +275,27 @@ const syncMobileNavAria = isOpen => {
   // Toggle button state
   toggleBtn.setAttribute('aria-expanded', String(isOpen));
 };
+
+/**
+ * Function to make the language menu accessible.
+ */
+const makeLanguageMenuAccessible = () => {
+  const languageMenuToggle = document.querySelector('.nav-languages-toggle');
+  const languageSubmenu = document.getElementById('nav-languages');
+
+
+  languageMenuToggle.addEventListener('click', () => {
+    const isOpen = languageSubmenu.classList.toggle('is-open');
+    languageMenuToggle.setAttribute('aria-expanded', isOpen);
+  });
+
+  // Close the submenu when pressing Escape.
+  languageMenuToggle.addEventListener('keydown', e => {
+    if (e.key === 'Escape') {
+      languageSubmenu.classList.remove('is-open');
+      languageMenuToggle.setAttribute('aria-expanded', 'false');
+      languageMenuToggle.focus();
+    }
+  });
+};
+

--- a/assets/src/scss/layout/navbar/_languages.scss
+++ b/assets/src/scss/layout/navbar/_languages.scss
@@ -1,5 +1,19 @@
 @use "../../base/tokens" as tokens;
 
+.nav-languages-wrapper {
+  .nav-languages {
+    display: none;
+  }
+
+  &:hover .nav-languages {
+    display: block;
+  }
+
+  .nav-languages.is-open {
+    display: block;
+  }
+}
+
 .nav-languages-toggle {
   background: transparent;
   border: none;
@@ -27,18 +41,14 @@
       background-repeat: no-repeat;
     }
 
-    .nav-languages {
-      display: none;
-    }
-
     &:hover {
       &::after {
         transform: rotate(-90deg);
       }
+    }
 
-      .nav-languages {
-        display: block;
-      }
+    &[aria-expanded="true"]::after {
+      transform: rotate(-90deg);
     }
   }
 }

--- a/templates/navigation-bar.twig
+++ b/templates/navigation-bar.twig
@@ -31,12 +31,23 @@
 
     {% if site_languages is not empty and site_languages|length > 1 %}
     {% set current_lang = site_languages|filter(i => i.active)|first %}
-        <button
-            class="nav-languages-toggle"
-            type="button"
-        >{{ current_lang.code|capitalize }}
+        <div class="nav-languages-wrapper">
+            <button
+                class="nav-languages-toggle"
+                type="button"
+                title="{{__(current_lang.native_name, 'planet4-master-theme')}}"
+                aria-label="{{ __('Language Selection', 'planet4-master-theme')}}"
+                aria-expanded="false"
+                aria-controls="nav-languages"
+            >
+                {{ current_lang.code|capitalize }}
+                <span class="visually-hidden">
+                    {{ current_lang.native_name }}
+                </span>
+            </button>
+
             {% include 'language-switcher.twig' %}
-        </button>
+        </div>
     {% endif %}
 
     {% if mobile_tabs_menu %}


### PR DESCRIPTION
### Summary
The language selector dropdown is not operable using a keyboard.

<!-- Please provide a brief summary of the change introduced in this Pull Request. -->

---

<!-- Please add a reference link to the ticket, if one exists. -->
Ref: https://greenpeace-planet4.atlassian.net/browse/PLANET-8078

### Testing

<!-- Please add the steps required to test the changes in this Pull Request. -->
Language selector is now accessible via keyboard 

You can test the Africa [dev site](https://www-dev.greenpeace.org/africa/en/)
