### PR TITLE
PLANET-8134 Fix image caption broken HTML on frontend

### DIFF
--- a/src/ImageHandler.php
+++ b/src/ImageHandler.php
@@ -146,12 +146,11 @@ class ImageHandler
         // at the beginning or the end.
         $icon_class = str_ends_with($image_credit, '©') ? 'icon-right' : 'icon-left';
         $credit_div = '<div class="credit ' . $icon_class . '">' . esc_attr($image_credit) . '</div>';
-
         return str_replace(
-            empty($caption) ? '</figure>' : $caption,
+            empty($caption) ? '</figure>' : $caption . '</figcaption>',
             empty($caption) ?
                 '<figcaption>' . $credit_div . '</figcaption></figure>' :
-                $caption . $credit_div,
+                $caption . $credit_div . '</figcaption>',
             $content
         );
     }


### PR DESCRIPTION
Ref. https://greenpeace-planet4.atlassian.net/browse/PLANET-8134

### Summary

<!-- Please provide a brief summary of the change introduced in this Pull Request. -->

---
### Testing

**Steps to reproduce the issue -**
(Thanks to Pedro for discovering it 🙏 )

- Download [this image](https://www.greenpeace.org/static/planet4-international-stateless-develop/2023/02/164de024-gp0olg.jpg).
- Upload it to your local Media Library.
- Complete all the image metadata by copying it from [here](https://www-dev.greenpeace.org/international/wp-admin/post.php?post=58360&action=edit).
- Add the image to a post or page using the Image block.
- Click on the Add Caption button of the block.
- Add this caption: "Scientist Paul Johnston at work in Greenpeace Exeter lab, 1997."
- Save the changes.
- Check the front.

Once the issue is reproduce, please checkout `PLANET-8134-Fix-image-broken-caption` branch on local and check, the issue will no longer reproducible.