### PR TITLE
Add extra check to makeLanguageMenuAccessible function

### DIFF
--- a/assets/src/js/header/setupAccessibleNavMenu.js
+++ b/assets/src/js/header/setupAccessibleNavMenu.js
@@ -283,6 +283,9 @@ const makeLanguageMenuAccessible = () => {
   const languageMenuToggle = document.querySelector('.nav-languages-toggle');
   const languageSubmenu = document.getElementById('nav-languages');
 
+  if (!languageMenuToggle || !languageSubmenu) {
+    return;
+  }
 
   languageMenuToggle.addEventListener('click', () => {
     const isOpen = languageSubmenu.classList.toggle('is-open');


### PR DESCRIPTION
### Summary

We need to make sure that `languageMenuToggle` and `languageSubmenu` are defined

### Testing

Go to the homepage on local and you should see the following console error on `main` branch: 

```
Uncaught TypeError: Cannot read properties of null (reading 'addEventListener')
    at makeLanguageMenuAccessible (setupAccessibleNavMenu.js:287:22)
    at setupAccessibleNavMenu (setupAccessibleNavMenu.js:126:5)
    at setupHeader (header.js:19:25)
    at HTMLDocument.<anonymous> (app.js:19:14)
```
On this branch the warning should be gone.
