### PR TITLE
PLANET-8154 GP Media: Improve image alt text accessibility

### DIFF
--- a/src/ImageHandler.php
+++ b/src/ImageHandler.php
@@ -45,6 +45,29 @@ class ImageHandler
         add_filter('wp_image_editors', [$this, 'force_image_compression']);
         add_filter('wp_handle_upload_prefilter', [$this, 'image_type_validation']);
         add_filter('jpeg_quality', fn () => 60);
+        add_filter('render_block_core/image', [$this, 'add_figcaption_exception'], 10, 1);
+    }
+
+    /**
+     * Adds an aria-hidden attribute to all figcaption elements in image blocks.
+     *
+     * This ensures that screen readers do not read duplicate content when the image
+     * alt text and caption contain the same information, improving accessibility.
+     *
+     * @param string $block_content The HTML content of the rendered block.
+     *
+     * @return string Modified block HTML with updated figcaption attributes.
+     */
+    public function add_figcaption_exception(string $block_content): string
+    {
+        // Add aria-hidden to figcaption
+        $block_content = preg_replace(
+            '/<figcaption(?![^>]*aria-hidden)/',
+            '<figcaption aria-hidden="true"',
+            $block_content
+        );
+
+        return $block_content;
     }
 
     /**
@@ -104,26 +127,35 @@ class ImageHandler
 
     /**
      * Override the Gutenberg core/image block render method output,
-     * to add credit field in its caption text & image alt text as title.
+     * to add credit field in its caption text, alt and title attributes.
      *
      * @param array  $attributes    Attributes of the Gutenberg core/image block.
      * @param string $content The image element HTML.
      *
-     * @return string HTML content of image element with credit field in caption and alt text in image title.
+     * @return string HTML content of image element with credit field, alt text and title attributes.
      */
     public function p4_core_image_block_render(array $attributes, string $content): string
     {
         $image_id = isset($attributes['id']) ? trim(str_replace('attachment_', '', $attributes['id'])) : '';
         $img_post_meta = $image_id ? get_post_meta($image_id) : [];
+        $image = $image_id ? get_post($image_id) : null;
+        $image_title = $image->post_title ?? '';
+        $image_description = $image->post_content ?? '';
+
         if (!$img_post_meta) {
             return $content;
         }
 
         $credit = $img_post_meta[self::CREDIT_META_FIELD][0] ?? '';
-        $alt_text = $img_post_meta['_wp_attachment_image_alt'][0] ?? '';
 
-        if ($alt_text) {
-            $content = str_replace(' alt=', ' title="' . esc_attr($alt_text) . '" alt=', $content);
+        // Replace alt text with image description
+        if ($image_description) {
+            $content = $this->replace_alt_text_with_description($image_description, $content);
+        }
+
+        // Add or Replace Image title attribute to match the image title in media library
+        if ($image_title) {
+            $content = $this->update_image_title_with_gp_media($image_title, $content);
         }
 
         $image_credit = ' ' . $credit;
@@ -220,5 +252,58 @@ class ImageHandler
         );
 
         return $thumb;
+    }
+
+    /**
+     * Replace the alt attribute of an <img> tag with the provided description.
+     *
+     * @param string $description The image description to use as the alt text.
+     * @param string $content     The HTML content containing the <img> tag.
+     *
+     * @return string The updated HTML content with the modified alt attribute.
+     */
+    private function replace_alt_text_with_description(string $description, string $content): string
+    {
+
+        $image_description = trim($description);
+
+        // Replace existing alt attribute in <img>
+        return preg_replace(
+            '/(<img[^>]*?)alt=("|\')(.*?)\2/i',
+            '$1alt="' . esc_attr($image_description) . '"',
+            $content
+        );
+    }
+
+    /**
+     * Add a title attribute to <img> tags based on the provided title.
+     *
+     * @param string $title   The title to assign to the image element.
+     * @param string $content The HTML content containing the <img> tag.
+     *
+     * @return string The updated HTML content with the title attribute added where applicable.
+     */
+    private function update_image_title_with_gp_media(string $title, string $content): string
+    {
+        $content = preg_replace_callback(
+            '/<img[^>]+>/i',
+            function ($matches) use ($title) {
+                $img = $matches[0];
+
+                // If title already exists, don't overwrite it
+                if (strpos($img, 'title=') !== false) {
+                    return $img;
+                }
+
+                return str_replace(
+                    '<img',
+                    '<img title="' . esc_attr($title) . '"',
+                    $img
+                );
+            },
+            $content
+        );
+
+        return $content;
     }
 }

--- a/src/ImageHandler.php
+++ b/src/ImageHandler.php
@@ -2,6 +2,8 @@
 
 namespace P4\MasterTheme;
 
+use WP_HTML_Tag_Processor;
+
 /**
  * Class ImageHandler
  */
@@ -45,29 +47,6 @@ class ImageHandler
         add_filter('wp_image_editors', [$this, 'force_image_compression']);
         add_filter('wp_handle_upload_prefilter', [$this, 'image_type_validation']);
         add_filter('jpeg_quality', fn () => 60);
-        add_filter('render_block_core/image', [$this, 'add_figcaption_exception'], 10, 1);
-    }
-
-    /**
-     * Adds an aria-hidden attribute to all figcaption elements in image blocks.
-     *
-     * This ensures that screen readers do not read duplicate content when the image
-     * alt text and caption contain the same information, improving accessibility.
-     *
-     * @param string $block_content The HTML content of the rendered block.
-     *
-     * @return string Modified block HTML with updated figcaption attributes.
-     */
-    public function add_figcaption_exception(string $block_content): string
-    {
-        // Add aria-hidden to figcaption
-        $block_content = preg_replace(
-            '/<figcaption(?![^>]*aria-hidden)/',
-            '<figcaption aria-hidden="true"',
-            $block_content
-        );
-
-        return $block_content;
     }
 
     /**
@@ -127,7 +106,7 @@ class ImageHandler
 
     /**
      * Override the Gutenberg core/image block render method output,
-     * to add credit field in its caption text, alt and title attributes.
+     * to add credit in its caption and also add alt and title attributes.
      *
      * @param array  $attributes    Attributes of the Gutenberg core/image block.
      * @param string $content The image element HTML.
@@ -149,7 +128,7 @@ class ImageHandler
         $credit = $img_post_meta[self::CREDIT_META_FIELD][0] ?? '';
 
         // Replace alt text with image description
-        if ($image_description) {
+        if (trim($image_description)) {
             $content = $this->replace_alt_text_with_description($image_description, $content);
         }
 
@@ -178,12 +157,25 @@ class ImageHandler
         // at the beginning or the end.
         $icon_class = str_ends_with($image_credit, '©') ? 'icon-right' : 'icon-left';
         $credit_div = '<div class="credit ' . $icon_class . '">' . esc_attr($image_credit) . '</div>';
-        return str_replace(
-            empty($caption) ? '</figure>' : $caption . '</figcaption>',
-            empty($caption) ?
-                '<figcaption>' . $credit_div . '</figcaption></figure>' :
-                $caption . $credit_div . '</figcaption>',
-            $content
+
+        if (!empty($caption)) {
+            $content = $this->hide_figcaption_from_screen_readers($content);
+        }
+
+        if (empty($caption)) {
+            return preg_replace(
+                '/<\/figure>/i',
+                '<figcaption>' . $credit_div . '</figcaption></figure>',
+                $content,
+                1
+            );
+        }
+
+        return preg_replace(
+            '/(<figcaption\b[^>]*>)(.*?)(<\/figcaption>)/is',
+            '$1$2' . $credit_div . '$3',
+            $content,
+            1
         );
     }
 
@@ -269,7 +261,7 @@ class ImageHandler
 
         // Replace existing alt attribute in <img>
         return preg_replace(
-            '/(<img[^>]*?)alt=("|\')(.*?)\2/i',
+            '/(<img[^>]*?)alt=(["\'])(.*?)\2/i',
             '$1alt="' . esc_attr($image_description) . '"',
             $content
         );
@@ -291,18 +283,37 @@ class ImageHandler
                 $img = $matches[0];
 
                 // If title already exists, don't overwrite it
-                if (strpos($img, 'title=') !== false) {
+                if (preg_match('/\btitle\s*=/i', $img)) {
                     return $img;
                 }
 
-                return str_replace(
-                    '<img',
+                return preg_replace(
+                    '/<img\b(?![^>]*\btitle\s*=)/i',
                     '<img title="' . esc_attr($title) . '"',
-                    $img
+                    $img,
+                    1
                 );
             },
             $content
         );
+
+        return $content;
+    }
+
+    /**
+     * Add aria-hidden attribute to figcaption.
+     *
+     * @param string $content HTML content.
+     */
+    private function hide_figcaption_from_screen_readers(string $content): string
+    {
+        $processor = new WP_HTML_Tag_Processor($content);
+
+        if ($processor->next_tag('figcaption')) {
+            $processor->set_attribute('aria-hidden', 'true');
+
+            return $processor->get_updated_html();
+        }
 
         return $content;
     }


### PR DESCRIPTION
### Summary
Every time an image is being imported through Greenpeace Media we use 3 main metadata sources to compose what we use in the frontend. 

We currently do this:
   - alt-text: title + credit
   - caption (shown under the image): description + credit
   - title tag (shown on hover): title + credit

We should adjust those based on accessibility best practices while taking into account how screen readers interact with those metadata.
<!-- Please provide a brief summary of the change introduced in this Pull Request. -->

---

<!-- Please add a reference link to the ticket, if one exists. -->
**Ref:  https://greenpeace-planet4.atlassian.net/browse/PLANET-8154**

### Testing

<!-- Please add the steps required to test the changes in this Pull Request. -->
First, import and Image from the GP Media Library, then create a new page and add an Image block to the page with the imported image.

- Remove credit from the hover title and use only the title. ✅ 
- Use description for the alt-text instead of the title.✅ 
- Keep caption intact (description & credit).✅ 
- Ensure caption is not being picked up by screen readers (eg. by using aria-hidden="true"). This is needed to avoid duplication, as screen readers will pick up the alt-text anyway.✅ 