### PR TITLE
Make sure focus is updated only when tabbing in Actions List

### DIFF
--- a/assets/src/blocks/CarouselHeader/CarouselControls.js
+++ b/assets/src/blocks/CarouselHeader/CarouselControls.js
@@ -43,20 +43,14 @@ export const CarouselControls = forwardRef(({
                   } : {}}
                 >
                   <button
-                    onClick={() => {
+                    onClick={e => {
                       if (index !== currentSlide) {
-                        goToSlide({newSlide: index});
+                        // eslint-disable-next-line @wordpress/no-global-active-element
+                        goToSlide({newSlide: index, fromTab: e.target === document.activeElement});
                         setAutoplay(false);
                       }
                     }}
                     tabIndex={0}
-                    onKeyDown={e => {
-                      if ((e.key === 'Enter' || e.key === ' ') && index !== currentSlide) {
-                        e.preventDefault();
-                        goToSlide({newSlide: index, fromTab: true});
-                        setAutoplay(false);
-                      }
-                    }}
                     // translators: %s: slide header
                     aria-label={sprintf(__('Go to %s slide', 'planet4-master-theme'), slides[index].header)}
                     aria-current={index === currentSlide ? 'true' : undefined}
@@ -71,16 +65,10 @@ export const CarouselControls = forwardRef(({
       <nav aria-label={__('Greenpeace highlights carousel controls', 'planet4-master-theme')} ref={controlsRef}>
         <button
           className="carousel-control-prev"
-          onClick={() => {
-            goToPrevSlide();
+          onClick={e => {
+            // eslint-disable-next-line @wordpress/no-global-active-element
+            goToPrevSlide(e.target === document.activeElement);
             setAutoplay(false);
-          }}
-          onKeyDown={e => {
-            if ((e.key === 'Enter' || e.key === ' ')) {
-              e.preventDefault();
-              goToPrevSlide(true);
-              setAutoplay(false);
-            }
           }}
           // translators: %s: slide header
           aria-label={sprintf(__('Go to previous slide %s', 'planet4-master-theme'), slides[currentSlide - 1] && slides[currentSlide - 1].header ? slides[currentSlide - 1].header : slides[slides.length - 1].header)}
@@ -90,16 +78,10 @@ export const CarouselControls = forwardRef(({
         </button>
         <button
           className="carousel-control-next"
-          onClick={() => {
-            goToNextSlide();
+          onClick={e => {
+            // eslint-disable-next-line @wordpress/no-global-active-element
+            goToNextSlide(e.target === document.activeElement);
             setAutoplay(false);
-          }}
-          onKeyDown={e => {
-            if ((e.key === 'Enter' || e.key === ' ')) {
-              e.preventDefault();
-              goToNextSlide(true);
-              setAutoplay(false);
-            }
           }}
           // translators: %s: slide header
           aria-label={sprintf(__('Go to next slide %s', 'planet4-master-theme'), slides[currentSlide + 1] && slides[currentSlide + 1].header ? slides[currentSlide + 1].header : slides[0].header)}

--- a/assets/src/js/query_loop_carousel.js
+++ b/assets/src/js/query_loop_carousel.js
@@ -203,8 +203,7 @@ export const setupQueryLoopCarousel = () => {
           // Also update the aria-live text so that the screen reader announces the slide change.
           const indicatorButtons = layout.querySelectorAll('.carousel-indicators li');
           [...carouselButtons, ...indicatorButtons].forEach(button => {
-            button.addEventListener('click', () => {
-
+            button.addEventListener('click', e => {
               const observer = new MutationObserver(() => {
                 const currentSlide = layout.querySelector('.carousel-item.active');
                 const match = currentSlide.className.match(/carousel-slide-(\d+)/);
@@ -222,13 +221,17 @@ export const setupQueryLoopCarousel = () => {
 
                 if (!currentSlide) {return;}
 
-                const focusTarget = currentSlide.querySelector('a');
+                // This means that it's a tabbing event and not a click,
+                // therefore we need to move the focus to the first item.
+                if (e.target === layout.ownerDocument.activeElement) {
+                  const focusTarget = currentSlide.querySelector('a');
 
-                if (focusTarget) {
-                  focusTarget.focus();
-                } else {
-                  currentSlide.setAttribute('tabindex', '-1');
-                  currentSlide.focus();
+                  if (focusTarget) {
+                    focusTarget.focus();
+                  } else {
+                    currentSlide.setAttribute('tabindex', '-1');
+                    currentSlide.focus();
+                  }
                 }
 
                 observer.disconnect();


### PR DESCRIPTION
### Summary

When clicking on the arrows, the focus should not move. It should only happen when tabbing. This is a similar issue to what we recently solved for the Carousel Header [here](https://github.com/greenpeace/planet4-master-theme/pull/2991).

### Testing

Add an Actions List block to a page, with the carousel layout. Make sure that the focus only moves to the first item when tabbing on the arrows, but not when clicking on them.

<img width="348" height="524" alt="Screenshot 2026-05-28 at 17 39 41" src="https://github.com/user-attachments/assets/54d07fbf-04da-4742-bb19-4542542f3747" />
