### PR TITLE
PLANET-8186 Fix create/edit pattern fails with "Featured image is mandatory." error

### DIFF
--- a/assets/src/block-editor/setupBlockEditorValidations.js
+++ b/assets/src/block-editor/setupBlockEditorValidations.js
@@ -21,7 +21,10 @@ export const setupBlockEditorValidations = () => {
  * @return {Object} - An object containing individual validation flags and a combined `isValid` flag.
  */
 const getValidationState = select => {
-  const {getEditedPostAttribute} = select('core/editor');
+  const {getEditedPostAttribute, getCurrentPostType} = select('core/editor');
+  if (getCurrentPostType() === 'wp_block') {
+    return {postTitle: true, featuredImage: true, topicLink: true, isValid: true};
+  }
   const {getBlocks} = select('core/block-editor');
   const postTitle = Boolean(getEditedPostAttribute('title'));
   const featuredImage = Boolean(getEditedPostAttribute('featured_media'));

--- a/assets/src/block-editor/setupBlockEditorValidations.js
+++ b/assets/src/block-editor/setupBlockEditorValidations.js
@@ -22,6 +22,10 @@ export const setupBlockEditorValidations = () => {
  */
 const getValidationState = select => {
   const {getEditedPostAttribute, getCurrentPostType} = select('core/editor');
+  // Reusable blocks / synced patterns are stored as the 'wp_block' post type.
+  // They're design artifacts, not editorial content, so the post-level
+  // requirements (title, featured image, topic link) don't apply. Returning a
+  // fully-valid state stops these checks from blocking pattern create/edit.
   if (getCurrentPostType() === 'wp_block') {
     return {postTitle: true, featuredImage: true, topicLink: true, isValid: true};
   }


### PR DESCRIPTION
### Summary

The custom "Featured image is mandatory" validation is intended to enforce a featured image when publishing **posts** and **pages**. However, it also fires when creating or editing block patterns, blocking the editor with the error even though patterns have no featured image concept.

### Fix

Updated the validation logic for patterns post_type(pattern is stored as wp_block post_type) & allow it without validation checks

---

<!-- Please add a reference link to the ticket, if one exists. -->
Ref: 
https://greenpeace-planet4.atlassian.net/browse/PLANET-8186

### Testing

- Creating a new pattern no longer shows "Featured image is mandatory".
- Editing an existing pattern saves without the error.
- Publishing a post/page with no featured image is still blocked.
- Publishing a post/page with a featured image works as before.