### PR TITLE
PLANET-8092 Make Global Project mandatory when using Gravity Forms

### DIFF
--- a/assets/src/block-editor/setupBlockEditorValidations.js
+++ b/assets/src/block-editor/setupBlockEditorValidations.js
@@ -24,10 +24,10 @@ const getValidationState = select => {
   const {getEditedPostAttribute, getCurrentPostType} = select('core/editor');
   // Reusable blocks / synced patterns are stored as the 'wp_block' post type.
   // They're design artifacts, not editorial content, so the post-level
-  // requirements (title, featured image, topic link) don't apply. Returning a
+  // requirements (title, featured image, topic link, valid forms) don't apply. Returning a
   // fully-valid state stops these checks from blocking pattern create/edit.
   if (getCurrentPostType() === 'wp_block') {
-    return {postTitle: true, featuredImage: true, topicLink: true, isValid: true};
+    return {postTitle: true, featuredImage: true, topicLink: true, isValid: true, validForms: true};
   }
   const {getBlocks} = select('core/block-editor');
   const allBlocks = getBlocks();

--- a/assets/src/block-editor/setupBlockEditorValidations.js
+++ b/assets/src/block-editor/setupBlockEditorValidations.js
@@ -30,14 +30,21 @@ const getValidationState = select => {
     return {postTitle: true, featuredImage: true, topicLink: true, isValid: true};
   }
   const {getBlocks} = select('core/block-editor');
+  const allBlocks = getBlocks();
   const postTitle = Boolean(getEditedPostAttribute('title'));
   const featuredImage = Boolean(getEditedPostAttribute('featured_media'));
-  const topicLink = checkTopicLinks(getBlocks());
+  const topicLink = checkTopicLinks(allBlocks);
+  // If there is a Gravity Forms block, we want to enforce setting the Global Project.
+  const hasForm = hasGravityFormsBlock(allBlocks);
+  const globalProject = getEditedPostAttribute('meta')?.p4_campaign_name;
+  const validForms = !hasForm || (hasForm && globalProject && globalProject !== 'not set');
+
   return {
     postTitle,
     featuredImage,
     topicLink,
-    isValid: postTitle && featuredImage && topicLink,
+    validForms,
+    isValid: postTitle && featuredImage && topicLink && validForms,
   };
 };
 
@@ -58,6 +65,14 @@ const checkTopicLinks = blocks => {
 };
 
 /**
+ * Checks whether there is a Gravity Forms block.
+ *
+ * @param {Object[]} blocks - Array of block objects from the block editor.
+ * @return {boolean} `true` when there is a Gravity Forms block, `false` otherwise.
+ */
+const hasGravityFormsBlock = blocks => Boolean(blocks.find(block => block.name === 'gravityforms/form'));
+
+/**
  * Builds a combined validation error message string based on the current validation state.
  * Returns `null` if all validations pass.
  *
@@ -65,9 +80,10 @@ const checkTopicLinks = blocks => {
  * @param {boolean} validationState.postTitle     - Whether the post has a title.
  * @param {boolean} validationState.featuredImage - Whether the post has a featured image.
  * @param {boolean} validationState.topicLink     - Whether all Topic Link blocks have a background image.
+ * @param {boolean} validationState.validForms    - If there is a Gravity Forms block on the page and a set Global Project.
  * @return {string|null} A space-separated string of error messages, or `null` if there are no errors.
  */
-const buildValidationMessage = ({postTitle, featuredImage, topicLink}) => {
+const buildValidationMessage = ({postTitle, featuredImage, topicLink, validForms}) => {
   const errors = [];
   if (!postTitle) {
     errors.push(__('Title is mandatory.', 'planet4-master-theme-backend'));
@@ -83,6 +99,16 @@ const buildValidationMessage = ({postTitle, featuredImage, topicLink}) => {
       )
     );
   }
+
+  if (!validForms) {
+    errors.push(
+      __(
+        'You need to select a Global Project in the sidebar (Analytics & Tracking), because you are using a Gravity Forms block.',
+        'planet4-master-theme-backend'
+      )
+    );
+  }
+
   if (errors.length === 0) {
     return null;
   }


### PR DESCRIPTION
### Summary

Ref: [PLANET-8092](https://greenpeace-planet4.atlassian.net/browse/PLANET-8092)

To understand which campaigns are driving action, we need petitions to be tagged with a Global Project. This variable is set from a dropdown menu in the sidebar when a page is created. If the page contains a Gravity Form block, the page should be prevented from being published until the creator chooses a Global Project from the dropdown. If a page creator tries to publish the page without the Global Project set, a warning should appear similar to the Feature Image warning to let the publisher know why the page has not been published. 

### Testing

1. Add a Gravity Forms to a page.
2. Make sure that the new warning is displayed in the editor, and the save/publish button is disabled.
3. Select a Global Project in the sidebar (in `Analytics & Tracking` section)
4. See that the warning is gone and it's now possible to save/publish the page.


[PLANET-8092]: https://greenpeace-planet4.atlassian.net/browse/PLANET-8092?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ