### PR TITLE
PLANET-8191 Fix publish validation and sidebar errors on wp_template,…

### DIFF
--- a/assets/src/block-editor/setupBlockEditorValidations.js
+++ b/assets/src/block-editor/setupBlockEditorValidations.js
@@ -22,11 +22,11 @@ export const setupBlockEditorValidations = () => {
  */
 const getValidationState = select => {
   const {getEditedPostAttribute, getCurrentPostType} = select('core/editor');
-  // Reusable blocks / synced patterns are stored as the 'wp_block' post type.
-  // They're design artifacts, not editorial content, so the post-level
-  // requirements (title, featured image, topic link, valid forms) don't apply. Returning a
-  // fully-valid state stops these checks from blocking pattern create/edit.
-  if (getCurrentPostType() === 'wp_block') {
+  // Reusable blocks / synced patterns ('wp_block'), custom templates ('wp_template'),
+  // and template parts ('wp_template_part') are design artifacts, not editorial content,
+  // so the post-level requirements (title, featured image, topic link, valid forms) don't apply.
+  // Returning a fully-valid state stops these checks from blocking their create/edit.
+  if (['wp_block', 'wp_template', 'wp_template_part'].includes(getCurrentPostType())) {
     return {postTitle: true, featuredImage: true, topicLink: true, isValid: true, validForms: true};
   }
   const {getBlocks} = select('core/block-editor');

--- a/assets/src/block-editor/setupBlockEditorValidations.js
+++ b/assets/src/block-editor/setupBlockEditorValidations.js
@@ -25,20 +25,19 @@ const ALLOWED_POST_TYPES = ['post', 'page', 'p4_action', 'campaign'];
 
 const getValidationState = select => {
   const {getEditedPostAttribute, getCurrentPostType} = select('core/editor');
-  // Skip validation for post types not in the whitelist (e.g. synced patterns,
-  // templates, template parts) they are design artifacts, not editorial content.
-  if (!ALLOWED_POST_TYPES.includes(getCurrentPostType())) {
-    return {postTitle: true, featuredImage: true, topicLink: true, isValid: true, validForms: true};
-  }
   const {getBlocks} = select('core/block-editor');
+  // skip=true for post types not in the whitelist (e.g. synced patterns, templates,
+  // template parts) They are design artifacts, not editorial content, so all checks
+  // short-circuit to valid. New checks added below automatically respect this flag.
+  const skip = !ALLOWED_POST_TYPES.includes(getCurrentPostType());
   const allBlocks = getBlocks();
-  const postTitle = Boolean(getEditedPostAttribute('title'));
-  const featuredImage = Boolean(getEditedPostAttribute('featured_media'));
-  const topicLink = checkTopicLinks(allBlocks);
+  const postTitle = skip || Boolean(getEditedPostAttribute('title'));
+  const featuredImage = skip || Boolean(getEditedPostAttribute('featured_media'));
+  const topicLink = skip || checkTopicLinks(allBlocks);
   // If there is a Gravity Forms block, we want to enforce setting the Global Project.
-  const hasForm = hasGravityFormsBlock(allBlocks);
+  const hasForm = !skip && hasGravityFormsBlock(allBlocks);
   const globalProject = getEditedPostAttribute('meta')?.p4_campaign_name;
-  const validForms = !hasForm || (hasForm && globalProject && globalProject !== 'not set');
+  const validForms = skip || !hasForm || (hasForm && globalProject && globalProject !== 'not set');
 
   return {
     postTitle,

--- a/assets/src/block-editor/setupBlockEditorValidations.js
+++ b/assets/src/block-editor/setupBlockEditorValidations.js
@@ -20,13 +20,14 @@ export const setupBlockEditorValidations = () => {
  * @param {Function} select - The WordPress data `select` function used to access store selectors.
  * @return {Object} - An object containing individual validation flags and a combined `isValid` flag.
  */
+// Post types for which publish validation (title, featured image, topic link) is enforced.
+const ALLOWED_POST_TYPES = ['post', 'page', 'p4_action', 'campaign'];
+
 const getValidationState = select => {
   const {getEditedPostAttribute, getCurrentPostType} = select('core/editor');
-  // Reusable blocks / synced patterns ('wp_block'), custom templates ('wp_template'),
-  // and template parts ('wp_template_part') are design artifacts, not editorial content,
-  // so the post-level requirements (title, featured image, topic link, valid forms) don't apply.
-  // Returning a fully-valid state stops these checks from blocking their create/edit.
-  if (['wp_block', 'wp_template', 'wp_template_part'].includes(getCurrentPostType())) {
+  // Skip validation for post types not in the whitelist (e.g. synced patterns,
+  // templates, template parts) they are design artifacts, not editorial content.
+  if (!ALLOWED_POST_TYPES.includes(getCurrentPostType())) {
     return {postTitle: true, featuredImage: true, topicLink: true, isValid: true, validForms: true};
   }
   const {getBlocks} = select('core/block-editor');

--- a/assets/src/block-editor/setupCustomSidebar.js
+++ b/assets/src/block-editor/setupCustomSidebar.js
@@ -44,6 +44,7 @@ const sidebarsForPostType = postType => {
 
 export const setupCustomSidebar = () => {
   let currentPostType = null;
+  let registeredSidebars = [];
   // Only subscribing after DOMContentLoaded avoids the troubles originating from wp.data emitting null values before that point.
   document.addEventListener('DOMContentLoaded', () => {
     wp.data.subscribe(() => {
@@ -53,11 +54,18 @@ export const setupCustomSidebar = () => {
       }
 
       currentPostType = newPostType;
+
+      // Unregister sidebars from the previous post type so they don't render
+      // (and crash) when their expected meta fields are absent (e.g. wp_template).
+      registeredSidebars.forEach(sidebar => wp.plugins.unregisterPlugin(sidebar.getId()));
+      registeredSidebars = [];
+
       const sidebars = sidebarsForPostType(newPostType);
       if (!sidebars) {
         return;
       }
 
+      registeredSidebars = sidebars;
       sidebars.forEach(sidebar => registerPlugin(sidebar.getId(), {
         icon: sidebar.getIcon ? sidebar.getIcon() : '',
         render: sidebar.render,

--- a/assets/src/block-editor/setupCustomSidebar.js
+++ b/assets/src/block-editor/setupCustomSidebar.js
@@ -55,8 +55,12 @@ export const setupCustomSidebar = () => {
 
       currentPostType = newPostType;
 
-      // Unregister sidebars from the previous post type so they don't render
-      // (and crash) when their expected meta fields are absent (e.g. wp_template).
+      // Unregister all sidebars registered for the previous post type before registering
+      // new ones. This is necessary because sidebars are registered globally via wp.plugins
+      // and persist across post type changes. Without this cleanup, sidebars built for
+      // editorial post types (post, page, p4_action, campaign) would remain active when
+      // switching to design-artifact post types like wp_template or wp_template_part,
+      // where their expected meta fields are absent causing editor crashes.
       registeredSidebars.forEach(sidebar => wp.plugins.unregisterPlugin(sidebar.getId()));
       registeredSidebars = [];
 


### PR DESCRIPTION
… and wp_template_part post types

### Summary
- Updated the validation logic for custom template post_type(custom templates are stored as wp_template & wp_template_part post_type) & allow it without validation checks
- Added `registeredSidebars = []` to keep track of the currently registered sidebars.
- On every post type change, all previously registered sidebars are unregistered using `wp.plugins.unregisterPlugin()` before any new sidebars are registered.
- For `wp_template` and `wp_template_part`, `sidebarsForPostType()` now returns `null`. As a result, existing sidebars are unregistered and no new sidebars are registered, preventing the editor crash.


---

<!-- Please add a reference link to the ticket, if one exists. -->
Ref: 
https://greenpeace-planet4.atlassian.net/browse/PLANET-8191

### Testing

<!-- Please add the steps required to test the changes in this Pull Request. -->
1. Add a new page/post click on template from page sidebar , add new template/edit existing template
2. the add/edit template works without validation error
