### PR TITLE
PLANET-8166: Carousel Header adjustments

### DIFF
--- a/assets/src/scss/blocks/CarouselHeader/CarouselHeaderStyle.scss
+++ b/assets/src/scss/blocks/CarouselHeader/CarouselHeaderStyle.scss
@@ -393,7 +393,6 @@ $medium-image-height: 600px;
     @include large-and-up {
       padding-top: 180px;
       padding-bottom: 32px;
-      margin-inline-start: 80px;
     }
 
     h2 {
@@ -416,12 +415,11 @@ $medium-image-height: 600px;
         width: 100%;
         color: var(--white);
         margin-bottom: 32px;
-        line-height: 1.3;
+        line-height: $line-height-2xl--font-family-primary;
         font-size: $font-size-xxl;
       }
 
       @include x-large-and-up {
-        font-size: $font-size-xxxl;
         max-width: 100%;
         width: 100%;
       }
@@ -456,7 +454,7 @@ $medium-image-height: 600px;
 
       @include large-and-up {
         font-size: var(--font-size-xl--font-family-secondary);
-        margin-bottom: 36px;
+        margin-bottom: 32px;
         color: var(--white);
       }
 
@@ -707,10 +705,6 @@ $medium-image-height: 600px;
       bottom: $sp-2x;
       left: 0;
       z-index: 9999;
-
-      > .container {
-        margin-inline-start: 80px;
-      }
     }
 
     @include x-large-and-up {


### PR DESCRIPTION
### Summary

This PR applies the following adjustments to the Carousel Header block:
- The title, description, and CTA are moved within the container limits to keep them within the page container.
- The heading font size is now 40px, the heading line height is 48px, and the bottom margin of the description is 32px to avoid the CTA overlapping the carousel controls.

**BEFORE:**
<img width="1488" height="496" alt="Screenshot from 2026-05-14 09-41-44" src="https://github.com/user-attachments/assets/563dbb02-5f2d-4551-9d43-7834e578067a" />

**NOW:**
<img width="1488" height="496" alt="Screenshot from 2026-05-14 09-41-09" src="https://github.com/user-attachments/assets/e3f1fad2-cf75-430c-b755-18ce9b010acb" />


---

Ref: https://greenpeace-planet4.atlassian.net/browse/PLANET-8166

### Testing

1. Check that the changes listed in the summary are fulfilled.
2. Check that the carousel elements (title, description, and CTA) are kept within the page container limits.
3. Check that CTA is no longer overlapping the carousel controls.
4. Try the previous steps using different lengths for the title and description, and different screen sizes.
