### PR TITLE
PLANET-8165: Serve Hubspot pages under P4 domain and path

### DIFF
--- a/admin/js/options.js
+++ b/admin/js/options.js
@@ -1,4 +1,5 @@
 
+const {__} = wp.i18n;
 
 function removeSpamButtonsBox () {
   const spamButtons = document.querySelectorAll('.checkforspam');
@@ -70,7 +71,7 @@ function toggleHubspotReverseProxySaveButton() {
     alertMessage = document.createElement('span');
     alertMessage.id = 'hubspot_reverse_alert';
     alertMessage.classList.add('hidden');
-    alertMessage.innerHTML = 'WARNING: The "Hubspot Domain" and the "P4 Path" are mandatory!';
+    alertMessage.innerHTML = __('WARNING: The "Hubspot Domain" and the "P4 Path" are mandatory!', 'planet4-master-theme-backend');
     alertMessage.style.marginInlineStart = '10px';
     saveButton.after(alertMessage);
   }

--- a/admin/js/options.js
+++ b/admin/js/options.js
@@ -1,11 +1,15 @@
-const spamButtons = document.querySelectorAll('.checkforspam');
 
-spamButtons.forEach(box => {
-  box.remove();
-});
+
+function removeSpamButtonsBox () {
+  const spamButtons = document.querySelectorAll('.checkforspam');
+
+  spamButtons.forEach(box => {
+    box.remove();
+  });
+}
 
 // Show/hide old special pages when enabling or disabling the new IA.
-document.addEventListener('DOMContentLoaded', () => {
+function toggleNewIaPages() {
   const newIASetting = document.querySelector('#new_ia');
   const analyticalCookiesCheckbox = document.querySelector('#enable_analytical_cookies');
 
@@ -45,4 +49,73 @@ document.addEventListener('DOMContentLoaded', () => {
       descriptionTextField.classList.toggle('hidden', !checked);
     });
   }
+}
+
+// Control the elements of the Hubspot Reverse Proxy form.
+function toggleHubspotReverseProxySaveButton() {
+  const reverseProxy = document.querySelector('#hubspot_reverse_proxy');
+  const saveButton = document.querySelector('#option_metabox input[type=submit]');
+  const domain = document.querySelector('.cmb2-id-hubspot-reverse-proxy-domain');
+  const p4Path = document.querySelector('.cmb2-id-hubspot-reverse-proxy-p4-path');
+  const hubspotPath = document.querySelector('.cmb2-id-hubspot-reverse-proxy-hubspot-path');
+
+  if (!reverseProxy || !saveButton || !domain || !p4Path || !hubspotPath) {
+    return;
+  }
+
+  // Create and insert an alert message:
+  let alertMessage = document.querySelector('#hubspot_reverse_alert');
+
+  if (!alertMessage) {
+    alertMessage = document.createElement('span');
+    alertMessage.id = 'hubspot_reverse_alert';
+    alertMessage.classList.add('hidden');
+    alertMessage.innerHTML = 'WARNING: All the fields must be complete to save the changes!';
+    alertMessage.style.marginInlineStart = '10px';
+    saveButton.insertAdjacentElement('afterend', alertMessage);
+  }
+
+  // Enable/disable the save button, and show/hide the alert message:
+  function toggleSaveButton() {
+    const proxyEnabled = reverseProxy.checked;
+    const fieldsEmpty =
+        domain.querySelector('input').value.trim() === '' ||
+        p4Path.querySelector('input').value.trim() === '' ||
+        hubspotPath.querySelector('input').value.trim() === '';
+
+    const shouldDisable = proxyEnabled && fieldsEmpty;
+    saveButton.disabled = shouldDisable;
+    alertMessage.classList.toggle('hidden', !shouldDisable);
+  }
+
+  // Show/hide the form fields:
+  function toggleTextFields() {
+    if (reverseProxy.checked) {
+      domain.classList.remove('hidden');
+      p4Path.classList.remove('hidden');
+      hubspotPath.classList.remove('hidden');
+    } else {
+      domain.classList.add('hidden');
+      p4Path.classList.add('hidden');
+      hubspotPath.classList.add('hidden');
+    }
+  }
+
+  toggleSaveButton();
+  toggleTextFields();
+
+  reverseProxy.addEventListener('change', () => {
+    toggleTextFields();
+    toggleSaveButton();
+  });
+
+  domain.querySelector('input').addEventListener('input', toggleSaveButton);
+  p4Path.querySelector('input').addEventListener('input', toggleSaveButton);
+  hubspotPath.querySelector('input').addEventListener('input', toggleSaveButton);
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  removeSpamButtonsBox();
+  toggleNewIaPages();
+  toggleHubspotReverseProxySaveButton();
 });

--- a/admin/js/options.js
+++ b/admin/js/options.js
@@ -70,7 +70,7 @@ function toggleHubspotReverseProxySaveButton() {
     alertMessage = document.createElement('span');
     alertMessage.id = 'hubspot_reverse_alert';
     alertMessage.classList.add('hidden');
-    alertMessage.innerHTML = 'WARNING: All the fields must be complete to save the changes!';
+    alertMessage.innerHTML = 'WARNING: The "Hubspot Domain" and the "P4 Path" are mandatory!';
     alertMessage.style.marginInlineStart = '10px';
     saveButton.after(alertMessage);
   }
@@ -78,10 +78,7 @@ function toggleHubspotReverseProxySaveButton() {
   // Enable/disable the save button, and show/hide the alert message:
   function toggleSaveButton() {
     const proxyEnabled = reverseProxy.checked;
-    const fieldsEmpty =
-        domain.querySelector('input').value.trim() === '' ||
-        p4Path.querySelector('input').value.trim() === '' ||
-        hubspotPath.querySelector('input').value.trim() === '';
+    const fieldsEmpty = domain.querySelector('input').value.trim() === '' || p4Path.querySelector('input').value.trim() === '';
 
     const shouldDisable = proxyEnabled && fieldsEmpty;
     saveButton.disabled = shouldDisable;

--- a/admin/js/options.js
+++ b/admin/js/options.js
@@ -72,7 +72,7 @@ function toggleHubspotReverseProxySaveButton() {
     alertMessage.classList.add('hidden');
     alertMessage.innerHTML = 'WARNING: All the fields must be complete to save the changes!';
     alertMessage.style.marginInlineStart = '10px';
-    saveButton.insertAdjacentElement('afterend', alertMessage);
+    saveButton.after(alertMessage);
   }
 
   // Enable/disable the save button, and show/hide the alert message:

--- a/src/HubspotReverseProxy.php
+++ b/src/HubspotReverseProxy.php
@@ -124,7 +124,7 @@ class HubspotReverseProxy
         // Forward only HubSpot-relevant cookies, never P4 session cookies.
         // https://knowledge.hubspot.com/privacy-and-consent/hubspot-cookie-security-and-privacy
         $allowed_cookies = [
-            '__cfduid', '__cf_bm', '__cfuvid', ' __hs_opt_out', '_hs_cookie_cat_pref',
+            '__cfduid', '__cf_bm', '__cfuvid', '__hs_opt_out', '_hs_cookie_cat_pref',
             'laboratory-anonymous-id', 'hs_login_email', 'hsgn', 'ak_bmsc', 'Hubspotapi',
             'Hubspotapi-csrf', 'Hubspotapi-lax', 'Hubspotapi-prefs', 'Hubspotapi-strict',
             'hs_langswitcher_choice', 'Hubspotutk', 'gbu9uvfhph6a0mdatwbzomssrlboczvs',

--- a/src/HubspotReverseProxy.php
+++ b/src/HubspotReverseProxy.php
@@ -64,7 +64,7 @@ class HubspotReverseProxy
         $hubspot_domain = rtrim($options['hubspot_reverse_proxy_domain'] ?? '', '/');
         $hubspot_path = trim($options['hubspot_reverse_proxy_hubspot_path'] ?? '', '/');
 
-        if (! $p4_path || ! $hubspot_domain || ! $hubspot_path) {
+        if (! $p4_path || ! $hubspot_domain) {
             return null;
         }
 

--- a/src/HubspotReverseProxy.php
+++ b/src/HubspotReverseProxy.php
@@ -22,7 +22,7 @@ class HubspotReverseProxy
     /**
      * Handles the reverse proxy logic on every WordPress request.
      *
-     * Security notice — trust assumption:
+     * Security notice. Trust assumption:
      * The response body is echoed without escaping (`echo $content['body']`), which is
      * fundamentally what a reverse proxy does. However, this means any XSS present on
      * the HubSpot side executes under the P4 origin and has full access to P4 cookies
@@ -111,13 +111,42 @@ class HubspotReverseProxy
 
         $forward_headers = [];
 
-        foreach ([ 'Accept', 'Accept-Language', 'Accept-Encoding', 'Cookie' ] as $h) {
+        // Forward browser hint headers as-is.
+        foreach (['Accept', 'Accept-Language', 'Accept-Encoding'] as $h) {
             $key = 'HTTP_' . strtoupper(str_replace('-', '_', $h));
             if (empty($_SERVER[$key])) {
                 continue;
             }
 
             $forward_headers[$h] = $_SERVER[$key];
+        }
+
+        // Forward only HubSpot-relevant cookies, never P4 session cookies.
+        // https://knowledge.hubspot.com/privacy-and-consent/hubspot-cookie-security-and-privacy
+        $allowed_cookies = [
+            '__cfduid', '__cf_bm', '__cfuvid', ' __hs_opt_out', '_hs_cookie_cat_pref',
+            'laboratory-anonymous-id', 'hs_login_email', 'hsgn', 'ak_bmsc', 'Hubspotapi',
+            'Hubspotapi-csrf', 'Hubspotapi-lax', 'Hubspotapi-prefs', 'Hubspotapi-strict',
+            'hs_langswitcher_choice', 'Hubspotutk', 'gbu9uvfhph6a0mdatwbzomssrlboczvs',
+            'AWSALB', 'AWSALBCORS', 'LiSESSIONID', 'LithiumVisitor', 'cg_uuid', 'messagesUtk',
+            '__hs_cookie_cat_pref', 'hs_high_contrast', '_conv_v', '_ga', '_gid', '__hssc',
+            '__hssrc', '__hstc', 'hs-messages-is-open', '__utma', '_conv_r', '__secure-rollout_token',
+            'YSC', 'VISITOR_INFO1_LIVE', 'VISITOR_PRIVACY_METADATA', '_fbp', '_gtmeec',
+            'FPAU', 'FPID', '__pdst', 'test_cookie', 'IDE',
+        ];
+
+        $filtered_cookies = [];
+        foreach (explode(';', $_SERVER['HTTP_COOKIE'] ?? '') as $cookie) {
+            [$name] = explode('=', trim($cookie), 2);
+            if (!in_array(trim($name), $allowed_cookies, true)) {
+                continue;
+            }
+
+            $filtered_cookies[] = trim($cookie);
+        }
+
+        if ($filtered_cookies) {
+            $forward_headers['Cookie'] = implode('; ', $filtered_cookies);
         }
 
         $response = wp_remote_get($target_url, [

--- a/src/HubspotReverseProxy.php
+++ b/src/HubspotReverseProxy.php
@@ -7,8 +7,7 @@ use WP;
 /**
  * Class HubspotReverseProxy
  *
- * bla bla bla
- *
+ * Proxies requests matching a configured P4 path to a corresponding HubSpot URL.
  */
 class HubspotReverseProxy
 {
@@ -20,8 +19,13 @@ class HubspotReverseProxy
         add_action( 'parse_request', [$this, 'p4_hubspot_reverse_proxy'] );
     }
 
-    public function p4_hubspot_reverse_proxy( WP $wp ): void {
-
+    /**
+     * Handles the reverse proxy logic on every WordPress request.
+     *
+     * @param WP $wp Current WordPress environment instance.
+     * @return void
+     */
+    public function p4_hubspot_reverse_proxy($wp): void {
         $target_url = $this->get_config_data($wp);
 
         if (!$target_url) {
@@ -42,6 +46,12 @@ class HubspotReverseProxy
         exit;
     }
 
+    /**
+     * Resolves the target HubSpot URL for the current request based on Planet4 options.
+     *
+     * @param WP $wp Current WordPress environment instance.
+     * @return string|null The target URL, or null if the request should not be proxied.
+     */
     private function get_config_data($wp)
     {
         $options = get_option( 'planet4_options', [] );
@@ -75,14 +85,22 @@ class HubspotReverseProxy
         return $target_url;
     }
 
+    /**
+     * Fetches the content of the target URL via an HTTP GET request.
+     *
+     * @param string $target_url The fully-qualified URL to fetch.
+     * @return array|null Associative array with 'body' and 'type' keys, or null on request failure.
+     */
     private function remote_get_content($target_url)
     {
         $query_string = $_SERVER['QUERY_STRING'] ?? '';
+
         if ( $query_string ) {
             $target_url .= '?' . $query_string;
         }
 
         $forward_headers = [];
+
         foreach ( [ 'Accept', 'Accept-Language', 'Accept-Encoding', 'Cookie' ] as $h ) {
             $key = 'HTTP_' . strtoupper( str_replace( '-', '_', $h ) );
             if ( ! empty( $_SERVER[ $key ] ) ) {
@@ -94,7 +112,6 @@ class HubspotReverseProxy
             'timeout'     => 15,
             'redirection' => 5,
             'headers'     => $forward_headers,
-            'user-agent'  => 'Planet4-ReverseProxy/1.0 (+https://planet4.greenpeace.org)',
             'sslverify'   => true,
         ] );
 
@@ -120,7 +137,10 @@ class HubspotReverseProxy
 
     /**
      * Injects a <link rel="canonical"> pointing at the original HubSpot URL.
-     * If a canonical already exists (HubSpot sometimes adds one), replace it.
+     *
+     * @param string $html The HTML content to modify.
+     * @param string $canonical_url The canonical URL to set.
+     * @return string The modified HTML with the canonical tag injected or replaced.
      */
     private function inject_canonical( string $html, string $canonical_url ): string {
         $tag = sprintf( '<link rel="canonical" href="%s">', esc_url( $canonical_url ) );

--- a/src/HubspotReverseProxy.php
+++ b/src/HubspotReverseProxy.php
@@ -16,16 +16,16 @@ class HubspotReverseProxy
      */
     public function __construct()
     {
-        add_action( 'parse_request', [$this, 'p4_hubspot_reverse_proxy'] );
+        add_action('parse_request', [$this, 'p4_hubspot_reverse_proxy']);
     }
 
     /**
      * Handles the reverse proxy logic on every WordPress request.
      *
      * @param WP $wp Current WordPress environment instance.
-     * @return void
      */
-    public function p4_hubspot_reverse_proxy($wp): void {
+    public function p4_hubspot_reverse_proxy(WP $wp): void
+    {
         $target_url = $this->get_config_data($wp);
 
         if (!$target_url) {
@@ -34,12 +34,12 @@ class HubspotReverseProxy
 
         $content = $this->remote_get_content($target_url);
 
-        if ( !$content ) {
+        if (!$content) {
             return;
         }
 
-        if ( str_contains( $content['type'], 'text/html' ) ) {
-            $content['body'] = $this->inject_canonical( $content['body'], $target_url );
+        if (str_contains($content['type'], 'text/html')) {
+            $content['body'] = $this->inject_canonical($content['body'], $target_url);
         }
 
         echo $content['body']; // phpcs:ignore WordPress.Security.EscapeOutput
@@ -52,34 +52,34 @@ class HubspotReverseProxy
      * @param WP $wp Current WordPress environment instance.
      * @return string|null The target URL, or null if the request should not be proxied.
      */
-    private function get_config_data($wp)
+    private function get_config_data(WP $wp): ?string
     {
-        $options = get_option( 'planet4_options', [] );
+        $options = get_option('planet4_options', []);
 
-        if ( empty( $options['hubspot_reverse_proxy'] ) ) {
+        if (empty($options['hubspot_reverse_proxy'])) {
             return null;
         }
 
-        $p4_path        = trim( $options['hubspot_reverse_proxy_p4_path'] ?? '', '/' );
-        $hubspot_domain = rtrim( $options['hubspot_reverse_proxy_domain'] ?? '', '/' );
-        $hubspot_path   = trim( $options['hubspot_reverse_proxy_hubspot_path'] ?? '', '/' );
+        $p4_path = trim($options['hubspot_reverse_proxy_p4_path'] ?? '', '/');
+        $hubspot_domain = rtrim($options['hubspot_reverse_proxy_domain'] ?? '', '/');
+        $hubspot_path = trim($options['hubspot_reverse_proxy_hubspot_path'] ?? '', '/');
 
-        if ( ! $p4_path || ! $hubspot_domain || ! $hubspot_path ) {
+        if (! $p4_path || ! $hubspot_domain || ! $hubspot_path) {
             return null;
         }
 
         // Ensure the domain includes a scheme.
-        if ( ! preg_match( '#^https?://#', $hubspot_domain ) ) {
+        if (! preg_match('#^https?://#', $hubspot_domain)) {
             $hubspot_domain = 'https://' . $hubspot_domain;
         }
 
-        $request_path = trim( $wp->request, '/' );
+        $request_path = trim($wp->request, '/');
 
-        if ( $request_path !== $p4_path && ! str_starts_with( $request_path, $p4_path . '/' ) ) {
+        if ($request_path !== $p4_path && ! str_starts_with($request_path, $p4_path . '/')) {
             return null;
         }
 
-        $sub_path   = substr( $request_path, strlen( $p4_path ) );
+        $sub_path = substr($request_path, strlen($p4_path));
         $target_url = $hubspot_domain . '/' . $hubspot_path . $sub_path;
 
         return $target_url;
@@ -91,43 +91,45 @@ class HubspotReverseProxy
      * @param string $target_url The fully-qualified URL to fetch.
      * @return array|null Associative array with 'body' and 'type' keys, or null on request failure.
      */
-    private function remote_get_content($target_url)
+    private function remote_get_content(string $target_url): ?array
     {
         $query_string = $_SERVER['QUERY_STRING'] ?? '';
 
-        if ( $query_string ) {
+        if ($query_string) {
             $target_url .= '?' . $query_string;
         }
 
         $forward_headers = [];
 
-        foreach ( [ 'Accept', 'Accept-Language', 'Accept-Encoding', 'Cookie' ] as $h ) {
-            $key = 'HTTP_' . strtoupper( str_replace( '-', '_', $h ) );
-            if ( ! empty( $_SERVER[ $key ] ) ) {
-                $forward_headers[ $h ] = $_SERVER[ $key ];
+        foreach ([ 'Accept', 'Accept-Language', 'Accept-Encoding', 'Cookie' ] as $h) {
+            $key = 'HTTP_' . strtoupper(str_replace('-', '_', $h));
+            if (empty($_SERVER[ $key ])) {
+                continue;
             }
+
+            $forward_headers[ $h ] = $_SERVER[ $key ];
         }
 
-        $response = wp_remote_get( $target_url, [
-            'timeout'     => 15,
+        $response = wp_remote_get($target_url, [
+            'timeout' => 15,
             'redirection' => 5,
-            'headers'     => $forward_headers,
-            'sslverify'   => true,
-        ] );
+            'headers' => $forward_headers,
+            'sslverify' => true,
+        ]);
 
-        if ( is_wp_error( $response ) ) {
+        if (is_wp_error($response)) {
             return null;
         }
 
-        $status_code  = wp_remote_retrieve_response_code( $response );
-        $content_type = wp_remote_retrieve_header( $response, 'content-type' );
-        $body         = wp_remote_retrieve_body( $response );
+        $status_code = wp_remote_retrieve_response_code($response);
+        $content_type = wp_remote_retrieve_header($response, 'content-type');
+        $body = wp_remote_retrieve_body($response);
 
-        http_response_code( (int) $status_code );
+        http_response_code((int) $status_code);
 
-        header( 'Content-Type: ' . $content_type );
-        header( 'X-Proxied-By: Planet4' );
-        header_remove( 'Link' );
+        header('Content-Type: ' . $content_type);
+        header('X-Proxied-By: Planet4');
+        header_remove('Link');
 
         return [
             'body' => $body,
@@ -142,15 +144,16 @@ class HubspotReverseProxy
      * @param string $canonical_url The canonical URL to set.
      * @return string The modified HTML with the canonical tag injected or replaced.
      */
-    private function inject_canonical( string $html, string $canonical_url ): string {
-        $tag = sprintf( '<link rel="canonical" href="%s">', esc_url( $canonical_url ) );
+    private function inject_canonical(string $html, string $canonical_url): string
+    {
+        $tag = sprintf('<link rel="canonical" href="%s">', esc_url($canonical_url));
 
         // Replace an existing canonical if present.
-        if ( preg_match( '/<link[^>]+rel=["\']canonical["\'][^>]*>/i', $html ) ) {
-            return preg_replace( '/<link[^>]+rel=["\']canonical["\'][^>]*>/i', $tag, $html );
+        if (preg_match('/<link[^>]+rel=["\']canonical["\'][^>]*>/i', $html)) {
+            return preg_replace('/<link[^>]+rel=["\']canonical["\'][^>]*>/i', $tag, $html);
         }
 
         // Otherwise inject just before </head>.
-        return str_ireplace( '</head>', $tag . "\n</head>", $html );
+        return str_ireplace('</head>', $tag . "\n</head>", $html);
     }
 }

--- a/src/HubspotReverseProxy.php
+++ b/src/HubspotReverseProxy.php
@@ -166,13 +166,13 @@ class HubspotReverseProxy
     private function rewrite_relative_urls(string $html, string $hubspot_domain): string
     {
         return preg_replace_callback(
-            '/(\b(?:src|href|action|srcset|data-[\w\-]+)=["\'])(\\/[^"\']*["\'])|(\\bstyle=["\'])([^"\']*url\\(\\/[^)]*\\)[^"\']*["\'])/',
+            '/(\b(?:src|href|action|srcset|data-[\w\-]+)=["\'])(\\/(?!\\/)[^"\']*["\'])|(\\bstyle=["\'])([^"\']*url\\(\\/(?!\\/)[^)]*\\)[^"\']*["\'])/',
             function (array $matches) use ($hubspot_domain): string {
                 if ($matches[1]) {
                     return $matches[1] . $hubspot_domain . $matches[2];
                 }
                 return $matches[3] . preg_replace(
-                    '/url\\((\\/[^)]*\\))/',
+                    '/url\\((\\/(?!\\/)[^)]*\\))/',
                     'url(' . $hubspot_domain . '$1)',
                     $matches[4]
                 );

--- a/src/HubspotReverseProxy.php
+++ b/src/HubspotReverseProxy.php
@@ -26,20 +26,21 @@ class HubspotReverseProxy
      */
     public function p4_hubspot_reverse_proxy(WP $wp): void
     {
-        $target_url = $this->get_config_data($wp);
+        $target_data = $this->get_config_data($wp);
 
-        if (!$target_url) {
+        if (!$target_data) {
             return;
         }
 
-        $content = $this->remote_get_content($target_url);
+        $content = $this->remote_get_content($target_data['target_url']);
 
         if (!$content) {
             return;
         }
 
         if (str_contains($content['type'], 'text/html')) {
-            $content['body'] = $this->inject_canonical($content['body'], $target_url);
+            $content['body'] = $this->inject_canonical($content['body'], $target_data['target_url']);
+            $content['body'] = $this->rewrite_relative_urls($content['body'], $target_data['hubspot_domain']);
         }
 
         echo $content['body']; // phpcs:ignore WordPress.Security.EscapeOutput
@@ -50,9 +51,9 @@ class HubspotReverseProxy
      * Resolves the target HubSpot URL for the current request based on Planet4 options.
      *
      * @param WP $wp Current WordPress environment instance.
-     * @return string|null The target URL, or null if the request should not be proxied.
+     * @return array|null The target URL and Hubspot domain, or null if the request should not be proxied.
      */
-    private function get_config_data(WP $wp): ?string
+    private function get_config_data(WP $wp): ?array
     {
         $options = get_option('planet4_options', []);
 
@@ -82,7 +83,10 @@ class HubspotReverseProxy
         $sub_path = substr($request_path, strlen($p4_path));
         $target_url = $hubspot_domain . '/' . $hubspot_path . $sub_path;
 
-        return $target_url;
+        return [
+            'hubspot_domain' => $hubspot_domain,
+            'target_url' => $target_url,
+        ];
     }
 
     /**
@@ -135,6 +139,25 @@ class HubspotReverseProxy
             'body' => $body,
             'type' => $content_type,
         ];
+    }
+
+    /**
+     * Rewrites root-relative URLs in proxied HTML to point to the HubSpot domain.
+     * The regex matches src="..." and href="..." attributes where the value starts with /
+     *
+     * @param string $html The HTML content to modify.
+     * @param string $hubspot_domain The HubSpot domain (with scheme, no trailing slash).
+     * @return string The modified HTML with rewritten URLs.
+     */
+    private function rewrite_relative_urls(string $html, string $hubspot_domain): string
+    {
+        return preg_replace_callback(
+            '/(\b(?:src|href|action)=")(\\/[^"]*")/',
+            function (array $matches) use ($hubspot_domain): string {
+                return $matches[1] . $hubspot_domain . $matches[2];
+            },
+            $html
+        );
     }
 
     /**

--- a/src/HubspotReverseProxy.php
+++ b/src/HubspotReverseProxy.php
@@ -143,18 +143,33 @@ class HubspotReverseProxy
 
     /**
      * Rewrites root-relative URLs in proxied HTML to point to the HubSpot domain.
-     * The regex matches src="..." and href="..." attributes where the value starts with /
+     * Both single- and double-quoted attribute values are supported.
+     * The regex matches the following patterns where the value starts with '/':
+     *  - src="..."        e.g. src="/images/logo.png"
+     *  - href="..."       e.g. href="/about"
+     *  - action="..."     e.g. action="/submit"
+     *  - srcset="..."     e.g. srcset="/img.png 1x, /img@2x.png 2x"
+     *  - data-*="..."     e.g. data-src="/lazy.jpg", data-bg-url="/hero.jpg"
+     *  - style="..."      e.g. style="background: url(/images/bg.jpg)"
      *
-     * @param string $html The HTML content to modify.
-     * @param string $hubspot_domain The HubSpot domain (with scheme, no trailing slash).
-     * @return string The modified HTML with rewritten URLs.
+     * @param string $html            The raw HTML returned from the HubSpot proxy.
+     * @param string $hubspot_domain  The absolute origin to prepend.
+     *
+     * @return string The HTML with all root-relative URLs rewritten to absolute HubSpot URLs.
      */
     private function rewrite_relative_urls(string $html, string $hubspot_domain): string
     {
         return preg_replace_callback(
-            '/(\b(?:src|href|action)=")(\\/[^"]*")/',
+            '/(\b(?:src|href|action|srcset|data-[\w\-]+)=["\'])(\\/[^"\']*["\'])|(\\bstyle=["\'])([^"\']*url\\(\\/[^)]*\\)[^"\']*["\'])/',
             function (array $matches) use ($hubspot_domain): string {
-                return $matches[1] . $hubspot_domain . $matches[2];
+                if ($matches[1]) {
+                    return $matches[1] . $hubspot_domain . $matches[2];
+                }
+                return $matches[3] . preg_replace(
+                    '/url\\((\\/[^)]*\\))/',
+                    'url(' . $hubspot_domain . '$1)',
+                    $matches[4]
+                );
             },
             $html
         );

--- a/src/HubspotReverseProxy.php
+++ b/src/HubspotReverseProxy.php
@@ -22,6 +22,12 @@ class HubspotReverseProxy
     /**
      * Handles the reverse proxy logic on every WordPress request.
      *
+     * Security notice — trust assumption:
+     * The response body is echoed without escaping (`echo $content['body']`), which is
+     * fundamentally what a reverse proxy does. However, this means any XSS present on
+     * the HubSpot side executes under the P4 origin and has full access to P4 cookies
+     * and localStorage.
+     *
      * @param WP $wp Current WordPress environment instance.
      */
     public function p4_hubspot_reverse_proxy(WP $wp): void

--- a/src/HubspotReverseProxy.php
+++ b/src/HubspotReverseProxy.php
@@ -81,7 +81,7 @@ class HubspotReverseProxy
 
         $request_path = trim($wp->request, '/');
 
-        // Only proxy paths that have content beyond the base segment, but ever the root itself.
+        // Only proxy paths that have content beyond the base segment, but never the root itself.
         if (!str_starts_with($request_path, $p4_path . '/')) {
             return null;
         }

--- a/src/HubspotReverseProxy.php
+++ b/src/HubspotReverseProxy.php
@@ -65,7 +65,7 @@ class HubspotReverseProxy
         $hubspot_domain = rtrim($options['hubspot_reverse_proxy_domain'] ?? '', '/');
         $hubspot_path = trim($options['hubspot_reverse_proxy_hubspot_path'] ?? '', '/');
 
-        if (! $p4_path || ! $hubspot_domain) {
+        if (!$p4_path || !$hubspot_domain) {
             return null;
         }
 
@@ -107,11 +107,11 @@ class HubspotReverseProxy
 
         foreach ([ 'Accept', 'Accept-Language', 'Accept-Encoding', 'Cookie' ] as $h) {
             $key = 'HTTP_' . strtoupper(str_replace('-', '_', $h));
-            if (empty($_SERVER[ $key ])) {
+            if (empty($_SERVER[$key])) {
                 continue;
             }
 
-            $forward_headers[ $h ] = $_SERVER[ $key ];
+            $forward_headers[$h] = $_SERVER[$key];
         }
 
         $response = wp_remote_get($target_url, [

--- a/src/HubspotReverseProxy.php
+++ b/src/HubspotReverseProxy.php
@@ -16,6 +16,12 @@ class HubspotReverseProxy
      */
     public function __construct()
     {
+        $hubspot_addon = function_exists('is_plugin_active') && is_plugin_active('gravityformshubspot/hubspot.php');
+
+        if (!$hubspot_addon) {
+            return;
+        }
+
         add_action('parse_request', [$this, 'p4_hubspot_reverse_proxy']);
     }
 

--- a/src/HubspotReverseProxy.php
+++ b/src/HubspotReverseProxy.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace P4\MasterTheme;
+
+use WP;
+
+/**
+ * Class HubspotReverseProxy
+ *
+ * bla bla bla
+ *
+ */
+class HubspotReverseProxy
+{
+    /**
+     * Constructor
+     */
+    public function __construct()
+    {
+        add_action( 'parse_request', [$this, 'p4_hubspot_reverse_proxy'] );
+    }
+
+    public function p4_hubspot_reverse_proxy( WP $wp ): void {
+
+        $target_url = $this->get_config_data($wp);
+
+        if (!$target_url) {
+            return;
+        }
+
+        $content = $this->remote_get_content($target_url);
+
+        if ( !$content ) {
+            return;
+        }
+
+        if ( str_contains( $content['type'], 'text/html' ) ) {
+            $content['body'] = $this->inject_canonical( $content['body'], $target_url );
+        }
+
+        echo $content['body']; // phpcs:ignore WordPress.Security.EscapeOutput
+        exit;
+    }
+
+    private function get_config_data($wp)
+    {
+        $options = get_option( 'planet4_options', [] );
+
+        if ( empty( $options['hubspot_reverse_proxy'] ) ) {
+            return null;
+        }
+
+        $p4_path        = trim( $options['hubspot_reverse_proxy_p4_path'] ?? '', '/' );
+        $hubspot_domain = rtrim( $options['hubspot_reverse_proxy_domain'] ?? '', '/' );
+        $hubspot_path   = trim( $options['hubspot_reverse_proxy_hubspot_path'] ?? '', '/' );
+
+        if ( ! $p4_path || ! $hubspot_domain || ! $hubspot_path ) {
+            return null;
+        }
+
+        // Ensure the domain includes a scheme.
+        if ( ! preg_match( '#^https?://#', $hubspot_domain ) ) {
+            $hubspot_domain = 'https://' . $hubspot_domain;
+        }
+
+        $request_path = trim( $wp->request, '/' );
+
+        if ( $request_path !== $p4_path && ! str_starts_with( $request_path, $p4_path . '/' ) ) {
+            return null;
+        }
+
+        $sub_path   = substr( $request_path, strlen( $p4_path ) );
+        $target_url = $hubspot_domain . '/' . $hubspot_path . $sub_path;
+
+        return $target_url;
+    }
+
+    private function remote_get_content($target_url)
+    {
+        $query_string = $_SERVER['QUERY_STRING'] ?? '';
+        if ( $query_string ) {
+            $target_url .= '?' . $query_string;
+        }
+
+        $forward_headers = [];
+        foreach ( [ 'Accept', 'Accept-Language', 'Accept-Encoding', 'Cookie' ] as $h ) {
+            $key = 'HTTP_' . strtoupper( str_replace( '-', '_', $h ) );
+            if ( ! empty( $_SERVER[ $key ] ) ) {
+                $forward_headers[ $h ] = $_SERVER[ $key ];
+            }
+        }
+
+        $response = wp_remote_get( $target_url, [
+            'timeout'     => 15,
+            'redirection' => 5,
+            'headers'     => $forward_headers,
+            'user-agent'  => 'Planet4-ReverseProxy/1.0 (+https://planet4.greenpeace.org)',
+            'sslverify'   => true,
+        ] );
+
+        if ( is_wp_error( $response ) ) {
+            return null;
+        }
+
+        $status_code  = wp_remote_retrieve_response_code( $response );
+        $content_type = wp_remote_retrieve_header( $response, 'content-type' );
+        $body         = wp_remote_retrieve_body( $response );
+
+        http_response_code( (int) $status_code );
+
+        header( 'Content-Type: ' . $content_type );
+        header( 'X-Proxied-By: Planet4' );
+        header_remove( 'Link' );
+
+        return [
+            'body' => $body,
+            'type' => $content_type,
+        ];
+    }
+
+    /**
+     * Injects a <link rel="canonical"> pointing at the original HubSpot URL.
+     * If a canonical already exists (HubSpot sometimes adds one), replace it.
+     */
+    private function inject_canonical( string $html, string $canonical_url ): string {
+        $tag = sprintf( '<link rel="canonical" href="%s">', esc_url( $canonical_url ) );
+
+        // Replace an existing canonical if present.
+        if ( preg_match( '/<link[^>]+rel=["\']canonical["\'][^>]*>/i', $html ) ) {
+            return preg_replace( '/<link[^>]+rel=["\']canonical["\'][^>]*>/i', $tag, $html );
+        }
+
+        // Otherwise inject just before </head>.
+        return str_ireplace( '</head>', $tag . "\n</head>", $html );
+    }
+}

--- a/src/HubspotReverseProxy.php
+++ b/src/HubspotReverseProxy.php
@@ -75,14 +75,14 @@ class HubspotReverseProxy
             return null;
         }
 
-        // Ensure the domain includes a scheme.
-        if (! preg_match('#^https?://#', $hubspot_domain)) {
+        if (!preg_match('#^https?://#', $hubspot_domain)) {
             $hubspot_domain = 'https://' . $hubspot_domain;
         }
 
         $request_path = trim($wp->request, '/');
 
-        if ($request_path !== $p4_path && ! str_starts_with($request_path, $p4_path . '/')) {
+        // Only proxy paths that have content beyond the base segment, but ever the root itself.
+        if (!str_starts_with($request_path, $p4_path . '/')) {
             return null;
         }
 
@@ -166,6 +166,7 @@ class HubspotReverseProxy
     private function rewrite_relative_urls(string $html, string $hubspot_domain): string
     {
         return preg_replace_callback(
+            // phpcs:ignore Generic.Files.LineLength.MaxExceeded
             '/(\b(?:src|href|action|srcset|data-[\w\-]+)=["\'])(\\/(?!\\/)[^"\']*["\'])|(\\bstyle=["\'])([^"\']*url\\(\\/(?!\\/)[^)]*\\)[^"\']*["\'])/',
             function (array $matches) use ($hubspot_domain): string {
                 if ($matches[1]) {

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -96,6 +96,7 @@ final class Loader
             Sentry::class,
             PostFunctionsHandler::class,
             HtmlPostProcessor::class,
+            HubspotReverseProxy::class,
         ];
 
         if (is_admin()) {

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -602,18 +602,12 @@ class Settings
                         'type' => 'checkbox',
                     ],
                     [
-                        'name' => __('Domain', 'planet4-master-theme-backend'),
+                        'name' => __('Hubspot Domain', 'planet4-master-theme-backend'),
                         'id' => 'hubspot_reverse_proxy_domain',
                         'type' => 'text',
                         'attributes' => ['type' => 'text'],
                         'classes' => 'hidden',
-                    ],
-                    [
-                        'name' => __('P4 Path', 'planet4-master-theme-backend'),
-                        'id' => 'hubspot_reverse_proxy_p4_path',
-                        'type' => 'text',
-                        'attributes' => ['type' => 'text'],
-                        'classes' => 'hidden',
+                        'description' => __('Landing pages domain from Hubspot Settings > Tools > Content > Domain & URLs.', 'planet4-master-theme-backend'),
                     ],
                     [
                         'name' => __('Hubspot Path', 'planet4-master-theme-backend'),
@@ -621,25 +615,25 @@ class Settings
                         'type' => 'text',
                         'attributes' => ['type' => 'text'],
                         'classes' => 'hidden',
+                        'description' => __('Path slug your Hubspot landing pages use. Usually empty or language specific.', 'planet4-master-theme-backend'),
+                    ],
+                    [
+                        'name' => __('P4 Path', 'planet4-master-theme-backend'),
+                        'id' => 'hubspot_reverse_proxy_p4_path',
+                        'type' => 'text',
+                        'attributes' => ['type' => 'text'],
+                        'classes' => 'hidden',
+                        'description' => __('Path slug to use for serving the landing pages.', 'planet4-master-theme-backend'),
+                    ],
+                    [
+                        'name' => __('Hubspot tracking code', 'planet4-master-theme-backend'),
+                        'desc' => __('Paste here the tracking code from your Hubspot account.', 'planet4-master-theme-backend'),
+                        'id' => 'hubspot_tracking_code',
+                        'type' => 'textarea',
+                        'attributes' => ['type' => 'text'],
                     ],
                 ],
             ];
-
-            array_push(
-                $this->subpages['planet4_settings_analytics']['fields'],
-                [
-                    'name' => __('Hubspot tracking code', 'planet4-master-theme-backend'),
-                    'desc' => __(
-                        'Paste here the tracking code from your Hubspot account.',
-                        'planet4-master-theme-backend'
-                    ),
-                    'id' => 'hubspot_tracking_code',
-                    'type' => 'textarea',
-                    'attributes' => [
-                        'type' => 'text',
-                    ],
-                ],
-            );
         }
     }
 

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -592,6 +592,36 @@ class Settings
         $is_gf_hubspot_addon = function_exists('is_plugin_active') && is_plugin_active('gravityformshubspot/hubspot.php');
         // phpcs:ignore SlevomatCodingStandard.ControlStructures.EarlyExit.EarlyExitNotUsed
         if ($is_gf_hubspot_addon) {
+            $this->subpages['planet4_settings_hubspot'] = [
+                'title'  => 'Hubspot',
+                'fields' => [
+                    [
+                        'name' => __( 'Reverse Proxy', 'planet4-master-theme-backend' ),
+                        'desc' => __( 'Enables reverse proxy for Hubspot hosted content.', 'planet4-master-theme-backend' ),
+                        'id'   => 'hubspot_reverse_proxy',
+                        'type' => 'checkbox',
+                    ],
+                    [
+                        'name' => __('Domain', 'planet4-master-theme-backend'),
+                        'id' => 'hubspot_reverse_proxy_domain',
+                        'type' => 'text',
+                        'attributes' => ['type' => 'text'],
+                    ],
+                    [
+                        'name' => __('P4 Path', 'planet4-master-theme-backend'),
+                        'id' => 'hubspot_reverse_proxy_p4_path',
+                        'type' => 'text',
+                        'attributes' => ['type' => 'text'],
+                    ],
+                    [
+                        'name' => __('Hubspot Path', 'planet4-master-theme-backend'),
+                        'id' => 'hubspot_reverse_proxy_hubspot_path',
+                        'type' => 'text',
+                        'attributes' => ['type' => 'text'],
+                    ],
+                ],
+            ];
+
             array_push(
                 $this->subpages['planet4_settings_analytics']['fields'],
                 [

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -593,12 +593,12 @@ class Settings
         // phpcs:ignore SlevomatCodingStandard.ControlStructures.EarlyExit.EarlyExitNotUsed
         if ($is_gf_hubspot_addon) {
             $this->subpages['planet4_settings_hubspot'] = [
-                'title'  => 'Hubspot',
+                'title' => 'Hubspot',
                 'fields' => [
                     [
-                        'name' => __( 'Reverse Proxy', 'planet4-master-theme-backend' ),
-                        'desc' => __( 'Enables reverse proxy for Hubspot hosted content.', 'planet4-master-theme-backend' ),
-                        'id'   => 'hubspot_reverse_proxy',
+                        'name' => __('Reverse Proxy', 'planet4-master-theme-backend'),
+                        'desc' => __('Enables reverse proxy for Hubspot hosted content.', 'planet4-master-theme-backend'),
+                        'id' => 'hubspot_reverse_proxy',
                         'type' => 'checkbox',
                     ],
                     [
@@ -868,33 +868,35 @@ class Settings
         $screen = get_current_screen();
 
         // Check if this is a P4 Settings page:
-        if ($screen && str_starts_with( $screen->base, 'planet-4_page_planet4_' )) {
-            wp_register_style(
-                'options-style',
-                get_template_directory_uri() . '/admin/css/options.css',
-                [],
-                Loader::theme_file_ver('admin/css/options.css')
-            );
-            wp_enqueue_style('options-style');
-
-            /* Load additional styles for production environments. */
-            if (defined('WP_APP_ENV') && in_array(WP_APP_ENV, ['production', 'staging'], true)) {
-                wp_enqueue_style(
-                    'admin-notices-style',
-                    get_template_directory_uri() . '/admin/css/notices.css',
-                    [],
-                    Loader::theme_file_ver('admin/css/notices.css')
-                );
-            }
-
-            wp_enqueue_script(
-                'options-script',
-                get_template_directory_uri() . '/admin/js/options.js',
-                [],
-                Loader::theme_file_ver('admin/js/options.js'),
-                true
-            );
-            wp_enqueue_script('options-script');
+        if (!$screen || !str_starts_with($screen->base, 'planet-4_page_planet4_')) {
+            return;
         }
+
+        wp_register_style(
+            'options-style',
+            get_template_directory_uri() . '/admin/css/options.css',
+            [],
+            Loader::theme_file_ver('admin/css/options.css')
+        );
+        wp_enqueue_style('options-style');
+
+        /* Load additional styles for production environments. */
+        if (defined('WP_APP_ENV') && in_array(WP_APP_ENV, ['production', 'staging'], true)) {
+            wp_enqueue_style(
+                'admin-notices-style',
+                get_template_directory_uri() . '/admin/css/notices.css',
+                [],
+                Loader::theme_file_ver('admin/css/notices.css')
+            );
+        }
+
+        wp_enqueue_script(
+            'options-script',
+            get_template_directory_uri() . '/admin/js/options.js',
+            [],
+            Loader::theme_file_ver('admin/js/options.js'),
+            true
+        );
+        wp_enqueue_script('options-script');
     }
 }

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -606,18 +606,21 @@ class Settings
                         'id' => 'hubspot_reverse_proxy_domain',
                         'type' => 'text',
                         'attributes' => ['type' => 'text'],
+                        'classes' => 'hidden',
                     ],
                     [
                         'name' => __('P4 Path', 'planet4-master-theme-backend'),
                         'id' => 'hubspot_reverse_proxy_p4_path',
                         'type' => 'text',
                         'attributes' => ['type' => 'text'],
+                        'classes' => 'hidden',
                     ],
                     [
                         'name' => __('Hubspot Path', 'planet4-master-theme-backend'),
                         'id' => 'hubspot_reverse_proxy_hubspot_path',
                         'type' => 'text',
                         'attributes' => ['type' => 'text'],
+                        'classes' => 'hidden',
                     ],
                 ],
             ];
@@ -862,31 +865,36 @@ class Settings
      */
     public function enqueue_admin_assets(): void
     {
-        wp_register_style(
-            'options-style',
-            get_template_directory_uri() . '/admin/css/options.css',
-            [],
-            Loader::theme_file_ver('admin/css/options.css')
-        );
-        wp_enqueue_style('options-style');
+        $screen = get_current_screen();
 
-        /* Load additional styles for production environments. */
-        if (defined('WP_APP_ENV') && in_array(WP_APP_ENV, ['production', 'staging'], true)) {
-            wp_enqueue_style(
-                'admin-notices-style',
-                get_template_directory_uri() . '/admin/css/notices.css',
+        // Check if this is a P4 Settings page:
+        if ($screen && str_starts_with( $screen->base, 'planet-4_page_planet4_' )) {
+            wp_register_style(
+                'options-style',
+                get_template_directory_uri() . '/admin/css/options.css',
                 [],
-                Loader::theme_file_ver('admin/css/notices.css')
+                Loader::theme_file_ver('admin/css/options.css')
             );
-        }
+            wp_enqueue_style('options-style');
 
-        wp_enqueue_script(
-            'options-script',
-            get_template_directory_uri() . '/admin/js/options.js',
-            [],
-            Loader::theme_file_ver('admin/js/options.js'),
-            true
-        );
-        wp_enqueue_script('options-script');
+            /* Load additional styles for production environments. */
+            if (defined('WP_APP_ENV') && in_array(WP_APP_ENV, ['production', 'staging'], true)) {
+                wp_enqueue_style(
+                    'admin-notices-style',
+                    get_template_directory_uri() . '/admin/css/notices.css',
+                    [],
+                    Loader::theme_file_ver('admin/css/notices.css')
+                );
+            }
+
+            wp_enqueue_script(
+                'options-script',
+                get_template_directory_uri() . '/admin/js/options.js',
+                [],
+                Loader::theme_file_ver('admin/js/options.js'),
+                true
+            );
+            wp_enqueue_script('options-script');
+        }
     }
 }


### PR DESCRIPTION
### Summary

This PR introduces a mechanism to intercept requests to a P4 website path, fetch content from Hubspot, and render it. Additionally, the following changes were included:
- The code in the `admin/js/options.js` file was arranged within functions to make it clearer.
- The code in the `src/Settings.php` file was adjusted to enqueue admin CSS and JS only in admin pages. 

---

Ref: https://greenpeace-planet4.atlassian.net/browse/PLANET-8165

### Testing

1. Log in to the website admin area.
2. Go to Planet 4 > Hubspot (`/wp-admin/admin.php?page=planet4_settings_hubspot`)
3. Check the "Reverse Proxy" box.
4. Complete the text fields using the data from "Reverse Proxy Data Examples" (check below)
5. Use the data from column Hubspot Domain to complete the field Hubspot Domain.
2. Use the data from column Hubspot Path to complete the field Hubspot Path, or leave it empty.
3. Use the data from column Hubspot Slug to create the page URL as explained in step 9.
4. Choose any string for the field P4 Path (for example, `p4-path`).
8. Save the changes.
9. Visit the webpage with the URL structure `[website-domain]/[P4 path]` or `[website-domain]/[p4-path]/[hubspot-slug]`, for example, `http://www.planet4.test/p4-path` or `http://www.planet4.test/p4-path/no-more-oil-wars`.
10. Check that Hubspot's content is rendered.
11. Check that the content is not rendered if the "Reverse Proxy" box is unchecked.
12. Check that the text fields in Planet 4 > Hubspot are hidden if the "Reverse Proxy" box is unchecked.
13. Check that the Save button in Planet 4 > Hubspot is disabled if at least one of the text fields is empty.

#### Reverse Proxy Data Examples:

| Hubspot Domain                  | Hubspot Path | Hubspot Slug                               |
|---------------------------------|--------------|--------------------------------------------|
| act.greenpeace.ca               | en-ca        | -                                          |
| act.greenpeace.ca               | en-ca        | no-more-oil-wars                           |
| pages.greenpeaceafrica.org      | -            | -                                          |
| pages.greenpeaceafrica.org      | -            | plastic-audit-supermarket-edition          |
| pages.greenpeaceafrica.org      | -            | stop-the-industrial-plunder-of-west-africa |
| acthubspot.greenpeace.org.au    | -            | -                                          |
| acthubspot.greenpeace.org.au    | -            | stop-big-gas                               |
| donatehubspot.greenpeace.org.au | -            | -                                          |
| donatehubspot.greenpeace.org.au | -            | stop-big-gas                               |