### PR TITLE
PLANET-7940: UX fixes and adjustments in the Actions List block

### DIFF
--- a/assets/src/block-editor/QueryLoopBlockExtension/index.js
+++ b/assets/src/block-editor/QueryLoopBlockExtension/index.js
@@ -219,6 +219,11 @@ export const setupQueryLoopBlockExtension = () => {
           [attributes.layout.type]
         );
 
+        const manualOverrideLabel =
+          isActionsList ?
+            __('CAUTION: Adding actions individually will override the automatic functionality of this block.', 'planet4-master-theme-backend') :
+            __('CAUTION: Adding posts individually will override the automatic functionality of this block. For good user experience, please include at least 3 articles in list view, 4 articles in grid view, and 9 articles in carousel view, so that spacing and alignment of the design remains intact.', 'planet4-master-theme-backend');
+
         return useMemo(() => (
           <>
             <InspectorControls>
@@ -239,7 +244,7 @@ export const setupQueryLoopBlockExtension = () => {
               {
                 <PanelBody title={__('Manual override', 'planet4-master-theme-backend')} initialOpen={query.postIn.length > 0}>
                   <PostSelector
-                    label={__('CAUTION: Adding posts individually will override the automatic functionality of this block. For good user experience, please include at least 3 articles in list view, 4 articles in grid view, and 9 articles in carousel view, so that spacing and alignment of the design remains intact.', 'planet4-master-theme-backend')}
+                    label={manualOverrideLabel}
                     selected={query.postIn || []}
                     onChange={updateQuery}
                     postType={query.postType || 'post'}

--- a/assets/src/blocks/ActionsList/index.js
+++ b/assets/src/blocks/ActionsList/index.js
@@ -131,7 +131,7 @@ export const registerActionsListBlock = () => {
   registerBlockVariation('core/query', {
     name: ACTIONS_LIST_BLOCK_NAME,
     title: 'Actions List',
-    description: __('Integrate images and text cards to automatically display tags, take action pages, or Posts in a three or four column layout displayed in a grid or carousel.', 'planet4-master-theme-backend'),
+    description: __('Display your Actions using dynamic cards that can be filtered by Category, Tag, or Action type, and shown in either a grid or carousel view.', 'planet4-master-theme-backend'),
     icon: 'list-view',
     scope: ['inserter'],
     allowedControls: ['taxQuery', 'pages', 'offset'],

--- a/assets/src/js/actions_list_load_more.js
+++ b/assets/src/js/actions_list_load_more.js
@@ -22,8 +22,9 @@ export const setupActionsListLoadMore = () => {
     }
 
     const posts = [...block.querySelectorAll('.wp-block-post')];
-    if (!posts || posts.length <= postsPerRow * 2) {
-      loadMoreButtonContainer.classList.add('d-none');
+    if (posts && posts.length > postsPerRow * 2) {
+      loadMoreButtonContainer.classList.add('d-flex');
+    } else {
       return;
     }
 

--- a/assets/src/js/actions_list_load_more.js
+++ b/assets/src/js/actions_list_load_more.js
@@ -9,6 +9,10 @@ export const setupActionsListLoadMore = () => {
   if (window.innerWidth >= 768 && window.innerWidth < 992) {
     postsPerRow = 2;
   }
+  // For small screens we only show 1 post per row.
+  else if (window.innerWidth < 768) {
+    postsPerRow = 1;
+  }
 
   if (!gridBlocks.length) {
     return;
@@ -24,8 +28,10 @@ export const setupActionsListLoadMore = () => {
     const posts = [...block.querySelectorAll('.wp-block-post')];
     if (posts && posts.length > postsPerRow * 2) {
       loadMoreButtonContainer.classList.add('d-flex');
+      loadMoreButtonContainer.classList.remove('d-none');
     } else {
-      return;
+      loadMoreButtonContainer.classList.remove('d-flex');
+      loadMoreButtonContainer.classList.add('d-none');
     }
 
     const loadMoreButton = loadMoreButtonContainer.querySelector('.wp-element-button');

--- a/assets/src/js/actions_list_load_more.js
+++ b/assets/src/js/actions_list_load_more.js
@@ -26,6 +26,7 @@ export const setupActionsListLoadMore = () => {
     }
 
     const posts = [...block.querySelectorAll('.wp-block-post')];
+
     if (posts && posts.length > postsPerRow * 2) {
       loadMoreButtonContainer.classList.add('d-flex');
       loadMoreButtonContainer.classList.remove('d-none');

--- a/assets/src/js/actions_list_load_more.js
+++ b/assets/src/js/actions_list_load_more.js
@@ -4,18 +4,19 @@
  */
 export const setupActionsListLoadMore = () => {
   const gridBlocks = document.querySelectorAll('.actions-list.is-custom-layout-grid');
-  let postsPerRow = 3;
-  // For medium screens we only show 2 posts per row.
-  if (window.innerWidth >= 768 && window.innerWidth < 992) {
-    postsPerRow = 2;
-  }
-  // For small screens we only show 1 post per row.
-  else if (window.innerWidth < 768) {
-    postsPerRow = 1;
-  }
 
   if (!gridBlocks.length) {
     return;
+  }
+
+  let postsPerRow = 3;
+
+  if (window.innerWidth >= 768 && window.innerWidth < 992) {
+    // For medium screens we only show 2 posts per row.
+    postsPerRow = 2;
+  } else if (window.innerWidth < 768) {
+    // For small screens we only show 1 post per row.
+    postsPerRow = 1;
   }
 
   // Implement "load more" behaviour for grid layouts.

--- a/assets/src/js/app.js
+++ b/assets/src/js/app.js
@@ -30,7 +30,13 @@ document.addEventListener('DOMContentLoaded', () => {
   if(document.querySelectorAll('.actions-list.is-custom-layout-grid').length) {
     import('./actions_list_load_more').then(({setupActionsListLoadMore}) => {
       setupActionsListLoadMore();
-      window.addEventListener('resize', setupActionsListLoadMore);
+
+      let resizeTimer;
+      const handleResize = () => {
+        clearTimeout(resizeTimer);
+        resizeTimer = setTimeout(() => setupActionsListLoadMore(), 150);
+      };
+      window.addEventListener('resize', handleResize);
     });
   }
 });

--- a/assets/src/js/app.js
+++ b/assets/src/js/app.js
@@ -3,6 +3,7 @@ import 'bootstrap';
 import {setupCookies} from './cookies';
 import {setupHeader} from './header';
 import {setupCountrySelector} from './country_selector';
+import {setupActionsListLoadMore} from './actions_list_load_more';
 
 function requireAll(r) {
   r.keys().forEach(r);
@@ -14,6 +15,8 @@ document.addEventListener('DOMContentLoaded', () => {
   setupCookies();
   setupHeader();
   setupCountrySelector();
+  setupActionsListLoadMore();
+  window.addEventListener('resize', setupActionsListLoadMore);
 
   if(!!document.querySelector('body.search')) {
     import('./search').then(({setupSearch}) => {
@@ -24,19 +27,6 @@ document.addEventListener('DOMContentLoaded', () => {
   if(document.querySelectorAll('[class*="is-custom-layout-"]').length) {
     import('./query_loop_carousel').then(({setupQueryLoopCarousel}) => {
       setupQueryLoopCarousel();
-    });
-  }
-
-  if(document.querySelectorAll('.actions-list.is-custom-layout-grid').length) {
-    import('./actions_list_load_more').then(({setupActionsListLoadMore}) => {
-      setupActionsListLoadMore();
-
-      let resizeTimer;
-      const handleResize = () => {
-        clearTimeout(resizeTimer);
-        resizeTimer = setTimeout(() => setupActionsListLoadMore(), 150);
-      };
-      window.addEventListener('resize', handleResize);
     });
   }
 });

--- a/assets/src/scss/blocks/ActionsList/ActionsListStyle.scss
+++ b/assets/src/scss/blocks/ActionsList/ActionsListStyle.scss
@@ -7,6 +7,7 @@
 
   .load-more-actions-container {
     margin-top: $sp-4;
+    display: none;
   }
 
   .carousel-item-wrapper {

--- a/assets/src/scss/editorOverrides.scss
+++ b/assets/src/scss/editorOverrides.scss
@@ -379,6 +379,39 @@ input.describe[type=text][data-setting=caption] {
 }
 
 // Override Query Loop within editor
+.is-custom-layout-grid {
+
+  &.actions-list.block-editor-block-list__block {
+
+    @include mobile-only {
+      .wp-block-post:nth-child(n+4) {
+        display: block;
+      }
+      .wp-block-post:nth-child(n+5) {
+        display: none;
+      }
+    }
+
+    @include medium-and-less {
+      .wp-block-post:nth-child(n+5) {
+        display: block;
+      }
+      .wp-block-post:nth-child(n+6) {
+        display: none;
+      }
+    }
+
+    @include large-and-up {
+      .wp-block-post:nth-child(n+7) {
+        display: block;
+      }
+      .wp-block-post:nth-child(n+8) {
+        display: none;
+      }
+    }
+  }
+}
+
 .is-custom-layout-carousel {
   flex-direction: column;
 

--- a/assets/src/scss/editorOverrides.scss
+++ b/assets/src/scss/editorOverrides.scss
@@ -380,9 +380,7 @@ input.describe[type=text][data-setting=caption] {
 
 // Override Query Loop within editor
 .is-custom-layout-grid {
-
   &.actions-list.block-editor-block-list__block {
-
     .load-more-actions-container {
       display: flex;
     }
@@ -391,6 +389,7 @@ input.describe[type=text][data-setting=caption] {
       .wp-block-post:nth-child(n+4) {
         display: block;
       }
+
       .wp-block-post:nth-child(n+5) {
         display: none;
       }
@@ -400,6 +399,7 @@ input.describe[type=text][data-setting=caption] {
       .wp-block-post:nth-child(n+5) {
         display: block;
       }
+
       .wp-block-post:nth-child(n+6) {
         display: none;
       }
@@ -409,6 +409,7 @@ input.describe[type=text][data-setting=caption] {
       .wp-block-post:nth-child(n+7) {
         display: block;
       }
+
       .wp-block-post:nth-child(n+8) {
         display: none;
       }

--- a/assets/src/scss/editorOverrides.scss
+++ b/assets/src/scss/editorOverrides.scss
@@ -383,6 +383,10 @@ input.describe[type=text][data-setting=caption] {
 
   &.actions-list.block-editor-block-list__block {
 
+    .load-more-actions-container {
+      display: flex;
+    }
+
     @include mobile-only {
       .wp-block-post:nth-child(n+4) {
         display: block;

--- a/assets/src/scss/editorOverrides.scss
+++ b/assets/src/scss/editorOverrides.scss
@@ -390,6 +390,12 @@ input.describe[type=text][data-setting=caption] {
     margin-bottom: 0;
   }
 
+  &.actions-list {
+    .wp-block-post-template {
+      width: 100%;
+    }
+  }
+
   .wp-block-post-template {
     display: flex;
     padding: 0 8px 8px 8px !important;


### PR DESCRIPTION
### Summary

This PR introduces the following changes to the Actions List block:

- In the editor:
  - For the Grid layout, display a maximum of 6 elements instead of 5.
  - For the Carousel layout, fix items looking very thin when there are fewer than 3.
  - Update the block description: “Display your Actions using dynamic cards that can be filtered by Category, Tag, or Action type, and shown in either a grid or carousel view.“
  - Update the Manual Override feature of the block: "CAUTION: Adding actions individually will override the automatic functionality of this block."

- In the front:
  - Remove the flicker from the “Load More” button when fewer than 6 elements are displayed using the Grid layout.

---

Ref: https://greenpeace-planet4.atlassian.net/browse/PLANET-7940

### Testing

1. Check that the changes detailed above are correctly introduced.