### PR TITLE
Fix unknown `area-label` attribute

### DIFF
--- a/assets/src/blocks/CarouselHeader/Slide.js
+++ b/assets/src/blocks/CarouselHeader/Slide.js
@@ -8,8 +8,7 @@ export const SlideWithRef = ({
   <li
     className={`carousel-item ${active ? 'active' : ''}`}
     tabIndex={focusable ? 0 : -1}
-    // eslint-disable-next-line react/no-unknown-property
-    area-hidden={focusable ? 'false' : 'true'}
+    aria-hidden={focusable ? 'false' : 'true'}
     ref={ref}
     role="tabpanel"
     alt=""


### PR DESCRIPTION
### Summary
The attribute `area-label` should be replaced with `aria-label`. Wrong typo.

<!-- Please add a reference link to the ticket, if one exists. -->
Ref: No ticket needed.

### Testing
No testing needed. Just a typo issue.
