### PR TITLE
Make sure Carousel Header focus changes only with tabbing

### DIFF
--- a/assets/src/blocks/CarouselHeader/CarouselControls.js
+++ b/assets/src/blocks/CarouselHeader/CarouselControls.js
@@ -6,10 +6,11 @@ export const CarouselControls = forwardRef(({
   goToNextSlide = () => {},
   goToSlide = () => {},
   handleAutoplay = () => {},
+  setAutoplay = () => {},
   currentSlide = null,
   slides = null,
   autoplay,
-  disableControls,
+  autoplayToggle,
 }, ref) => {
   const controlsRef = useRef();
 
@@ -18,7 +19,7 @@ export const CarouselControls = forwardRef(({
       {/* Indicators */}
       <div className="carousel-indicators-wrapper">
         <div className="container">
-          {disableControls && (
+          {autoplayToggle && (
             <>
               <button
                 aria-label={__('Autoplay', 'planet4-master-theme')}
@@ -44,14 +45,16 @@ export const CarouselControls = forwardRef(({
                   <button
                     onClick={() => {
                       if (index !== currentSlide) {
-                        goToSlide({newSlide: index, fromClick: true});
+                        goToSlide({newSlide: index});
+                        setAutoplay(false);
                       }
                     }}
                     tabIndex={0}
                     onKeyDown={e => {
                       if ((e.key === 'Enter' || e.key === ' ') && index !== currentSlide) {
                         e.preventDefault();
-                        goToSlide({newSlide: index, fromClick: true});
+                        goToSlide({newSlide: index, fromTab: true});
+                        setAutoplay(false);
                       }
                     }}
                     // translators: %s: slide header
@@ -66,15 +69,38 @@ export const CarouselControls = forwardRef(({
       </div>
       {/* Arrows */}
       <nav aria-label={__('Greenpeace highlights carousel controls', 'planet4-master-theme')} ref={controlsRef}>
-
-        <button className="carousel-control-prev" onClick={goToPrevSlide}
+        <button
+          className="carousel-control-prev"
+          onClick={() => {
+            goToPrevSlide();
+            setAutoplay(false);
+          }}
+          onKeyDown={e => {
+            if ((e.key === 'Enter' || e.key === ' ')) {
+              e.preventDefault();
+              goToPrevSlide(true);
+              setAutoplay(false);
+            }
+          }}
           // translators: %s: slide header
           aria-label={sprintf(__('Go to previous slide %s', 'planet4-master-theme'), slides[currentSlide - 1] && slides[currentSlide - 1].header ? slides[currentSlide - 1].header : slides[slides.length - 1].header)}
         >
           <span className="carousel-control-prev-icon" aria-hidden="true"><i></i></span>
           <span className="visually-hidden">{__('Previous', 'planet4-master-theme')}</span>
         </button>
-        <button className="carousel-control-next" onClick={goToNextSlide}
+        <button
+          className="carousel-control-next"
+          onClick={() => {
+            goToNextSlide();
+            setAutoplay(false);
+          }}
+          onKeyDown={e => {
+            if ((e.key === 'Enter' || e.key === ' ')) {
+              e.preventDefault();
+              goToNextSlide(true);
+              setAutoplay(false);
+            }
+          }}
           // translators: %s: slide header
           aria-label={sprintf(__('Go to next slide %s', 'planet4-master-theme'), slides[currentSlide + 1] && slides[currentSlide + 1].header ? slides[currentSlide + 1].header : slides[0].header)}
         >
@@ -84,5 +110,17 @@ export const CarouselControls = forwardRef(({
       </nav>
 
     </>
-  ), [currentSlide, disableControls, autoplay, slides, ref, controlsRef, goToPrevSlide, goToNextSlide, goToSlide, handleAutoplay]);
+  ), [
+    currentSlide,
+    setAutoplay,
+    autoplayToggle,
+    autoplay,
+    slides,
+    ref,
+    controlsRef,
+    goToPrevSlide,
+    goToNextSlide,
+    goToSlide,
+    handleAutoplay,
+  ]);
 });

--- a/assets/src/blocks/CarouselHeader/CarouselHeaderFrontend.js
+++ b/assets/src/blocks/CarouselHeader/CarouselHeaderFrontend.js
@@ -31,24 +31,15 @@ export const CarouselHeaderFrontend = ({slides, carousel_autoplay, className, de
     >
       {(slides.length > 1) ? (
         <CarouselControls
-          goToPrevSlide={() => {
-            setAutoplay(() => {
-              goToPrevSlide(true);
-              return false;
-            });
-          }}
-          goToNextSlide={() => {
-            setAutoplay(() => {
-              goToNextSlide(true);
-              return false;
-            });
-          }}
+          goToPrevSlide={goToPrevSlide}
+          goToNextSlide={goToNextSlide}
+          setAutoplay={setAutoplay}
           goToSlide={goToSlide}
           handleAutoplay={handleAutoplay}
           slides={slides}
           currentSlide={currentSlide}
           autoplay={autoplay}
-          disableControls={carousel_autoplay}
+          autoplayToggle={carousel_autoplay}
           ref={indicatorsRef}
         />
       ) : null}

--- a/assets/src/blocks/CarouselHeader/useSlides.js
+++ b/assets/src/blocks/CarouselHeader/useSlides.js
@@ -128,7 +128,7 @@ export const useSlides = (
     document.removeEventListener('keydown', onkeyboardHandler);
   }, [indicatorsRef]);
 
-  const goToSlide = useCallback(({newSlide, forceCurrentSlide = false, fromClick = false}) => {
+  const goToSlide = useCallback(({newSlide, forceCurrentSlide = false, fromTab = false}) => {
     if (!slidesRef.current) {
       return;
     }
@@ -148,10 +148,10 @@ export const useSlides = (
       activeElement.classList.add(exitTransitionClass);
       nextElement.classList.add(enterTransitionClass);
 
-      if(fromClick) {
+      if (fromTab) {
         const heading = nextElement.querySelector('h2');
 
-        if(heading) {
+        if (heading) {
           heading.focus();
 
           document.addEventListener('keydown', onkeyboardHandler);
@@ -181,12 +181,12 @@ export const useSlides = (
     }
   }, [currentSlide, getOrder, options, sliding, setCarouselHeight, slidesRef, onkeyboardHandler]);
 
-  const goToPrevSlide = useCallback((fromClick = false) => {
-    goToSlide({newSlide: (currentSlide - 1 < 0) ? totalSlides - 1 : currentSlide - 1, fromClick});
+  const goToPrevSlide = useCallback((fromTab = false) => {
+    goToSlide({newSlide: (currentSlide - 1 < 0) ? totalSlides - 1 : currentSlide - 1, fromTab});
   }, [currentSlide, totalSlides, goToSlide]);
 
-  const goToNextSlide = useCallback((fromClick = false) => {
-    goToSlide({newSlide: (currentSlide + 1 >= totalSlides) ? 0 : currentSlide + 1, fromClick});
+  const goToNextSlide = useCallback((fromTab = false) => {
+    goToSlide({newSlide: (currentSlide + 1 >= totalSlides) ? 0 : currentSlide + 1, fromTab});
   }, [currentSlide, totalSlides, goToSlide]);
 
   useHammerSwipe(containerRef, goToNextSlide, goToPrevSlide);

--- a/assets/src/scss/blocks/CarouselHeader/CarouselHeaderStyle.scss
+++ b/assets/src/scss/blocks/CarouselHeader/CarouselHeaderStyle.scss
@@ -424,7 +424,7 @@ $medium-image-height: 600px;
         width: 100%;
       }
 
-      &:focus {
+      &:focus-visible {
         @include focus-styles();
       }
     }


### PR DESCRIPTION
### Summary

Before this fix the focus went to the heading also when clicking on the arrows, which looked weird. It needs to happen only when the user is tabbing.

Ref: [Slack thread](https://greenpeace.slack.com/archives/C0151L0KKNX/p1779748245904929)

### Testing

Make sure that the focus goes to the heading when interacting with the arrows/indicators while tabbing, but **not** when clicking. Also, clicking on the heading should no longer show the focus styles, they should only be applied when tabbing.
