### PR TITLE
PLANET-8005: Prevent screen reader announcemnts on autoplay

### DIFF
--- a/assets/src/blocks/CarouselHeader/CarouselControls.js
+++ b/assets/src/blocks/CarouselHeader/CarouselControls.js
@@ -55,8 +55,13 @@ export const CarouselControls = forwardRef(({
                       }
                     }}
                     tabIndex={0}
-                    // translators: %s: slide header or fallback slide number
-                    aria-label={sprintf(__('Go to %s', 'planet4-master-theme'),slides[index].header || sprintf(__('slide %d', 'planet4-master-theme'), index + 1))}
+                    aria-label={sprintf(
+                      // translators: %S: slide header
+                      __('Go to %s', 'planet4-master-theme'), slides[index].header ||
+                      sprintf(
+                        // translators: %d: slide number
+                        __('slide %d', 'planet4-master-theme'), index + 1)
+                    )}
                   />
                 </li>
               )

--- a/assets/src/blocks/CarouselHeader/CarouselControls.js
+++ b/assets/src/blocks/CarouselHeader/CarouselControls.js
@@ -53,7 +53,7 @@ export const CarouselControls = forwardRef(({
                     tabIndex={0}
                     // translators: %s: slide header
                     aria-label={sprintf(__('Go to %s slide', 'planet4-master-theme'), slides[index].header)}
-                    aria-current={index === currentSlide ? 'true' : undefined}
+                    aria-current={index === currentSlide && !autoplay ? 'true' : undefined}
                   />
                 </li>
               )

--- a/assets/src/blocks/CarouselHeader/CarouselControls.js
+++ b/assets/src/blocks/CarouselHeader/CarouselControls.js
@@ -98,7 +98,7 @@ export const CarouselControls = forwardRef(({
       </nav>
 
       {/* This will help screen readers to announce the current slide */}
-      {autoplay && (
+      {!autoplay && (
         <div aria-live="polite" aria-atomic="true" className="visually-hidden">
           {
             // translators: %s: slide number

--- a/assets/src/blocks/CarouselHeader/CarouselControls.js
+++ b/assets/src/blocks/CarouselHeader/CarouselControls.js
@@ -44,6 +44,7 @@ export const CarouselControls = forwardRef(({
                 >
                   <button
                     onClick={e => {
+                      setAutoplay(false);
                       if (index !== currentSlide) {
                         // eslint-disable-next-line @wordpress/no-global-active-element
                         goToSlide({newSlide: index, fromTab: e.target === document.activeElement});
@@ -51,6 +52,7 @@ export const CarouselControls = forwardRef(({
                     }}
                     tabIndex={0}
                     onKeyDown={e => {
+                      setAutoplay(false);
                       if ((e.key === 'Enter' || e.key === ' ') && index !== currentSlide) {
                         e.preventDefault();
                         goToSlide({newSlide: index, fromTab: true});

--- a/assets/src/blocks/CarouselHeader/CarouselControls.js
+++ b/assets/src/blocks/CarouselHeader/CarouselControls.js
@@ -97,7 +97,13 @@ export const CarouselControls = forwardRef(({
           <span className="visually-hidden">{__('Next', 'planet4-master-theme')}</span>
         </button>
       </nav>
-
+      {/* This will help screen readers to announce the current slide */}
+      <div aria-live="polite" aria-atomic="true" className="visually-hidden">
+        {
+          // translators: %s: slide number
+          sprintf(__('Slide %s', 'planet4-master-theme'), currentSlide + 1)
+        }
+      </div>
     </>
   ), [
     currentSlide,

--- a/assets/src/blocks/CarouselHeader/CarouselControls.js
+++ b/assets/src/blocks/CarouselHeader/CarouselControls.js
@@ -47,7 +47,6 @@ export const CarouselControls = forwardRef(({
                       if (index !== currentSlide) {
                         // eslint-disable-next-line @wordpress/no-global-active-element
                         goToSlide({newSlide: index, fromTab: e.target === document.activeElement});
-                        setAutoplay(false);
                       }
                     }}
                     tabIndex={0}
@@ -55,12 +54,10 @@ export const CarouselControls = forwardRef(({
                       if ((e.key === 'Enter' || e.key === ' ') && index !== currentSlide) {
                         e.preventDefault();
                         goToSlide({newSlide: index, fromTab: true});
-                        setAutoplay(false);
                       }
                     }}
                     // translators: %s: slide header or fallback slide number
                     aria-label={sprintf(__('Go to %s', 'planet4-master-theme'),slides[index].header || sprintf(__('slide %d', 'planet4-master-theme'), index + 1))}
-                    aria-current={index === currentSlide && !autoplay ? 'true' : undefined}
                   />
                 </li>
               )
@@ -97,13 +94,16 @@ export const CarouselControls = forwardRef(({
           <span className="visually-hidden">{__('Next', 'planet4-master-theme')}</span>
         </button>
       </nav>
+
       {/* This will help screen readers to announce the current slide */}
-      <div aria-live="polite" aria-atomic="true" className="visually-hidden">
-        {
-          // translators: %s: slide number
-          sprintf(__('Slide %s', 'planet4-master-theme'), currentSlide + 1)
-        }
-      </div>
+      {autoplay && (
+        <div aria-live="polite" aria-atomic="true" className="visually-hidden">
+          {
+            // translators: %s: slide number
+            sprintf(__('Slide %s', 'planet4-master-theme'), currentSlide + 1)
+          }
+        </div>
+      )}
     </>
   ), [
     currentSlide,

--- a/assets/src/blocks/CarouselHeader/CarouselControls.js
+++ b/assets/src/blocks/CarouselHeader/CarouselControls.js
@@ -99,7 +99,7 @@ export const CarouselControls = forwardRef(({
         <div aria-live="polite" aria-atomic="true" className="visually-hidden">
           {
             // translators: %s: slide number
-            sprintf(__('Slide %s', 'planet4-master-theme'), currentSlide + 1)
+            sprintf(__('Slide %d', 'planet4-master-theme'), currentSlide + 1)
           }
         </div>
       )}

--- a/assets/src/blocks/CarouselHeader/CarouselControls.js
+++ b/assets/src/blocks/CarouselHeader/CarouselControls.js
@@ -98,7 +98,7 @@ export const CarouselControls = forwardRef(({
       {!autoplay && (
         <div aria-live="polite" aria-atomic="true" className="visually-hidden">
           {
-            // translators: %s: slide number
+            // translators: %d: slide number
             sprintf(__('Slide %d', 'planet4-master-theme'), currentSlide + 1)
           }
         </div>

--- a/assets/src/blocks/CarouselHeader/CarouselControls.js
+++ b/assets/src/blocks/CarouselHeader/CarouselControls.js
@@ -56,7 +56,7 @@ export const CarouselControls = forwardRef(({
                     }}
                     tabIndex={0}
                     aria-label={sprintf(
-                      // translators: %S: slide header
+                      // translators: %s: slide header
                       __('Go to %s', 'planet4-master-theme'), slides[index].header ||
                       sprintf(
                         // translators: %d: slide number

--- a/assets/src/blocks/CarouselHeader/CarouselControls.js
+++ b/assets/src/blocks/CarouselHeader/CarouselControls.js
@@ -51,8 +51,15 @@ export const CarouselControls = forwardRef(({
                       }
                     }}
                     tabIndex={0}
-                    // translators: %s: slide header
-                    aria-label={sprintf(__('Go to %s slide', 'planet4-master-theme'), slides[index].header)}
+                    onKeyDown={e => {
+                      if ((e.key === 'Enter' || e.key === ' ') && index !== currentSlide) {
+                        e.preventDefault();
+                        goToSlide({newSlide: index, fromTab: true});
+                        setAutoplay(false);
+                      }
+                    }}
+                    // translators: %s: slide header or fallback slide number
+                    aria-label={sprintf(__('Go to %s', 'planet4-master-theme'),slides[index].header || sprintf(__('slide %d', 'planet4-master-theme'), index + 1))}
                     aria-current={index === currentSlide && !autoplay ? 'true' : undefined}
                   />
                 </li>

--- a/assets/src/blocks/CarouselHeader/CarouselControls.js
+++ b/assets/src/blocks/CarouselHeader/CarouselControls.js
@@ -45,19 +45,16 @@ export const CarouselControls = forwardRef(({
                   <button
                     onClick={e => {
                       setAutoplay(false);
+                      // eslint-disable-next-line @wordpress/no-global-active-element
+                      if (e.target === document.activeElement) {
+                        e.preventDefault();
+                      }
                       if (index !== currentSlide) {
                         // eslint-disable-next-line @wordpress/no-global-active-element
                         goToSlide({newSlide: index, fromTab: e.target === document.activeElement});
                       }
                     }}
                     tabIndex={0}
-                    onKeyDown={e => {
-                      setAutoplay(false);
-                      if ((e.key === 'Enter' || e.key === ' ') && index !== currentSlide) {
-                        e.preventDefault();
-                        goToSlide({newSlide: index, fromTab: true});
-                      }
-                    }}
                     // translators: %s: slide header or fallback slide number
                     aria-label={sprintf(__('Go to %s', 'planet4-master-theme'),slides[index].header || sprintf(__('slide %d', 'planet4-master-theme'), index + 1))}
                   />

--- a/assets/src/blocks/CarouselHeader/CarouselHeaderEditor.js
+++ b/assets/src/blocks/CarouselHeader/CarouselHeaderEditor.js
@@ -19,7 +19,7 @@ export const CarouselHeaderEditor = ({setAttributes, attributes}) => {
   const {carousel_autoplay, slides, className} = attributes;
   const slidesRef = useRef([]);
 
-  const {currentSlide, goToSlide, goToNextSlide, goToPrevSlide, autoplay} = useSlides(slidesRef, slides.length);
+  const {currentSlide, goToSlide, goToNextSlide, goToPrevSlide, autoplay, setAutoplay, handleAutoplay, indicatorsRef} = useSlides(slidesRef, slides.length);
 
   const changeSlideAttribute = useCallback((slideAttributeName, index) => value => {
     const newSlides = JSON.parse(JSON.stringify(slides));
@@ -132,13 +132,16 @@ export const CarouselHeaderEditor = ({setAttributes, attributes}) => {
           ))}
           {(slides.length > 1) && (
             <CarouselControls
-              goToPrevSlide={() => goToPrevSlide(autoplay)}
-              goToNextSlide={() => goToNextSlide(autoplay)}
+              goToPrevSlide={goToPrevSlide}
+              goToNextSlide={goToNextSlide}
+              setAutoplay={setAutoplay}
               goToSlide={goToSlide}
+              handleAutoplay={handleAutoplay}
               slides={slides}
               currentSlide={currentSlide}
               autoplay={autoplay}
-              disableControls={carousel_autoplay}
+              autoplayToggle={carousel_autoplay}
+              ref={indicatorsRef}
             />
           )}
         </ul>
@@ -161,5 +164,8 @@ export const CarouselHeaderEditor = ({setAttributes, attributes}) => {
     changeSlideImage,
     removeSlide,
     updateCurrentImageIndex,
+    setAutoplay,
+    indicatorsRef,
+    handleAutoplay,
   ]);
 };

--- a/assets/src/blocks/CarouselHeader/CarouselHeaderFrontend.js
+++ b/assets/src/blocks/CarouselHeader/CarouselHeaderFrontend.js
@@ -29,6 +29,8 @@ export const CarouselHeaderFrontend = ({slides, carousel_autoplay, className, de
       ref={containerRef}
       aria-label={__('Greenpeace highlights', 'planet4-blocks')}
       aria-roledescription="carousel"
+      onFocus={() => setAutoplay(false)}
+      onTouchStart={() => setAutoplay(false)}
     >
       {(slides.length > 1) ? (
         <CarouselControls

--- a/assets/src/blocks/CarouselHeader/CarouselHeaderFrontend.js
+++ b/assets/src/blocks/CarouselHeader/CarouselHeaderFrontend.js
@@ -20,6 +20,7 @@ export const CarouselHeaderFrontend = ({slides, carousel_autoplay, className, de
     handleAutoplay,
     setAutoplay,
     autoplay,
+    handleUserInteraction,
   } = useSlides(slidesRef, slides.length, containerRef, carousel_autoplay, headingsRef, indicatorsRef);
 
   return useMemo(() => (
@@ -50,6 +51,7 @@ export const CarouselHeaderFrontend = ({slides, carousel_autoplay, className, de
             active={currentSlide === index}
             focusable={currentSlide === index}
             ref={element => slidesRef ? slidesRef.current[index] = element : null}
+            handleUserInteraction={handleUserInteraction}
           >
             <SlideBackground decoding={decoding} slide={slide} />
             <StaticCaption slide={slide} focusable={currentSlide === index} />
@@ -70,5 +72,6 @@ export const CarouselHeaderFrontend = ({slides, carousel_autoplay, className, de
     goToSlide,
     goToPrevSlide,
     goToNextSlide,
+    handleUserInteraction,
   ]);
 };

--- a/assets/src/blocks/CarouselHeader/Slide.js
+++ b/assets/src/blocks/CarouselHeader/Slide.js
@@ -4,6 +4,7 @@ export const SlideWithRef = ({
   children,
   active,
   focusable,
+  handleUserInteraction,
 }, ref) => useMemo(() => (
   <li
     className={`carousel-item ${active ? 'active' : ''}`}
@@ -13,11 +14,16 @@ export const SlideWithRef = ({
     ref={ref}
     role="tabpanel"
     alt=""
+    onFocus={evt => {
+      evt.preventDefault();
+      evt.stopPropagation();
+      handleUserInteraction();
+    }}
   >
     <div className="carousel-item-mask">
       {children}
     </div>
   </li>
-), [children, active, focusable, ref]);
+), [children, active, focusable, handleUserInteraction, ref]);
 
 export const Slide = forwardRef(SlideWithRef);

--- a/assets/src/blocks/CarouselHeader/Slide.js
+++ b/assets/src/blocks/CarouselHeader/Slide.js
@@ -9,6 +9,7 @@ export const SlideWithRef = ({
     className={`carousel-item ${active ? 'active' : ''}`}
     tabIndex={focusable ? 0 : -1}
     aria-hidden={focusable ? 'false' : 'true'}
+    aria-current={active ? 'true' : 'false'}
     ref={ref}
     role="tabpanel"
     alt=""

--- a/assets/src/blocks/CarouselHeader/Slide.js
+++ b/assets/src/blocks/CarouselHeader/Slide.js
@@ -10,7 +10,6 @@ export const SlideWithRef = ({
     className={`carousel-item ${active ? 'active' : ''}`}
     tabIndex={focusable ? 0 : -1}
     aria-hidden={focusable ? 'false' : 'true'}
-    aria-current={active ? 'true' : 'false'}
     ref={ref}
     role="tabpanel"
     alt=""

--- a/assets/src/blocks/CarouselHeader/useSlides.js
+++ b/assets/src/blocks/CarouselHeader/useSlides.js
@@ -53,6 +53,12 @@ export const useSlides = (
     },
   };
 
+  const stopAutoplay = useCallback(() => {
+    if (autoplay) {
+      setAutoplay(false);
+    }
+  }, [autoplay]);
+
   const handleAutoplay = useCallback(() => {
     if (isIntersecting) {
       setAutoplay(!autoplay);
@@ -208,6 +214,25 @@ export const useSlides = (
 
     return () => window.removeEventListener('resize', () => setCarouselHeight(currentSlideRef));
   }, [currentSlide, setCarouselHeight, containerRef, slidesRef]);
+
+  useEffect(() => {
+    if (!containerRef || !containerRef.current) {
+      return;
+    }
+
+    const carouselRef = containerRef.current;
+    const handleUserInteraction = () => stopAutoplay();
+
+    carouselRef.addEventListener('pointerdown', handleUserInteraction);
+    carouselRef.addEventListener('touchstart', handleUserInteraction, {passive: true});
+    carouselRef.addEventListener('focusin', handleUserInteraction);
+
+    return () => {
+      carouselRef.removeEventListener('pointerdown', handleUserInteraction);
+      carouselRef.removeEventListener('touchstart', handleUserInteraction);
+      carouselRef.removeEventListener('focusin', handleUserInteraction);
+    };
+  }, [containerRef, stopAutoplay]);
 
   useEffect(() => {
     if (autoplay && totalSlides > 1 && isIntersecting) {

--- a/assets/src/blocks/CarouselHeader/useSlides.js
+++ b/assets/src/blocks/CarouselHeader/useSlides.js
@@ -34,7 +34,7 @@ export const useSlides = (
   const [autoplay, setAutoplay] = useState(carousel_autoplay);
   const [currentSlide, setCurrentSlide] = useState(0);
   const [sliding, setSliding] = useState(false);
-  const [isIntersecting, setIsIntersecting] = useState(false);
+  const [isIntersecting, setIsIntersecting] = useState();
   // Set up the autoplay for the slides
   const timerRef = useRef(null);
 
@@ -53,17 +53,13 @@ export const useSlides = (
     },
   };
 
-  const stopAutoplay = useCallback(() => {
-    if (autoplay) {
-      setAutoplay(false);
-    }
+  const handleAutoplay = useCallback(() => {
+    setAutoplay(!autoplay);
   }, [autoplay]);
 
-  const handleAutoplay = useCallback(() => {
-    if (isIntersecting) {
-      setAutoplay(!autoplay);
-    }
-  }, [autoplay, isIntersecting]);
+  const handleUserInteraction = useCallback(() => {
+    setAutoplay(false);
+  }, []);
 
   const getOrder = useCallback(newSlide => {
     let order = newSlide < currentSlide ? 'prev' : 'next';
@@ -138,12 +134,8 @@ export const useSlides = (
   }, [indicatorsRef]);
 
   const goToSlide = useCallback(({newSlide, forceCurrentSlide = false, fromTab = false}) => {
-    if (!slidesRef.current) {
+    if (!slidesRef.current || !isIntersecting) {
       return;
-    }
-
-    if(fromTab) {
-      stopAutoplay();
     }
 
     const nextElement = slidesRef.current[newSlide];
@@ -192,7 +184,7 @@ export const useSlides = (
         unsetTransitionClasses();
       }
     }
-  }, [currentSlide, getOrder, options, sliding, setCarouselHeight, slidesRef, onkeyboardHandler, stopAutoplay]);
+  }, [currentSlide, getOrder, options, sliding, setCarouselHeight, slidesRef, onkeyboardHandler, isIntersecting]);
 
   const goToPrevSlide = useCallback((fromTab = false) => {
     goToSlide({newSlide: (currentSlide - 1 < 0) ? totalSlides - 1 : currentSlide - 1, fromTab});
@@ -225,21 +217,16 @@ export const useSlides = (
     }
 
     const carouselRef = containerRef.current;
-    const handleUserInteraction = () => stopAutoplay();
 
-    carouselRef.addEventListener('pointerdown', handleUserInteraction);
     carouselRef.addEventListener('touchstart', handleUserInteraction, {passive: true});
-    carouselRef.addEventListener('focusin', handleUserInteraction);
 
     return () => {
-      carouselRef.removeEventListener('pointerdown', handleUserInteraction);
       carouselRef.removeEventListener('touchstart', handleUserInteraction);
-      carouselRef.removeEventListener('focusin', handleUserInteraction);
     };
-  }, [containerRef, stopAutoplay]);
+  }, [containerRef, handleUserInteraction]);
 
   useEffect(() => {
-    if (autoplay && totalSlides > 1 && isIntersecting) {
+    if (autoplay && totalSlides > 1) {
       if (timerRef.current) {
         clearTimeout(timerRef.current);
       }
@@ -248,7 +235,7 @@ export const useSlides = (
     } else if (timerRef.current) {
       clearTimeout(timerRef.current);
     }
-  }, [totalSlides, autoplay, timerRef, goToNextSlide, isIntersecting]);
+  }, [totalSlides, autoplay, timerRef, goToNextSlide]);
 
   useEffect(() => {
     if (!containerRef?.current || !carousel_autoplay) {
@@ -286,5 +273,6 @@ export const useSlides = (
     headingsRef,
     indicatorsRef,
     isIntersecting,
+    handleUserInteraction,
   };
 };

--- a/assets/src/blocks/CarouselHeader/useSlides.js
+++ b/assets/src/blocks/CarouselHeader/useSlides.js
@@ -204,26 +204,10 @@ export const useSlides = (
     const currentSlideRef = slidesRef.current[currentSlide];
     if (currentSlideRef) {
       setCarouselHeight(currentSlideRef);
-
       window.addEventListener('resize', () => setCarouselHeight(currentSlideRef));
     }
-
     return () => window.removeEventListener('resize', () => setCarouselHeight(currentSlideRef));
   }, [currentSlide, setCarouselHeight, containerRef, slidesRef]);
-
-  useEffect(() => {
-    if (!containerRef || !containerRef.current) {
-      return;
-    }
-
-    const carouselRef = containerRef.current;
-
-    carouselRef.addEventListener('touchstart', handleUserInteraction, {passive: true});
-
-    return () => {
-      carouselRef.removeEventListener('touchstart', handleUserInteraction);
-    };
-  }, [containerRef, handleUserInteraction]);
 
   useEffect(() => {
     if (autoplay && totalSlides > 1) {

--- a/assets/src/blocks/CarouselHeader/useSlides.js
+++ b/assets/src/blocks/CarouselHeader/useSlides.js
@@ -34,7 +34,7 @@ export const useSlides = (
   const [autoplay, setAutoplay] = useState(carousel_autoplay);
   const [currentSlide, setCurrentSlide] = useState(0);
   const [sliding, setSliding] = useState(false);
-  const [isIntersecting, setIsIntersecting] = useState();
+  const [isIntersecting, setIsIntersecting] = useState(true);
   // Set up the autoplay for the slides
   const timerRef = useRef(null);
 

--- a/assets/src/blocks/CarouselHeader/useSlides.js
+++ b/assets/src/blocks/CarouselHeader/useSlides.js
@@ -142,6 +142,10 @@ export const useSlides = (
       return;
     }
 
+    if(fromTab) {
+      stopAutoplay();
+    }
+
     const nextElement = slidesRef.current[newSlide];
     const activeElement = slidesRef.current[currentSlide];
 
@@ -188,7 +192,7 @@ export const useSlides = (
         unsetTransitionClasses();
       }
     }
-  }, [currentSlide, getOrder, options, sliding, setCarouselHeight, slidesRef, onkeyboardHandler]);
+  }, [currentSlide, getOrder, options, sliding, setCarouselHeight, slidesRef, onkeyboardHandler, stopAutoplay]);
 
   const goToPrevSlide = useCallback((fromTab = false) => {
     goToSlide({newSlide: (currentSlide - 1 < 0) ? totalSlides - 1 : currentSlide - 1, fromTab});


### PR DESCRIPTION
### Summary
We might need to prevent screen readers to announce current slide information without the user interaction. It causes confusion for end-to-end user ONLY on Mobile.

Demo page: https://www-dev.greenpeace.org/test-deimos/test/

---

<!-- Please add a reference link to the ticket, if one exists. -->
Ref: https://greenpeace-planet4.atlassian.net/browse/PLANET-8005

### Testing
**USE A SCREEN READER FOR TESTING**
<!-- Please add the steps required to test the changes in this Pull Request. -->
1. Create a new page
2. Insert a new Carousel Header Block with at least 3 slides.
3. Enabled the `autoplay` feature
4. Save

Or use an existing Carousel but remember to enable the `autoplay` feature.


