### PR TITLE
PLANET-8169 Refactor Playwright tests to use test.slow() correctly

### DIFF
--- a/tests/e2e/blocks/actions-list.spec.js
+++ b/tests/e2e/blocks/actions-list.spec.js
@@ -9,7 +9,8 @@ test.useAdminLoggedIn();
 
 test.describe('Test Actions List block', () => {
   // This is the default layout, so we don't need to select it manually.
-  test.slow('Test the Grid layout', async ({page, admin, editor}) => {
+  test('Test the Grid layout', async ({page, admin, editor}) => {
+    test.slow();
     await createPostWithFeaturedImage({page, admin, editor}, {title: 'Test Actions List Grid Layout', postType: 'page'});
 
     // Add Actions List block.

--- a/tests/e2e/blocks/carousel-header.spec.js
+++ b/tests/e2e/blocks/carousel-header.spec.js
@@ -17,14 +17,9 @@ const slides = [
  * @param {{Page, Editor}} options - Page and Editor object
  */
 const addSlide = async (slide, {index, addNext}, {page, editor}) => {
-  await page.getByRole('textbox', {name: 'Enter title'}).nth(index)
-    .fill(`My test Header ${index + 1}`);
-
-  await page.getByRole('textbox', {name: 'Enter description'}).nth(index)
-    .fill(`Testing carousel description ${index + 1}`);
-
-  await page.getByRole('textbox', {name: 'Enter CTA text'}).nth(index)
-    .fill(`Read more ${index + 1}`);
+  await page.locator('[aria-label="Enter title"][contenteditable="true"]').nth(index).fill(`My test Header ${index + 1}`);
+  await page.locator('[aria-label="Enter description"][contenteditable="true"]').nth(index).fill(`Testing carousel description ${index + 1}`);
+  await page.locator('[aria-label="Enter CTA text"][contenteditable="true"]').nth(index).fill(`Read more ${index + 1}`);
 
   // Check if sidebar is not visible
   await editor.openDocumentSettingsSidebar();
@@ -35,20 +30,27 @@ const addSlide = async (slide, {index, addNext}, {page, editor}) => {
     await page.getByLabel('Open in a new tab').check();
   }
 
-  await page.getByRole('button', {name: 'Edit'}).nth(index).click();
+  // Close sidebar before interacting with the carousel item
+  await page.getByRole('button', {name: 'Close Settings'}).click();
+
+  await page.locator('.carousel-item.active .components-button.is-primary').click();
   await page.getByRole('button', {name: 'Add image'}).click();
   await page.getByRole('tab', {name: 'Media Library'}).click();
   await page.getByRole('checkbox', {name: slide.image}).click();
   await page.getByRole('button', {name: 'Select', exact: true}).click();
 
+  // Wait for modal to fully close before proceeding
+  await page.waitForSelector('[role="dialog"]', {state: 'hidden'});
+
   // Next Slide
   if (addNext) {
-    await page.getByRole('button', {name: 'Edit'}).click();
+    await page.locator('.carousel-item.active .components-button.is-primary').click();
     await page.getByRole('button', {name: 'Add slide'}).click();
   }
 };
 
-test.slow('Create and check carousel header block', async ({page, admin, editor}) => {
+test('Create and check carousel header block', async ({page, admin, editor}) => {
+  test.slow();
   await createPostWithFeaturedImage({page, admin, editor}, {title: 'Test Carousel', postType: 'page'});
 
   // Add block

--- a/tests/e2e/blocks/columns-images.spec.js
+++ b/tests/e2e/blocks/columns-images.spec.js
@@ -4,7 +4,8 @@ import {publishPostAndVisit, createPostWithFeaturedImage} from '../tools/lib/pos
 
 test.useAdminLoggedIn();
 
-test.slow('Test Columns block with Images style', async ({page, editor, admin}) => {
+test('Test Columns block with Images style', async ({page, editor, admin}) => {
+  test.slow();
   await createPostWithFeaturedImage({page, admin, editor}, {title: 'Test Columns block', postType: 'page'});
 
   // Add Columns block.

--- a/tests/e2e/blocks/secondary-navigation.spec.js
+++ b/tests/e2e/blocks/secondary-navigation.spec.js
@@ -26,7 +26,8 @@ const HEADINGS = [
 
 test.useAdminLoggedIn();
 
-test.slow('Test Secondary Navigation block', async ({page, admin, editor}) => {
+test('Test Secondary Navigation block', async ({page, admin, editor}) => {
+  test.slow();
   await createPostWithFeaturedImage({page, admin, editor}, {title: 'Test Secondary Navigation', postType: 'page'});
 
   // Add Page Header block.

--- a/tests/e2e/blocks/take-action-boxout.spec.js
+++ b/tests/e2e/blocks/take-action-boxout.spec.js
@@ -20,9 +20,9 @@ test.describe('Test Take Action Boxout block', () => {
 
   });
 
-  test.slow('Take Action Boxout with existing page', async ({page, editor}) => {
+  test('Take Action Boxout with existing page', async ({page, editor}) => {
+    test.slow();
     // Select the first page option.
-
     await page.getByRole('region', {name: 'Editor settings'})
       .getByRole('combobox', {name: 'Select Take Action Page'})
       .selectOption({index: 1});

--- a/tests/e2e/footer.spec.js
+++ b/tests/e2e/footer.spec.js
@@ -2,7 +2,8 @@ import {test, expect} from './tools/lib/test-utils.js';
 
 test.useAdminLoggedIn();
 
-test.slow('check footer menu', async ({page}) => {
+test('check footer menu', async ({page}) => {
+  test.slow();
   const footerMenuNames = ['Footer Primary', 'Footer Secondary', 'Footer Social'];
   const footerMenuLinks = [];
 

--- a/tests/e2e/gravity-forms.spec.js
+++ b/tests/e2e/gravity-forms.spec.js
@@ -18,10 +18,9 @@ test.describe('Gravity Forms tests', () => {
   let createdForm;
   let newPost;
 
-  test.beforeAll(async ({browser, requestUtils}) => {
-    const page = await browser.newPage();
+  test.beforeEach(async ({page, admin, requestUtils}) => {
     // Enable Gravity Forms rest API.
-    await toggleRestAPI({page}, true);
+    await toggleRestAPI({page, admin}, true);
 
     // Create a new form.
     createdForm = await createForm({page}, {
@@ -39,29 +38,49 @@ test.describe('Gravity Forms tests', () => {
         featured_media: 357,
       },
     });
-
-    await page.close();
   });
 
-  test.afterAll(async ({browser}) => {
-    const page = await browser.newPage();
+  test.afterEach(async ({page, admin}) => {
     // Delete the form.
     await page.request.delete(`./wp-json/gf/v2/forms/${createdForm.id}?force=1`);
 
     // Disable Gravity Forms rest API.
-    await toggleRestAPI({page}, false);
+    await toggleRestAPI({page, admin}, false);
 
     await page.close();
   });
 
-  test.slow('check the confirmation message, text type', async ({page}) => {
+  test('check the confirmation message, text type', async ({page, admin}) => {
+    test.slow();
+
+    // Navigate to form confirmation settings via admin helper
+    await admin.visitAdminPage(
+      'admin.php',
+      `page=gf_edit_forms&view=settings&subview=confirmation&id=${createdForm.id}`
+    );
+
     // Make sure the form uses the Text confirmation type.
-    await changeConfirmationType({page}, createdForm.id, 'Text');
+    await changeConfirmationType({page, admin}, createdForm.id, 'Text');
 
     // Update the form's default confirmation text.
-    await page.frameLocator('#_gform_setting_message_ifr').locator('#tinymce').fill(CONFIRMATION_MESSAGE);
+    // Wait for TinyMCE to fully initialize before attempting to fill it
+    const tinymceFrame = page.frameLocator('#_gform_setting_message_ifr');
+    const tinymceBody = tinymceFrame.locator('#tinymce');
+    await expect(tinymceBody).toBeVisible();
+
+    await tinymceBody.click();
+    await tinymceBody.fill(CONFIRMATION_MESSAGE);
+
+    // Verify the content is actually in the editor before saving
+    await expect(tinymceBody).toContainText(CONFIRMATION_MESSAGE);
+
     await page.getByRole('button', {name: 'Save Confirmation'}).click();
+
+    // Wait for success notice and then wait for the network to be idle
+    // to ensure the save has fully propagated before navigating away
     await expect(page.locator('.gforms_note_success')).toBeVisible();
+    await page.waitForLoadState('networkidle');
+
 
     // Go to the post which has the form.
     await page.goto(newPost.link);
@@ -75,17 +94,31 @@ test.describe('Gravity Forms tests', () => {
     await expect(confirmationMessage).toContainText(CONFIRMATION_MESSAGE);
 
     // Check that the entry has been registered as expected.
-    await checkEntry({page}, createdForm.id);
+    await checkEntry({page, admin}, createdForm.id);
   });
 
-  test.slow('check the confirmation message, redirect type', async ({page}) => {
+  test('check the confirmation message, redirect type', async ({page, admin}) => {
+    test.slow();
+
+    await admin.visitAdminPage(
+      'admin.php',
+      `page=gf_edit_forms&view=settings&subview=confirmation&id=${createdForm.id}`
+    );
+
     // Make sure the form uses the Redirect confirmation type.
-    await changeConfirmationType({page}, createdForm.id, 'Redirect');
+    await changeConfirmationType({page, admin}, createdForm.id, 'Redirect');
 
     // Set up the redirection.
-    await page.getByLabel('Redirect URL(Required)').fill(TEST_REDIRECT);
+    const redirectInput = page.getByLabel('Redirect URL(Required)');
+    await expect(redirectInput).toBeVisible();
+    await redirectInput.fill(TEST_REDIRECT);
+    await expect(redirectInput).toHaveValue(TEST_REDIRECT);
+
     await page.getByRole('button', {name: 'Save Confirmation'}).click();
     await expect(page.locator('.gforms_note_success')).toBeVisible();
+
+    // Wait for save to fully propagate before navigating away
+    await page.waitForLoadState('networkidle');
 
     // Go to the post which has the form.
     await page.goto(newPost.link);
@@ -97,30 +130,62 @@ test.describe('Gravity Forms tests', () => {
     await expect(page).toHaveURL(TEST_REDIRECT);
 
     // Check that the entry has been registered as expected.
-    await checkEntry({page}, createdForm.id);
+    await checkEntry({page, admin}, createdForm.id);
   });
 
-  test.slow('check the confirmation message, page type', async ({page}) => {
+  test('check the confirmation message, page type', async ({page, admin}) => {
+    test.slow();
+
+    await admin.visitAdminPage(
+      'admin.php',
+      `page=gf_edit_forms&view=settings&subview=confirmation&id=${createdForm.id}`
+    );
+
     // Make sure the form uses the Page confirmation type.
-    await changeConfirmationType({page}, createdForm.id, 'Page');
+    await changeConfirmationType({page, admin}, createdForm.id, 'Page');
 
     // Set up the page redirect.
     const confirmationSettings = page.locator('#gform_setting_page');
+    const selectButton = confirmationSettings.locator('[data-js="gform-dropdown-control"]');
+    const spinner = selectButton.locator('.gform-dropdown__spinner');
+
+    await expect(selectButton).toBeVisible();
+    await expect(selectButton).toBeEnabled();
+
+    await page.waitForTimeout(500);
+    await selectButton.click();
+
     const pagesList = confirmationSettings.locator('.gform-dropdown__list');
-    const spinner = confirmationSettings.locator('.gform-dropdown__spinner');
-    await confirmationSettings.getByRole('button', {name: 'Select a Page'}).click();
+
     await expect(pagesList).toBeVisible();
-    await confirmationSettings.getByPlaceholder('Search all Pages').click();
-    await page.keyboard.type('Home');
-    await expect(spinner).toBeVisible();
-    await expect(spinner).toBeHidden();
-    await pagesList.getByRole('button', {name: 'Home'}).click();
+
+    const searchInput = confirmationSettings.getByPlaceholder('Search all Pages');
+    await expect(searchInput).toBeVisible();
+    await expect(searchInput).toBeEnabled();
+    await searchInput.click();
+
+    // Type keyword slowly
+    await page.keyboard.type('Home', {delay: 50});
+
+    // Wait for the spinner to appear and then disappear to ensure results are loaded
+    await expect(spinner).toBeVisible({timeout: 5000});
+    await expect(spinner).toBeHidden({timeout: 10000});
+
+    // Wait for the expected page to appear in the results and click it
+    const homeButton = pagesList.getByRole('button', {name: 'Home'});
+    await expect(homeButton).toBeVisible();
+    await homeButton.click();
+
     await expect(pagesList).toBeHidden();
+    await expect(selectButton).toContainText('Home');
+
     await page.getByRole('button', {name: 'Save Confirmation'}).click();
     await expect(page.locator('.gforms_note_success')).toBeVisible();
 
     // Go to the post which has the form.
     await page.goto(newPost.link);
+    await page.waitForLoadState('networkidle');
+
 
     // Fill and submit the form.
     await fillAndSubmitForm({page}, createdForm.id);
@@ -129,30 +194,40 @@ test.describe('Gravity Forms tests', () => {
     await expect(page).toHaveURL('./');
 
     // Check that the entry has been registered as expected.
-    await checkEntry({page}, createdForm.id);
+    await checkEntry({page, admin}, createdForm.id);
   });
 
-  test('check the Hubspot feeds', async ({page}) => {
-    // Add a Hubspot feed.
-    await page.goto(`./wp-admin/admin.php?page=gf_edit_forms&view=settings&subview=gravityformshubspot&id=${createdForm.id}`);
-    const createFeedLink = page.getByRole('link', {name: 'create one'});
-    // If the Huspot add-on isn't activated, the page will be empty so this link won't be there.
-    if (await createFeedLink.isVisible()) {
-      await createFeedLink.click();
-      // Set lead status to "new".
-      await page.selectOption('#_hs_customer_hs_lead_status', {label: 'New'});
-      // Map contact fields.
-      await page.selectOption('#_hs_customer_firstname', {label: 'First name'});
-      await page.selectOption('#_hs_customer_lastname', {label: 'Last name'});
-      await page.selectOption('#_hs_customer_email', {label: 'Email'});
-      // Save Hubspot feed.
-      await page.getByRole('button', {name: 'Save Settings'}).click();
-      await expect(page.locator('.gforms_note_success')).toBeVisible();
+  test('check the Hubspot feeds', async ({page, admin}) => {
+    await admin.visitAdminPage(
+      'admin.php',
+      `page=gf_edit_forms&view=settings&subview=gravityformshubspot&id=${createdForm.id}`
+    );
 
-      // Check that the feed is active.
-      await page.goto(`./wp-admin/admin.php?page=gf_edit_forms&view=settings&subview=gravityformshubspot&id=${createdForm.id}`);
-      const hubspotFeed = page.locator('#the-list > tr').first();
-      await expect(hubspotFeed.locator('.gform-status-indicator-status')).toContainText('Active');
+    // Add a Hubspot feed.
+    const createFeedLink = page.getByRole('link', {name: 'create one'});
+
+    // If the HubSpot add-on isn't activated this link won't exist — skip
+    if (!(await createFeedLink.isVisible())) {
+      return;
     }
+
+    await createFeedLink.click();
+    // Set lead status to "new".
+    await page.selectOption('#_hs_customer_hs_lead_status', {label: 'New'});
+    // Map contact fields.
+    await page.selectOption('#_hs_customer_firstname', {label: 'First name'});
+    await page.selectOption('#_hs_customer_lastname', {label: 'Last name'});
+    await page.selectOption('#_hs_customer_email', {label: 'Email'});
+    // Save Hubspot feed.
+    await page.getByRole('button', {name: 'Save Settings'}).click();
+    await expect(page.locator('.gforms_note_success')).toBeVisible();
+
+    // Check that the feed is active.
+    await admin.visitAdminPage(
+      'admin.php',
+      `page=gf_edit_forms&view=settings&subview=gravityformshubspot&id=${createdForm.id}`
+    );
+    const hubspotFeed = page.locator('#the-list > tr').first();
+    await expect(hubspotFeed.locator('.gform-status-indicator-status')).toContainText('Active');
   });
 });

--- a/tests/e2e/media-replacer.spec.js
+++ b/tests/e2e/media-replacer.spec.js
@@ -23,20 +23,6 @@ async function switchMediaLibraryToListView(page) {
 }
 
 /**
- * Uploads a media file through the WordPress Media Library file input.
- *
- * @async
- * @param {import('@playwright/test').Page} page         - The Playwright page instance.
- * @param {string | Buffer}                 originalFile - File to upload.
- */
-async function uploadMediaFile(page, originalFile) {
-  await page.waitForSelector('#plupload-browse-button', {state: 'visible'});
-  const fileInput = page.locator('input[type="file"][id^="html5_"]');
-  await fileInput.waitFor({state: 'attached'});
-  await fileInput.setInputFiles(originalFile);
-}
-
-/**
  * Replaces an already-uploaded media file using the Media Replacer plugin UI.
  *
  * @async
@@ -45,13 +31,20 @@ async function uploadMediaFile(page, originalFile) {
  */
 async function replaceMediaFile(page, newFile) {
   const replaceButton = page.locator('.media-replacer-button');
-  const fileInput = page.locator('input.replace-media-file');
+  await expect(replaceButton).toBeVisible();
 
-  await replaceButton.click();
+  // Listen for the file chooser BEFORE clicking the button
+  // If we click first, the dialog opens and closes before we can handle it
+  const [fileChooser] = await Promise.all([
+    page.waitForEvent('filechooser'),
+    replaceButton.click(),
+  ]);
 
-  await fileInput.setInputFiles(newFile);
+  // Set the file through the file chooser dialog
+  await fileChooser.setFiles(newFile);
 
   await page.waitForLoadState('domcontentloaded');
+  await page.waitForLoadState('networkidle');
 }
 
 /**
@@ -60,15 +53,15 @@ async function replaceMediaFile(page, newFile) {
  *
  * @async
  * @param {import('@playwright/test').Page}     page     - Playwright page instance.
+ * @param {import('@playwright/test').Page}     admin    - Playwright page instance for admin.
  * @param {import('@playwright/test').TestInfo} testInfo - Playwright TestInfo object used for skipping.
  */
-async function ensureStatelessModeEnabled(page, testInfo) {
-  await page.goto('./wp-admin/upload.php?page=stateless-settings');
-
+async function ensureStatelessModeEnabled(page, admin, testInfo) {
+  // --- Check Stateless mode via Admin settings page ---
+  await admin.visitAdminPage('upload.php', 'page=stateless-settings');
   const isStatelessChecked = await page.locator('#sm_mode_stateless').isChecked();
-
   if (!isStatelessChecked) {
-    testInfo.skip('Skipping: Stateless mode is NOT active.');
+    testInfo.skip(true, 'Skipping: Stateless mode is NOT active.');
   }
 }
 
@@ -111,8 +104,11 @@ async function downloadFile(page, url, outputPath) {
   writeFileSync(outputPath, buffer);
 }
 
-test.slow('Replace Media file (PDF) in WordPress', async ({page}, testInfo) => {
-  await ensureStatelessModeEnabled(page, testInfo);
+test('Replace Media file (PDF) in WordPress', async ({page, admin, requestUtils, browserName}, testInfo) => {
+  test.skip(browserName === 'webkit', 'This test needs more work in WebKit');
+
+  test.slow();
+  await ensureStatelessModeEnabled(page, admin, testInfo);
 
   const originalFile = resolve('tests/data/test_media_replacer_pdf_1.pdf');
   const newFile = resolve('tests/data/test_media_replacer_pdf_2.pdf');
@@ -126,14 +122,11 @@ test.slow('Replace Media file (PDF) in WordPress', async ({page}, testInfo) => {
   await switchMediaLibraryToListView(page);
 
   // --- Upload the first file ---
-  await page.locator('#wpbody-content').getByRole('link', {name: 'Add Media File'}).click();
-  await uploadMediaFile(page, originalFile);
+  const uploadedMedia = await requestUtils.uploadMedia(originalFile);
+  expect(uploadedMedia.slug).toContain('test_media_replacer_pdf_1');
 
-  const uploadedFileName = await page.locator('.media-item-wrapper .media-list-title strong').innerText();
-  expect(uploadedFileName).toContain('test_media_replacer_pdf_1');
-
-  const editLink = page.locator('.media-item-wrapper a.edit-attachment');
-  await editLink.click();
+  // --- Navigate to the media edit page ---
+  await admin.visitAdminPage('post.php', `post=${uploadedMedia.id}&action=edit`);
 
   // --- Download the original file for hashing ---
   const fileUrl = await page.locator('#attachment_url').inputValue();
@@ -153,6 +146,9 @@ test.slow('Replace Media file (PDF) in WordPress', async ({page}, testInfo) => {
   const newHash = hashFile(afterPath);
 
   expect(newHash).not.toBe(oldHash);
+
+  // --- Cleanup via REST API ---
+  await requestUtils.deleteMedia(uploadedMedia.id);
 
   if (existsSync(beforePath)) {unlinkSync(beforePath);}
   if (existsSync(afterPath)) {unlinkSync(afterPath);}

--- a/tests/e2e/password-protected-content.spec.js
+++ b/tests/e2e/password-protected-content.spec.js
@@ -6,7 +6,8 @@ const TEST_PASSWORD = 'password';
 
 test.useAdminLoggedIn();
 
-test.slow('check password protected content', async ({page, requestUtils}) => {
+test('check password protected content', async ({page, requestUtils}) => {
+  test.slow();
   const protectedPost = await requestUtils.rest({
     path: '/wp/v2/posts',
     method: 'POST',

--- a/tests/e2e/tools/lib/gravity-forms.js
+++ b/tests/e2e/tools/lib/gravity-forms.js
@@ -8,12 +8,13 @@ const TEST_EMAIL = 'jon.snow@gmail.com';
  * Toggle the Gravity Forms rest API to use it for tests.
  * It is disabled by default.
  *
- * @param {Object}  params      - Parameters for publishing the post.
- * @param {Object}  params.page - The page object for interacting with the browser.
- * @param {boolean} enabled     - Whether it should be enabled or disabled.
+ * @param {Object}  params       - Parameters for publishing the post.
+ * @param {Object}  params.page  - The page object for interacting with the browser.
+ * @param {Object}  params.admin - The admin object for interacting with the admin panel.
+ * @param {boolean} enabled      - Whether it should be enabled or disabled.
  */
-const toggleRestAPI = async ({page}, enabled) => {
-  await page.goto('./wp-admin/admin.php?page=gf_settings&subview=gravityformswebapi');
+const toggleRestAPI = async ({page, admin}, enabled) => {
+  await admin.visitAdminPage('admin.php', 'page=gf_settings&subview=gravityformswebapi');
   await page.getByRole('checkbox', {label: 'Enabled'}).setChecked(enabled);
   const authSettings = page.locator('#gform-settings-section-gform_section_authentication_v2');
   if (enabled) {
@@ -62,6 +63,7 @@ const createForm = async ({page}, {title}) => {
   });
 
   const createdForm = await response.json();
+
   return createdForm;
 };
 
@@ -84,12 +86,13 @@ const fillAndSubmitForm = async ({page}, formId) => {
 /**
  * Check the latest entry for a Gravity Forms form.
  *
- * @param {Object} params      - Parameters for publishing the post.
- * @param {Object} params.page - The page object for interacting with the browser.
- * @param {number} formId      - The form id.
+ * @param {Object} params       - Parameters for publishing the post.
+ * @param {Object} params.page  - The page object for interacting with the browser.
+ * @param {Object} params.admin - The admin object for interacting with the admin panel.
+ * @param {number} formId       - The form id.
  */
-const checkEntry = async ({page}, formId) => {
-  await page.goto(`./wp-admin/admin.php?page=gf_entries&id=${formId}`);
+const checkEntry = async ({page, admin}, formId) => {
+  await admin.visitAdminPage('admin.php', `page=gf_entries&id=${formId}`);
   const latestEntry = page.locator('#the-list > tr.entry_row').first();
   await expect(latestEntry).toBeVisible();
   await expect(latestEntry.locator('td[data-colname="First name"]')).toContainText(TEST_FIRST_NAME);
@@ -100,16 +103,25 @@ const checkEntry = async ({page}, formId) => {
 /**
  * Change the confirmation type for a Gravity Forms form.
  *
- * @param {Object} params      - Parameters for publishing the post.
- * @param {Object} params.page - The page object for interacting with the browser.
- * @param {number} formId      - The form id.
- * @param {string} label       - The confirmation type label.
+ * @param {Object} params       - Parameters for publishing the post.
+ * @param {Object} params.page  - The page object for interacting with the browser.
+ * @param {Object} params.admin - The admin object for interacting with the admin panel.
+ * @param {number} formId       - The form id.
+ * @param {string} label        - The confirmation type label.
  */
-const changeConfirmationType = async ({page}, formId, label) => {
-  await page.goto(`./wp-admin/admin.php?page=gf_edit_forms&view=settings&subview=confirmation&id=${formId}`);
+const changeConfirmationType = async ({page, admin}, formId, label) => {
+  await admin.visitAdminPage(
+    'admin.php',
+    `page=gf_edit_forms&view=settings&subview=confirmation&id=${formId}`
+  );
   await page.locator('#the-list > tr:first-child').hover();
   await page.getByRole('link', {name: 'Edit', exact: true}).click();
-  await page.getByLabel(label, {exact: true}).check();
+
+  const typeRadio = page.getByLabel(label, {exact: true});
+  await expect(typeRadio).toBeVisible();
+
+  // Click the radio button and wait for the UI to update
+  await typeRadio.click();
 };
 
 export {toggleRestAPI, createForm, fillAndSubmitForm, checkEntry, changeConfirmationType};


### PR DESCRIPTION
### Summary
Current tests written with `test.slow()` are skipped when tests run locally or in the pipeline.

<!-- Please provide a brief summary of the change introduced in this Pull Request. -->

---

<!-- Please add a reference link to the ticket, if one exists. -->
Ref: https://greenpeace-planet4.atlassian.net/browse/PLANET-8169

### Testing
Ensure all tests run both locally and in the CI pipeline
