### PR TITLE
Fix resistance hub campaign card layout

### DIFF
--- a/assets/src/scss/blocks/ActionsList/ActionsListStyle.scss
+++ b/assets/src/scss/blocks/ActionsList/ActionsListStyle.scss
@@ -71,7 +71,7 @@
 
       .wp-block-post-title a {
         text-decoration: underline;
-        text-underline-offset: 4px;
+        text-underline-offset: 1px;
       }
     }
 

--- a/assets/src/scss/blocks/ActionsList/ActionsListStyle.scss
+++ b/assets/src/scss/blocks/ActionsList/ActionsListStyle.scss
@@ -71,7 +71,7 @@
 
       .wp-block-post-title a {
         text-decoration: underline;
-        text-underline-offset: 1px;
+        text-underline-offset: 4px;
       }
     }
 

--- a/assets/src/scss/pages/_resistance-hub-campaign.scss
+++ b/assets/src/scss/pages/_resistance-hub-campaign.scss
@@ -140,7 +140,7 @@
       }
 
       .wp-block-group.is-layout-flow {
-        padding: 0 20px;
+        padding: 20px;
       }
 
       .chip-deadline {

--- a/assets/src/scss/pages/_resistance-hub-campaign.scss
+++ b/assets/src/scss/pages/_resistance-hub-campaign.scss
@@ -126,6 +126,10 @@
       .wp-block-post-title {
         font-size: 32px;
         line-height: 1.275;
+
+        a {
+          text-underline-offset: 4px;
+        }
       }
 
       .wp-block-post-excerpt p {


### PR DESCRIPTION
Ref: https://greenpeace-planet4.atlassian.net/browse/PLANET-8159

### Summary
This PR includes the fix of paddings and text underline offset that were recntly modified.

<!-- Please add a reference link to the ticket, if one exists. -->
Ref: https://greenpeace-planet4.atlassian.net/browse/PLANET-8159

Before
<img width="1024" height="606" alt="image" src="https://github.com/user-attachments/assets/ce97f4db-011f-4a0f-a8e2-3c16ac63180a" />

After
<img width="396" height="548" alt="Screenshot 2026-04-28 at 7 23 03 AM" src="https://github.com/user-attachments/assets/d2a2d145-da3b-47f9-9387-2043f0fb84de" />


### Testing
- Resistance Hub Demo page https://www-dev.greenpeace.org/test-phobos/petitions/resistance-hub-demo-page-2/
- Actions List demo page https://www-dev.greenpeace.org/test-phobos/actions-list/

