### PR TITLE
Write an e2e test for the Actions List block manual override

### DIFF
--- a/tests/e2e/blocks/actions-list.spec.js
+++ b/tests/e2e/blocks/actions-list.spec.js
@@ -33,8 +33,8 @@ test.describe('Test Actions List block', () => {
     await admin.visitAdminPage('admin.php', 'page=planet4_settings_analytics');
     const takeActionPageId = await page.locator('#take_action_page').inputValue();
 
-    // Skip Test if the new IA is not enabled or if the "Take Action" page ID is not available.
-    test.skip(!isNewIA || !takeActionPageId, 'The new IA must be enabled to run this test.');
+    // Skip Test if the new IA is not enabled or if the "Take Action" page ID is not available or gotten from the Analytics settings.
+    test.skip(!isNewIA || !takeActionPageId, 'The new IA must be enabled or the "Take Action" page ID must be available to run this test.');
 
     // Create 2 actions to be selected via the Manual Override.
     const regularActionTitles = [
@@ -64,13 +64,13 @@ test.describe('Test Actions List block', () => {
       });
     }
 
-    // Combine all action titles if needed downstream.
+    // Combine all action titles.
     const actionTitles = [...regularActionTitles, ...childActionTitles];
 
     // Create a page to hold the Actions List block.
     await createPostWithFeaturedImage({page, admin, editor}, {title: 'Test Actions List, Manual Override', postType: 'page'});
 
-    // Add a Actions List block using the Manual Override to select the 2 actions created above.
+    // Add a Actions List block using the Manual Override to select the actions created above.
     await addActionsListBlockWithManualOverride(page, actionTitles);
 
     // Publish page.

--- a/tests/e2e/blocks/actions-list.spec.js
+++ b/tests/e2e/blocks/actions-list.spec.js
@@ -1,9 +1,11 @@
-import {test, expect} from '../tools/lib/test-utils.js';
+import {test} from '../tools/lib/test-utils.js';
 import {publishPostAndVisit, createPostWithFeaturedImage} from '../tools/lib/post.js';
-import {searchAndInsertBlock} from '../tools/lib/editor';
-
-const TEST_TITLE = 'Campaigns';
-const TEST_CATEGORY = 'Energy';
+import {
+  addActionsListBlock,
+  checkActionsListBlock,
+  addActionsListBlockWithManualOverride,
+  checkActionsListBlockWithManualOverride,
+} from '../tools/lib/actions-list.js';
 
 test.useAdminLoggedIn();
 
@@ -14,36 +16,65 @@ test.describe('Test Actions List block', () => {
     await createPostWithFeaturedImage({page, admin, editor}, {title: 'Test Actions List Grid Layout', postType: 'page'});
 
     // Add Actions List block.
-    await searchAndInsertBlock({page}, 'Actions List');
-
-    // Set Actions per page to 2.
-    await page.getByRole('spinbutton', {name: 'Items per page'}).fill('2');
-
-    // Filter by "Energy" category.
-    const editorSettings = page.getByRole('region', {name: 'Editor settings'});
-    await editorSettings.getByRole('button', {name: 'Filters options'}).click();
-    await page.getByLabel('Show Taxonomies').click();
-    await editorSettings.getByLabel('Categories').fill(TEST_CATEGORY);
-    await editorSettings.locator(
-      '.components-form-token-field__suggestion', {hasText: TEST_CATEGORY}
-    ).click();
-    await expect(editorSettings.locator(
-      '.components-form-token-field__token-text', {hasText: TEST_CATEGORY})
-    ).toBeVisible();
-
-    // Change the title.
-    await page.getByRole('document', {name: 'Block: Heading'}).fill(TEST_TITLE);
+    await addActionsListBlock(page);
 
     // Publish page.
     await publishPostAndVisit({page, editor});
 
-    // Test that the block is displayed as expected in the frontend.
-    const block = page.locator('.p4-query-loop');
-    await expect(block).toHaveClass(/is-custom-layout-grid/);
-    await expect(block.locator('h2.wp-block-heading')).toHaveText(TEST_TITLE);
-    await expect(block.locator('.wp-block-post')).toHaveCount(2);
-    for (const category of await block.locator('.wp-block-post-terms').all()) {
-      await expect(category).toHaveText(TEST_CATEGORY);
+    // Check the Actions List block.
+    await checkActionsListBlock(page);
+  });
+
+  test('Test the Manual Override', async ({page, admin, editor, requestUtils}) => {
+    // Fetch the "Take Action" parent page ID
+    const takeActionPages = await requestUtils.rest({
+      path: '/wp/v2/pages',
+      method: 'GET',
+      params: {slug: 'take-action'},
+    });
+    const takeActionPageId = takeActionPages[0].id;
+
+    // Create 2 actions to be selected via the Manual Override.
+    const regularActionTitles = [
+      'Test Actions List Manual Override Action 1',
+      'Test Actions List Manual Override Action 2',
+    ];
+
+    for (const title of regularActionTitles) {
+      await requestUtils.rest({
+        path: '/wp/v2/p4_action',
+        method: 'POST',
+        data: {title, status: 'publish'},
+      });
     }
+
+    // Create 2 actions as children of the "Take Action" page.
+    const childActionTitles = [
+      'Test Actions List Manual Override Child Action 1',
+      'Test Actions List Manual Override Child Action 2',
+    ];
+
+    for (const title of childActionTitles) {
+      await requestUtils.rest({
+        path: '/wp/v2/p4_action',
+        method: 'POST',
+        data: {title, status: 'publish', parent: takeActionPageId},
+      });
+    }
+
+    // Combine all action titles if needed downstream.
+    const actionTitles = [...regularActionTitles, ...childActionTitles];
+
+    // Create a page to hold the Actions List block.
+    await createPostWithFeaturedImage({page, admin, editor}, {title: 'Test Actions List, Manual Override', postType: 'page'});
+
+    // Add a Actions List block using the Manual Override to select the 2 actions created above.
+    await addActionsListBlockWithManualOverride(page, actionTitles);
+
+    // Publish page.
+    await publishPostAndVisit({page, editor});
+
+    // Check that the block displays correctly in the frontend.
+    await checkActionsListBlockWithManualOverride(page, actionTitles);
   });
 });

--- a/tests/e2e/blocks/actions-list.spec.js
+++ b/tests/e2e/blocks/actions-list.spec.js
@@ -6,6 +6,7 @@ import {
   addActionsListBlockWithManualOverride,
   checkActionsListBlockWithManualOverride,
 } from '../tools/lib/actions-list.js';
+import {isNewIAEnabled} from '../tools/lib/check-new-ia.js';
 
 test.useAdminLoggedIn();
 
@@ -26,13 +27,14 @@ test.describe('Test Actions List block', () => {
   });
 
   test('Test the Manual Override', async ({page, admin, editor, requestUtils}) => {
-    // Fetch the "Take Action" parent page ID
-    const takeActionPages = await requestUtils.rest({
-      path: '/wp/v2/pages',
-      method: 'GET',
-      params: {slug: 'take-action'},
-    });
-    const takeActionPageId = takeActionPages[0].id;
+    const isNewIA = await isNewIAEnabled(admin, page);
+
+    // Get the "Take Action" page ID from the Analytics settings.
+    await admin.visitAdminPage('admin.php', 'page=planet4_settings_analytics');
+    const takeActionPageId = await page.locator('#take_action_page').inputValue();
+
+    // Skip Test if the new IA is not enabled or if the "Take Action" page ID is not available.
+    test.skip(!isNewIA || !takeActionPageId, 'The new IA must be enabled to run this test.');
 
     // Create 2 actions to be selected via the Manual Override.
     const regularActionTitles = [

--- a/tests/e2e/special-pages.spec.js
+++ b/tests/e2e/special-pages.spec.js
@@ -1,13 +1,12 @@
 import {test, expect} from './tools/lib/test-utils.js';
+import {isNewIAEnabled} from './tools/lib/check-new-ia.js';
 
 test.useAdminLoggedIn();
 
 test('Test special pages (Act and Explore)', async ({page, admin, requestUtils}) => {
   // Check if new IA is enabled, in which case the Act and Explore pages have been removed.
-  await admin.visitAdminPage('admin.php', 'page=planet4_settings_navigation');
-  await page.waitForSelector('#new_ia');
-  const isNewIAEnabled = await page.locator('#new_ia').isChecked();
-  if (isNewIAEnabled) {
+  const isNewIA = await isNewIAEnabled(admin, page);
+  if (isNewIA) {
     await expect(page.locator('#act_page')).toBeHidden();
     await expect(page.locator('#explore_page')).toBeHidden();
   } else {

--- a/tests/e2e/tools/lib/actions-list.js
+++ b/tests/e2e/tools/lib/actions-list.js
@@ -1,0 +1,32 @@
+import {addListBlock, addListBlockWithManualOverride, checkListBlock} from './query-loop-utils.js';
+
+const BLOCK_NAME = 'Actions List';
+const TEST_TITLE = 'Campaigns';
+const TEST_CATEGORY = 'Energy';
+const MANUAL_OVERRIDE_TITLE = 'Actions';
+
+export async function addActionsListBlock(page, layout) {
+  await addListBlock(page, BLOCK_NAME, 2, {layout, category: TEST_CATEGORY, title: TEST_TITLE});
+}
+
+export async function addActionsListBlockWithManualOverride(page, actionTitles) {
+  await addListBlockWithManualOverride(page, BLOCK_NAME, actionTitles, MANUAL_OVERRIDE_TITLE);
+}
+
+export async function checkActionsListBlock(page) {
+  await checkListBlock(page, {
+    layout: 'grid',
+    title: TEST_TITLE,
+    count: 2,
+    category: TEST_CATEGORY,
+  });
+}
+
+export async function checkActionsListBlockWithManualOverride(page, actionTitles) {
+  await checkListBlock(page, {
+    layout: 'grid',
+    title: MANUAL_OVERRIDE_TITLE,
+    count: actionTitles.length,
+    postTitles: actionTitles,
+  });
+}

--- a/tests/e2e/tools/lib/actions-list.js
+++ b/tests/e2e/tools/lib/actions-list.js
@@ -5,14 +5,32 @@ const TEST_TITLE = 'Campaigns';
 const TEST_CATEGORY = 'Energy';
 const MANUAL_OVERRIDE_TITLE = 'Actions';
 
+/**
+ * Adds the Actions List block to the page.
+ *
+ * @param {import('@playwright/test').Page} page   - The Playwright page instance.
+ * @param {string}                          layout - The layout of the block.
+ */
 export async function addActionsListBlock(page, layout) {
   await addListBlock(page, BLOCK_NAME, 2, {layout, category: TEST_CATEGORY, title: TEST_TITLE});
 }
 
+/**
+ * Adds the Actions List block to the page with the Manual Override posts selected.
+ *
+ * @param {import('@playwright/test').Page} page         - The Playwright page instance.
+ * @param {string[]}                        actionTitles - The titles of the actions to include in the block to override the default ones.
+ */
 export async function addActionsListBlockWithManualOverride(page, actionTitles) {
   await addListBlockWithManualOverride(page, BLOCK_NAME, actionTitles, MANUAL_OVERRIDE_TITLE);
 }
 
+
+/**
+ * Validate the Actions List block tests.
+ *
+ * @param {import('@playwright/test').Page} page - The Playwright page instance.
+ */
 export async function checkActionsListBlock(page) {
   await checkListBlock(page, {
     layout: 'grid',
@@ -22,6 +40,12 @@ export async function checkActionsListBlock(page) {
   });
 }
 
+/**
+ * Validate the Actions List block tests with manual override.
+ *
+ * @param {import('@playwright/test').Page} page         - The Playwright page instance.
+ * @param {string[]}                        actionTitles - The titles of the actions to include in the block to override the default ones.
+ */
 export async function checkActionsListBlockWithManualOverride(page, actionTitles) {
   await checkListBlock(page, {
     layout: 'grid',

--- a/tests/e2e/tools/lib/check-new-ia.js
+++ b/tests/e2e/tools/lib/check-new-ia.js
@@ -1,3 +1,9 @@
+/**
+ * Checks if the new IA is enabled.
+ *
+ * @param {import('@playwright/test').Admin} admin - The Playwright admin instance.
+ * @param {import('@playwright/test').Page}  page  - The Playwright page instance.
+ */
 async function isNewIAEnabled (admin, page) {
   await admin.visitAdminPage('admin.php', 'page=planet4_settings_navigation');
   await page.waitForSelector('#new_ia');

--- a/tests/e2e/tools/lib/check-new-ia.js
+++ b/tests/e2e/tools/lib/check-new-ia.js
@@ -1,0 +1,8 @@
+async function isNewIAEnabled (admin, page) {
+  await admin.visitAdminPage('admin.php', 'page=planet4_settings_navigation');
+  await page.waitForSelector('#new_ia');
+  const isEnabled = await page.locator('#new_ia').isChecked();
+  return isEnabled;
+}
+
+export {isNewIAEnabled};

--- a/tests/e2e/tools/lib/posts-list.js
+++ b/tests/e2e/tools/lib/posts-list.js
@@ -6,14 +6,32 @@ const TEST_TITLE = 'Related Stories';
 const TEST_CATEGORY = 'Energy';
 const MANUAL_OVERRIDE_TITLE = 'Posts';
 
+/**
+ * Adds the Posts List block to the page.
+ *
+ * @param {import('@playwright/test').Page} page   - The Playwright page instance.
+ * @param {string}                          layout - The layout of the block.
+ */
 export async function addPostsListBlock(page, layout) {
   await addListBlock(page, BLOCK_NAME, 4, {layout, category: TEST_CATEGORY, title: TEST_TITLE});
 }
 
+/**
+ * Adds the Posts List block to the page with the Manual Override posts selected.
+ *
+ * @param {import('@playwright/test').Page} page       - The Playwright page instance.
+ * @param {string[]}                        postTitles - The titles of the posts to include in the block to override the default ones.
+ */
 export async function addPostsListBlockWithManualOverride(page, postTitles) {
   await addListBlockWithManualOverride(page, BLOCK_NAME, postTitles, MANUAL_OVERRIDE_TITLE);
 }
 
+/**
+ * Validate the Posts List block tests.
+ *
+ * @param {import('@playwright/test').Page} page   - The Playwright page instance.
+ * @param {string}                          layout - The layout of the block.
+ */
 export async function checkPostsListBlock(page, layout) {
   await checkListBlock(page, {
     layout,
@@ -24,6 +42,12 @@ export async function checkPostsListBlock(page, layout) {
   });
 }
 
+/**
+ * Validate the Posts List block tests with manual override.
+ *
+ * @param {import('@playwright/test').Page} page       - The Playwright page instance.
+ * @param {string[]}                        postTitles - The titles of the posts to include in the block to override the default ones.
+ */
 export async function checkPostsListBlockWithManualOverride(page, postTitles) {
   await checkListBlock(page, {
     layout: 'list',
@@ -33,6 +57,11 @@ export async function checkPostsListBlockWithManualOverride(page, postTitles) {
   });
 }
 
+/**
+ * Validate the Posts List block tests with carousel layout.
+ *
+ * @param {import('@playwright/test').Page} page - The Playwright page instance.
+ */
 export async function checkPostsListBlockCarouselLayout(page) {
   await checkPostsListBlock(page, 'carousel');
 

--- a/tests/e2e/tools/lib/posts-list.js
+++ b/tests/e2e/tools/lib/posts-list.js
@@ -1,95 +1,42 @@
-import {searchAndInsertBlock} from './editor.js';
+import {addListBlock, addListBlockWithManualOverride, checkListBlock} from './query-loop-utils.js';
 import {expect} from './test-utils.js';
 
+const BLOCK_NAME = 'Posts List';
 const TEST_TITLE = 'Related Stories';
 const TEST_CATEGORY = 'Energy';
 const MANUAL_OVERRIDE_TITLE = 'Posts';
 
-async function addPostsListBlock(page, layout) {
-  // Add Posts List block.
-  await searchAndInsertBlock({page}, 'Posts List');
-
-  // Select wanted layout. If none is provided it means we are using the default one which is List.
-  if (layout) {
-    await page.getByRole('radio', {name: layout}).check();
-  }
-
-  // Change amount of posts from 3 to 4.
-  await page.getByRole('spinbutton', {name: 'Items per page'}).fill('4');
-
-  // Filter by "Energy" category.
-  const editorSettings = page.getByRole('region', {name: 'Editor settings'});
-  await editorSettings.getByRole('button', {name: 'Filters options'}).click();
-  await page.getByLabel('Show Taxonomies').click();
-  await editorSettings.getByLabel('Categories').fill(TEST_CATEGORY);
-  await editorSettings.locator(
-    '.components-form-token-field__suggestion', {hasText: TEST_CATEGORY}
-  ).click();
-  await expect(editorSettings.locator(
-    '.components-form-token-field__token-text', {hasText: TEST_CATEGORY})
-  ).toBeVisible();
-
-  // Change the title.
-  await page.getByRole('document', {name: 'Block: Heading'}).fill(TEST_TITLE);
+export async function addPostsListBlock(page, layout) {
+  await addListBlock(page, BLOCK_NAME, 4, {layout, category: TEST_CATEGORY, title: TEST_TITLE});
 }
 
-async function addPostsListBlockWithManualOverride(page, postTitles) {
-  // Add Posts List block (default List layout).
-  await searchAndInsertBlock({page}, 'Posts List');
-
-  // Change amount of posts from 3 to 4.
-  await page.getByRole('spinbutton', {name: 'Items per page'}).fill('4');
-
-  // Expand the "Manual override" panel and select posts.
-  const editorSettings = page.getByRole('region', {name: 'Editor settings'});
-  const manualOverridePanel = editorSettings.getByRole('button', {name: 'Manual override'});
-  if (await manualOverridePanel.getAttribute('aria-expanded') === 'false') {
-    await manualOverridePanel.click();
-  }
-
-  // Select each post via the token field autocomplete.
-  for (const title of postTitles) {
-    await editorSettings.locator('.components-form-token-field__input').fill(title);
-    // Use .first() to guard against duplicate suggestions
-    await editorSettings.locator(
-      '.components-form-token-field__suggestion', {hasText: title}
-    ).first().click();
-    await expect(editorSettings.locator(
-      '.components-form-token-field__token-text', {hasText: title})
-    ).toBeVisible();
-  }
-
-  // Change the block title.
-  await page.getByRole('document', {name: 'Block: Heading'}).fill(MANUAL_OVERRIDE_TITLE);
+export async function addPostsListBlockWithManualOverride(page, postTitles) {
+  await addListBlockWithManualOverride(page, BLOCK_NAME, postTitles, MANUAL_OVERRIDE_TITLE);
 }
 
-async function checkPostsListBlock(page, layout) {
-  // Test that the block is displayed as expected in the frontend.
-  const block = page.locator('.p4-query-loop');
-  await expect(block).toContainClass(`is-custom-layout-${layout}`);
-  await expect(block.locator('h2.wp-block-heading')).toHaveText(TEST_TITLE);
-  await expect(block.locator('.wp-block-post')).toHaveCount(4);
-  for (const category of await block.locator('.wp-block-post-terms:not(.taxonomy-post_tag)').all()) {
-    await expect(category).toHaveText(TEST_CATEGORY);
-  }
+export async function checkPostsListBlock(page, layout) {
+  await checkListBlock(page, {
+    layout,
+    title: TEST_TITLE,
+    count: 4,
+    category: TEST_CATEGORY,
+    categoryLocator: '.wp-block-post-terms:not(.taxonomy-post_tag)',
+  });
 }
 
-async function checkPostsListBlockWithManualOverride(page, postTitles) {
-  const block = page.locator('.p4-query-loop');
-  await expect(block).toContainClass('is-custom-layout-list');
-  await expect(block.locator('h2.wp-block-heading')).toHaveText(MANUAL_OVERRIDE_TITLE);
-  await expect(block.locator('.wp-block-post')).toHaveCount(postTitles.length);
-  for (const title of postTitles) {
-    await expect(block.locator('.wp-block-post-title', {hasText: title})).toBeVisible();
-  }
+export async function checkPostsListBlockWithManualOverride(page, postTitles) {
+  await checkListBlock(page, {
+    layout: 'list',
+    title: MANUAL_OVERRIDE_TITLE,
+    count: postTitles.length,
+    postTitles,
+  });
 }
 
-async function checkPostsListBlockCarouselLayout(page) {
+export async function checkPostsListBlockCarouselLayout(page) {
   await checkPostsListBlock(page, 'carousel');
 
   const block = page.locator('.p4-query-loop');
   await expect(block.locator('.carousel.slide')).toBeVisible();
   await expect(block.locator('.carousel-item.active')).toBeVisible();
 }
-
-export {addPostsListBlock, addPostsListBlockWithManualOverride, checkPostsListBlock, checkPostsListBlockWithManualOverride, checkPostsListBlockCarouselLayout};

--- a/tests/e2e/tools/lib/query-loop-utils.js
+++ b/tests/e2e/tools/lib/query-loop-utils.js
@@ -1,6 +1,14 @@
 import {searchAndInsertBlock} from './editor.js';
 import {expect} from './test-utils.js';
 
+/**
+ * Adds and configures a Query List block in the block editor.
+ *
+ * @param {import('@playwright/test').Page} page         - The Playwright page instance.
+ * @param {string}                          blockName    - The name of the block to search for and insert.
+ * @param {number}                          itemsPerPage - The number of items to display per page.
+ * @param {Object}                          [config={}]  - Optional configuration settings for the block.
+ */
 export async function addListBlock(page, blockName, itemsPerPage, config = {}) {
   await searchAndInsertBlock({page}, blockName);
 
@@ -28,6 +36,14 @@ export async function addListBlock(page, blockName, itemsPerPage, config = {}) {
   }
 }
 
+/**
+ * Updates the existing Query Loop block with a Manual Override to select specific posts and override the default ones.
+ *
+ * @param {import('@playwright/test').Page} page          - The Playwright page instance.
+ * @param {string}                          blockName     - The name of the block to search for and insert.
+ * @param {string[]}                        titles        - New Post titles to override existing ones.
+ * @param {string}                          overrideTitle - New Page title to override the default.
+ */
 export async function addListBlockWithManualOverride(page, blockName, titles, overrideTitle) {
   await searchAndInsertBlock({page}, blockName);
 
@@ -52,6 +68,12 @@ export async function addListBlockWithManualOverride(page, blockName, titles, ov
   await page.getByRole('document', {name: 'Block: Heading'}).fill(overrideTitle);
 }
 
+/**
+ * Validates test expectations for the Query Loop block.
+ *
+ * @param {import('@playwright/test').Page} page        - The Playwright page instance.
+ * @param {Object}                          [config={}] - Optional configuration settings for the block.
+ */
 export async function checkListBlock(page, config = {}) {
   const block = page.locator('.p4-query-loop');
 

--- a/tests/e2e/tools/lib/query-loop-utils.js
+++ b/tests/e2e/tools/lib/query-loop-utils.js
@@ -1,0 +1,78 @@
+import {searchAndInsertBlock} from './editor.js';
+import {expect} from './test-utils.js';
+
+export async function addListBlock(page, blockName, itemsPerPage, config = {}) {
+  await searchAndInsertBlock({page}, blockName);
+
+  if (config.layout) {
+    await page.getByRole('radio', {name: config.layout}).check();
+  }
+
+  await page.getByRole('spinbutton', {name: 'Items per page'}).fill(String(itemsPerPage));
+
+  if (config.category) {
+    const editorSettings = page.getByRole('region', {name: 'Editor settings'});
+    await editorSettings.getByRole('button', {name: 'Filters options'}).click();
+    await page.getByLabel('Show Taxonomies').click();
+    await editorSettings.getByLabel('Categories').fill(config.category);
+    await editorSettings.locator(
+      '.components-form-token-field__suggestion', {hasText: config.category}
+    ).click();
+    await expect(editorSettings.locator(
+      '.components-form-token-field__token-text', {hasText: config.category})
+    ).toBeVisible();
+  }
+
+  if (config.title) {
+    await page.getByRole('document', {name: 'Block: Heading'}).fill(config.title);
+  }
+}
+
+export async function addListBlockWithManualOverride(page, blockName, titles, overrideTitle) {
+  await searchAndInsertBlock({page}, blockName);
+
+  await page.getByRole('spinbutton', {name: 'Items per page'}).fill('4');
+
+  const editorSettings = page.getByRole('region', {name: 'Editor settings'});
+  const manualOverridePanel = editorSettings.getByRole('button', {name: 'Manual override'});
+  if (await manualOverridePanel.getAttribute('aria-expanded') === 'false') {
+    await manualOverridePanel.click();
+  }
+
+  for (const title of titles) {
+    await editorSettings.locator('.components-form-token-field__input').fill(title);
+    await editorSettings.locator(
+      '.components-form-token-field__suggestion', {hasText: title}
+    ).first().click();
+    await expect(editorSettings.locator(
+      '.components-form-token-field__token-text', {hasText: title})
+    ).toBeVisible();
+  }
+
+  await page.getByRole('document', {name: 'Block: Heading'}).fill(overrideTitle);
+}
+
+export async function checkListBlock(page, config = {}) {
+  const block = page.locator('.p4-query-loop');
+
+  if (config.layout) {
+    await expect(block).toContainClass(`is-custom-layout-${config.layout}`);
+  }
+  if (config.title) {
+    await expect(block.locator('h2.wp-block-heading')).toHaveText(config.title);
+  }
+  if (config.count !== undefined) {
+    await expect(block.locator('.wp-block-post')).toHaveCount(config.count);
+  }
+  if (config.category) {
+    const categorySelector = config.categoryLocator ?? '.wp-block-post-terms';
+    for (const category of await block.locator(categorySelector).all()) {
+      await expect(category).toHaveText(config.category);
+    }
+  }
+  if (config.postTitles) {
+    for (const title of config.postTitles) {
+      await expect(block.locator('.wp-block-post-title', {hasText: title})).toBeVisible();
+    }
+  }
+}


### PR DESCRIPTION
### Summary
Expanding Actions List block test scenarios to include manual override.

<!-- Please provide a brief summary of the change introduced in this Pull Request. -->

---

<!-- Please add a reference link to the ticket, if one exists. -->
**Ref: https://greenpeace-planet4.atlassian.net/browse/PLANET-8054**

### Testing

<!-- Please add the steps required to test the changes in this Pull Request. -->
 - Login to the Admin Panel.

 - Create two new Actions.

 - Create two new Pages that are children pages of the designated “Take Action” page.

 - Create a new Page.

 - Add a Actions List block:

    - Pick the Grid layout

   - Use the “Manual Override” to select the two Actions and the two Pages created in previous steps.

   - Change block title to "Campaigns"

 - Publish the page.

 - Navigate to the frontend view of that Page and verify that all of the above properties are working as expected.

   - Block title

   - There are 4 actions displayed

   - Assess the 4 actions are indeed the ones created (eg. by title)
