### PR TITLE
Correct misleading docblocks in Like SQL class

### DIFF
--- a/src/BlockReportSearch/Block/Sql/Like.php
+++ b/src/BlockReportSearch/Block/Sql/Like.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Block search regex
+ * Block search LIKE pattern
  */
 
 namespace P4\MasterTheme\BlockReportSearch\Block\Sql;
@@ -9,7 +9,7 @@ namespace P4\MasterTheme\BlockReportSearch\Block\Sql;
 use P4\MasterTheme\BlockReportSearch\Block\Query\Parameters;
 
 /**
- * Regular expression used in SQL query
+ * LIKE pattern used in SQL query
  */
 class Like
 {


### PR DESCRIPTION
### Summary

The `Like` class in `src/BlockReportSearch/Block/Sql/Like.php` was added alongside its sibling `Regex` in [PR #2303](https://github.com/greenpeace/planet4-master-theme/pull/2303). Both classes share the same structure, and the docblocks on `Like.php` were copied from `Regex.php` but never updated for the new class. They describe the file as implementing a regex, when in fact the class builds SQL `LIKE` patterns.

Current (incorrect) docblocks:
- File-level: `* Block search regex`
- Class-level: `* Regular expression used in SQL query`

The class uses `%` wildcards and is consumed by a `LIKE` query (compare the two classes — `Regex.php` uses `.*`, `[^/]*`, regex anchors; `Like.php` uses `%` wildcards and produces a LIKE pattern).

This PR updates both docblocks to describe the `LIKE` pattern behaviour the class actually implements, so maintainers looking at the file in isolation aren't misled.

No behaviour change — comment-only edit.

Ref: commit [1de71054](https://github.com/greenpeace/planet4-master-theme/commit/1de71054) PLANET-7527 Move blocks report into master theme

### Testing

1. `git diff` — only the two docblock lines change.
2. `composer sniffs` — no new phpcs errors.
3. No code paths touched, no functional change.