### PR TITLE
PLANET-7974  Add live region and clear slide context to Actions List

### DIFF
--- a/assets/src/js/query_loop_carousel.js
+++ b/assets/src/js/query_loop_carousel.js
@@ -141,7 +141,7 @@ export const setupQueryLoopCarousel = () => {
           carouselItem.classList.add('carousel-item', 'carousel-li', `carousel-slide-${totalCarouselItems}`);
           list.append(carouselItem);
 
-          itemWrapper = document.createElement('div');
+          itemWrapper = document.createElement('ul');
           itemWrapper.classList.add('carousel-item-wrapper');
 
           carouselItem.append(itemWrapper);

--- a/assets/src/js/query_loop_carousel.js
+++ b/assets/src/js/query_loop_carousel.js
@@ -1,7 +1,7 @@
 import {v4 as uuid} from 'uuid';
 
 // Constants
-const {__} = wp.i18n;
+const {__, sprintf} = wp.i18n;
 const ARROW_DIRECTIONS = ['prev', 'next'];
 const LAYOUTS = {
   carousel: 'carousel',
@@ -57,6 +57,18 @@ export const setupQueryLoopCarousel = () => {
       const isPostsList = layout.className.includes('posts-list');
       const itemsPerSlide = isPostsList ? 4 : 3;
 
+      // Add some accessibility attributes
+      layout.setAttribute('role', 'region');
+      layout.setAttribute('aria-label', __('Actions List', 'planet4-master-theme'));
+      layout.setAttribute('aria-roledescription', 'carousel');
+
+      // Add an aria-live div to announce slide changes.
+      const announcement = document.createElement('div');
+      announcement.setAttribute('aria-live', 'polite');
+      announcement.classList.add('visually-hidden');
+      announcement.id = `announce-${uniqueId}`;
+      layout.appendChild(announcement);
+
       // Adapt it as bootstrap carousel
       const carousel = document.createElement('div');
       carousel.setAttribute('id', uniqueId);
@@ -69,7 +81,7 @@ export const setupQueryLoopCarousel = () => {
 
       const backToList = document.createElement('a');
       backToList.href = `#${uniqueId}`;
-      backToList.textContent = __('Back to Actions List', 'planet4-master-theme-backend');
+      backToList.textContent = __('Back to Actions List', 'planet4-master-theme');
       backToList.classList.add('carousel-skip-link');
       backToList.setAttribute('role', 'link');
 
@@ -175,12 +187,24 @@ export const setupQueryLoopCarousel = () => {
         }
 
         if (layout.className.includes(BLOCK_CLASSNAMES.actionsList)) {
-          // Moves the focus to the next slide when the carousel arrows are hit.
-          carouselButtons.forEach(button => {
+          // Moves the focus to the next slide when the carousel arrows or indicators are hit.
+          // Also update the aria-live text so that the screen reader announces the slide change.
+          const indicatorButtons = layout.querySelectorAll('.carousel-indicators li');
+          [...carouselButtons, ...indicatorButtons].forEach(button => {
             button.addEventListener('click', () => {
 
               const observer = new MutationObserver(() => {
                 const currentSlide = layout.querySelector('.carousel-item.active');
+                const currentSlideClasses = currentSlide.classList.value.split(' ');
+                const currentSlideNumber = currentSlideClasses.find(c => c.indexOf('carousel-slide-') !== -1).replace('carousel-slide-', '');
+                const slides = layout.querySelectorAll('.carousel-item').length;
+
+                announcement.innerText = sprintf(
+                /* translators: 1: current slide number, 2: total amount of slides */
+                  __('Slide %1$d from %2$d', 'planet4-master-theme'),
+                  Number(currentSlideNumber) + 1,
+                  slides
+                );
 
                 if (!currentSlide) {return;}
 

--- a/assets/src/js/query_loop_carousel.js
+++ b/assets/src/js/query_loop_carousel.js
@@ -124,15 +124,18 @@ export const setupQueryLoopCarousel = () => {
 
       posts.forEach((post, index) => {
         if (index % itemsPerSlide === 0) {
-          // Reset link that is only accessible via JS
-          slideReset = document.createElement('a');
-          slideReset.classList.add('carousel-ghost-link');
-          slideReset.setAttribute('aria-hidden', 'true');
-          slideReset.setAttribute('tabindex', '-1');
-          slideReset.style.position = 'absolute';
-          slideReset.style.opacity = '0';
-          slideReset.style.pointerEvents = 'none';
-          list.appendChild(slideReset);
+          // Add a reset link that is only accessible via JS.
+          // Only for the Posts List block, not Actions List.
+          if (layout.className.includes(BLOCK_CLASSNAMES.postsList)) {
+            slideReset = document.createElement('a');
+            slideReset.classList.add('carousel-ghost-link');
+            slideReset.setAttribute('aria-hidden', 'true');
+            slideReset.setAttribute('tabindex', '-1');
+            slideReset.style.position = 'absolute';
+            slideReset.style.opacity = '0';
+            slideReset.style.pointerEvents = 'none';
+            list.appendChild(slideReset);
+          }
 
           carouselItem = document.createElement('li');
           carouselItem.classList.add('carousel-item', 'carousel-li', `carousel-slide-${totalCarouselItems}`);

--- a/assets/src/js/query_loop_carousel.js
+++ b/assets/src/js/query_loop_carousel.js
@@ -181,7 +181,11 @@ export const setupQueryLoopCarousel = () => {
 
                   // This adds a voice over so the screen reader reads out which Slide you are on.
                   resetFocusLink.removeAttribute('aria-hidden');
-                  resetFocusLink.setAttribute('aria-label', `Slide ${slideIndex}`);
+                  resetFocusLink.setAttribute('aria-label', sprintf(
+                  /* translators: 1: current slide number */
+                    __('Slide %1$d', 'planet4-master-theme'),
+                    slideIndex + 1
+                  ));
                   resetFocusLink.focus();
                 }
               }, 600);
@@ -198,14 +202,14 @@ export const setupQueryLoopCarousel = () => {
 
               const observer = new MutationObserver(() => {
                 const currentSlide = layout.querySelector('.carousel-item.active');
-                const currentSlideClasses = currentSlide.classList.value.split(' ');
-                const currentSlideNumber = currentSlideClasses.find(c => c.indexOf('carousel-slide-') !== -1).replace('carousel-slide-', '');
+                const match = currentSlide.className.match(/carousel-slide-(\d+)/);
+                const slideIndex = match ? parseInt(match[1], 10) : null;
                 const slides = layout.querySelectorAll('.carousel-item').length;
 
                 announcement.innerText = sprintf(
-                /* translators: 1: current slide number, 2: total amount of slides */
+                  /* translators: 1: current slide number, 2: total amount of slides */
                   __('Slide %1$d from %2$d', 'planet4-master-theme'),
-                  Number(currentSlideNumber) + 1,
+                  slideIndex + 1,
                   slides
                 );
 

--- a/assets/src/js/query_loop_carousel.js
+++ b/assets/src/js/query_loop_carousel.js
@@ -77,7 +77,7 @@ export const setupQueryLoopCarousel = () => {
         layout.setAttribute('aria-roledescription', 'carousel');
       }
 
-      // Only add indicators if there are more items to show
+      // Only add indicators, aria-live element, and back to list link if there are more items to show
       if (posts.length > itemsPerSlide) {
         indicators = document.createElement('ol');
         indicators.classList.add(`${LAYOUTS.carousel}-indicators`);
@@ -133,7 +133,7 @@ export const setupQueryLoopCarousel = () => {
         if (index % itemsPerSlide === 0) {
           // Add a reset link that is only accessible via JS.
           // Only for the Posts List block, not Actions List.
-          if (layout.className.includes(BLOCK_CLASSNAMES.postsList)) {
+          if (isPostsList) {
             slideReset = document.createElement('a');
             slideReset.classList.add('carousel-ghost-link');
             slideReset.setAttribute('aria-hidden', 'true');
@@ -211,12 +211,14 @@ export const setupQueryLoopCarousel = () => {
                 const slideIndex = match ? parseInt(match[1], 10) : null;
                 const slides = layout.querySelectorAll('.carousel-item').length;
 
-                announcement.innerText = sprintf(
-                  /* translators: 1: current slide number, 2: total amount of slides */
-                  __('Slide %1$d from %2$d', 'planet4-master-theme'),
-                  slideIndex + 1,
-                  slides
-                );
+                if (announcement) {
+                  announcement.innerText = sprintf(
+                    /* translators: 1: current slide number, 2: total amount of slides */
+                    __('Slide %1$d from %2$d', 'planet4-master-theme'),
+                    slideIndex + 1,
+                    slides
+                  );
+                }
 
                 if (!currentSlide) {return;}
 

--- a/assets/src/js/query_loop_carousel.js
+++ b/assets/src/js/query_loop_carousel.js
@@ -45,29 +45,20 @@ export const setupQueryLoopCarousel = () => {
       return;
     }
 
+    // This is for the carousel layout, we need to setup the arrows and indicators.
+    // Or hide them if there are not enough items to scroll.
     if (layout.className.includes(LAYOUTS.carousel)) {
-      // This is for the carousel layout, we need to setup the arrows and indicators.
-      // Or hide them if there are not enough items to scroll.
       const list = layout.querySelector('.wp-block-post-template');
-      if (!list) {
+      const isPostsList = layout.className.includes(BLOCK_CLASSNAMES.postsList);
+      const isActionsList = layout.className.includes(BLOCK_CLASSNAMES.actionsList);
+      if (!list || (!isActionsList && !isPostsList)) {
         return;
       }
+
       let indicators = null;
+      let announcement = null;
       const uniqueId = `${LAYOUTS.carousel}-${uuid()}`;
-      const isPostsList = layout.className.includes('posts-list');
       const itemsPerSlide = isPostsList ? 4 : 3;
-
-      // Add some accessibility attributes
-      layout.setAttribute('role', 'region');
-      layout.setAttribute('aria-label', __('Actions List', 'planet4-master-theme'));
-      layout.setAttribute('aria-roledescription', 'carousel');
-
-      // Add an aria-live div to announce slide changes.
-      const announcement = document.createElement('div');
-      announcement.setAttribute('aria-live', 'polite');
-      announcement.classList.add('visually-hidden');
-      announcement.id = `announce-${uniqueId}`;
-      layout.appendChild(announcement);
 
       // Adapt it as bootstrap carousel
       const carousel = document.createElement('div');
@@ -79,13 +70,12 @@ export const setupQueryLoopCarousel = () => {
       carousel.append(list);
       const posts = list.querySelectorAll('.wp-block-post');
 
-      const backToList = document.createElement('a');
-      backToList.href = `#${uniqueId}`;
-      backToList.textContent = __('Back to Actions List', 'planet4-master-theme');
-      backToList.classList.add('carousel-skip-link');
-      backToList.setAttribute('role', 'link');
-
-      layout.append(backToList);
+      if (isActionsList) {
+        // Add some accessibility attributes
+        layout.setAttribute('role', 'region');
+        layout.setAttribute('aria-label', __('Actions List', 'planet4-master-theme'));
+        layout.setAttribute('aria-roledescription', 'carousel');
+      }
 
       // Only add indicators if there are more items to show
       if (posts.length > itemsPerSlide) {
@@ -111,6 +101,23 @@ export const setupQueryLoopCarousel = () => {
         // Align the controls in the middle
         const controls = layout.querySelector(BUTTONS_CLASS);
         controls.style.top = (list.getBoundingClientRect().height / 2) - (controls.getBoundingClientRect().height / 2);
+
+        if (isActionsList) {
+          // Add an aria-live div to announce slide changes.
+          announcement = document.createElement('div');
+          announcement.setAttribute('aria-live', 'polite');
+          announcement.classList.add('visually-hidden');
+          announcement.id = `announce-${uniqueId}`;
+          layout.appendChild(announcement);
+
+          // Add a hidden link to get back to the list.
+          const backToList = document.createElement('a');
+          backToList.href = `#${uniqueId}`;
+          backToList.textContent = __('Back to Actions List', 'planet4-master-theme');
+          backToList.classList.add('carousel-skip-link');
+          backToList.setAttribute('role', 'link');
+          layout.append(backToList);
+        }
       } else {
         // Remove arrows if they are not needed
         removeArrows(layout);
@@ -168,7 +175,7 @@ export const setupQueryLoopCarousel = () => {
 
         const carouselButtons = layout.querySelectorAll(`${BUTTONS_CLASS} ${CONTROLS_CLASS}-next, ${BUTTONS_CLASS} ${CONTROLS_CLASS}-prev`);
 
-        if (layout.className.includes(BLOCK_CLASSNAMES.postsList)) {
+        if (isPostsList) {
           // This resets the focus to the ghost element so users can tab over the new slide.
           carouselButtons.forEach(button => {
             button.addEventListener('click', () => {
@@ -191,9 +198,7 @@ export const setupQueryLoopCarousel = () => {
               }, 600);
             });
           });
-        }
-
-        if (layout.className.includes(BLOCK_CLASSNAMES.actionsList)) {
+        } else if (isActionsList) {
           // Moves the focus to the next slide when the carousel arrows or indicators are hit.
           // Also update the aria-live text so that the screen reader announces the slide change.
           const indicatorButtons = layout.querySelectorAll('.carousel-indicators li');


### PR DESCRIPTION
### Summary

This is for screen readers and therefore better accessibility. This commit also updates the indicators' click behaviour to be the same as the arrows

Ref: [PLANET-7974](https://greenpeace-planet4.atlassian.net/browse/PLANET-7974)

**Requirements**

1. Wrap the entire Action List block in a `div` with the following attributes:
  - role="region"
  - aria-label="Actions list" 
  - aria-roledescription="carousel"

2. Add a visually hidden live status element that updates to “Slide X of Y” when the user navigates between these sets. 

### Testing

On local you can go to the [Take Action page](http://www.planet4.test/take-action/) for example, since it has an Actions List block already, you just need to change it to a carousel. Or you can use the [venus Take Action page](https://www-dev.greenpeace.org/test-venus/take-action/) that is also used for UAT. Then you can test the following:
1. When clicking on the indicators (the dots) the focus behaviour is now the same as with the arrows, meaning that the focus goes to the first Action in the new slide.
2. Using a screen reader, make sure that `Slide X of Y` is announced when changing slides.

[PLANET-7974]: https://greenpeace-planet4.atlassian.net/browse/PLANET-7974?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ