### PR TITLE
PLANET-8145 Enforce image size in carousel header

### DIFF
--- a/assets/src/blocks/CarouselHeader/CarouselHeaderEditor.js
+++ b/assets/src/blocks/CarouselHeader/CarouselHeaderEditor.js
@@ -81,8 +81,15 @@ export const CarouselHeaderEditor = ({setAttributes, attributes}) => {
     if (!image) {
       return slide;
     }
-    const image_srcset = toSrcSet(Object.values(image.media_details.sizes));
-    return ({...slide, image_url: image.source_url, image_srcset, image_alt: image.alt_text});
+    const sizes = image.media_details.sizes;
+    const image_srcset = toSrcSet(Object.values(sizes));
+    // Prefer a registered resized size over the original full-resolution upload.
+    const image_url = sizes['retina-large']?.source_url ||
+      sizes.large?.source_url ||
+      sizes.medium_large?.source_url ||
+      sizes.medium?.source_url ||
+      image.source_url;
+    return ({...slide, image_url, image_srcset, image_alt: image.alt_text});
   }), [needsMigration, slides]);
 
   return useMemo(() => (

--- a/assets/src/blocks/CarouselHeader/CarouselHeaderEditor.js
+++ b/assets/src/blocks/CarouselHeader/CarouselHeaderEditor.js
@@ -6,7 +6,7 @@ import {CarouselControls} from './CarouselControls';
 
 // Carousel Header Editor
 import {Sidebar} from './Sidebar';
-import {EditableBackground} from './EditableBackground';
+import {EditableBackground, getLargestSizeUrl} from './EditableBackground';
 
 const {useSelect} = wp.data;
 const {useCallback, useMemo, useRef} = wp.element;
@@ -81,14 +81,9 @@ export const CarouselHeaderEditor = ({setAttributes, attributes}) => {
     if (!image) {
       return slide;
     }
-    const sizes = image.media_details.sizes;
-    const image_srcset = toSrcSet(Object.values(sizes));
+    const image_srcset = toSrcSet(Object.values(image.media_details.sizes));
     // Prefer a registered resized size over the original full-resolution upload.
-    const image_url = sizes['retina-large']?.source_url ||
-      sizes.large?.source_url ||
-      sizes.medium_large?.source_url ||
-      sizes.medium?.source_url ||
-      image.source_url;
+    const image_url = getLargestSizeUrl(image);
     return ({...slide, image_url, image_srcset, image_alt: image.alt_text});
   }), [needsMigration, slides]);
 

--- a/assets/src/blocks/CarouselHeader/EditableBackground.js
+++ b/assets/src/blocks/CarouselHeader/EditableBackground.js
@@ -3,7 +3,24 @@ import {toSrcSet} from './CarouselHeaderEditor';
 
 const {MediaUpload, MediaUploadCheck} = wp.blockEditor;
 const {Button, Dropdown} = wp.components;
-const {__} = wp.i18n;
+const {__, sprintf} = wp.i18n;
+
+// Maximum image file size allowed for carousel header slides (1 MB).
+const MAX_IMAGE_FILESIZE_BYTES = 1024 * 1024;
+
+// Resolve the URL for the largest registered (resized) image, never the original upload.
+// Falls back gracefully if a size is not available.
+const getLargestSizeUrl = image => {
+  const sizes = image?.sizes || {};
+  return (
+    sizes['retina-large']?.url ||
+    sizes.large?.url ||
+    sizes.medium_large?.url ||
+    sizes.medium?.url ||
+    // As a last resort use the original URL so the slide is not left empty.
+    image?.url
+  );
+};
 
 export const EditableBackground = ({
   image_url,
@@ -21,12 +38,26 @@ export const EditableBackground = ({
   <MediaUploadCheck>
     <MediaUpload
       onSelect={image => {
-        const {id, alt_text, url, sizes} = image;
-        changeSlideImage(index, id, url, alt_text, toSrcSet(Object.values(sizes)));
+        const {id, alt_text, sizes, filesizeInBytes, fileLength} = image;
+        const fileSize = filesizeInBytes ?? fileLength ?? 0;
+
+        if (fileSize > MAX_IMAGE_FILESIZE_BYTES) {
+          // eslint-disable-next-line no-alert
+          window.alert(sprintf(
+            // translators: %s is the maximum allowed image size in megabytes.
+            __('The selected image is too large. Please use an image smaller than %s MB for the carousel header.', 'planet4-master-theme-backend'),
+            (MAX_IMAGE_FILESIZE_BYTES / (1024 * 1024)).toFixed(0)
+          ));
+          return;
+        }
+
+        // Use the largest registered size instead of the original image so we never serve a multi-MB upload to the front end.
+        const resizedUrl = getLargestSizeUrl(image);
+        changeSlideImage(index, id, resizedUrl, alt_text, toSrcSet(Object.values(sizes)));
       }}
-      allowedTypes={['image/jpg', 'image/jpeg']}
+      allowedTypes={['image/jpeg', 'image/webp']}
       value={image_id}
-      title={'Select or Upload Photo (only jpg/jpeg)'}
+      title={__('Select or Upload Photo (only jpg/webp, max 1 MB)', 'planet4-master-theme-backend')}
       render={mediaUploadInstance => (
         <>
           <div className="background-holder">

--- a/assets/src/blocks/CarouselHeader/EditableBackground.js
+++ b/assets/src/blocks/CarouselHeader/EditableBackground.js
@@ -8,6 +8,28 @@ const {__, sprintf} = wp.i18n;
 // Maximum image file size allowed for carousel header slides (1 MB).
 const MAX_IMAGE_FILESIZE_BYTES = 1024 * 1024;
 
+// MIME types accepted for carousel header slide images. `allowedTypes` on MediaUpload only filters the Media
+// Library grid; drag-and-drop and the "Upload files" tab can still bring in other types, so we re-check here.
+const ALLOWED_MIME_TYPES = ['image/jpeg', 'image/webp'];
+
+// Extract the MIME type from a WordPress media object. Different WP versions
+// expose it as `mime`, `mime_type`, or via `subtype` so we try them in order.
+const getMimeType = image => {
+  if (!image) {
+    return '';
+  }
+  if (image.mime) {
+    return image.mime;
+  }
+  if (image.mime_type) {
+    return image.mime_type;
+  }
+  if (image.subtype) {
+    return `image/${image.subtype}`;
+  }
+  return '';
+};
+
 // Resolve the URL for the largest registered (resized) image, never the original upload.
 // Falls back gracefully if a size is not available.
 const getLargestSizeUrl = image => {
@@ -39,6 +61,19 @@ export const EditableBackground = ({
     <MediaUpload
       onSelect={image => {
         const {id, alt_text, sizes, filesizeInBytes, fileLength} = image;
+        const mimeType = getMimeType(image);
+
+        // Reject anything that is not JPG / WebP. Defends against PNGs and other types that can slip in
+        // via drag-and-drop, the Upload tab, or pre-existing entries in the Media Library.
+        if (!ALLOWED_MIME_TYPES.includes(mimeType)) {
+          // eslint-disable-next-line no-alert
+          window.alert(__(
+            'Only JPG and WebP images are allowed for the carousel header. Please choose a different file.',
+            'planet4-master-theme-backend'
+          ));
+          return;
+        }
+
         const fileSize = filesizeInBytes ?? fileLength ?? 0;
 
         if (fileSize > MAX_IMAGE_FILESIZE_BYTES) {

--- a/assets/src/blocks/CarouselHeader/EditableBackground.js
+++ b/assets/src/blocks/CarouselHeader/EditableBackground.js
@@ -12,24 +12,6 @@ const MAX_IMAGE_FILESIZE_BYTES = 1024 * 1024;
 // Library grid; drag-and-drop and the "Upload files" tab can still bring in other types, so we re-check here.
 const ALLOWED_MIME_TYPES = ['image/jpeg', 'image/webp'];
 
-// Extract the MIME type from a WordPress media object. Different WP versions
-// expose it as `mime`, `mime_type`, or via `subtype` so we try them in order.
-const getMimeType = image => {
-  if (!image) {
-    return '';
-  }
-  if (image.mime) {
-    return image.mime;
-  }
-  if (image.mime_type) {
-    return image.mime_type;
-  }
-  if (image.subtype) {
-    return `image/${image.subtype}`;
-  }
-  return '';
-};
-
 // Resolve the URL for the largest registered (resized) image, never the original upload.
 // Falls back gracefully if a size is not available.
 const getLargestSizeUrl = image => {
@@ -60,8 +42,8 @@ export const EditableBackground = ({
   <MediaUploadCheck>
     <MediaUpload
       onSelect={image => {
-        const {id, alt_text, sizes, filesizeInBytes, fileLength} = image;
-        const mimeType = getMimeType(image);
+        const {id, alt_text, sizes, filesizeInBytes} = image;
+        const mimeType = image?.mime ?? image?.mime_type ?? (image?.subtype && `image/${image.subtype}`) ?? '';
 
         // Reject anything that is not JPG / WebP. Defends against PNGs and other types that can slip in
         // via drag-and-drop, the Upload tab, or pre-existing entries in the Media Library.
@@ -74,9 +56,7 @@ export const EditableBackground = ({
           return;
         }
 
-        const fileSize = filesizeInBytes ?? fileLength ?? 0;
-
-        if (fileSize > MAX_IMAGE_FILESIZE_BYTES) {
+        if ((filesizeInBytes ?? 0) > MAX_IMAGE_FILESIZE_BYTES) {
           // eslint-disable-next-line no-alert
           window.alert(sprintf(
             // translators: %s is the maximum allowed image size in megabytes.
@@ -90,7 +70,7 @@ export const EditableBackground = ({
         const resizedUrl = getLargestSizeUrl(image);
         changeSlideImage(index, id, resizedUrl, alt_text, toSrcSet(Object.values(sizes)));
       }}
-      allowedTypes={['image/jpeg', 'image/webp']}
+      allowedTypes={ALLOWED_MIME_TYPES}
       value={image_id}
       title={__('Select or Upload Photo (only jpg/webp, max 1 MB)', 'planet4-master-theme-backend')}
       render={mediaUploadInstance => (

--- a/assets/src/blocks/CarouselHeader/EditableBackground.js
+++ b/assets/src/blocks/CarouselHeader/EditableBackground.js
@@ -14,15 +14,17 @@ const ALLOWED_MIME_TYPES = ['image/jpeg', 'image/webp'];
 
 // Resolve the URL for the largest registered (resized) image, never the original upload.
 // Falls back gracefully if a size is not available.
-const getLargestSizeUrl = image => {
-  const sizes = image?.sizes || {};
+export const getLargestSizeUrl = image => {
+  const sizes = image?.sizes || image?.media_details?.sizes || {};
+  const pickUrl = size => size?.url || size?.source_url;
   return (
-    sizes['retina-large']?.url ||
-    sizes.large?.url ||
-    sizes.medium_large?.url ||
-    sizes.medium?.url ||
+    pickUrl(sizes['retina-large']) ||
+    pickUrl(sizes.large) ||
+    pickUrl(sizes.medium_large) ||
+    pickUrl(sizes.medium) ||
     // As a last resort use the original URL so the slide is not left empty.
-    image?.url
+    image?.url ||
+    image?.source_url
   );
 };
 

--- a/assets/src/blocks/CarouselHeader/EditableBackground.js
+++ b/assets/src/blocks/CarouselHeader/EditableBackground.js
@@ -3,10 +3,7 @@ import {toSrcSet} from './CarouselHeaderEditor';
 
 const {MediaUpload, MediaUploadCheck} = wp.blockEditor;
 const {Button, Dropdown} = wp.components;
-const {__, sprintf} = wp.i18n;
-
-// Maximum image file size allowed for carousel header slides (1 MB).
-const MAX_IMAGE_FILESIZE_BYTES = 1024 * 1024;
+const {__} = wp.i18n;
 
 // MIME types accepted for carousel header slide images. `allowedTypes` on MediaUpload only filters the Media
 // Library grid; drag-and-drop and the "Upload files" tab can still bring in other types, so we re-check here.
@@ -44,7 +41,7 @@ export const EditableBackground = ({
   <MediaUploadCheck>
     <MediaUpload
       onSelect={image => {
-        const {id, alt_text, sizes, filesizeInBytes} = image;
+        const {id, alt_text, sizes} = image;
         const mimeType = image?.mime ?? image?.mime_type ?? (image?.subtype && `image/${image.subtype}`) ?? '';
 
         // Reject anything that is not JPG / WebP. Defends against PNGs and other types that can slip in
@@ -58,23 +55,13 @@ export const EditableBackground = ({
           return;
         }
 
-        if ((filesizeInBytes ?? 0) > MAX_IMAGE_FILESIZE_BYTES) {
-          // eslint-disable-next-line no-alert
-          window.alert(sprintf(
-            // translators: %d is the maximum allowed image size in megabytes.
-            __('The selected image is too large. Please use an image smaller than %d MB for the Carousel Header.', 'planet4-master-theme-backend'),
-            Math.round(MAX_IMAGE_FILESIZE_BYTES / (1024 * 1024))
-          ));
-          return;
-        }
-
         // Use the largest registered size instead of the original image so we never serve a multi-MB upload to the front end.
         const resizedUrl = getLargestSizeUrl(image);
         changeSlideImage(index, id, resizedUrl, alt_text, toSrcSet(Object.values(sizes)));
       }}
       allowedTypes={ALLOWED_MIME_TYPES}
       value={image_id}
-      title={__('Select or Upload Photo (only jpg/webp, max 1 MB)', 'planet4-master-theme-backend')}
+      title={__('Select or Upload Photo (jpg/webp only)', 'planet4-master-theme-backend')}
       render={mediaUploadInstance => (
         <>
           <div className="background-holder">

--- a/assets/src/blocks/CarouselHeader/EditableBackground.js
+++ b/assets/src/blocks/CarouselHeader/EditableBackground.js
@@ -52,7 +52,7 @@ export const EditableBackground = ({
         if (!ALLOWED_MIME_TYPES.includes(mimeType)) {
           // eslint-disable-next-line no-alert
           window.alert(__(
-            'Only JPG and WebP images are allowed for the carousel header. Please choose a different file.',
+            'Only JPG and WebP images are allowed for the Carousel Header. Please choose a different file.',
             'planet4-master-theme-backend'
           ));
           return;
@@ -61,9 +61,9 @@ export const EditableBackground = ({
         if ((filesizeInBytes ?? 0) > MAX_IMAGE_FILESIZE_BYTES) {
           // eslint-disable-next-line no-alert
           window.alert(sprintf(
-            // translators: %s is the maximum allowed image size in megabytes.
-            __('The selected image is too large. Please use an image smaller than %s MB for the carousel header.', 'planet4-master-theme-backend'),
-            (MAX_IMAGE_FILESIZE_BYTES / (1024 * 1024)).toFixed(0)
+            // translators: %d is the maximum allowed image size in megabytes.
+            __('The selected image is too large. Please use an image smaller than %d MB for the Carousel Header.', 'planet4-master-theme-backend'),
+            Math.round(MAX_IMAGE_FILESIZE_BYTES / (1024 * 1024))
           ));
           return;
         }

--- a/src/ImageHandler.php
+++ b/src/ImageHandler.php
@@ -34,6 +34,12 @@ class ImageHandler
             'save' => 'imagegif',
             'extension' => 'gif',
         ],
+        IMAGETYPE_WEBP => [
+            'mime' => 'image/webp',
+            'create' => 'imagecreatefromwebp',
+            'save' => 'imagewebp',
+            'extension' => 'webp',
+        ],
     ];
 
     /**
@@ -78,10 +84,10 @@ class ImageHandler
             return $file;
         }
 
-        $allowed_wp_img_ext = array('jpg', 'jpeg', 'png', 'gif', 'ico');
+        $allowed_wp_img_ext = array('jpg', 'jpeg', 'png', 'gif', 'ico', 'webp');
 
         if (!in_array(strtolower($file_type['ext']), $allowed_wp_img_ext)) {
-            $file['error'] = 'Only JPG, PNG, ICO, and GIF images are allowed for upload.';
+            $file['error'] = 'Only JPG, PNG, ICO, GIF, and WebP images are allowed for upload.';
         }
 
         return $file;


### PR DESCRIPTION
Ref. https://greenpeace-planet4.atlassian.net/browse/PLANET-8145

### Summary
Currently, the carousel header on desktop uses the full image as uploaded. The upload limit is somewhere around 50MB and if editors upload images that large, it will be shown in the slider.
The suggestion is to either limit image size for use in the carousel to < 1MB (or even less) or use automatically converted images,

---
### Testing

1. Log in to the WordPress admin dashboard.
2. Edit a page and add the **Carousel Header** block.
3. Click **Edit** , **Add image** on a slide.
4. Try selecting/uploading a PNG file.
   * Confirm the picker rejects PNG files.
   * Only JPG/JPEG and WebP files should be selectable.
   * Verify the modal title reads:
     > `Select or Upload Photo (only jpg/webp, max 1 MB)`
5. ~~Upload a JPG image larger than 1 MB and try selecting it.~~
   ~~* Expect a browser alert similar to:~~
     ~~> `The selected image is too large…`~~
   ~~* Confirm the slide image is not updated.~~

> Note: If the uploaded image is larger than 1 MB, the Carousel Header will automatically use a resized version of the image that is under 1 MB.

6. Upload/select a JPG image ~~under 1 MB.~~
   * No alert should appear.
   * Confirm the slide updates correctly.
7. Repeat the same test with a WebP image ~~under 1 MB.~~
   * Confirm it behaves the same way as JPG.
8. With a slide image selected, open browser DevTools , **Elements** tab and inspect the slide `<img>` element.
   * Confirm the `src` contains a resized image suffix (e.g. `-2048x1366.jpg`) instead of the original filename.
   * Confirm the `srcset` attribute is populated.
9. Save the page.
10. Open the **Code Editor** view (or inspect the block comment in post content).
    * Confirm `slides[i].image_url` contains the resized image URL.
11. Also check the frontend page 
    * Expect the hero `<img>` to load a resized file
    
**NOTE:**
Previously, Planet 4 only allowed JPG, PNG, ICO, and GIF mime types for uploads.
Image type validation is implemented [here](https://github.com/greenpeace/planet4-master-theme/blob/main/src/ImageHandler.php#L69-L88).
As part of this ticket, WebP support has been added to the list of allowed image formats.