### PR TITLE
Hide Avatars plugin license notice

### DIFF
--- a/admin/css/notices.css
+++ b/admin/css/notices.css
@@ -11,6 +11,7 @@
 #gf_dashboard_message,
 [data-ep-notice],
 .otgs-installer-notice-plugin-recommendation,
-.welcome-panel-content {
+.welcome-panel-content,
+div.error:has(a[href*="gpavatars_list_options"]) {
   display: none;
 }


### PR DESCRIPTION
### Summary

<img width="911" height="64" alt="image" src="https://github.com/user-attachments/assets/6bd6d80a-0a08-4dfe-8cf6-0f46e849ab63" />

This may be confusing for NRO admins, so better hide it. At least in production.

There is no specific class to target, so instead targetting the href content.

---

### Testing

<!-- Please add the steps required to test the changes in this Pull Request. -->
1. Even in this branch, you should be able to see the notice on almost all Admin screens.
2. Change `WP_APP_ENV` to `production` in `.wp-env.override.json`.
3. Restart the environment.
4. The notice should no longer be visible.
