### PR TITLE
PLANET-8155: Set Custom as the default query type for the Query Loop

### DIFF
--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -77,7 +77,6 @@ class MasterSite extends \Timber\Site
             // Disable WP Block Patterns.
             remove_theme_support('core-block-patterns');
         }
-
         add_post_type_support('page', 'excerpt'); // Added excerpt option to pages.
 
         add_filter('timber/context', [$this, 'add_to_context']);
@@ -97,6 +96,7 @@ class MasterSite extends \Timber\Site
         add_action('pre_insert_term', [$this, 'disallow_insert_term'], 1, 2);
         add_filter('wp_dropdown_users_args', [$this, 'filter_authors'], 10, 1);
         add_filter('http_request_timeout', fn () => 10);
+        add_filter('register_block_type_args', [$this, 'set_custom_query_type'], 10, 2);
 
         add_action('after_setup_theme', function (): void {
             register_nav_menus(
@@ -258,6 +258,22 @@ class MasterSite extends \Timber\Site
                 return $classes;
             }
         );
+    }
+
+    /**
+     * Set "Custom" as the default query type for the native Query block.
+     */
+    public function set_custom_query_type(array $args, string $block_type): array
+    {
+        if ($block_type !== 'core/query') {
+            return $args;
+        }
+
+        if (isset($args['attributes']['query']['default']['inherit'])) {
+            $args['attributes']['query']['default']['inherit'] = false;
+        }
+
+        return $args;
     }
 
     /**

--- a/tests/e2e/blocks/actions-list.spec.js
+++ b/tests/e2e/blocks/actions-list.spec.js
@@ -9,7 +9,7 @@ test.useAdminLoggedIn();
 
 test.describe('Test Actions List block', () => {
   // This is the default layout, so we don't need to select it manually.
-  test('Test the Grid layout', async ({page, admin, editor}) => {
+  test.slow('Test the Grid layout', async ({page, admin, editor}) => {
     await createPostWithFeaturedImage({page, admin, editor}, {title: 'Test Actions List Grid Layout', postType: 'page'});
 
     // Add Actions List block.

--- a/tests/e2e/blocks/take-action-boxout.spec.js
+++ b/tests/e2e/blocks/take-action-boxout.spec.js
@@ -20,7 +20,7 @@ test.describe('Test Take Action Boxout block', () => {
 
   });
 
-  test('Take Action Boxout with existing page', async ({page, editor}) => {
+  test.slow('Take Action Boxout with existing page', async ({page, editor}) => {
     // Select the first page option.
 
     await page.getByRole('region', {name: 'Editor settings'})


### PR DESCRIPTION
### Summary

The default Query Type of the native Query Loop block does not render the posts as expected (but it does in the editor). Besides this not being a bug but the normal behavior, it can be misleading for editors. Taking that into consideration, this PR sets "Custom" as the default Query Type of the native Query Loop block.

<img width="269" height="282" alt="Screenshot from 2026-04-16 10-10-40" src="https://github.com/user-attachments/assets/f5ce8b18-c172-4fb2-aed0-c12fa20befe8" />

---

Ref: 
- https://greenpeace-planet4.atlassian.net/browse/PLANET-8155
- https://greenpeace-gpi.slack.com/archives/C0160MX64AG/p1776244669542409

### Testing

1. Run the website locally.
2. Switch to the `main` branch and add a new native Query Loop block.
3. Check the default Query Type in the block settings. It should be "Default".
4. Switch to this PR branch and add a new native Query Loop block.
3. Check the default Query Type in the block settings. It should be "Custom".