### PR TITLE
PLANET-8200 Disable new Timeline block navigation in the editor

### DIFF
--- a/assets/src/blocks/Timeline/NewTimelineFrontend.js
+++ b/assets/src/blocks/Timeline/NewTimelineFrontend.js
@@ -242,7 +242,7 @@ export const NewTimelineFrontend = ({attributes}) => {
           <p className="page-section-description text-center" dangerouslySetInnerHTML={{__html: description}} />
         }
 
-        <YearsNavigation years={processedSheetData.map(({year}) => year)} />
+        <YearsNavigation isEditing={isEditing} years={processedSheetData.map(({year}) => year)} />
         <fieldset className="timeline-group">
           {processedSheetData.map(({year, list}) => (
             <div className="timeline-block-year-group" id={year} key={year}>

--- a/assets/src/blocks/Timeline/YearsNavigation.js
+++ b/assets/src/blocks/Timeline/YearsNavigation.js
@@ -1,7 +1,7 @@
 import {useState, useEffect, useRef} from '@wordpress/element';
 const {sprintf, __} = wp.i18n;
 
-export const YearsNavigation = ({years}) => {
+export const YearsNavigation = ({years, isEditing}) => {
   const [showLeftArrow, setShowLeftArrow] = useState(false);
   const [showRightArrow, setShowRightArrow] = useState(false);
   const [activeYear, setActiveYear] = useState('');
@@ -46,8 +46,12 @@ export const YearsNavigation = ({years}) => {
     setTimeout(() => isManualScroll.current = false, 500);
   };
 
-  // This runs to auto update the URL and active year class, works on scroll
+  // This runs to auto update the URL and active year class, works on scroll.
+  // Only in the frontend.
   useEffect(() => {
+    if (isEditing) {
+      return;
+    }
     const observerOptions = {
       root: null,
       rootMargin: '0px',
@@ -108,14 +112,19 @@ export const YearsNavigation = ({years}) => {
   }, [activeYear, years]);
 
   // Make sure that the body has overflow set to "visible", otherwise the "sticky"
-  // position of the navigation won't work.
-  useEffect(() => document.body.classList.add('overflow-visible'), []);
+  // position of the navigation won't work. Only in the frontend.
+  useEffect(() => {
+    if (isEditing) {
+      return;
+    }
+    document.body.classList.add('overflow-visible');
+  });
 
   // This adds arrows to the container to indicate more elements available
-  // It also works for RTL sites
+  // It also works for RTL sites. Only in the frontend.
   useEffect(() => {
     const navEl = yearsListRef.current;
-    if (!navEl) {return;}
+    if (!navEl || isEditing) {return;}
 
     const items = navEl.querySelectorAll('li');
     if (!items.length) {return;}
@@ -153,7 +162,7 @@ export const YearsNavigation = ({years}) => {
 
   return (
     <nav
-      className="years-navigation d-flex justify-content-center"
+      className={`years-navigation d-flex justify-content-center ${isEditing && 'no-scroll'}`}
       aria-label={sprintf(
       /* translators: 1: amount of years in the timeline */
         __('Timeline, list with %1$d items', 'planet4-blocks'),
@@ -173,7 +182,7 @@ export const YearsNavigation = ({years}) => {
               href={`#${year}`}
               onClick={() => handleClick(year)}
               data-target={year}
-              className={`${activeYear === year ? 'active': ''}`}
+              className={`${!isEditing && activeYear === year ? 'active': ''}`}
             >
               {year}
             </a>

--- a/assets/src/blocks/Timeline/YearsNavigation.js
+++ b/assets/src/blocks/Timeline/YearsNavigation.js
@@ -118,7 +118,7 @@ export const YearsNavigation = ({years, isEditing}) => {
       return;
     }
     document.body.classList.add('overflow-visible');
-  });
+  }, []);
 
   // This adds arrows to the container to indicate more elements available
   // It also works for RTL sites. Only in the frontend.
@@ -162,7 +162,7 @@ export const YearsNavigation = ({years, isEditing}) => {
 
   return (
     <nav
-      className={`years-navigation d-flex justify-content-center ${isEditing && 'no-scroll'}`}
+      className={`years-navigation d-flex justify-content-center ${isEditing ? 'no-scroll' : ''}`}
       aria-label={sprintf(
       /* translators: 1: amount of years in the timeline */
         __('Timeline, list with %1$d items', 'planet4-blocks'),

--- a/assets/src/scss/blocks/Timeline/TimelineStyle.scss
+++ b/assets/src/scss/blocks/Timeline/TimelineStyle.scss
@@ -602,12 +602,19 @@
   }
 
   .years-navigation {
-    position: sticky;
     background-color: var(--beige-100);
     z-index: 999;
     padding: $sp-1x 0;
     top: 68px;
     margin: 0 auto $sp-2 auto;
+
+    &:not(.no-scroll) {
+      position: sticky;
+    }
+
+    &.no-scroll li a {
+      pointer-events: none;
+    }
 
     body.admin-bar & {
       top: 100px;


### PR DESCRIPTION
### Summary

The years navigation should only work in the frontend, not in the editor. Here is what needs to be **disabled**:

- URL updating when scrolling
- Active year markup
- Navigation being sticky
- Years being clickable
- “overflow-visible” class being added to the body
- Arrows being shown

Ref: [PLANET-8200](https://greenpeace-planet4.atlassian.net/browse/PLANET-8200)

### Testing

1. You can use this [page](https://www-dev.greenpeace.org/test-oberon/timeline/) I made for UAT, or on local:
    - Make sure to enable the new Timeline block in the settings (`Planet 4 > Features`).
    - Add a Timeline block to a page. You can use this [spreadsheet](https://docs.google.com/spreadsheets/d/1tYlLd_Fx0T_7ZEaf2y9dLfRnr5HzEOW_s0wELp5-j4s/) for example.
2. Make sure the years navigation is disabled in the editor (see all the requirements above).
3. Make sure everything still works properly in the frontend.


[PLANET-8200]: https://greenpeace-planet4.atlassian.net/browse/PLANET-8200?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ