### PR TITLE
PLANET-8102: Fix missing "alt" in the TAB block

### DIFF
--- a/assets/src/blocks/TakeActionBoxout/TakeActionBoxoutEditor.js
+++ b/assets/src/blocks/TakeActionBoxout/TakeActionBoxoutEditor.js
@@ -76,9 +76,11 @@ export const TakeActionBoxoutEditor = ({
       actPageList.find(actPageFound => take_action_page === actPageFound.id) :
       null;
 
+    const {getMedia} = select('core');
+
     const actPageImageId = actPage?.featured_media;
 
-    const customImage = customImageId && select('core').getMedia(customImageId);
+    const customImage = customImageId && getMedia(customImageId);
     const customImageFromId = customImage?.source_url;
 
     /* eslint-disable no-shadow */
@@ -87,8 +89,8 @@ export const TakeActionBoxoutEditor = ({
     const link = !actPage ? customLink : actPage.link;
     const linkText = !actPage ? customLinkText : actPage?.meta?.action_button_text || DEFAULT_BUTTON_TEXT;
     const imageId = !actPage ? customImageId : actPageImageId;
-    const imageUrl = !actPage ? customImageFromId : select('core').getMedia(actPageImageId)?.source_url;
-    const imageAlt = !actPage ? customImage?.alt_text : '';
+    const imageUrl = !actPage ? customImageFromId : getMedia(actPageImageId)?.source_url;
+    const imageAlt = !actPage ? customImage?.alt_text : getMedia(actPageImageId)?.alt_text;
     /* eslint-enable no-shadow */
 
     return {


### PR DESCRIPTION
### Summary

This PR adds the corresponding "alt" attribute to the image of the Take Action Boxout block when a Take Action page is selected.

---

Ref: https://greenpeace-planet4.atlassian.net/browse/PLANET-8102

### Testing

1. Run the website locally.
2. Switch to the `main` branch.
3. Add a Take Action Boxout block to any page.
4. Do not select any Take Action Page and upload a custom background image. Check that the image of the Take Action Boxout block contains the "alt" attribute corresponding to the custom background image.
6. Go back to the block editor and select a Take Action Page. Check that the image of the Take Action Boxout block contains no value for the "alt" attribute.
7. Switch to this PR branch.
8. Go back to the block editor, do not select any Take Action Page and upload a custom background image. Check that the image of the Take Action Boxout block contains the "alt" attribute corresponding to the custom background image.
6. Go back to the block editor and select a Take Action Page. Check that the image of the Take Action Boxout block contains the "alt" attribute corresponding to the take action page.