### PR TITLE
Carousel Header: fix play and stop handlers

### DIFF
--- a/assets/src/blocks/CarouselHeader/useSlides.js
+++ b/assets/src/blocks/CarouselHeader/useSlides.js
@@ -34,6 +34,7 @@ export const useSlides = (
   const [autoplay, setAutoplay] = useState(carousel_autoplay);
   const [currentSlide, setCurrentSlide] = useState(0);
   const [sliding, setSliding] = useState(false);
+  const [isIntersecting, setIsIntersecting] = useState(false);
   // Set up the autoplay for the slides
   const timerRef = useRef(null);
 
@@ -53,8 +54,10 @@ export const useSlides = (
   };
 
   const handleAutoplay = useCallback(() => {
-    setAutoplay(!autoplay);
-  }, [autoplay]);
+    if(isIntersecting) {
+      setAutoplay(!autoplay);
+    }
+  }, [autoplay, isIntersecting]);
 
   const getOrder = useCallback(newSlide => {
     let order = newSlide < currentSlide ? 'prev' : 'next';
@@ -207,7 +210,7 @@ export const useSlides = (
   }, [currentSlide, setCarouselHeight, containerRef, slidesRef]);
 
   useEffect(() => {
-    if (autoplay && totalSlides > 1) {
+    if (autoplay && totalSlides > 1 && isIntersecting) {
       if (timerRef.current) {
         clearTimeout(timerRef.current);
       }
@@ -216,7 +219,7 @@ export const useSlides = (
     } else if (timerRef.current) {
       clearTimeout(timerRef.current);
     }
-  }, [totalSlides, autoplay, timerRef, goToNextSlide]);
+  }, [totalSlides, autoplay, timerRef, goToNextSlide, isIntersecting]);
 
   useEffect(() => {
     if (!containerRef?.current || !carousel_autoplay) {
@@ -225,7 +228,7 @@ export const useSlides = (
 
     const observer = new IntersectionObserver(
       ([entry]) => {
-        setAutoplay(entry.isIntersecting);
+        setIsIntersecting(entry.isIntersecting);
       },
       {
         root: null,
@@ -253,5 +256,6 @@ export const useSlides = (
     autoplay,
     headingsRef,
     indicatorsRef,
+    isIntersecting,
   };
 };

--- a/assets/src/blocks/CarouselHeader/useSlides.js
+++ b/assets/src/blocks/CarouselHeader/useSlides.js
@@ -54,7 +54,7 @@ export const useSlides = (
   };
 
   const handleAutoplay = useCallback(() => {
-    if(isIntersecting) {
+    if (isIntersecting) {
       setAutoplay(!autoplay);
     }
   }, [autoplay, isIntersecting]);
@@ -105,14 +105,14 @@ export const useSlides = (
 
     const carouselItem = event.target.closest('.carousel-item');
     // Only applied to the carousel item
-    if(!carouselItem) {
+    if (!carouselItem) {
       return;
     }
 
     const headingFocused = event.target.tagName === 'H2';
     const cta = carouselItem.querySelector('.action-button a');
 
-    if(headingFocused && cta) {
+    if (headingFocused && cta) {
       return;
     }
 


### PR DESCRIPTION
### Summary
The issue happens by the IntersectionObserver feature. See the reported issue [here](https://github.com/greenpeace/planet4-master-theme/pull/2991#pullrequestreview-4370734393).

<!-- Please add a reference link to the ticket, if one exists. -->
Ref: No ticket

### Testing

<!-- Please add the steps required to test the changes in this Pull Request. -->
1. Create or reuse an existing CHB and set to `autoplay`
2. Make sure that the controls `play` or `pause` can be clicked 
