### PR TITLE
PLANET-8178 Add images to new Timeline block

### DIFF
--- a/assets/src/blocks/Timeline/NewTimelineFrontend.js
+++ b/assets/src/blocks/Timeline/NewTimelineFrontend.js
@@ -56,6 +56,9 @@ export const NewTimelineFrontend = ({attributes}) => {
     const [expanded, setExpanded] = useState(false);
     const contentId = `timeline-content-${event.day}-${event.month}`;
 
+    // Check if the event has a media, and if that media is an image.
+    const hasImage = event.media && event.media.match(/\.(jpeg|jpg|gif|png)$/) !== null;
+
     return (
       <li className="timeline-block-event">
         <p
@@ -64,7 +67,7 @@ export const NewTimelineFrontend = ({attributes}) => {
         >
           {getLocalizedDate(event.day, event.month)}
         </p>
-        {event.media && (
+        {hasImage && (
           <img
             src={event.media}
             alt={event.media_caption ?? ''}

--- a/assets/src/blocks/Timeline/NewTimelineFrontend.js
+++ b/assets/src/blocks/Timeline/NewTimelineFrontend.js
@@ -72,7 +72,7 @@ export const NewTimelineFrontend = ({attributes}) => {
             src={event.media}
             alt={event.media_caption ?? ''}
             loading="lazy"
-            onError={() => console.log('Could not load image')} //eslint-disable-line no-console
+            onError={e => e.currentTarget.style.display = 'none'} //eslint-disable-line no-console
           />
         )}
         <h3 className="timeline-block-event-title">{event.headline}</h3>

--- a/assets/src/blocks/Timeline/NewTimelineFrontend.js
+++ b/assets/src/blocks/Timeline/NewTimelineFrontend.js
@@ -57,7 +57,7 @@ export const NewTimelineFrontend = ({attributes}) => {
     const contentId = `timeline-content-${event.day}-${event.month}`;
 
     // Check if the event has a media, and if that media is an image.
-    const hasImage = event.media && event.media.match(/\.(jpeg|jpg|gif|png)$/) !== null;
+    const hasImage = event.media && event.media.match(/\.(jpeg|jpg|gif|png)$/i) !== null;
 
     return (
       <li className="timeline-block-event">

--- a/assets/src/blocks/Timeline/NewTimelineFrontend.js
+++ b/assets/src/blocks/Timeline/NewTimelineFrontend.js
@@ -72,7 +72,7 @@ export const NewTimelineFrontend = ({attributes}) => {
             src={event.media}
             alt={event.media_caption ?? ''}
             loading="lazy"
-            onError={e => e.currentTarget.style.display = 'none'} //eslint-disable-line no-console
+            onError={e => e.currentTarget.style.display = 'none'}
           />
         )}
         <h3 className="timeline-block-event-title">{event.headline}</h3>

--- a/assets/src/blocks/Timeline/NewTimelineFrontend.js
+++ b/assets/src/blocks/Timeline/NewTimelineFrontend.js
@@ -65,7 +65,7 @@ export const NewTimelineFrontend = ({attributes}) => {
           {getLocalizedDate(event.day, event.month)}
         </p>
         {event.media && (
-          <img src={event.media} alt={event.media_caption ?? ''} />
+          <img src={event.media} alt={event.media_caption ?? ''} loading="lazy" />
         )}
         <h3 className="timeline-block-event-title">{event.headline}</h3>
         <div className="timeline-description-wrapper">

--- a/assets/src/blocks/Timeline/NewTimelineFrontend.js
+++ b/assets/src/blocks/Timeline/NewTimelineFrontend.js
@@ -65,7 +65,12 @@ export const NewTimelineFrontend = ({attributes}) => {
           {getLocalizedDate(event.day, event.month)}
         </p>
         {event.media && (
-          <img src={event.media} alt={event.media_caption ?? ''} loading="lazy" />
+          <img
+            src={event.media}
+            alt={event.media_caption ?? ''}
+            loading="lazy"
+            onError={() => console.log('Could not load image')} //eslint-disable-line no-console
+          />
         )}
         <h3 className="timeline-block-event-title">{event.headline}</h3>
         <div className="timeline-description-wrapper">

--- a/assets/src/blocks/Timeline/NewTimelineFrontend.js
+++ b/assets/src/blocks/Timeline/NewTimelineFrontend.js
@@ -64,6 +64,9 @@ export const NewTimelineFrontend = ({attributes}) => {
         >
           {getLocalizedDate(event.day, event.month)}
         </p>
+        {event.media && (
+          <img src={event.media} alt={event.media_caption ?? ''} />
+        )}
         <h3 className="timeline-block-event-title">{event.headline}</h3>
         <div className="timeline-description-wrapper">
           <p

--- a/assets/src/blocks/Timeline/NewTimelineFrontend.js
+++ b/assets/src/blocks/Timeline/NewTimelineFrontend.js
@@ -57,7 +57,7 @@ export const NewTimelineFrontend = ({attributes}) => {
     const contentId = `timeline-content-${event.day}-${event.month}`;
 
     // Check if the event has a media, and if that media is an image.
-    const hasImage = event.media && event.media.match(/\.(jpeg|jpg|gif|png)$/i) !== null;
+    const hasImage = event.media && /\.(jpg|jpeg|png|webp|avif|gif|svg)(\?.*)?$/i.test(event.media);
 
     return (
       <li className="timeline-block-event">

--- a/assets/src/scss/blocks/Timeline/TimelineStyle.scss
+++ b/assets/src/scss/blocks/Timeline/TimelineStyle.scss
@@ -381,6 +381,14 @@
     background-color: var(--white);
     padding: $sp-3;
 
+    img {
+      border-radius: 4px;
+      width: 100%;
+      margin-bottom: $sp-1x;
+      object-fit: cover;
+      height: 200px;
+    }
+
     .timeline-block-event-day {
       display: inline-block;
       border: 1px solid var(--grey-300);
@@ -491,6 +499,10 @@
       width: 420px;
       height: fit-content;
       position: relative;
+
+      img {
+        height: 250px;
+      }
 
       &::after {
         content: "";

--- a/assets/src/scss/blocks/Timeline/TimelineStyle.scss
+++ b/assets/src/scss/blocks/Timeline/TimelineStyle.scss
@@ -386,7 +386,7 @@
       width: 100%;
       margin-bottom: $sp-1x;
       object-fit: cover;
-      height: 200px;
+      height: 164px;
     }
 
     .timeline-block-event-day {
@@ -501,7 +501,7 @@
       position: relative;
 
       img {
-        height: 250px;
+        height: 212px;
       }
 
       &::after {


### PR DESCRIPTION
### Summary

Ref: [PLANET-8178](https://greenpeace-planet4.atlassian.net/browse/PLANET-8178)

Same as the current implementation, we need to add support for images in the new Timeline block. The images are already part of the spreadsheet template.

### Testing

Add a Timeline block to a page and make sure that the images are now present and respect the [mockups](https://www.figma.com/design/9NtbY8n3at8uOEJTsLrETb/P4-Design-System?node-id=7882-35417&p=f). You can use [this spreadsheet](https://docs.google.com/spreadsheets/d/1tYlLd_Fx0T_7ZEaf2y9dLfRnr5HzEOW_s0wELp5-j4s/) for example.
Alternatively, you can use [this page](https://www-dev.greenpeace.org/test-tavros/timeline-block/) I made for UAT.

[PLANET-8178]: https://greenpeace-planet4.atlassian.net/browse/PLANET-8178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ