### PR TITLE
PLANET-8156 Fix posts list blocks post date shows todays date

### DIFF
--- a/assets/src/blocks/PostsList/index.js
+++ b/assets/src/blocks/PostsList/index.js
@@ -107,7 +107,16 @@ export const getPostListBlockTemplate = (title = __('Related Posts', 'planet4-ma
         ['core/post-excerpt'],
         ['core/group', {className: 'posts-list-meta'}, [
           ['core/post-author-name', {isLink: true}],
-          ['core/post-date'],
+          ['core/post-date', {
+            metadata: {
+              bindings: {
+                datetime: {
+                  source: 'core/post-data',
+                  args: {field: 'date'},
+                },
+              },
+            },
+          }],
         ]],
       ]],
     ]],

--- a/src/Migrations/M063RemoveStaleDatetimeFromPostsListBlock.php
+++ b/src/Migrations/M063RemoveStaleDatetimeFromPostsListBlock.php
@@ -128,9 +128,11 @@ class M063RemoveStaleDatetimeFromPostsListBlock extends MigrationScript
                 }
             }
 
-            if (!empty($block['innerBlocks'])) {
-                $block['innerBlocks'] = self::fix_post_date_blocks($block['innerBlocks']);
+            if (empty($block['innerBlocks'])) {
+                continue;
             }
+
+            $block['innerBlocks'] = self::fix_post_date_blocks($block['innerBlocks']);
         }
 
         return $blocks;

--- a/src/Migrations/M063RemoveStaleDatetimeFromPostsListBlock.php
+++ b/src/Migrations/M063RemoveStaleDatetimeFromPostsListBlock.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace P4\MasterTheme\Migrations;
+
+use P4\MasterTheme\MigrationRecord;
+use P4\MasterTheme\MigrationScript;
+
+/**
+ * Fix `core/post-date` blocks inside Posts List blocks affected by a WordPress 6.9 regression.
+ *
+ * The editor's useEffect sets `datetime` to today's date on `core/post-date` blocks when the
+ * attribute is undefined. When the page is saved, this value is persisted and the PHP renderer
+ * uses it for every post in the loop, showing today's date instead of each post's actual
+ * publish date.
+ *
+ * This migration removes the stale `datetime` attribute and adds the `core/post-data` block
+ * binding so the editor reads the correct date from post context and won't re-write a stale
+ * value on subsequent saves.
+ */
+class M063RemoveStaleDatetimeFromPostsListBlock extends MigrationScript
+{
+    /**
+     * Perform the actual migration.
+     *
+     * @param MigrationRecord $record Information on the execution, can be used to add logs.
+     * phpcs:disable SlevomatCodingStandard.Functions.UnusedParameter -- interface implementation
+     */
+    public static function execute(MigrationRecord $record): void
+    {
+        $check_is_valid_block = function ($block) {
+            return self::check_is_valid_block($block);
+        };
+
+        $transform_block = function ($block) {
+            return self::transform_block($block);
+        };
+
+        Utils\Functions::execute_block_migration(
+            Utils\Constants::BLOCK_QUERY,
+            $check_is_valid_block,
+            $transform_block,
+            $record
+        );
+    }
+    // phpcs:enable SlevomatCodingStandard.Functions.UnusedParameter
+
+    /**
+     * Check whether a block is a Posts List block that has a `core/post-date` needing a fix.
+     * A fix is needed when the block either has a stale `datetime` attribute or is missing
+     * the `core/post-data` binding that prevents the editor from re-writing a stale value.
+     *
+     * @param array $block - A block data array.
+     */
+    private static function check_is_valid_block(array $block): bool
+    {
+        if (!is_array($block) || !isset($block['blockName']) || !isset($block['attrs']['namespace'])) {
+            return false;
+        }
+
+        if (
+            $block['blockName'] !== Utils\Constants::BLOCK_QUERY ||
+            $block['attrs']['namespace'] !== Utils\Constants::BLOCK_POSTS_LIST
+        ) {
+            return false;
+        }
+
+        return self::has_post_date_needing_fix($block['innerBlocks'] ?? []);
+    }
+
+    /**
+     * Recursively check whether any `core/post-date` block needs fixing.
+     *
+     * @param array $blocks - Array of block data arrays.
+     */
+    private static function has_post_date_needing_fix(array $blocks): bool
+    {
+        foreach ($blocks as $block) {
+            if (isset($block['blockName']) && $block['blockName'] === Utils\Constants::BLOCK_DATE) {
+                if (
+                    isset($block['attrs']['datetime']) ||
+                    !isset($block['attrs']['metadata']['bindings']['datetime'])
+                ) {
+                    return true;
+                }
+            }
+
+            if (!empty($block['innerBlocks']) && self::has_post_date_needing_fix($block['innerBlocks'])) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Remove the stale `datetime` attribute and add the `core/post-data` binding to all
+     * nested `core/post-date` blocks so the editor reads the correct date from post context.
+     *
+     * @param array $block - A block data array.
+     * @return array - The transformed block.
+     */
+    private static function transform_block(array $block): array
+    {
+        $block['innerBlocks'] = self::fix_post_date_blocks($block['innerBlocks'] ?? []);
+
+        return $block;
+    }
+
+    /**
+     * Recursively fix `core/post-date` blocks.
+     *
+     * @param array $blocks - Array of block data arrays.
+     * @return array - The updated blocks.
+     */
+    private static function fix_post_date_blocks(array $blocks): array
+    {
+        foreach ($blocks as &$block) {
+            if (isset($block['blockName']) && $block['blockName'] === Utils\Constants::BLOCK_DATE) {
+                if (isset($block['attrs']['datetime'])) {
+                    unset($block['attrs']['datetime']);
+                }
+
+                if (!isset($block['attrs']['metadata']['bindings']['datetime'])) {
+                    $block['attrs']['metadata']['bindings']['datetime'] = [
+                        'source' => 'core/post-data',
+                        'args' => ['field' => 'date'],
+                    ];
+                }
+            }
+
+            if (!empty($block['innerBlocks'])) {
+                $block['innerBlocks'] = self::fix_post_date_blocks($block['innerBlocks']);
+            }
+        }
+
+        return $blocks;
+    }
+}

--- a/src/Migrations/M064RemoveStaleDatetimeFromPostsListBlock.php
+++ b/src/Migrations/M064RemoveStaleDatetimeFromPostsListBlock.php
@@ -17,7 +17,7 @@ use P4\MasterTheme\MigrationScript;
  * binding so the editor reads the correct date from post context and won't re-write a stale
  * value on subsequent saves.
  */
-class M063RemoveStaleDatetimeFromPostsListBlock extends MigrationScript
+class M064RemoveStaleDatetimeFromPostsListBlock extends MigrationScript
 {
     /**
      * Perform the actual migration.

--- a/src/Migrator.php
+++ b/src/Migrator.php
@@ -64,6 +64,7 @@ use P4\MasterTheme\Migrations\M060RemoveCountrySelectorText;
 use P4\MasterTheme\Migrations\M061RemovePlanet4BlocksFeature;
 use P4\MasterTheme\Migrations\M062ActionsListStretchedLinkRefactor;
 use P4\MasterTheme\Migrations\M063ActionsListCarouselAccessibility;
+use P4\MasterTheme\Migrations\M064RemoveStaleDatetimeFromPostsListBlock;
 
 /**
  * Run any new migration scripts and record results in the log.
@@ -145,6 +146,7 @@ class Migrator
             M061RemovePlanet4BlocksFeature::class,
             M062ActionsListStretchedLinkRefactor::class,
             M063ActionsListCarouselAccessibility::class,
+            M064RemoveStaleDatetimeFromPostsListBlock::class,
         ];
 
         // Loop migrations and run those that haven't run yet.


### PR DESCRIPTION
Ref. https://greenpeace-planet4.atlassian.net/browse/PLANET-8156

### Summary

In WordPress 6.9(Gutenberg PR [#70585](https://github.com/WordPress/gutenberg/pull/70585)), `core/post-date`'s JavaScript edit component has:
```
// post-date/edit.js
useEffect( () => {
    if ( datetime === undefined ) {
        __unstableMarkNextChangeAsNotPersistent();
        setAttributes( { datetime: new Date() } );  // Sets TODAY's date!
    }
}, [ datetime ] );
```
When we add or edit a page with a PostsList block, the editor sets `datetime = new Date()` on every core/post-date block (intending it to be non-persistent). However, this value gets saved to the database when the page is saved.

The new PHP renderer in WordPress 6.9 then uses this stored datetime attribute for all posts in the loop instead of each post's actual publish date:
```
// wp-includes/blocks/post-date.php                          
if ( ! isset( $attributes['datetime'] ) && ... ) {
    // Get actual post date via core/post-data bindings
    $attributes['datetime'] = $source->get_value( $source_args, $block, 'datetime' );
}
// But if datetime IS already set (saved as today by the editor), it skips this ↑ and uses the stored date for ALL posts 
```
---
**References:**
- https://github.com/WordPress/gutenberg/pull/70585                                                                                                                                                                                            
- https://github.com/WordPress/WordPress/blob/master/wp-includes/blocks/post-date.php
- https://github.com/WordPress/gutenberg/issues/67520


### Testing

1. On your local dev environment, add a new **Posts List** block to any page or post, then view it on the frontend.
2. Verify that the newly added Posts List block incorrectly shows **today’s date** for all listed posts.
3. Now check out the `PLANET-8156_fix_posts_list_date_block` branch locally.
4. Run `npm run build`.
5. Repeat Step 1 (add a new Posts List block and view it on the frontend). It should now display the **actual post dates** correctly.

For migration script testing, Run the migration script on local `npx wp-env run cli wp p4-run-activator`, The migration script will fix existing Posts list blocks post-date block.