### PR TITLE
PLANET-8057 Write an e2e test for the Posts List block manual override

### DIFF
--- a/tests/e2e/blocks/posts-list.spec.js
+++ b/tests/e2e/blocks/posts-list.spec.js
@@ -1,6 +1,11 @@
 import {test} from '../tools/lib/test-utils.js';
 import {publishPostAndVisit, createPostWithFeaturedImage} from '../tools/lib/post.js';
-import {addPostsListBlock, checkPostsListBlock} from '../tools/lib/posts-list.js';
+import {
+  addPostsListBlock,
+  addPostsListBlockWithManualOverride,
+  checkPostsListBlock,
+  checkPostsListBlockWithManualOverride,
+} from '../tools/lib/posts-list.js';
 
 test.useAdminLoggedIn();
 
@@ -30,5 +35,35 @@ test.describe('Test Posts List block', () => {
 
     // Test that the block is displayed as expected in the frontend.
     await checkPostsListBlock(page, 'grid');
+  });
+
+  test('Test the Manual Override', async ({page, admin, editor, requestUtils}) => {
+    // Create 4 posts to be selected via the Manual Override.
+    const postTitles = [
+      'Test Posts List Manual Override Post 1',
+      'Test Posts List Manual Override Post 2',
+      'Test Posts List Manual Override Post 3',
+      'Test Posts List Manual Override Post 4',
+    ];
+
+    for (const title of postTitles) {
+      await requestUtils.rest({
+        path: '/wp/v2/posts',
+        method: 'POST',
+        data: {title, status: 'publish'},
+      });
+    }
+
+    // Create a page to hold the Posts List block.
+    await createPostWithFeaturedImage({page, admin, editor}, {title: 'Test Posts List, Manual Override', postType: 'page'});
+
+    // Add a Posts List block using the Manual Override to select the 4 posts created above.
+    await addPostsListBlockWithManualOverride(page, postTitles);
+
+    // Publish page.
+    await publishPostAndVisit({page, editor});
+
+    // Check that the block displays correctly in the frontend.
+    await checkPostsListBlockWithManualOverride(page, postTitles);
   });
 });

--- a/tests/e2e/tools/lib/posts-list.js
+++ b/tests/e2e/tools/lib/posts-list.js
@@ -3,6 +3,7 @@ import {expect} from './test-utils.js';
 
 const TEST_TITLE = 'Related Stories';
 const TEST_CATEGORY = 'Energy';
+const MANUAL_OVERRIDE_TITLE = 'Posts';
 
 async function addPostsListBlock(page, layout) {
   // Add Posts List block.
@@ -32,6 +33,36 @@ async function addPostsListBlock(page, layout) {
   await page.getByRole('document', {name: 'Block: Heading'}).fill(TEST_TITLE);
 }
 
+async function addPostsListBlockWithManualOverride(page, postTitles) {
+  // Add Posts List block (default List layout).
+  await searchAndInsertBlock({page}, 'Posts List');
+
+  // Change amount of posts from 3 to 4.
+  await page.getByRole('spinbutton', {name: 'Items per page'}).fill('4');
+
+  // Expand the "Manual override" panel and select posts.
+  const editorSettings = page.getByRole('region', {name: 'Editor settings'});
+  const manualOverridePanel = editorSettings.getByRole('button', {name: 'Manual override'});
+  if (await manualOverridePanel.getAttribute('aria-expanded') === 'false') {
+    await manualOverridePanel.click();
+  }
+
+  // Select each post via the token field autocomplete.
+  for (const title of postTitles) {
+    await editorSettings.locator('.components-form-token-field__input').fill(title);
+    // Use .first() to guard against duplicate suggestions
+    await editorSettings.locator(
+      '.components-form-token-field__suggestion', {hasText: title}
+    ).first().click();
+    await expect(editorSettings.locator(
+      '.components-form-token-field__token-text', {hasText: title})
+    ).toBeVisible();
+  }
+
+  // Change the block title.
+  await page.getByRole('document', {name: 'Block: Heading'}).fill(MANUAL_OVERRIDE_TITLE);
+}
+
 async function checkPostsListBlock(page, layout) {
   // Test that the block is displayed as expected in the frontend.
   const block = page.locator('.p4-query-loop');
@@ -43,4 +74,14 @@ async function checkPostsListBlock(page, layout) {
   }
 }
 
-export {addPostsListBlock, checkPostsListBlock};
+async function checkPostsListBlockWithManualOverride(page, postTitles) {
+  const block = page.locator('.p4-query-loop');
+  await expect(block).toContainClass('is-custom-layout-list');
+  await expect(block.locator('h2.wp-block-heading')).toHaveText(MANUAL_OVERRIDE_TITLE);
+  await expect(block.locator('.wp-block-post')).toHaveCount(postTitles.length);
+  for (const title of postTitles) {
+    await expect(block.locator('.wp-block-post-title', {hasText: title})).toBeVisible();
+  }
+}
+
+export {addPostsListBlock, addPostsListBlockWithManualOverride, checkPostsListBlock, checkPostsListBlockWithManualOverride};


### PR DESCRIPTION
Ref. https://greenpeace-planet4.atlassian.net/browse/PLANET-8057

### Test Steps
   1. Login to the Admin Panel.
   2. Create four new Posts.
   3. Create a new Page.
   4. Add a Posts List block:
        a. Pick the List layout
        b. Use the “Manual Override” to select the four Posts created in previous step.
        c. Change block title to "Posts"
   5. Publish the page.
   6. Navigate to the frontend view of that Page and verify that all of the above properties are working as expected.
        - Block title
        - There are 4 posts displayed
        - Assess the 4 posts are indeed the ones created (eg. by title)

### Testing
On local you can run `npx playwright test tests/e2e/blocks/posts-list.spec.js`
