### PR TITLE
Align license metadata with GPL-3.0 LICENSE file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
       "email": "planet4-group@greenpeace.org"
     }
   ],
-  "license": "MIT",
+  "license": "GPL-3.0-or-later",
   "repositories": [
     {
       "type": "composer",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "name": "planet4-master-theme",
-      "license": "GPL-3.0",
+      "license": "GPL-3.0-or-later",
       "dependencies": {
         "@popperjs/core": "^2.11.8",
         "@wordpress/edit-post": "^7.28.1",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Master theme for the Planet 4 Wordpress project",
   "repository": "git@github.com:greenpeace/planet4-master-theme.git",
   "author": "Greenpeace International",
-  "license": "GPL-3.0",
+  "license": "GPL-3.0-or-later",
   "scripts": {
     "start": "wp-scripts start --config webpack.config.js --mode=development",
     "build": "wp-scripts build --config webpack.config.js --mode=production",

--- a/style.css
+++ b/style.css
@@ -4,8 +4,8 @@ Theme URI: https://github.com/greenpeace/planet4-master-theme
 Description: Master theme for the Planet 4 Wordpress project
 Author: Greenpeace International
 Author URI: https://github.com/greenpeace
-License: MIT
-License URI: https://opensource.org/licenses/MIT
+License: GPL-3.0-or-later
+License URI: https://www.gnu.org/licenses/gpl-3.0.html
 Tags: light, accessibility-ready
 Text Domain: planet4-master-theme
 */


### PR DESCRIPTION
### Summary

The project's LICENSE file is the GNU GPL v3 text, and the repository was explicitly switched from MIT to GPL in 2020 (commit [e2b883e8](https://github.com/greenpeace/planet4-master-theme/commit/e2b883e8) "Switch to GPL", with the rationale "To align with WP standards, but also with the rest of our code projects").

`package.json` was updated to reflect that change, but two other files still declare the old MIT license:

- `composer.json` → `"license": "MIT"`
- `style.css` theme header → `License: MIT`

This PR updates both to `GPL-3.0-or-later` so the metadata matches the LICENSE file.

The SPDX identifier `GPL-3.0` (used in `package.json`) is now flagged by `composer validate` as deprecated:

> License "GPL-3.0" is a deprecated SPDX license identifier, use "GPL-3.0-only" or "GPL-3.0-or-later" instead

`GPL-3.0-or-later` also matches the "or any later version" language in the root LICENSE file.

---

Ref: commit [e2b883e8](https://github.com/greenpeace/planet4-master-theme/commit/e2b883e8) Switch to GPL

### Testing

1. `composer validate --no-check-all --no-check-publish` — reports "./composer.json is valid" with no warnings.
2. WordPress still reads `style.css` theme header the same way (License field is informational metadata).
3. No code or build output changes.