### PR TITLE
PLANET-8187 Fix Gallery Block Slider not sliding issue

### DIFF
--- a/assets/src/blocks/Gallery/GalleryCarousel.js
+++ b/assets/src/blocks/Gallery/GalleryCarousel.js
@@ -27,7 +27,7 @@ export const GalleryCarousel = ({images, onImageClick, isEditing}) => {
     return order;
   }, [currentSlide, lastSlide]);
 
-  const goToSlide = useCallback(newSlide => {
+  const goToSlide = useCallback(({newSlide}) => {
     const nextElement = slidesRef.current[newSlide];
     const activeElement = slidesRef.current[currentSlide];
     if (newSlide !== currentSlide && nextElement && activeElement && !sliding) {


### PR DESCRIPTION
### Summary

In GalleryCarousel.js, goToSlide() is defined to accept a plain number, but every call site passes an object {newSlide: value}.
So slidesRef.current[newSlide] always gets undefined (object used as array key), the nextElement && activeElement guard fails, and slides never advance.

---

Ref. https://greenpeace-planet4.atlassian.net/browse/PLANET-8187

### Testing

- Add a new page and insert a Gallery block with the Slider style.
- Verify that the slider functions correctly when clicking the left/right navigation arrows and the bottom slide navigation controls.
