### PR TITLE
Fix image size enforce in the Carousel Header

### DIFF
--- a/assets/src/blocks/CarouselHeader/CarouselHeaderEditor.js
+++ b/assets/src/blocks/CarouselHeader/CarouselHeaderEditor.js
@@ -6,7 +6,7 @@ import {CarouselControls} from './CarouselControls';
 
 // Carousel Header Editor
 import {Sidebar} from './Sidebar';
-import {EditableBackground, getLargestSizeUrl} from './EditableBackground';
+import {EditableBackground, getLargestSizeUrl, getSrcSetSizes} from './EditableBackground';
 
 const {useSelect} = wp.data;
 const {useCallback, useMemo, useRef} = wp.element;
@@ -81,7 +81,8 @@ export const CarouselHeaderEditor = ({setAttributes, attributes}) => {
     if (!image) {
       return slide;
     }
-    const image_srcset = toSrcSet(Object.values(image.media_details.sizes));
+    const image_srcset = toSrcSet(getSrcSetSizes(image.media_details.sizes));
+
     // Prefer a registered resized size over the original full-resolution upload.
     const image_url = getLargestSizeUrl(image);
     return ({...slide, image_url, image_srcset, image_alt: image.alt_text});

--- a/assets/src/blocks/CarouselHeader/EditableBackground.js
+++ b/assets/src/blocks/CarouselHeader/EditableBackground.js
@@ -25,6 +25,18 @@ export const getLargestSizeUrl = image => {
   );
 };
 
+// Check if an image is very large.
+const isValidSize = key =>
+  key !== 'full' &&
+  key !== 'scaled' &&
+  key !== 'original';
+
+// Remove very large images from the SRC set.
+export const getSrcSetSizes = (sizes = {}) =>
+  Object.entries(sizes)
+    .filter(([key, value]) => isValidSize(key) && value?.source_url)
+    .map(([, value]) => value);
+
 export const EditableBackground = ({
   image_url,
   image_alt,
@@ -57,7 +69,7 @@ export const EditableBackground = ({
 
         // Use the largest registered size instead of the original image so we never serve a multi-MB upload to the front end.
         const resizedUrl = getLargestSizeUrl(image);
-        changeSlideImage(index, id, resizedUrl, alt_text, toSrcSet(Object.values(sizes)));
+        changeSlideImage(index, id, resizedUrl, alt_text, toSrcSet(getSrcSetSizes(sizes)));
       }}
       allowedTypes={ALLOWED_MIME_TYPES}
       value={image_id}

--- a/assets/src/blocks/CarouselHeader/EditableBackground.js
+++ b/assets/src/blocks/CarouselHeader/EditableBackground.js
@@ -20,8 +20,8 @@ export const getLargestSizeUrl = image => {
     pickUrl(sizes.medium_large) ||
     pickUrl(sizes.medium) ||
     // As a last resort use the original URL so the slide is not left empty.
-    image?.url ||
-    image?.source_url
+    image?.source_url ||
+    image?.url
   );
 };
 
@@ -52,8 +52,9 @@ export const EditableBackground = ({
 }) => (
   <MediaUploadCheck>
     <MediaUpload
-      onSelect={image => {
-        const {id, alt_text, sizes} = image;
+      onSelect={async image => {
+        const imageRecord = await wp.data.resolveSelect('core').getMedia(image.id);
+        const {id, alt_text} = image;
         const mimeType = image?.mime ?? image?.mime_type ?? (image?.subtype && `image/${image.subtype}`) ?? '';
 
         // Reject anything that is not JPG / WebP. Defends against PNGs and other types that can slip in
@@ -68,8 +69,8 @@ export const EditableBackground = ({
         }
 
         // Use the largest registered size instead of the original image so we never serve a multi-MB upload to the front end.
-        const resizedUrl = getLargestSizeUrl(image);
-        changeSlideImage(index, id, resizedUrl, alt_text, toSrcSet(getSrcSetSizes(sizes)));
+        const resizedUrl = getLargestSizeUrl(imageRecord);
+        changeSlideImage(index, id, resizedUrl, alt_text, toSrcSet(getSrcSetSizes(imageRecord.media_details?.sizes)));
       }}
       allowedTypes={ALLOWED_MIME_TYPES}
       value={image_id}


### PR DESCRIPTION
### Summary

The [recent changes](https://github.com/greenpeace/planet4-master-theme/pull/2979) introduced to enforce the maximum image size in the Carousel Header block were not working correctly. Those changes made the images' `src` in the block use the URL of the largest registered (resized) image, not the original upload. Whilst this is correct, the `src` attribute is a mere fallback for `srcset`, which remained unchanged. 

This PR removes the largest images from the `srcset` attribute to serve the correct ones.

---

Ref: 
- https://greenpeace.slack.com/archives/C014UMRC4AJ/p1781701159247099?thread_ts=1781688231.371389&cid=C014UMRC4AJ
- https://github.com/greenpeace/planet4-master-theme/pull/2979

### Testing

1. Run the `main` branch on your local environment.
2. In a Carousel Header block, upload an image larger than 1MB and smaller than 2500px (this last part is important to avoid WordPress re-escaling, which also reduces the file weight).
3. If the "Migrate Image Data" button appears, you can use it.
4. Save the changes.
5. Go to the front, open the development console, and reload the page.
6. In the Elements tab, check that the `src` contains a resized image suffix instead of the original filename.
7. In the Elements tab, check that the `srcset` attribute does not contain the original file or the full-sized file.
8. In the Network tab, check that the loaded image is not the original, and it weighs less than 1MB.

### Comparison

| Broken                                                    | Fixed                                                       |
|-----------------------------------------------------------|-------------------------------------------------------------|
| https://www-dev.greenpeace.org/gutenberg/carousel-header/ | https://www-dev.greenpeace.org/test-saturn/carousel-header/ |
| <img width="1466" height="784" alt="Screenshot-from-2026-06-18-15-17-58" src="https://github.com/user-attachments/assets/2ece92aa-1006-4a24-965c-4aa860c276c6" />                                                         | <img width="1466" height="784" alt="Screenshot-from-2026-06-18-15-17-38" src="https://github.com/user-attachments/assets/79b6b564-5068-408f-81b6-8a35be5f7d8a" />                                                           |