### PR TITLE
PLANET-8174 Make images alt-text mandatory for publishing

### DIFF
--- a/assets/src/block-editor/setupBlockEditorValidations.js
+++ b/assets/src/block-editor/setupBlockEditorValidations.js
@@ -90,6 +90,37 @@ const checkTopicLinks = blocks => {
 const hasGravityFormsBlock = blocks => Boolean(blocks.find(block => block.name === 'gravityforms/form'));
 
 /**
+ * Returns the trimmed alt text from a block attributes object, or an empty
+ * string if it's missing or not a string.
+ *
+ * @param {Object} attributes - Block attributes object.
+ * @return {string} The trimmed alt text.
+ */
+const getImageBlockAltText = attributes => {
+  if (!attributes || typeof attributes.alt !== 'string') {
+    return '';
+  }
+  return attributes.alt.trim();
+};
+
+/**
+ * Returns `true` when the given core/image block has media selected (an `id`
+ * or `url`) but no non-empty alt text. Empty placeholder blocks (no media
+ * picked yet) are not publish-blockers.
+ *
+ * @param {Object} block - A core/image block from the editor.
+ * @return {boolean} Whether the block should block publish.
+ */
+const isImageBlockMissingAlt = block => {
+  const attributes = block.attributes || {};
+  const hasMedia = Boolean(attributes.id || attributes.url);
+  if (!hasMedia) {
+    return false;
+  }
+  return getImageBlockAltText(attributes) === '';
+};
+
+/**
  * Recursively checks whether every `core/image` block in the editor (including
  * nested image blocks inside Group / Columns / Cover / etc.) has a non-empty
  * `alt` attribute. Whitespace-only alt text is treated as missing.
@@ -107,24 +138,13 @@ const checkImageBlocksAltText = blocks => {
       continue;
     }
 
-    if (block.name === 'core/image') {
-      // Only flag image blocks that actually have media selected.
-      // An empty placeholder block (no id/url yet) is not a publish-blocker.
-      const hasMedia = Boolean(
-        (block.attributes && (block.attributes.id || block.attributes.url))
-      );
-      const alt = block.attributes && typeof block.attributes.alt === 'string' ?
-        block.attributes.alt.trim() :
-        '';
-      if (hasMedia && alt === '') {
-        return false;
-      }
+    if (block.name === 'core/image' && isImageBlockMissingAlt(block)) {
+      return false;
     }
 
-    if (block.innerBlocks && block.innerBlocks.length > 0) {
-      if (!checkImageBlocksAltText(block.innerBlocks)) {
-        return false;
-      }
+    const hasInnerBlocks = block.innerBlocks && block.innerBlocks.length > 0;
+    if (hasInnerBlocks && !checkImageBlocksAltText(block.innerBlocks)) {
+      return false;
     }
   }
 

--- a/assets/src/block-editor/setupBlockEditorValidations.js
+++ b/assets/src/block-editor/setupBlockEditorValidations.js
@@ -38,13 +38,15 @@ const getValidationState = select => {
   const hasForm = !skip && hasGravityFormsBlock(allBlocks);
   const globalProject = getEditedPostAttribute('meta')?.p4_campaign_name;
   const validForms = skip || !hasForm || (hasForm && globalProject && globalProject !== 'not set');
+  const imagesAlt = !skip && checkImageBlocksAltText(allBlocks);
 
   return {
     postTitle,
     featuredImage,
     topicLink,
     validForms,
-    isValid: postTitle && featuredImage && topicLink && validForms,
+    imagesAlt,
+    isValid: postTitle && featuredImage && topicLink && validForms && imagesAlt,
   };
 };
 
@@ -73,6 +75,48 @@ const checkTopicLinks = blocks => {
 const hasGravityFormsBlock = blocks => Boolean(blocks.find(block => block.name === 'gravityforms/form'));
 
 /**
+ * Recursively checks whether every `core/image` block in the editor (including
+ * nested image blocks inside Group / Columns / Cover / etc.) has a non-empty
+ * `alt` attribute. Whitespace-only alt text is treated as missing.
+ *
+ * @param {Object[]} blocks - Array of block objects from the block editor.
+ * @return {boolean} `true` if every core/image block has alt text; `false` otherwise.
+ */
+const checkImageBlocksAltText = blocks => {
+  if (!Array.isArray(blocks) || blocks.length === 0) {
+    return true;
+  }
+
+  for (const block of blocks) {
+    if (!block) {
+      continue;
+    }
+
+    if (block.name === 'core/image') {
+      // Only flag image blocks that actually have media selected.
+      // An empty placeholder block (no id/url yet) is not a publish-blocker.
+      const hasMedia = Boolean(
+        (block.attributes && (block.attributes.id || block.attributes.url))
+      );
+      const alt = block.attributes && typeof block.attributes.alt === 'string' ?
+        block.attributes.alt.trim() :
+        '';
+      if (hasMedia && alt === '') {
+        return false;
+      }
+    }
+
+    if (block.innerBlocks && block.innerBlocks.length > 0) {
+      if (!checkImageBlocksAltText(block.innerBlocks)) {
+        return false;
+      }
+    }
+  }
+
+  return true;
+};
+
+/**
  * Builds a combined validation error message string based on the current validation state.
  * Returns `null` if all validations pass.
  *
@@ -81,9 +125,10 @@ const hasGravityFormsBlock = blocks => Boolean(blocks.find(block => block.name =
  * @param {boolean} validationState.featuredImage - Whether the post has a featured image.
  * @param {boolean} validationState.topicLink     - Whether all Topic Link blocks have a background image.
  * @param {boolean} validationState.validForms    - If there is a Gravity Forms block on the page and a set Global Project.
+ * @param {boolean} validationState.imagesAlt     - Whether every core/image block has non-empty alt text.
  * @return {string|null} A space-separated string of error messages, or `null` if there are no errors.
  */
-const buildValidationMessage = ({postTitle, featuredImage, topicLink, validForms}) => {
+const buildValidationMessage = ({postTitle, featuredImage, topicLink, validForms, imagesAlt}) => {
   const errors = [];
   if (!postTitle) {
     errors.push(__('Title is mandatory.', 'planet4-master-theme-backend'));
@@ -104,6 +149,15 @@ const buildValidationMessage = ({postTitle, featuredImage, topicLink, validForms
     errors.push(
       __(
         'You need to select a Global Project in the sidebar (Analytics & Tracking), because you are using a Gravity Forms block.',
+        'planet4-master-theme-backend'
+      )
+    );
+  }
+
+  if (!imagesAlt) {
+    errors.push(
+      __(
+        'Alt text is mandatory for all Image blocks.',
         'planet4-master-theme-backend'
       )
     );

--- a/assets/src/block-editor/setupBlockEditorValidations.js
+++ b/assets/src/block-editor/setupBlockEditorValidations.js
@@ -1,4 +1,4 @@
-const {__} = wp.i18n;
+const {__, sprintf} = wp.i18n;
 const {registerPlugin} = wp.plugins;
 const {useSelect, dispatch} = wp.data;
 const {useEffect, useRef} = wp.element;
@@ -15,6 +15,11 @@ export const setupBlockEditorValidations = () => {
 
 // Check whether the "Enforce images alt-text" feature flag is enabled.
 const isAltTextEnforcementEnabled = Boolean(window.p4_vars.features.mandatory_image_alt_text);
+
+// Minimum number of characters required in a core/image block's alt text
+// before publishing. Whitespace is trimmed before the length is measured.
+// Mirrors MasterSite::MIN_ALT_TEXT_LENGTH on the server side.
+const MIN_ALT_TEXT_LENGTH = 10;
 
 /**
  * Retrieves the current validation state from the block and post editor stores.
@@ -109,7 +114,7 @@ const isImageBlockMissingAlt = block => {
   if (!hasMedia) {
     return false;
   }
-  return getImageBlockAltText(attributes) === '';
+  return getImageBlockAltText(attributes).length < MIN_ALT_TEXT_LENGTH;
 };
 
 /**
@@ -183,9 +188,13 @@ const buildValidationMessage = ({postTitle, featuredImage, topicLink, validForms
 
   if (!imagesAlt) {
     errors.push(
-      __(
-        'Alt text is mandatory for all Image blocks.',
-        'planet4-master-theme-backend'
+      sprintf(
+        // translators: %d is the minimum number of characters required for alt text.
+        __(
+          'Alt text is mandatory for all Image blocks and must be at least %d characters long.',
+          'planet4-master-theme-backend'
+        ),
+        MIN_ALT_TEXT_LENGTH
       )
     );
   }

--- a/assets/src/block-editor/setupBlockEditorValidations.js
+++ b/assets/src/block-editor/setupBlockEditorValidations.js
@@ -101,20 +101,21 @@ const getImageBlockAltText = attributes => {
 };
 
 /**
- * Returns `true` when the given core/image block has media selected (an `id`
- * or `url`) but no non-empty alt text. Empty placeholder blocks (no media
- * picked yet) are not publish-blockers.
+ * Returns `true` when the given core/image block is OK to publish, either it
+ * has no media selected yet (placeholder), or its alt text is at least
+ * MIN_ALT_TEXT_LENGTH characters.
  *
  * @param {Object} block - A core/image block from the editor.
- * @return {boolean} Whether the block should block publish.
+ * @return {boolean} `true` when the block passes the alt-text rule.
  */
-const isImageBlockMissingAlt = block => {
+const isImageBlockAltValid = block => {
   const attributes = block.attributes || {};
   const hasMedia = Boolean(attributes.id || attributes.url);
+  // Placeholder blocks (no media picked yet) are not publish-blockers, so they pass the check.
   if (!hasMedia) {
-    return false;
+    return true;
   }
-  return getImageBlockAltText(attributes).length < MIN_ALT_TEXT_LENGTH;
+  return getImageBlockAltText(attributes).length >= MIN_ALT_TEXT_LENGTH;
 };
 
 /**
@@ -135,7 +136,7 @@ const checkImageBlocksAltText = blocks => {
       continue;
     }
 
-    if (block.name === 'core/image' && isImageBlockMissingAlt(block)) {
+    if (block.name === 'core/image' && !isImageBlockAltValid(block)) {
       return false;
     }
 

--- a/assets/src/block-editor/setupBlockEditorValidations.js
+++ b/assets/src/block-editor/setupBlockEditorValidations.js
@@ -14,6 +14,17 @@ export const setupBlockEditorValidations = () => {
 };
 
 /**
+ * Check whether the "Enforce images alt-text" feature flag is enabled.
+ *
+ * @return {boolean} `true` when the feature is enabled. If the localized vars are missing entirely,
+ *  it default to NOT enforcing, to avoid blocking the editor unexpectedly.
+ */
+const isAltTextEnforcementEnabled = () => {
+  const features = (window.p4_vars && window.p4_vars.features) || {};
+  return Boolean(features.mandatory_image_alt_text);
+};
+
+/**
  * Retrieves the current validation state from the block and post editor stores.
  * Intended to be used as a selector callback with `useSelect`.
  *
@@ -38,7 +49,11 @@ const getValidationState = select => {
   const hasForm = !skip && hasGravityFormsBlock(allBlocks);
   const globalProject = getEditedPostAttribute('meta')?.p4_campaign_name;
   const validForms = skip || !hasForm || (hasForm && globalProject && globalProject !== 'not set');
-  const imagesAlt = !skip && checkImageBlocksAltText(allBlocks);
+  // When the feature flag is off, treat the alt-text check as passing so it
+  // contributes nothing to `isValid` and produces no notice.
+  const imagesAlt = skip || isAltTextEnforcementEnabled() ?
+    checkImageBlocksAltText(allBlocks) :
+    true;
 
   return {
     postTitle,

--- a/assets/src/block-editor/setupBlockEditorValidations.js
+++ b/assets/src/block-editor/setupBlockEditorValidations.js
@@ -13,16 +13,8 @@ export const setupBlockEditorValidations = () => {
   });
 };
 
-/**
- * Check whether the "Enforce images alt-text" feature flag is enabled.
- *
- * @return {boolean} `true` when the feature is enabled. If the localized vars are missing entirely,
- *  it default to NOT enforcing, to avoid blocking the editor unexpectedly.
- */
-const isAltTextEnforcementEnabled = () => {
-  const features = (window.p4_vars && window.p4_vars.features) || {};
-  return Boolean(features.mandatory_image_alt_text);
-};
+// Check whether the "Enforce images alt-text" feature flag is enabled.
+const isAltTextEnforcementEnabled = Boolean(window.p4_vars.features.mandatory_image_alt_text);
 
 /**
  * Retrieves the current validation state from the block and post editor stores.
@@ -51,8 +43,8 @@ const getValidationState = select => {
   const validForms = skip || !hasForm || (hasForm && globalProject && globalProject !== 'not set');
   // When the feature flag is off, treat the alt-text check as passing so it
   // contributes nothing to `isValid` and produces no notice.
-  const imagesAlt = skip || isAltTextEnforcementEnabled() ?
-    checkImageBlocksAltText(allBlocks) :
+  const imagesAlt = isAltTextEnforcementEnabled ?
+    skip || checkImageBlocksAltText(allBlocks) :
     true;
 
   return {
@@ -97,7 +89,7 @@ const hasGravityFormsBlock = blocks => Boolean(blocks.find(block => block.name =
  * @return {string} The trimmed alt text.
  */
 const getImageBlockAltText = attributes => {
-  if (!attributes || typeof attributes.alt !== 'string') {
+  if (!attributes || !attributes.alt || typeof attributes.alt !== 'string') {
     return '';
   }
   return attributes.alt.trim();

--- a/src/Features/MandatoryImageAltText.php
+++ b/src/Features/MandatoryImageAltText.php
@@ -31,7 +31,7 @@ class MandatoryImageAltText extends Feature
     protected static function description(): string
     {
         return __(
-            'All images included in a Post would require an alt-text before publishing.',
+            'Blocks publishing when a core Image block is missing alt-text.',
             'planet4-master-theme-backend'
         );
     }

--- a/src/Features/MandatoryImageAltText.php
+++ b/src/Features/MandatoryImageAltText.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace P4\MasterTheme\Features;
+
+use P4\MasterTheme\Feature;
+
+/**
+ * @see description().
+ */
+class MandatoryImageAltText extends Feature
+{
+    /**
+     * @inheritDoc
+     */
+    public static function id(): string
+    {
+        return 'mandatory_image_alt_text';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected static function name(): string
+    {
+        return __('Enforce images alt-text', 'planet4-master-theme-backend');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected static function description(): string
+    {
+        return __(
+            'All images included in a Post would require an alt-text before publishing.',
+            'planet4-master-theme-backend'
+        );
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function show_toggle_production(): bool
+    {
+        return true;
+    }
+}

--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -306,9 +306,8 @@ class MasterSite extends \Timber\Site
 
         if (self::content_contains_image_blocks_without_alt($content)) {
             $err_message = __(
-                'Alt text is required for every Image block before publishing. '
-                . 'Please add a description that conveys each image’s purpose, '
-                . 'then try publishing again.',
+                'Alt text is required for every Image block before publishing.
+                Please add a description that conveys each image’s purpose, then try publishing again.',
                 'planet4-master-theme-backend'
             );
 
@@ -372,10 +371,12 @@ class MasterSite extends \Timber\Site
                 }
             }
 
-            if (!empty($block['innerBlocks']) && is_array($block['innerBlocks'])) {
-                if (self::blocks_have_image_without_alt($block['innerBlocks'])) {
-                    return true;
-                }
+            if (empty($block['innerBlocks']) || !is_array($block['innerBlocks'])) {
+                continue;
+            }
+
+            if (self::blocks_have_image_without_alt($block['innerBlocks'])) {
+                return true;
             }
         }
 

--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -3,6 +3,7 @@
 namespace P4\MasterTheme;
 
 use P4\MasterTheme\Features\Dev\CoreBlockPatterns;
+use P4\MasterTheme\Features\MandatoryImageAltText;
 use Timber\Timber;
 use WP_Error;
 
@@ -281,13 +282,17 @@ class MasterSite extends \Timber\Site
      */
     public static function require_image_alt_text(array $data): ?array
     {
+        // Only enforce when the "Enforce images alt-text" feature
+        // is enabled under WP-admin > Planet4 > Features.
+        if (!MandatoryImageAltText::is_active()) {
+            return $data;
+        }
+
         // Allow migrations to bypass the alt-text requirement.
         if (!empty($GLOBALS['p4_skip_require_image_alt'])) {
             return $data;
         }
 
-        // Only enforce on publish, on content types we care about, and only when
-        // post_content was supplied (some saves don't include it).
         if (
             empty($data['post_status'])
             || $data['post_status'] !== 'publish'

--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -89,6 +89,7 @@ class MasterSite extends \Timber\Site
         add_filter('safe_style_css', [$this, 'set_custom_allowed_css_properties']);
         add_filter('wp_kses_allowed_html', [$this, 'set_custom_allowed_attributes_filter'], 10, 2);
         add_filter('wp_insert_post_data', [$this, 'require_post_title'], 10, 1);
+        add_filter('wp_insert_post_data', [$this, 'require_image_alt_text'], 10, 1);
         add_action('init', [$this, 'p4_master_theme_setup']);
         add_action('pre_insert_term', [$this, 'disallow_insert_term'], 1, 2);
         add_filter('wp_dropdown_users_args', [$this, 'filter_authors'], 10, 1);
@@ -271,6 +272,114 @@ class MasterSite extends \Timber\Site
         }
 
         return $data;
+    }
+
+    /**
+     * Make alt-text mandatory on publish for every core/image block in the post.
+     * Migrations can bypass this check by setting $GLOBALS['p4_skip_require_image_alt']
+     * before saving (see Migrations\Utils\Functions::execute_block_migration()).
+     */
+    public static function require_image_alt_text(array $data): ?array
+    {
+        // Allow migrations to bypass the alt-text requirement.
+        if (!empty($GLOBALS['p4_skip_require_image_alt'])) {
+            return $data;
+        }
+
+        // Only enforce on publish, on content types we care about, and only when
+        // post_content was supplied (some saves don't include it).
+        if (
+            empty($data['post_status'])
+            || $data['post_status'] !== 'publish'
+            || empty($data['post_content'])
+        ) {
+            return $data;
+        }
+
+        $types = Search\Filters\ContentTypes::get_all();
+        if (!isset($data['post_type']) || !in_array($data['post_type'], array_keys($types), true)) {
+            return $data;
+        }
+
+        // wp_insert_post_data passes slashed data; unslash before parsing blocks.
+        $content = wp_unslash($data['post_content']);
+
+        if (self::content_contains_image_blocks_without_alt($content)) {
+            $err_message = __(
+                'Alt text is required for every Image block before publishing. '
+                . 'Please add a description that conveys each image’s purpose, '
+                . 'then try publishing again.',
+                'planet4-master-theme-backend'
+            );
+
+            defined('WP_CLI') && WP_CLI
+                ? throw new \Exception($err_message)
+                : wp_die(esc_html($err_message));
+        }
+
+        return $data;
+    }
+
+    /**
+     * Returns true when the given block-serialized HTML contains at least one
+     * core/image block (including nested ones) with media selected but no
+     * non-empty alt attribute.
+     *
+     * @param string $content - Post content (serialized blocks).
+     */
+    private static function content_contains_image_blocks_without_alt(string $content): bool
+    {
+        if (!function_exists('parse_blocks') || trim($content) === '') {
+            return false;
+        }
+
+        $blocks = parse_blocks($content);
+        if (empty($blocks)) {
+            return false;
+        }
+
+        return self::blocks_have_image_without_alt($blocks);
+    }
+
+    /**
+     * Walk a parsed block tree and return true on the first core/image block
+     * that has media (id or url) but no non-empty alt attribute.
+     *
+     * @param array $blocks - Parsed blocks (output of parse_blocks()).
+     */
+    private static function blocks_have_image_without_alt(array $blocks): bool
+    {
+        foreach ($blocks as $block) {
+            if (!is_array($block)) {
+                continue;
+            }
+
+            $block_name = $block['blockName'] ?? null;
+            $attrs = $block['attrs'] ?? [];
+
+            if ($block_name === 'core/image') {
+                $has_media = !empty($attrs['id']) || !empty($attrs['url']);
+                $alt = isset($attrs['alt']) && is_string($attrs['alt']) ? trim($attrs['alt']) : '';
+
+                if ($alt === '' && !empty($block['innerHTML'])) {
+                    if (preg_match('/<img\b[^>]*\balt\s*=\s*"([^"]*)"/i', $block['innerHTML'], $m)) {
+                        $alt = trim($m[1]);
+                    }
+                }
+
+                if ($has_media && $alt === '') {
+                    return true;
+                }
+            }
+
+            if (!empty($block['innerBlocks']) && is_array($block['innerBlocks'])) {
+                if (self::blocks_have_image_without_alt($block['innerBlocks'])) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -320,7 +320,7 @@ class MasterSite extends \Timber\Site
                 // translators: %d is the minimum number of characters required for alt text.
                 __(
                     // phpcs:ignore Generic.Files.LineLength.MaxExceeded
-                    'Alt text of at least %d characters is required for every Image block before publishing. Please add a description that conveys each image’s purpose, then try publishing again.',
+                    'Alt text of at least %d characters is required for all Image blocks. Please add a description to each image before publishing',
                     'planet4-master-theme-backend'
                 ),
                 self::MIN_ALT_TEXT_LENGTH

--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -14,6 +14,12 @@ use WP_Error;
 class MasterSite extends \Timber\Site
 {
     /**
+     * Minimum number of characters required in a core/image block's alt text
+     * before publishing. Whitespace is trimmed before the length is measured.
+     */
+    public const MIN_ALT_TEXT_LENGTH = 10;
+
+    /**
      * Theme directory
      *
      */
@@ -310,10 +316,14 @@ class MasterSite extends \Timber\Site
         $content = wp_unslash($data['post_content']);
 
         if (self::content_contains_image_blocks_without_alt($content)) {
-            $err_message = __(
-                'Alt text is required for every Image block before publishing.
-                Please add a description that conveys each image’s purpose, then try publishing again.',
-                'planet4-master-theme-backend'
+            $err_message = sprintf(
+                // translators: %d is the minimum number of characters required for alt text.
+                __(
+                    // phpcs:ignore Generic.Files.LineLength.MaxExceeded
+                    'Alt text of at least %d characters is required for every Image block before publishing. Please add a description that conveys each image’s purpose, then try publishing again.',
+                    'planet4-master-theme-backend'
+                ),
+                self::MIN_ALT_TEXT_LENGTH
             );
 
             defined('WP_CLI') && WP_CLI
@@ -372,7 +382,8 @@ class MasterSite extends \Timber\Site
     }
 
     /**
-     * Whether a parsed core/image block has media selected (id or url) but no non-empty alt text.
+     * Whether a parsed core/image block has media selected (id or url) but
+     * its alt text is shorter than MIN_ALT_TEXT_LENGTH characters.
      *
      * @param array $block - A parsed block (output of parse_blocks()).
      */
@@ -381,7 +392,7 @@ class MasterSite extends \Timber\Site
         $attrs = $block['attrs'] ?? [];
         $has_media = !empty($attrs['id']) || !empty($attrs['url']);
 
-        return $has_media && self::read_image_block_alt($block) === '';
+        return $has_media && mb_strlen(self::read_image_block_alt($block)) < self::MIN_ALT_TEXT_LENGTH;
     }
 
     /**

--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -346,6 +346,45 @@ class MasterSite extends \Timber\Site
     }
 
     /**
+     * Read the alt text from a parsed core/image block.
+     *
+     * @param array $block - A parsed block (output of parse_blocks()).
+     */
+    private static function read_image_block_alt(array $block): string
+    {
+        $attrs = $block['attrs'] ?? [];
+
+        if (isset($attrs['alt']) && is_string($attrs['alt'])) {
+            $alt = trim($attrs['alt']);
+            if ($alt !== '') {
+                return $alt;
+            }
+        }
+
+        if (
+            !empty($block['innerHTML'])
+            && preg_match('/<img\b[^>]*\balt\s*=\s*"([^"]*)"/i', $block['innerHTML'], $m)
+        ) {
+            return trim($m[1]);
+        }
+
+        return '';
+    }
+
+    /**
+     * Whether a parsed core/image block has media selected (id or url) but no non-empty alt text.
+     *
+     * @param array $block - A parsed block (output of parse_blocks()).
+     */
+    private static function is_image_block_missing_alt(array $block): bool
+    {
+        $attrs = $block['attrs'] ?? [];
+        $has_media = !empty($attrs['id']) || !empty($attrs['url']);
+
+        return $has_media && self::read_image_block_alt($block) === '';
+    }
+
+    /**
      * Walk a parsed block tree and return true on the first core/image block
      * that has media (id or url) but no non-empty alt attribute.
      *
@@ -358,29 +397,13 @@ class MasterSite extends \Timber\Site
                 continue;
             }
 
-            $block_name = $block['blockName'] ?? null;
-            $attrs = $block['attrs'] ?? [];
-
-            if ($block_name === 'core/image') {
-                $has_media = !empty($attrs['id']) || !empty($attrs['url']);
-                $alt = isset($attrs['alt']) && is_string($attrs['alt']) ? trim($attrs['alt']) : '';
-
-                if ($alt === '' && !empty($block['innerHTML'])) {
-                    if (preg_match('/<img\b[^>]*\balt\s*=\s*"([^"]*)"/i', $block['innerHTML'], $m)) {
-                        $alt = trim($m[1]);
-                    }
-                }
-
-                if ($has_media && $alt === '') {
-                    return true;
-                }
+            $is_image = (($block['blockName'] ?? null) === 'core/image');
+            if ($is_image && self::is_image_block_missing_alt($block)) {
+                return true;
             }
 
-            if (empty($block['innerBlocks']) || !is_array($block['innerBlocks'])) {
-                continue;
-            }
-
-            if (self::blocks_have_image_without_alt($block['innerBlocks'])) {
+            $inner_block = $block['innerBlocks'] ?? null;
+            if (is_array($inner_block) && self::blocks_have_image_without_alt($inner_block)) {
                 return true;
             }
         }

--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -382,22 +382,31 @@ class MasterSite extends \Timber\Site
     }
 
     /**
-     * Whether a parsed core/image block has media selected (id or url) but
-     * its alt text is shorter than MIN_ALT_TEXT_LENGTH characters.
+     * Whether a parsed core/image block passes the alt-text rule.
+     *
+     * Returns true when either:
+     *  - the block has no media selected yet (a placeholder block), or
+     *  - its alt text is at least MIN_ALT_TEXT_LENGTH characters
      *
      * @param array $block - A parsed block (output of parse_blocks()).
      */
-    private static function is_image_block_missing_alt(array $block): bool
+    private static function is_image_block_alt_valid(array $block): bool
     {
         $attrs = $block['attrs'] ?? [];
         $has_media = !empty($attrs['id']) || !empty($attrs['url']);
 
-        return $has_media && mb_strlen(self::read_image_block_alt($block)) < self::MIN_ALT_TEXT_LENGTH;
+        // Placeholder blocks (no media selected yet) are not publish-blockers, so they pass the check.
+        if (!$has_media) {
+            return true;
+        }
+
+        // mb_strlen counts characters, not bytes, so multi-byte alphabets are measured correctly.
+        return mb_strlen(self::read_image_block_alt($block)) >= self::MIN_ALT_TEXT_LENGTH;
     }
 
     /**
      * Walk a parsed block tree and return true on the first core/image block
-     * that has media (id or url) but no non-empty alt attribute.
+     * whose alt text fails the alt-text rule.
      *
      * @param array $blocks - Parsed blocks (output of parse_blocks()).
      */
@@ -409,7 +418,7 @@ class MasterSite extends \Timber\Site
             }
 
             $is_image = (($block['blockName'] ?? null) === 'core/image');
-            if ($is_image && self::is_image_block_missing_alt($block)) {
+            if ($is_image && !self::is_image_block_alt_valid($block)) {
                 return true;
             }
 

--- a/src/MigrationStatus.php
+++ b/src/MigrationStatus.php
@@ -102,12 +102,12 @@ class MigrationStatus
                     <td>' . $key . '</td>
                     <td>' . str_replace('P4\MasterTheme\Migrations\\', '', $p4_migration['id']) . '</td>
                     <td>
-                        <div class="datetime">' . $p4_migration['start_time']->date . ' ' .
-                $p4_migration['start_time']->timezone . '</div>
+                        <div class="datetime">' . $p4_migration['start_time']->format('Y-m-d H:i:s') . ' ' .
+                $p4_migration['start_time']->getTimezone()->getName() . '</div>
                     </td>
                     <td>
-                        <div class="datetime">' . $p4_migration['end_time']->date . ' ' .
-                $p4_migration['end_time']->timezone . '</div>
+                        <div class="datetime">' . $p4_migration['end_time']->format('Y-m-d H:i:s') . ' ' .
+                $p4_migration['end_time']->getTimezone()->getName() . '</div>
                     </td>
                     <td>' . $this->calculateTimeDiff($p4_migration['start_time'], $p4_migration['end_time']) . '</td>
                     <td class="' . $migration_status_class . '">' . $migration_status . '</td>

--- a/src/Migrations/Utils/Functions.php
+++ b/src/Migrations/Utils/Functions.php
@@ -49,6 +49,12 @@ class Functions
             // that do not have a title, which is common in migrations.
             $GLOBALS['p4_skip_require_post_title'] = true;
 
+            // Same idea for the alt-text requirement on core/image blocks.
+            // Migrations re-save legacy content that may pre-date the alt-text rule,
+            // so we bypass the publish guard here and log any offending image blocks
+            // below (see log_image_blocks_missing_alt()).
+            $GLOBALS['p4_skip_require_image_alt'] = true;
+
             foreach ($posts as $post) {
                 try {
                     if (empty($post->post_content)) {
@@ -65,6 +71,11 @@ class Functions
                     if (!is_array($blocks)) {
                         throw new \Exception("Invalid block structure for post #" . $current_post_id);
                     }
+
+                    // Log (do not modify) any core/image blocks that are missing alt-text.
+                    // We leave the offending blocks unchanged so editors can fix them by hand,
+                    // but record them in the migration log for visibility.
+                    self::log_image_blocks_missing_alt($blocks, $current_post_id, $record);
 
                     // Process blocks recursively.
                     $blocks = self::process_blocks_recursive(
@@ -114,6 +125,8 @@ class Functions
 
             // Remove the global variable to skip the post title requirement.
             unset($GLOBALS['p4_skip_require_post_title']);
+            // Remove the global variable to skip the image alt-text requirement.
+            unset($GLOBALS['p4_skip_require_image_alt']);
         } catch (\Throwable $e) {
             echo "Migration wasn't executed for block: ", $block_name ?? 'unknown', "\n";
             echo $e->getMessage(), "\n";
@@ -166,6 +179,78 @@ class Functions
         unset($block);
 
         return $blocks;
+    }
+
+    /**
+     * Walk a parsed block tree, find every core/image block missing alt-text,
+     * and append a warning line per offender to the migration record.
+     *
+     * @param array $blocks - Parsed blocks (output of WP_Block_Parser::parse()).
+     * @param int $post_id - The ID of the post being migrated (for the log line).
+     * @param MigrationRecord|null $record - Optional migration record to log into.
+     */
+    private static function log_image_blocks_missing_alt(
+        array $blocks,
+        int $post_id,
+        ?MigrationRecord $record
+    ): void {
+        if (!$record) {
+            return;
+        }
+
+        $count = self::count_image_blocks_missing_alt($blocks);
+        if ($count === 0) {
+            return;
+        }
+
+        $record->add_log(
+            sprintf(
+                'PID: %d - Skipped %d core/image block(s) with missing alt-text. ',
+                $post_id,
+                $count
+            )
+        );
+    }
+
+    /**
+     * Recursively count core/image blocks that have media selected but no
+     * non-empty alt attribute (checking both block attrs and innerHTML).
+     *
+     * @param array $blocks - Parsed blocks (output of WP_Block_Parser::parse()).
+     */
+    private static function count_image_blocks_missing_alt(array $blocks): int
+    {
+        $count = 0;
+
+        foreach ($blocks as $block) {
+            if (!is_array($block)) {
+                continue;
+            }
+
+            $block_name = $block['blockName'] ?? null;
+            $attrs = $block['attrs'] ?? [];
+
+            if ($block_name === 'core/image') {
+                $has_media = !empty($attrs['id']) || !empty($attrs['url']);
+                $alt = isset($attrs['alt']) && is_string($attrs['alt']) ? trim($attrs['alt']) : '';
+
+                if ($alt === '' && !empty($block['innerHTML'])) {
+                    if (preg_match('/<img\b[^>]*\balt\s*=\s*"([^"]*)"/i', $block['innerHTML'], $m)) {
+                        $alt = trim($m[1]);
+                    }
+                }
+
+                if ($has_media && $alt === '') {
+                    $count++;
+                }
+            }
+
+            if (!empty($block['innerBlocks']) && is_array($block['innerBlocks'])) {
+                $count += self::count_image_blocks_missing_alt($block['innerBlocks']);
+            }
+        }
+
+        return $count;
     }
 
     /**

--- a/src/Migrations/Utils/Functions.php
+++ b/src/Migrations/Utils/Functions.php
@@ -245,9 +245,11 @@ class Functions
                 }
             }
 
-            if (!empty($block['innerBlocks']) && is_array($block['innerBlocks'])) {
-                $count += self::count_image_blocks_missing_alt($block['innerBlocks']);
+            if (empty($block['innerBlocks']) || !is_array($block['innerBlocks'])) {
+                continue;
             }
+
+            $count += self::count_image_blocks_missing_alt($block['innerBlocks']);
         }
 
         return $count;

--- a/src/Migrations/Utils/Functions.php
+++ b/src/Migrations/Utils/Functions.php
@@ -51,8 +51,7 @@ class Functions
 
             // Same idea for the alt-text requirement on core/image blocks.
             // Migrations re-save legacy content that may pre-date the alt-text rule,
-            // so we bypass the publish guard here and log any offending image blocks
-            // below (see log_image_blocks_missing_alt()).
+            // so we bypass the publish guard.
             $GLOBALS['p4_skip_require_image_alt'] = true;
 
             foreach ($posts as $post) {
@@ -71,11 +70,6 @@ class Functions
                     if (!is_array($blocks)) {
                         throw new \Exception("Invalid block structure for post #" . $current_post_id);
                     }
-
-                    // Log (do not modify) any core/image blocks that are missing alt-text.
-                    // We leave the offending blocks unchanged so editors can fix them by hand,
-                    // but record them in the migration log for visibility.
-                    self::log_image_blocks_missing_alt($blocks, $current_post_id, $record);
 
                     // Process blocks recursively.
                     $blocks = self::process_blocks_recursive(
@@ -179,108 +173,6 @@ class Functions
         unset($block);
 
         return $blocks;
-    }
-
-    /**
-     * Walk a parsed block tree, find every core/image block missing alt-text,
-     * and append a warning line per offender to the migration record.
-     *
-     * @param array $blocks - Parsed blocks (output of WP_Block_Parser::parse()).
-     * @param int $post_id - The ID of the post being migrated (for the log line).
-     * @param MigrationRecord|null $record - Optional migration record to log into.
-     */
-    private static function log_image_blocks_missing_alt(
-        array $blocks,
-        int $post_id,
-        ?MigrationRecord $record
-    ): void {
-        if (!$record) {
-            return;
-        }
-
-        $count = self::count_image_blocks_missing_alt($blocks);
-        if ($count === 0) {
-            return;
-        }
-
-        $record->add_log(
-            sprintf(
-                'PID: %d - Skipped %d core/image block(s) with missing alt-text. ',
-                $post_id,
-                $count
-            )
-        );
-    }
-
-    /**
-     * Read the alt text from a parsed core/image block.
-     *
-     * @param array $block - A parsed block (output of WP_Block_Parser::parse()).
-     */
-    private static function read_image_block_alt(array $block): string
-    {
-        $attrs = $block['attrs'] ?? [];
-
-        if (isset($attrs['alt']) && is_string($attrs['alt'])) {
-            $alt = trim($attrs['alt']);
-            if ($alt !== '') {
-                return $alt;
-            }
-        }
-
-        if (
-            !empty($block['innerHTML'])
-            && preg_match('/<img\b[^>]*\balt\s*=\s*"([^"]*)"/i', $block['innerHTML'], $m)
-        ) {
-            return trim($m[1]);
-        }
-
-        return '';
-    }
-
-    /**
-     * Whether a parsed core/image block has media selected (id or url) but no
-     * non-empty alt text.
-     *
-     * @param array $block - A parsed block (output of WP_Block_Parser::parse()).
-     */
-    private static function is_image_block_missing_alt(array $block): bool
-    {
-        $attrs = $block['attrs'] ?? [];
-        $has_media = !empty($attrs['id']) || !empty($attrs['url']);
-
-        return $has_media && self::read_image_block_alt($block) === '';
-    }
-
-    /**
-     * Recursively count core/image blocks that have media selected but no
-     * non-empty alt attribute (checking both block attrs and innerHTML).
-     *
-     * @param array $blocks - Parsed blocks (output of WP_Block_Parser::parse()).
-     */
-    private static function count_image_blocks_missing_alt(array $blocks): int
-    {
-        $count = 0;
-
-        foreach ($blocks as $block) {
-            if (!is_array($block)) {
-                continue;
-            }
-
-            $is_image = (($block['blockName'] ?? null) === 'core/image');
-            if ($is_image && self::is_image_block_missing_alt($block)) {
-                $count++;
-            }
-
-            $inner = $block['innerBlocks'] ?? null;
-            if (!is_array($inner)) {
-                continue;
-            }
-
-            $count += self::count_image_blocks_missing_alt($inner);
-        }
-
-        return $count;
     }
 
     /**

--- a/src/Migrations/Utils/Functions.php
+++ b/src/Migrations/Utils/Functions.php
@@ -213,6 +213,46 @@ class Functions
     }
 
     /**
+     * Read the alt text from a parsed core/image block.
+     *
+     * @param array $block - A parsed block (output of WP_Block_Parser::parse()).
+     */
+    private static function read_image_block_alt(array $block): string
+    {
+        $attrs = $block['attrs'] ?? [];
+
+        if (isset($attrs['alt']) && is_string($attrs['alt'])) {
+            $alt = trim($attrs['alt']);
+            if ($alt !== '') {
+                return $alt;
+            }
+        }
+
+        if (
+            !empty($block['innerHTML'])
+            && preg_match('/<img\b[^>]*\balt\s*=\s*"([^"]*)"/i', $block['innerHTML'], $m)
+        ) {
+            return trim($m[1]);
+        }
+
+        return '';
+    }
+
+    /**
+     * Whether a parsed core/image block has media selected (id or url) but no
+     * non-empty alt text.
+     *
+     * @param array $block - A parsed block (output of WP_Block_Parser::parse()).
+     */
+    private static function is_image_block_missing_alt(array $block): bool
+    {
+        $attrs = $block['attrs'] ?? [];
+        $has_media = !empty($attrs['id']) || !empty($attrs['url']);
+
+        return $has_media && self::read_image_block_alt($block) === '';
+    }
+
+    /**
      * Recursively count core/image blocks that have media selected but no
      * non-empty alt attribute (checking both block attrs and innerHTML).
      *
@@ -227,29 +267,15 @@ class Functions
                 continue;
             }
 
-            $block_name = $block['blockName'] ?? null;
-            $attrs = $block['attrs'] ?? [];
-
-            if ($block_name === 'core/image') {
-                $has_media = !empty($attrs['id']) || !empty($attrs['url']);
-                $alt = isset($attrs['alt']) && is_string($attrs['alt']) ? trim($attrs['alt']) : '';
-
-                if ($alt === '' && !empty($block['innerHTML'])) {
-                    if (preg_match('/<img\b[^>]*\balt\s*=\s*"([^"]*)"/i', $block['innerHTML'], $m)) {
-                        $alt = trim($m[1]);
-                    }
-                }
-
-                if ($has_media && $alt === '') {
-                    $count++;
-                }
+            $is_image = (($block['blockName'] ?? null) === 'core/image');
+            if ($is_image && self::is_image_block_missing_alt($block)) {
+                $count++;
             }
 
-            if (empty($block['innerBlocks']) || !is_array($block['innerBlocks'])) {
-                continue;
+            $inner = $block['innerBlocks'] ?? null;
+            if (is_array($inner)) {
+                $count += self::count_image_blocks_missing_alt($inner);
             }
-
-            $count += self::count_image_blocks_missing_alt($block['innerBlocks']);
         }
 
         return $count;

--- a/src/Migrations/Utils/Functions.php
+++ b/src/Migrations/Utils/Functions.php
@@ -273,9 +273,11 @@ class Functions
             }
 
             $inner = $block['innerBlocks'] ?? null;
-            if (is_array($inner)) {
-                $count += self::count_image_blocks_missing_alt($inner);
+            if (!is_array($inner)) {
+                continue;
             }
+
+            $count += self::count_image_blocks_missing_alt($inner);
         }
 
         return $count;

--- a/src/Settings/Features.php
+++ b/src/Settings/Features.php
@@ -12,6 +12,7 @@ use P4\MasterTheme\Features\OldPostsArchiveNotice;
 use P4\MasterTheme\Features\ActionsTaskType;
 use P4\MasterTheme\Features\ActionsDeadline;
 use P4\MasterTheme\Features\ActionsUserPersonalization;
+use P4\MasterTheme\Features\MandatoryImageAltText;
 use P4\MasterTheme\Loader;
 use P4\MasterTheme\Settings;
 use CMB2;
@@ -100,6 +101,7 @@ class Features
             ActionsTaskType::class,
             ActionsDeadline::class,
             ActionsUserPersonalization::class,
+            MandatoryImageAltText::class,
 
             // Dev only.
             DisableDataSync::class,


### PR DESCRIPTION
### Summary

This PR enforces modern accessibility standards by making alt text mandatory for images before publishing a new post. This helps ensure that all images include descriptive alternative text for improved accessibility.

---

Ref. https://greenpeace-planet4.atlassian.net/browse/PLANET-8174

### Testing

1. On local dev env, checkout `PLANET-8174_img_alt_text_mandatory` branch and run `npm run build`
2. Go to **WP-admin > Planet4 > Features** and confirm the new "_Enforce images alt-text_" toggle is visible.
3. With the toggle OFF, create a new post with a core Image block and select/upload an image without alt text. Try publishing.
     - Confirm the post publishes successfully, no validation error, no disabled Publish button.
4. Enable the toggle in **WP-admin > Planet4 > Features**, save, and reload the editor.
5. Create a new post with a core Image block and select/upload an image without alt text.
6. Try publishing the post.
     - Confirm the following error message is displayed:
     > Updating failed. Alt text is required for every Image block before publishing. Please add a description that conveys each image’s purpose, then try publishing again.
5. Test nested blocks:
     - Add an Image block inside another block (e.g. a Columns block).
     - Select/upload an image without alt text.
     - Confirm the same validation error message is displayed when publishing.
6. Test the migration fix:
     - Set up at least one published post containing an Image block without alt text.
     - Trigger any block migration.
     - Confirm the migration completes successfully without triggering a wp_die() error related to alt text validation.

**Note:** I have also added a small fix related to the "Data Migration" admin [page](https://www-dev.greenpeace.org/test-umbriel/wp-admin/admin.php?page=planet4_migration_status). This change should resolve the following two Sentry warnings:
[Warning: Undefined property: DateTime::$date](https://greenpeace-international.sentry.io/issues/7257380646/?environment=production&environment=development&environment=staging&environment=prod&project=4508408819417088&query=is%3Aunresolved%20server_name%3Aumbriel&referrer=issue-stream)
[Warning: Undefined property: DateTime::$timezone](https://greenpeace-international.sentry.io/issues/7257380647/?environment=production&environment=development&environment=staging&environment=prod&project=4508408819417088&query=is%3Aunresolved%20server_name%3Aumbriel&referrer=issue-stream)
- To test this compare the Data migration page on any other [test instance](https://www-dev.greenpeace.org/test-titan/wp-admin/admin.php?page=planet4_migration_status) and [test telesto](https://www-dev.greenpeace.org/test-telesto/wp-admin/admin.php?page=planet4_migration_status) instance.

---
**Amendment:** In addition to making alt text mandatory for core Image blocks, we have also introduced a minimum alt text length requirement of 10 characters.