### PR TITLE
Remove "resource_class: xlarge" from the "create-zip" job in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -255,7 +255,6 @@ jobs:
             --test-instance $(cat /tmp/workspace/test-instance)
 
   create-zip:
-    resource_class: xlarge
     docker:
       - image: cimg/node:20.18.0
         auth:


### PR DESCRIPTION
### Summary

Remove `resource_class: xlarge` from the `create-zip` job in CircleCI

---

Ref: https://greenpeace-gpi.slack.com/archives/C0160MX64AG/p1778505157366849?thread_ts=1778483106.940469&cid=C0160MX64AG