### PR TITLE
Disable username/password login when enforce_sso is on

### DIFF
--- a/admin/css/options.css
+++ b/admin/css/options.css
@@ -76,3 +76,9 @@
     font-weight: bold;
   }
 }
+
+/* Hide the "Automatically redirect to Google" option. */
+label[for="input_ga_auto_login"],
+input#input_ga_auto_login {
+  display: none;
+}

--- a/src/LoginHandler.php
+++ b/src/LoginHandler.php
@@ -36,29 +36,13 @@ class LoginHandler
         add_action('login_footer', function (): void {
             $html = ob_get_clean();
 
-            $features = get_option('planet4_features', []);
-            $enforce_sso = !empty($features['enforce_sso']);
-
             // Clean up the HTML by removing the "Remember Me" checkbox
             $html = preg_replace('/<p[^>]*class=["\']forgetmenot["\'][^>]*>.*?<\/p>/is', '', $html);
 
-            if ($enforce_sso) {
-                if (isset($_GET['loggedout']) && $_GET['loggedout'] === 'true') {
-                    wp_redirect(home_url());
-                    exit;
-                }
-
-                $gal_instance = google_apps_login();
-                if (!method_exists($gal_instance, 'ga_start_auth_get_url')) {
-                    return;
-                }
-
-                $ga_url = $gal_instance->ga_start_auth_get_url();
-
-                if (!empty($ga_url)) {
-                    wp_redirect(esc_url_raw($ga_url));
-                    exit;
-                }
+            // Redirect to the homepage when the user has just logged out.
+            if (isset($_GET['loggedout']) && $_GET['loggedout'] === 'true') {
+                wp_redirect(home_url());
+                exit;
             }
 
             echo $html;
@@ -80,6 +64,7 @@ class LoginHandler
         add_filter('authenticate', [$this, 'enforce_google_signon'], 4, 3);
         add_filter('authenticate', [$this, 'check_google_login_error'], 30, 1);
         add_filter('authenticate', [$this, 'custom_block_login_if_rate_limited'], 30, 3);
+        add_filter('authenticate', [$this, 'disable_credentials_login'], 100, 1);
         add_filter('login_headerurl', [$this, 'add_login_logo_url']);
         add_filter('login_headertext', [$this, 'add_login_logo_url_title']);
         add_action('login_enqueue_scripts', [$this, 'add_login_stylesheet']);
@@ -372,5 +357,34 @@ class LoginHandler
         }
 
         return true;
+    }
+
+    /**
+     * Disables login with username and password when enforce_sso feature is enabled.
+     *
+     * @param WP_User|WP_Error $user The current user logging in.
+     */
+    public function disable_credentials_login(
+        WP_User|WP_Error|null $user
+    ): WP_User|WP_Error|null {
+        $features = get_option('planet4_features', []);
+        $enforce_sso = !empty($features['enforce_sso']);
+
+        if (!$enforce_sso) {
+            return $user;
+        }
+
+        // Block login if it's a POST request, which indicates an attempt to log in with credentials.
+        if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+            return new WP_Error(
+                'google_only_login',
+                __(
+                    'Please use the Google login button instead.',
+                    'planet4-master-theme-backend'
+                )
+            );
+        }
+
+        return $user;
     }
 }


### PR DESCRIPTION
### Summary

Instead of relying just to redirection we can make sure that plain is completely disabled.

### Testing

On local environemnt:
1. Make sure enforce_sso and ga_login redirection is off:
```
npx wp-env run cli wp option patch delete planet4_features enforce_sso
npx wp-env run cli wp option patch delete galogin ga_auto_login
```
2. You should see the normal login screen
3. You should be able to login using credentials
4. Enable the sso flag:
```
npx wp-env run cli wp option patch insert planet4_features enforce_sso on
```
5. You should see the normal login screen
6. Trying to login with credentials you should be getting an error
7. Enable redirection:
```
npx wp-env run cli wp option patch update galogin ga_auto_login 1
```
8. You should be redirected straight to Google