### PR TITLE
Replace the HTML parser in the `HtmlPostProcessor` class

### DIFF
--- a/assets/src/scss/base/_icons.scss
+++ b/assets/src/scss/base/_icons.scss
@@ -30,7 +30,8 @@ a.standalone-link {
   }
 }
 
-a.pdf-link {
+// Do no apply the icon to links within headings:
+a.pdf-link:not(h1 > a, h2 > a, h3 > a, h4 > a, h5 > a, h6 > a) {
   &::after {
     content: "";
     display: inline-block;
@@ -46,18 +47,23 @@ a.pdf-link {
   }
 }
 
-a.external-link {
-  &::after {
-    content: "";
-    display: inline-block;
-    background-color: currentcolor;
-    height: .7rem;
-    width: .7rem;
-    margin-inline-start: .2rem;
-    margin-inline-end: .1rem;
-    mask-image: url("../../images/external-link.svg");
-    mask-size: contain;
-    mask-repeat: no-repeat;
-    mask-position: center;
+// Do not apply the icon to external links that are not part of article, .page-content, or .author-details:
+article,
+.page-content,
+.author-details {
+  a.external-link {
+    &::after {
+      content: "";
+      display: inline-block;
+      background-color: currentcolor;
+      height: .7rem;
+      width: .7rem;
+      margin-inline-start: .2rem;
+      margin-inline-end: .1rem;
+      mask-image: url("../../images/external-link.svg");
+      mask-size: contain;
+      mask-repeat: no-repeat;
+      mask-position: center;
+    }
   }
 }

--- a/single.php
+++ b/single.php
@@ -81,27 +81,40 @@ if ('yes' === $timber_post->include_articles) {
         $category_id_array[] = $category->id;
     }
 
-    $block_attributes = [
-        'query' => [
-            'perPage' => 3,
-            'post_type' => 'post',
-            'taxQuery' => [
-                'post_tag' => $tag_id_array,
-                'category' => $category_id_array,
-            ],
-            'exclude' => [$timber_post->ID],
+    $articles_query = new WP_Query([
+        'post_type' => 'post',
+        'posts_per_page' => 3,
+        'post__not_in' => [$timber_post->ID],
+        'tax_query' => [
+            'relation' => 'OR',
+            ['taxonomy' => 'post_tag', 'field' => 'term_id', 'terms' => $tag_id_array],
+            ['taxonomy' => 'category', 'field' => 'term_id', 'terms' => $category_id_array],
         ],
-        'className' => 'posts-list p4-query-loop is-custom-layout-list',
-        'layout' => [
-            'type' => 'default',
-            'columnCount' => 3,
-        ],
-        'namespace' => 'planet4-blocks/posts-list',
-    ];
+    ]);
 
-    $timber_post->articles = '<!-- wp:p4/related-posts {"query_attributes" : '
-        . wp_json_encode($block_attributes) .
-    '} /-->';
+    // Display the "Related Posts" section only when it contains posts.
+    if ($articles_query->have_posts()) {
+        $block_attributes = [
+            'query' => [
+                'perPage' => 3,
+                'post_type' => 'post',
+                'taxQuery' => [
+                    'post_tag' => $tag_id_array,
+                    'category' => $category_id_array,
+                ],
+                'exclude' => [$timber_post->ID],
+            ],
+            'className' => 'posts-list p4-query-loop is-custom-layout-list',
+            'layout' => [
+                'type' => 'default',
+                'columnCount' => 3,
+            ],
+            'namespace' => 'planet4-blocks/posts-list',
+        ];
+        $timber_post->articles = '<!-- wp:p4/related-posts {"query_attributes" : '
+            . wp_json_encode($block_attributes) .
+            '} /-->';
+    }
 }
 
 if (! empty($take_action_page) && ! has_block('planet4-blocks/take-action-boxout')) {

--- a/single.php
+++ b/single.php
@@ -86,9 +86,11 @@ if ('yes' === $timber_post->include_articles) {
         'posts_per_page' => 3,
         'post__not_in' => [$timber_post->ID],
         'tax_query' => [
-            'relation' => 'OR',
-            ['taxonomy' => 'post_tag', 'field' => 'term_id', 'terms' => $tag_id_array],
-            ['taxonomy' => 'category', 'field' => 'term_id', 'terms' => $category_id_array],
+            [
+                'taxonomy' => 'post_tag',
+                'field' => 'term_id',
+                'terms' => $tag_id_array
+            ]
         ],
     ]);
 

--- a/single.php
+++ b/single.php
@@ -86,11 +86,8 @@ if ('yes' === $timber_post->include_articles) {
         'posts_per_page' => 3,
         'post__not_in' => [$timber_post->ID],
         'tax_query' => [
-            [
-                'taxonomy' => 'post_tag',
-                'field' => 'term_id',
-                'terms' => $tag_id_array,
-            ],
+            ['taxonomy' => 'post_tag', 'field' => 'term_id', 'terms' => $tag_id_array],
+            ['taxonomy' => 'category', 'field' => 'term_id', 'terms' => $category_id_array],
         ],
     ]);
 

--- a/single.php
+++ b/single.php
@@ -89,8 +89,8 @@ if ('yes' === $timber_post->include_articles) {
             [
                 'taxonomy' => 'post_tag',
                 'field' => 'term_id',
-                'terms' => $tag_id_array
-            ]
+                'terms' => $tag_id_array,
+            ],
         ],
     ]);
 

--- a/src/Blocks/QueryLoopExtension.php
+++ b/src/Blocks/QueryLoopExtension.php
@@ -309,6 +309,9 @@ class QueryLoopExtension
      * Removes the "No Results" inner block from a Post List or an Actions List block
      * when the title and the description of the block are empty.
      *
+     * Removes the "See all Posts" link from a Post List or an Actions List block
+     * when the block has no posts.
+     *
      * @param string $block_content The HTML generated for the block.
      * @param array  $block         The block.
      *
@@ -330,22 +333,34 @@ class QueryLoopExtension
         libxml_clear_errors();
         $xpath = new DOMXPath($dom);
 
+        $posts_list = $xpath->query("//*[contains(@class, 'wp-block-post-template')]");
         $post_title = $xpath->query("//*[contains(@class, 'wp-block-heading')]");
         $post_description = $xpath->query(
             "//*[contains(@class, 'p4-query-loop')]//p[not(ancestor::*[contains(@class, 'wp-block-query-no-results')])]"
         );
 
+        $list_is_empty = $posts_list->length === 0 || trim($posts_list->item(0)->textContent) === '';
         $title_is_empty = $post_title->length === 0 || trim($post_title->item(0)->textContent) === '';
         $description_is_empty = $post_description->length === 0 || trim($post_description->item(0)->textContent) === '';
 
-        if (!$title_is_empty || !$description_is_empty) {
+        if (!$list_is_empty) {
             return $block_content;
         }
 
-        // Strip only the no-results block, return the rest intact
-        $no_results = $xpath->query("//*[contains(@class, 'wp-block-query-no-results')]");
-        foreach ($no_results as $node) {
-            $node->parentNode->removeChild($node);
+        // Strip the "see all posts" link, keep the rest intact.
+        if ($list_is_empty) {
+            $see_all_link = $xpath->query("//*[contains(@class, 'see-all-link')]");
+            foreach ($see_all_link as $node) {
+                $node->parentNode->removeChild($node);
+            }
+        }
+
+        // Strip the no-results block, keep the rest intact.
+        if ($title_is_empty && $description_is_empty) {
+            $no_results = $xpath->query("//*[contains(@class, 'wp-block-query-no-results')]");
+            foreach ($no_results as $node) {
+                $node->parentNode->removeChild($node);
+            }
         }
 
         return $dom->saveHTML();

--- a/src/Blocks/QueryLoopExtension.php
+++ b/src/Blocks/QueryLoopExtension.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace P4\MasterTheme\Blocks;
 
 use WP_Block;
+use DOMDocument;
+use DOMXPath;
 
 /**
  * Enhances the query loop block with custom filtering logic for specific blocks.
@@ -36,6 +38,7 @@ class QueryLoopExtension
         add_filter('render_block_data', [self::class, 'track_posts_list_context'], 10, 1);
         add_filter('render_block', [self::class, 'add_data_attributes_to_posts_list_block'], 10, 2);
         add_filter('render_block', [self::class, 'add_data_attributes_to_actions_list_block'], 10, 2);
+        add_filter('render_block_core/query', [self::class, 'remove_no_post_text'], 10, 2);
     }
 
     /**
@@ -283,7 +286,6 @@ class QueryLoopExtension
      *
      * @return string The updated block content.
      */
-
     public static function add_data_attributes_to_actions_list_block(string $block_content, array $block): string
     {
         if (
@@ -301,5 +303,51 @@ class QueryLoopExtension
         );
 
         return $block_content;
+    }
+
+    /**
+     * Removes the "No Results" inner block from a Post List or an Actions List block
+     * when the title and the description of the block are empty.
+     *
+     * @param string $block_content The HTML generated for the block.
+     * @param array  $block         The block.
+     *
+     * @return string The updated block content.
+     */
+    public static function remove_no_post_text(string $block_content, array $block): string
+    {
+        $classes = $block['attrs']['className'] ?? '';
+        if (!str_contains($classes, 'p4-query-loop')) {
+            return $block_content;
+        }
+
+        $dom = new DOMDocument();
+        libxml_use_internal_errors(true);
+        $dom->loadHTML(
+            mb_encode_numericentity($block_content, [0x80, 0x10FFFF, 0, 0x1FFFFF], 'UTF-8'),
+            LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD
+        );
+        libxml_clear_errors();
+        $xpath = new DOMXPath($dom);
+
+        $post_title = $xpath->query("//*[contains(@class, 'wp-block-heading')]");
+        $post_description = $xpath->query(
+            "//*[contains(@class, 'p4-query-loop')]//p[not(ancestor::*[contains(@class, 'wp-block-query-no-results')])]"
+        );
+
+        $title_is_empty = $post_title->length === 0 || trim($post_title->item(0)->textContent) === '';
+        $description_is_empty = $post_description->length === 0 || trim($post_description->item(0)->textContent) === '';
+
+        if (!$title_is_empty || !$description_is_empty) {
+            return $block_content;
+        }
+
+        // Strip only the no-results block, return the rest intact
+        $no_results = $xpath->query("//*[contains(@class, 'wp-block-query-no-results')]");
+        foreach ($no_results as $node) {
+            $node->parentNode->removeChild($node);
+        }
+
+        return $dom->saveHTML();
     }
 }

--- a/src/HtmlPostProcessor.php
+++ b/src/HtmlPostProcessor.php
@@ -32,20 +32,22 @@ class HtmlPostProcessor
         while ($processor->next_tag('a')) {
             $href = $processor->get_attribute('href') ?? '';
             $classes = $processor->get_attribute('class') ?? '';
+            $class_list = preg_split('/\s+/', trim($classes));
 
-            if (empty($href)) {
+            $is_pdf = $this->is_pdf_link($href, $class_list);
+            $is_external_link = $this->is_external_link($href, $class_list);
+
+            if (empty($href) || (!$is_pdf && !$is_external_link)) {
                 continue;
             }
 
-            $class_list = preg_split('/\s+/', trim($classes));
-
-            if ($this->is_pdf_link($href, $class_list)) {
+            if ($is_pdf) {
                 $processor->add_class('pdf-link');
                 $processor->set_attribute('title', __('This link will open a PDF file', 'planet4-master-theme'));
                 continue;
             }
 
-            if (!$this->is_external_link($href, $class_list)) {
+            if (!$is_external_link) {
                 continue;
             }
 

--- a/src/HtmlPostProcessor.php
+++ b/src/HtmlPostProcessor.php
@@ -2,159 +2,111 @@
 
 namespace P4\MasterTheme;
 
-use DOMDocument;
-use DOMXPath;
-
 /**
  * Class HtmlPostProcessor
  *
  * Intercepts and transforms the final HTML output of a page before it is sent to the browser.
- *
  */
 class HtmlPostProcessor
 {
-    /**
-     * Constructor
-     */
+    private string $home_host;
+
     public function __construct()
     {
+        $this->home_host = parse_url(home_url(), PHP_URL_HOST);
         add_filter('wp_template_enhancement_output_buffer', [$this, 'manage_output_buffer']);
     }
 
     /**
-     * Processes the page output buffer by parsing it as HTML, applying various
-     * DOM transformations, and returning the modified HTML string.
+     * Processes the page output buffer, applying various transformations,
+     * and returning the modified HTML string.
+     *
+     * Adds the class "pdf-link" to the links connected to PDF files.
+     *
+     * Adds the class "external-link" to the external links.
      */
     public function manage_output_buffer(string $buffer): string
     {
-        // Create a new DOM document to parse and manipulate the HTML.
-        $dom = new DOMDocument();
+        $processor = new \WP_HTML_Tag_Processor($buffer);
 
-        // Suppress XML/HTML parsing warnings.
-        libxml_use_internal_errors(true);
+        while ($processor->next_tag('a')) {
+            $href = $processor->get_attribute('href') ?? '';
+            $classes = $processor->get_attribute('class') ?? '';
 
-        // Load the buffer as HTML into the DOM.
-        $dom->loadHTML(
-            mb_encode_numericentity($buffer, [0x80, 0x10FFFF, 0, 0x1FFFFF], 'UTF-8'),
-            LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD
-        );
-
-        // Discard any parsing errors accumulated above.
-        libxml_clear_errors();
-
-        // Create an XPath evaluator to allow the helper methods below to query
-        // and target specific nodes within the DOM tree.
-        $xpath = new DOMXPath($dom);
-
-        $this->setup_pdf_icon($xpath);
-        $this->setup_external_links($xpath);
-
-        return $dom->saveHTML();
-    }
-
-    /**
-     * Adds the class "pdf-link" to the links connected to PDF files.
-     */
-    private function setup_pdf_icon(DOMXPath $xpath): void
-    {
-        $links =
-            $xpath->query("
-                //a[contains(@href, '.pdf')
-                and not(contains(@class, 'search-result-item-headline'))
-                and not(contains(@class, 'cover-card-heading'))
-                and not(contains(@class, 'pdf-link'))]");
-
-        foreach ($links as $link) {
-            $parent_tag = $link->parentNode->nodeName;
-            $has_image = $xpath->query(".//img", $link)->length > 0;
-            $text = trim($link->textContent);
-
-            // Skip headings, image links, and empty links
-            if (in_array(strtoupper($parent_tag), ['H1', 'H2', 'H3', 'H4', 'H5', 'H6']) || $has_image || $text === '') {
+            if (empty($href)) {
                 continue;
             }
 
-            $classes = $link->getAttribute('class');
-            $link->setAttribute('class', trim($classes . ' pdf-link'));
-            $link->setAttribute('title', __('This link will open a PDF file', 'planet4-master-theme'));
+            $class_list = preg_split('/\s+/', trim($classes));
+
+            if ($this->is_pdf_link($href, $class_list)) {
+                $processor->add_class('pdf-link');
+                $processor->set_attribute('title', __('This link will open a PDF file', 'planet4-master-theme'));
+                continue;
+            }
+
+            if (!$this->is_external_link($href, $class_list)) {
+                continue;
+            }
+
+            $processor->add_class('external-link');
+            $domain = str_replace('www.', '', parse_url($href, PHP_URL_HOST) ?? '');
+            $processor->set_attribute(
+                'title',
+                sprintf(
+                    // translators: 1: URL domain
+                    __('This link will lead you to %1$s', 'planet4-master-theme'),
+                    $domain
+                )
+            );
         }
+
+        return $processor->get_updated_html();
     }
 
     /**
-     * Adds the class "external-link" to the external links.
+     * Checks if a link is linked to a PDF file, considering some exceptions.
      */
-    private function setup_external_links(DOMXPath $xpath): void
+    private function is_pdf_link(string $href, array $class_list): bool
     {
-        $excluded_classes = ['btn', 'cover-card-heading', 'wp-block-button__link', 'share-btn'];
-        $containers = [
-            ".//*[contains(@class, 'page-content')]//a",
-            ".//article//a",
-            ".//*[contains(@class, 'author-details')]//a"];
+        if (!str_contains($href, '.pdf')) {
+            return false;
+        }
 
-        foreach ($containers as $container_query) {
-            $links = $xpath->query($container_query);
-
-            foreach ($links as $link) {
-                $href = $link->getAttribute('href');
-                $classes = $link->getAttribute('class');
-                $parent_tag = strtoupper($link->parentNode->nodeName);
-                $text = trim($link->textContent);
-
-                // Skip if no href
-                if (empty($href)) {
-                    continue;
-                }
-
-                // Skip excluded classes
-                $has_excluded_class = false;
-                foreach ($excluded_classes as $excluded_class) {
-                    if (str_contains($classes, $excluded_class)) {
-                        $has_excluded_class = true;
-                        break;
-                    }
-                }
-                if ($has_excluded_class) {
-                    continue;
-                }
-
-                // Skip excluded href patterns
-                if (
-                    str_contains($href, parse_url(home_url(), PHP_URL_HOST)) ||
-                    str_contains($href, '.pdf') ||
-                    str_starts_with($href, '/') ||
-                    str_starts_with($href, '#') ||
-                    str_starts_with($href, 'javascript:') ||
-                    str_starts_with($href, 'mailto:') ||
-                    str_starts_with($href, 'tel:')
-                ) {
-                    continue;
-                }
-
-                // Skip links inside .boxout
-                $in_boxout = $xpath->query("ancestor::*[contains(@class, 'boxout')]", $link)->length > 0;
-                if ($in_boxout) {
-                    continue;
-                }
-
-                // Skip headings and empty links
-                if (in_array($parent_tag, ['H1', 'H2', 'H3', 'H4', 'H5', 'H6']) || $text === '') {
-                    continue;
-                }
-
-                // Add external-link class
-                $link->setAttribute('class', trim($classes . ' external-link'));
-
-                // Set title with domain
-                $domain = str_replace('www.', '', parse_url($href, PHP_URL_HOST));
-                $link->setAttribute(
-                    'title',
-                    sprintf(
-                        // translators: 1: URL domain
-                        __('This link will lead you to %1$s', 'planet4-master-theme'),
-                        $domain
-                    )
-                );
+        $excluded = ['search-result-item-headline', 'cover-card-heading', 'pdf-link'];
+        foreach ($excluded as $class) {
+            if (in_array($class, $class_list, true)) {
+                return false;
             }
         }
+
+        return true;
+    }
+
+    /**
+     * Checks if a link is external, considering some exceptions.
+     */
+    private function is_external_link(string $href, array $class_list): bool
+    {
+        if (
+            str_contains($href, $this->home_host) ||
+            str_contains($href, '.pdf') ||
+            str_starts_with($href, '/') ||
+            str_starts_with($href, '#') ||
+            str_starts_with($href, 'javascript:') ||
+            str_starts_with($href, 'mailto:') ||
+            str_starts_with($href, 'tel:')
+        ) {
+            return false;
+        }
+
+        $excluded = ['btn', 'cover-card-heading', 'wp-block-button__link', 'share-btn', 'external-link'];
+        foreach ($excluded as $class) {
+            if (in_array($class, $class_list, true)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 }

--- a/src/HtmlPostProcessor.php
+++ b/src/HtmlPostProcessor.php
@@ -43,24 +43,22 @@ class HtmlPostProcessor
 
             if ($is_pdf) {
                 $processor->add_class('pdf-link');
-                $processor->set_attribute('title', __('This link will open a PDF file', 'planet4-master-theme'));
-                continue;
+                $processor->set_attribute(
+                    'title',
+                    __('This link will open a PDF file', 'planet4-master-theme')
+                );
+            } else {
+                $processor->add_class('external-link');
+                $domain = str_replace('www.', '', parse_url($href, PHP_URL_HOST) ?? '');
+                $processor->set_attribute(
+                    'title',
+                    sprintf(
+                        // translators: 1: URL domain
+                        __('This link will lead you to %1$s', 'planet4-master-theme'),
+                        $domain
+                    )
+                );
             }
-
-            if (!$is_external_link) {
-                continue;
-            }
-
-            $processor->add_class('external-link');
-            $domain = str_replace('www.', '', parse_url($href, PHP_URL_HOST) ?? '');
-            $processor->set_attribute(
-                'title',
-                sprintf(
-                    // translators: 1: URL domain
-                    __('This link will lead you to %1$s', 'planet4-master-theme'),
-                    $domain
-                )
-            );
         }
 
         return $processor->get_updated_html();

--- a/src/HtmlPostProcessor.php
+++ b/src/HtmlPostProcessor.php
@@ -46,57 +46,10 @@ class HtmlPostProcessor
         // and target specific nodes within the DOM tree.
         $xpath = new DOMXPath($dom);
 
-        $this->remove_related_section_no_posts($xpath);
-        $this->remove_no_post_text($xpath);
         $this->setup_pdf_icon($xpath);
         $this->setup_external_links($xpath);
 
         return $dom->saveHTML();
-    }
-
-    /**
-     * Removes the "Related Posts" section when it contains no posts.
-     */
-    private function remove_related_section_no_posts(DOMXPath $xpath): void
-    {
-        $sections = $xpath->query("//section[contains(@class, 'post-articles-block')]");
-
-        foreach ($sections as $section) {
-            $has_post_template = $xpath->query(".//*[contains(@class, 'wp-block-post-template')]", $section);
-
-            if ($has_post_template->length !== 0) {
-                continue;
-            }
-
-            $section->parentNode->removeChild($section);
-        }
-    }
-
-    /**
-     * Removes the "No Results" inner block from a Post List or an Actions List block
-     * when the title and the description of the block are empty.
-     */
-    private function remove_no_post_text(DOMXPath $xpath): void
-    {
-        $no_results =
-            $xpath->query("//*[contains(@class, 'p4-query-loop')]//*[contains(@class, 'wp-block-query-no-results')]");
-
-        foreach ($no_results as $no_results_block) {
-            $query_loop = $no_results_block->parentNode;
-
-            $post_title = $xpath->query(".//*[contains(@class, 'wp-block-heading')]", $query_loop);
-            $post_description = $xpath->query(".//p", $query_loop);
-
-            $title_is_empty = $post_title->length === 0 || trim($post_title->item(0)->textContent) === '';
-            $description_is_empty =
-                $post_description->length === 0 || trim($post_description->item(0)->textContent) === '';
-
-            if (!$title_is_empty || !$description_is_empty) {
-                continue;
-            }
-
-            $no_results_block->parentNode->removeChild($no_results_block);
-        }
     }
 
     /**

--- a/tests/e2e/related-posts.spec.js
+++ b/tests/e2e/related-posts.spec.js
@@ -12,7 +12,8 @@ test('Test Related Posts block', async ({page, requestUtils}) => {
       content: '<p>This is a test post</p>',
       status: 'publish',
       featured_media: 357,
-      categories: [2],
+      tags: [7], // tag: Renewables
+      categories: [2], // category: Energy
     },
   });
   const editUrl = `./wp-admin/post.php?post=${newPost.id}&action=edit`;


### PR DESCRIPTION
### Summary

The `HtmlPostProcessor` parses the raw HTML with `DOMDocument`, which misinterprets some Vue's attributes and identifies them as invalid HTML. This is causing issues in some websites relying on Vue.

Taking that into consideration:
- To remove the "no post text" from the query block, this PR encapsulates the HTML that is parsed via `DOMDocument` only within the Query block, so the rest of the DOM remains untouched.
- To remove the "Related Posts" section when a post has no related posts, this PR refactors the `single.php`.
- To add CSS classes to PDF links and external links, this PR replaces `DOMDocument` with a combination of `WP_HTML_Tag_Processor` and CSS.

---

Ref: https://greenpeace-gpi.slack.com/archives/C0160MX64AG/p1780904946715889

### Testing

1. Check that the "Related Posts" section is removed from posts when it contains no related posts.
2. Check that the "No Results" inner block from a Post List or an Actions List block is removed (in the front) when the title and the description of the block are empty.
3. Check that the class `pdf-link` is added to the links connected to PDF files (pay attention to the exceptions!).
4. Check that the class external-link is added to the external links  (pay attention to the exceptions!).
5. Check that Vue elements remain intact. This can be tested by simulating a Vue template, as it was explained [here](https://greenpeace-gpi.slack.com/archives/C0160MX64AG/p1780907423459559?thread_ts=1780904946.715889&cid=C0160MX64AG). 
