### PR TITLE
PLANET-8184 Configure PHPCS to enforce spacing rules

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -75,7 +75,7 @@ function planet4_get_option(string $key = '', $default = null)
 {
     $options = get_option('planet4_options');
 
-    return $options[ $key ] ?? $default;
+    return $options[$key] ?? $default;
 }
 
 // Timber loading

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<ruleset name="Planet4 Coding Standards">
-  <description>Generally-applicable sniffs for Planet4</description>
+<ruleset name="Planet 4 Coding Standards">
+  <description>Generally-applicable sniffs for Planet 4</description>
 
   <!-- Show sniffs, progress -->
   <arg value="sp"/>
@@ -31,15 +31,19 @@
     </properties>
   </rule>
 
+  <!-- Spacing -->
   <rule ref="SlevomatCodingStandard.Whitespaces.DuplicateSpaces">
     <properties>
       <property name="ignoreSpacesInComment" value="true"/>
     </properties>
   </rule>
+  <rule ref="Squiz.Arrays.ArrayBracketSpacing"/>
+  <rule ref="Squiz.Operators.ValidLogicalOperators"/>
+  <rule ref="Squiz.Functions.FunctionDeclarationArgumentSpacing"/>
+  <rule ref="Generic.Functions.FunctionCallArgumentSpacing"/>
 
   <rule ref="Generic.Files.LineLength">
     <properties>
-      <!-- <property name="lineLimit" value="80"/> -->
       <property name="absoluteLineLimit" value="120"/>
     </properties>
   </rule>
@@ -107,10 +111,11 @@
     </properties>
   </rule>
 
-  <!-- exclude vendor dirs -->
+  <!-- exclude vendor and build dirs -->
   <exclude-pattern>*/node_modules/*</exclude-pattern>
   <exclude-pattern>*/vendor/*</exclude-pattern>
   <exclude-pattern>languages/*.php</exclude-pattern>
+  <exclude-pattern>assets/build/*</exclude-pattern>
 
   <!-- @todo: Temporary exclude those rules for php8 job until php8.1 migration -->
   <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint">

--- a/src/ActionPage.php
+++ b/src/ActionPage.php
@@ -372,7 +372,7 @@ class ActionPage
             foreach ($rules as $match => $rule) {
                 $new_match = str_replace('%' . self::TAXONOMY_PARAMETER . '%', "($terms_slugs_regex)", $match);
                 $new_rule = str_replace('%' . self::TAXONOMY_PARAMETER . '%', self::TAXONOMY . '=', $rule);
-                $new_rules[ $new_match ] = $new_rule;
+                $new_rules[$new_match] = $new_rule;
             }
 
             return $new_rules;
@@ -398,7 +398,7 @@ class ActionPage
 
         if ($terms_slugs) {
             foreach ($terms_slugs as $slug) {
-                $rules[ $slug . '/?$' ] = 'index.php?' . self::TAXONOMY . '=' . $slug;
+                $rules[$slug . '/?$'] = 'index.php?' . self::TAXONOMY . '=' . $slug;
             }
         }
 
@@ -621,7 +621,7 @@ class ActionPage
                 printf(
                     '<option value="%1$s" %2$s>%3$s</option>',
                     esc_html($term->slug),
-                    ( ( isset($_GET[ self::TAXONOMY ]) && ( $_GET[ self::TAXONOMY ] === $term->slug ) ) ? ' selected="selected"' : '' ), // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+                    ( ( isset($_GET[self::TAXONOMY]) && ( $_GET[self::TAXONOMY] === $term->slug ) ) ? ' selected="selected"' : '' ), // phpcs:ignore WordPress.Security.NonceVerification.Recommended
                     esc_html($term->name)
                 );
             }

--- a/src/Admin/Transient.php
+++ b/src/Admin/Transient.php
@@ -104,7 +104,7 @@ class Transient
 
         $items = [];
         foreach ($keys as $key) {
-            $items[ $key ] = get_transient($key);
+            $items[$key] = get_transient($key);
         }
 
         return rest_ensure_response(

--- a/src/AdminAssets.php
+++ b/src/AdminAssets.php
@@ -34,8 +34,8 @@ class AdminAssets
         $donate_location = 'donate-menu';
 
         if (
-            ! isset($menus[ $navbar_location ])
-            && ! isset($menus[ $donate_location ])
+            !isset($menus[$navbar_location])
+            && !isset($menus[$donate_location])
         ) {
             return;
         }

--- a/src/Api/Settings.php
+++ b/src/Api/Settings.php
@@ -109,7 +109,7 @@ class Settings
         $plugins = get_plugins();
         $list = [];
         foreach ($plugins as $key => &$plugin) {
-            $list[ $key ] = [
+            $list[$key] = [
                 'name' => $plugin['Name'],
                 'version' => $plugin['Version'],
                 'active' => is_plugin_active($key),
@@ -133,7 +133,7 @@ class Settings
         foreach ($themes as $name => $theme) {
             $package_name = 'greenpeace/' . basename($theme->get_stylesheet_directory());
             $package = array_filter($packages, fn($p) => $p[0] === $package_name)[0] ?? null;
-            $list[ $name ] = [
+            $list[$name] = [
                 'name' => $theme->name,
                 'version' => $package ? $package[1] : $theme->version,
                 'dir' => $theme->get_stylesheet_directory(),

--- a/src/BlockReportSearch/Block/BlockUsageApi.php
+++ b/src/BlockReportSearch/Block/BlockUsageApi.php
@@ -85,13 +85,13 @@ class BlockUsageApi
             $styles = empty($item['block_styles']) ? [ 'n/a' ] : $item['block_styles'];
             foreach ($styles as $style) {
                 $type = $item['block_type'];
-                if (! isset($blocks[ $type ]['styles'][ $style ])) {
-                    $blocks[ $type ]['styles'][ $style ] = 0;
+                if (! isset($blocks[$type]['styles'][$style])) {
+                    $blocks[$type]['styles'][$style] = 0;
                 }
-                $blocks[ $type ]['styles'][ $style ]++;
-                $blocks[ $type ]['total']++;
+                $blocks[$type]['styles'][$style]++;
+                $blocks[$type]['total']++;
             }
-            ksort($blocks[ $type ]['styles']);
+            ksort($blocks[$type]['styles']);
         }
 
         return $blocks;

--- a/src/BlockReportSearch/Block/BlockUsageTable.php
+++ b/src/BlockReportSearch/Block/BlockUsageTable.php
@@ -276,7 +276,7 @@ class BlockUsageTable extends WP_List_Table
         ];
 
         $this->columns = array_merge(
-            [ $this->group_by => $default_columns[ $this->group_by ] ],
+            [ $this->group_by => $default_columns[$this->group_by] ],
             $default_columns
         );
 
@@ -350,7 +350,7 @@ class BlockUsageTable extends WP_List_Table
         $views = [];
         echo '<div style="clear: both;"><ul class="subsubsub" style="margin: 0;">';
         foreach ($unique_views as $class => $view) {
-            $views[ $class ] = "\t<li class='$class'>$view";
+            $views[$class] = "\t<li class='$class'>$view";
         }
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
         echo implode(" |</li>\n", $views) . "</li>\n";
@@ -442,7 +442,7 @@ class BlockUsageTable extends WP_List_Table
      */
     public function column_default($item, $column_name)
     {
-        return $item[ $column_name ] ?? '';
+        return $item[$column_name] ?? '';
     }
 
     /**
@@ -543,7 +543,7 @@ class BlockUsageTable extends WP_List_Table
         $first_col = array_key_first($cols);
         $block_name = $_GET['name'] ?? null;
 
-        if ($this->latest_row !== $item[ $first_col ]) {
+        if ($this->latest_row !== $item[$first_col]) {
             echo '<tr>';
             echo sprintf(
                 '<th colspan="%s"><strong>%s</strong></th>',
@@ -553,8 +553,8 @@ class BlockUsageTable extends WP_List_Table
             echo '</tr>';
         }
 
-        $this->latest_row = $item[ $first_col ];
-        $item[ $first_col ] = '';
+        $this->latest_row = $item[$first_col];
+        $item[$first_col] = '';
         parent::single_row($item);
     }
 

--- a/src/BlockReportSearch/Pattern/PatternUsage.php
+++ b/src/BlockReportSearch/Pattern/PatternUsage.php
@@ -122,13 +122,13 @@ class PatternUsage
                         }
                     }
 
-                    if (!$opts['use_templates'] || empty($templates[ $pattern->name ])) {
+                    if (!$opts['use_templates'] || empty($templates[$pattern->name])) {
                         continue;
                     }
 
                     $template_occ = substr_count(
                         $post->post_content,
-                        '<!-- wp:' . $templates[ $pattern->name ] . ' '
+                        '<!-- wp:' . $templates[$pattern->name] . ' '
                     );
                     if ($template_occ <= 0) {
                         continue;
@@ -192,7 +192,7 @@ class PatternUsage
                 continue;
             }
 
-            $lookup[ $pattern::get_name() ] = $matches[1];
+            $lookup[$pattern::get_name()] = $matches[1];
         }
 
         return $lookup;

--- a/src/BlockReportSearch/Pattern/PatternUsageApi.php
+++ b/src/BlockReportSearch/Pattern/PatternUsageApi.php
@@ -50,7 +50,7 @@ class PatternUsageApi
         ksort($patterns);
 
         foreach ($this->items as $item) {
-            $patterns[ $item['pattern_name'] ]['total']++;
+            $patterns[$item['pattern_name']]['total']++;
         }
 
         return $patterns;

--- a/src/BlockReportSearch/Pattern/PatternUsageTable.php
+++ b/src/BlockReportSearch/Pattern/PatternUsageTable.php
@@ -114,7 +114,7 @@ class PatternUsageTable extends WP_List_Table
             ->with_post_status(self::DEFAULT_POST_STATUS);
 
         $items = $this->get_items();
-        usort($items, fn ($a, $b) => $a[ $this->group_by ] <=> $b[ $this->group_by ]);
+        usort($items, fn ($a, $b) => $a[$this->group_by] <=> $b[$this->group_by]);
 
         // Pagination handling.
         $total_items = count($items);
@@ -268,7 +268,7 @@ class PatternUsageTable extends WP_List_Table
         ];
 
         $this->columns = array_merge(
-            [ $this->group_by => $default_columns[ $this->group_by ] ],
+            [ $this->group_by => $default_columns[$this->group_by] ],
             $default_columns
         );
 
@@ -368,18 +368,18 @@ class PatternUsageTable extends WP_List_Table
         $colspan = count($cols);
         $first_col = array_key_first($cols);
 
-        if ($this->latest_row !== $item[ $first_col ]) {
+        if ($this->latest_row !== $item[$first_col]) {
             echo '<tr>';
             echo sprintf(
                 '<th colspan="%s"><strong>%s</strong></th>',
                 esc_attr($colspan),
-                esc_html($item[ $first_col ])
+                esc_html($item[$first_col])
             );
             echo '</tr>';
         }
 
-        $this->latest_row = $item[ $first_col ];
-        $item[ $first_col ] = '';
+        $this->latest_row = $item[$first_col];
+        $item[$first_col] = '';
         parent::single_row($item);
     }
 
@@ -394,7 +394,7 @@ class PatternUsageTable extends WP_List_Table
      */
     public function column_default($item, $column_name)
     {
-        return $item[ $column_name ] ?? '';
+        return $item[$column_name] ?? '';
     }
     // phpcs:enable SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
 

--- a/src/BlockReportSearch/PatternSearch.php
+++ b/src/BlockReportSearch/PatternSearch.php
@@ -70,7 +70,7 @@ class PatternSearch
         $block_query = new BlockSqlQuery();
 
         $pattern_names = array_map(fn($p) => $p->name, $pattern_data);
-        $template_names = array_map(fn($n) => $templates[ $n ], $pattern_names);
+        $template_names = array_map(fn($n) => $templates[$n], $pattern_names);
         $template_ns = array_filter(array_unique(array_map(fn($n) => explode('/', $n)[0] ?? null, $template_names)));
 
         $post_ids = [];

--- a/src/BlockSettings.php
+++ b/src/BlockSettings.php
@@ -207,7 +207,7 @@ class BlockSettings
             'p4_action' => $action_block_types,
         ];
 
-        $allowed_p4_block_types = $all_allowed_p4_block_types[ $post_type ] ?? $all_allowed_p4_block_types['page'];
+        $allowed_p4_block_types = $all_allowed_p4_block_types[$post_type] ?? $all_allowed_p4_block_types['page'];
 
         return array_merge(self::WORDPRESS_BLOCKS, $allowed_p4_block_types);
     }

--- a/src/Blocks/BaseBlock.php
+++ b/src/Blocks/BaseBlock.php
@@ -262,7 +262,7 @@ abstract class BaseBlock
         $start = $matches[0][1][1] + 1;
         $content = substr($content, $start);
         preg_match_all('/<\/div>/', $content, $matches, PREG_OFFSET_CAPTURE);
-        $end = $matches[0][ count($matches[0]) - 2 ][1];
+        $end = $matches[0][count($matches[0]) - 2][1];
         $content = substr($content, 0, $end);
 
         return '<div data-hydrate="' . self::get_full_block_name()

--- a/src/Blocks/BlockList.php
+++ b/src/Blocks/BlockList.php
@@ -72,8 +72,8 @@ class BlockList
 
         $blocks = ( new WP_Block_Parser() )->parse($content);
         $parsed = array_filter($blocks, fn ($b) => ! empty($b['blockName']));
-        if (! isset($seen[ $post_id ])) {
-            $seen[ $post_id ] = [];
+        if (! isset($seen[$post_id])) {
+            $seen[$post_id] = [];
         }
 
         $list = [];
@@ -88,7 +88,7 @@ class BlockList
                 }
 
                 // Block pasted multiple times in same post.
-                if (in_array($ref_id, $seen[ $post_id ], true)) {
+                if (in_array($ref_id, $seen[$post_id], true)) {
                     continue;
                 }
 
@@ -96,10 +96,10 @@ class BlockList
                 // If the synced pattern is the same as the post currently parsed,
                 // or if it has been parsed previously in this process,
                 // this means it eventually loops back to itself.
-                $seen[ $post_id ][] = $ref_id;
+                $seen[$post_id][] = $ref_id;
                 if (
                     $ref_id === $post_id
-                    || isset($seen[ $ref_id ])
+                    || isset($seen[$ref_id])
                 ) {
                     self::report_synced_pattern_loop($ref_id, $post_id, $seen);
                     continue;

--- a/src/Blocks/Gallery.php
+++ b/src/Blocks/Gallery.php
@@ -161,7 +161,7 @@ class Gallery extends BaseBlock
 
         foreach ($exploded_images as $image_id) {
             $image_size = $fields['gallery_image_size'] ?? (
-                $fields['gallery_block_style'] ? $image_sizes[ $fields['gallery_block_style'] ] : null
+                $fields['gallery_block_style'] ? $image_sizes[$fields['gallery_block_style']] : null
             );
 
             $image_data = [];
@@ -176,7 +176,7 @@ class Gallery extends BaseBlock
             $image_data['image_sizes'] = wp_calculate_image_sizes($image_size, null, null, $image_id);
             $image_data['alt_text'] = get_post_meta($image_id, '_wp_attachment_image_alt', true);
             $image_data['caption'] = wp_get_attachment_caption($image_id);
-            $image_data['focus_image'] = $img_focus_points[ $image_id ] ?? '';
+            $image_data['focus_image'] = $img_focus_points[$image_id] ?? '';
             $attachment_fields = get_post_custom($image_id);
             $image_data['credits'] = '';
             if (isset($attachment_fields['_credit_text'][0]) && ! empty($attachment_fields['_credit_text'][0])) {

--- a/src/Feature.php
+++ b/src/Feature.php
@@ -74,7 +74,7 @@ abstract class Feature
 
         $features = get_option(static::options_key());
         $id = static::id();
-        $active = isset($features[ $id ]) && $features[ $id ];
+        $active = isset($features[$id]) && $features[$id];
 
         // Filter to allow setting a feature from code, to avoid chicken and egg problem when releasing adaptions to a
         // new feature.
@@ -114,7 +114,7 @@ abstract class Feature
     {
         $settings = get_option(static::options_key(), []);
 
-        $settings[ static::id() ] = 'on';
+        $settings[static::id()] = 'on';
         update_option(static::options_key(), $settings);
     }
 }

--- a/src/Importer.php
+++ b/src/Importer.php
@@ -122,7 +122,7 @@ class Importer
                 $new_attachment_id = $attachment_metadata->post_id;
                 $attachment_data = maybe_unserialize($attachment_metadata->meta_value);
                 $old_attachment_id = $attachment_data['image_meta']['imported_attachment_id'];
-                $this->attachment_mapping[ $old_attachment_id ] = $new_attachment_id;
+                $this->attachment_mapping[$old_attachment_id] = $new_attachment_id;
             }
         }
 
@@ -134,11 +134,11 @@ class Importer
                 preg_match_all('#(\d+)#', $new_filter_str, $matches, PREG_SET_ORDER);
 
                 foreach ($matches as $old_id) {
-                    if (!isset($this->attachment_mapping[ $old_id[0] ])) {
+                    if (!isset($this->attachment_mapping[$old_id[0]])) {
                         continue;
                     }
 
-                    $new_filter_str = str_replace($old_id[0], $this->attachment_mapping[ $old_id[0] ], $new_filter_str);
+                    $new_filter_str = str_replace($old_id[0], $this->attachment_mapping[$old_id[0]], $new_filter_str);
                 }
                 $filter_data_mapping[] = [ $filter_str, $new_filter_str ];
             } else {
@@ -166,11 +166,11 @@ class Importer
                     continue;
                 }
 
-                if (!isset($this->attachment_mapping[ $metadata['value'] ])) {
+                if (!isset($this->attachment_mapping[$metadata['value']])) {
                     continue;
                 }
 
-                $post['postmeta'][ $metakey ]['value'] = $this->attachment_mapping[ $metadata['value'] ];
+                $post['postmeta'][$metakey]['value'] = $this->attachment_mapping[$metadata['value']];
             }
             $postmeta = $post['postmeta'];
         }

--- a/src/MediaArchive/ApiClient.php
+++ b/src/MediaArchive/ApiClient.php
@@ -272,7 +272,7 @@ WHERE m.meta_key = "' . Image::ARCHIVE_ID_META_KEY . '"
         // Return as indexed array to make lookups easier.
         $indexed = [];
         foreach ($results as $result) {
-            $indexed[ $result['meta_value'] ] = (int) $result['id'];
+            $indexed[$result['meta_value']] = (int) $result['id'];
         }
 
         return $indexed;

--- a/src/MediaArchive/Image.php
+++ b/src/MediaArchive/Image.php
@@ -112,7 +112,7 @@ class Image implements JsonSerializable
             $image->original = $size;
         }
 
-        $image->wordpress_id = $images_in_wordpress[ $image->archive_id ] ?? null;
+        $image->wordpress_id = $images_in_wordpress[$image->archive_id] ?? null;
 
         return $image;
     }

--- a/src/MediaArchive/ImageSize.php
+++ b/src/MediaArchive/ImageSize.php
@@ -44,12 +44,12 @@ class ImageSize implements \JsonSerializable
         return array_reduce(
             $keys,
             static function ($carry, $key) use ($data) {
-                if (! empty($data[ $key ]['URI'])) {
+                if (!empty($data[$key]['URI'])) {
                     $size = new self();
 
-                    $size->url = $data[ $key ]['URI'];
-                    $size->width = (int) $data[ $key ]['Width'];
-                    $size->height = (int) $data[ $key ]['Height'];
+                    $size->url = $data[$key]['URI'];
+                    $size->width = (int) $data[$key]['Width'];
+                    $size->height = (int) $data[$key]['Height'];
 
                     $carry[] = $size;
                 }

--- a/src/Migration/Migrations/M006MoveFeaturesToSeparateOption.php
+++ b/src/Migration/Migrations/M006MoveFeaturesToSeparateOption.php
@@ -28,12 +28,12 @@ class M006MoveFeaturesToSeparateOption extends MigrationScript
         foreach ($feature_fields as $field) {
             $id = $field['id'];
 
-            $value = $settings[ $id ] ?? null;
+            $value = $settings[$id] ?? null;
             if (!$value) {
                 continue;
             }
 
-            $feature_values[ $id ] = $value;
+            $feature_values[$id] = $value;
         }
         update_option(Features::OPTIONS_KEY, $feature_values);
         $record->add_log(

--- a/src/Migration/Migrations/M009PopulateCookiesFields.php
+++ b/src/Migration/Migrations/M009PopulateCookiesFields.php
@@ -96,13 +96,13 @@ class M009PopulateCookiesFields extends MigrationScript
                     }
 
                     if (in_array($key, $settings_keys['titles'], true)) {
-                        $block_settings[ $key ] = wp_strip_all_tags($value, true);
+                        $block_settings[$key] = wp_strip_all_tags($value, true);
                     }
                     if (!in_array($key, $settings_keys['descriptions'], true)) {
                         continue;
                     }
 
-                    $block_settings[ $key ] = $value;
+                    $block_settings[$key] = $value;
                 }
 
                 // No data, skip this update.

--- a/src/Migration/Migrations/M013RemoveDuplicatedOptions.php
+++ b/src/Migration/Migrations/M013RemoveDuplicatedOptions.php
@@ -26,7 +26,7 @@ class M013RemoveDuplicatedOptions extends MigrationScript
                 continue;
             }
 
-            unset($options[ $feature ]);
+            unset($options[$feature]);
         }
 
         update_option('planet4_options', $options);

--- a/src/Migration/Migrations/M024RemoveNewIdentitySylesOption.php
+++ b/src/Migration/Migrations/M024RemoveNewIdentitySylesOption.php
@@ -19,8 +19,8 @@ class M024RemoveNewIdentitySylesOption extends MigrationScript
     protected static function execute(MigrationRecord $record): void
     {
         $options = get_option('planet4_options');
-        unset($options[ 'new_identity_styles' ]);
-        unset($options[ 'website_navigation_style' ]);
+        unset($options['new_identity_styles']);
+        unset($options['website_navigation_style']);
         update_option('planet4_options', $options);
     }
     // phpcs:enable SlevomatCodingStandard.Functions.UnusedParameter

--- a/src/Migration/Migrations/M027RemoveListingPageGridViewOption.php
+++ b/src/Migration/Migrations/M027RemoveListingPageGridViewOption.php
@@ -19,7 +19,7 @@ class M027RemoveListingPageGridViewOption extends MigrationScript
     protected static function execute(MigrationRecord $record): void
     {
         $options = get_option('planet4_options');
-        unset($options[ 'listing_page_grid_view' ]);
+        unset($options['listing_page_grid_view']);
         update_option('planet4_options', $options);
     }
     // phpcs:enable SlevomatCodingStandard.Functions.UnusedParameter

--- a/src/Migration/Migrations/M029RemoveTemplateEditorOption.php
+++ b/src/Migration/Migrations/M029RemoveTemplateEditorOption.php
@@ -22,7 +22,7 @@ class M029RemoveTemplateEditorOption extends MigrationScript
     {
         // Template editor feature flag.
         $features = get_option('planet4_features');
-        unset($features[ 'wp_template_editor' ]);
+        unset($features['wp_template_editor']);
         update_option('planet4_features', $features);
     }
 }

--- a/src/Migration/Migrations/M030RemovePurgeOnFeatureChangeOption.php
+++ b/src/Migration/Migrations/M030RemovePurgeOnFeatureChangeOption.php
@@ -22,7 +22,7 @@ class M030RemovePurgeOnFeatureChangeOption extends MigrationScript
     {
         // Purge on feature change feature flag.
         $features = get_option('planet4_features');
-        unset($features[ 'purge_on_feature_changes' ]);
+        unset($features['purge_on_feature_changes']);
         update_option('planet4_features', $features);
     }
 }

--- a/src/Migration/Migrations/M031MigrateMediaBlockToAudioVideoBlock.php
+++ b/src/Migration/Migrations/M031MigrateMediaBlockToAudioVideoBlock.php
@@ -274,7 +274,7 @@ class M031MigrateMediaBlockToAudioVideoBlock extends MigrationScript
      */
     private static function transform_block_to_embed(array $block, string $media_url, string $provider): array
     {
-        $type = $provider === self::SOURCE_YOUTUBE or $provider === self::SOURCE_VIMEO ? 'video' : 'rich';
+        $type = $provider === self::SOURCE_YOUTUBE || $provider === self::SOURCE_VIMEO ? 'video' : 'rich';
 
         // IMPORTANT: DO NOT MODIFY THIS FORMAT!
         $html_content = '<figure class="wp-block-embed is-type-' . $type . ' is-provider-' . $provider . ' wp-block-embed-' . $provider . ' wp-embed-aspect-16-9 wp-has-aspect-ratio"><div class="wp-block-embed__wrapper">

--- a/src/Migration/Migrations/M034PrePopulateOldPostsArchiveNotice.php
+++ b/src/Migration/Migrations/M034PrePopulateOldPostsArchiveNotice.php
@@ -33,10 +33,10 @@ class M034PrePopulateOldPostsArchiveNotice extends MigrationScript
             return;
         }
 
-        $options[ $prefix . 'cutoff' ] = $cutoff;
-        $options[ $prefix . 'title' ] = $title;
-        $options[ $prefix . 'description' ] = $description;
-        $options[ $prefix . 'button' ] = $button;
+        $options[$prefix . 'cutoff'] = $cutoff;
+        $options[$prefix . 'title'] = $title;
+        $options[$prefix . 'description'] = $description;
+        $options[$prefix . 'button'] = $button;
 
         $result = update_option('planet4_options', $options);
 

--- a/src/Migration/Migrations/M035MigrateCampaignCoversToP4ColumnsBlock.php
+++ b/src/Migration/Migrations/M035MigrateCampaignCoversToP4ColumnsBlock.php
@@ -66,7 +66,7 @@ class M035MigrateCampaignCoversToP4ColumnsBlock extends MigrationScript
         // For old cover type(earlier it was numeric).
         if (is_numeric($block['attrs']['cover_type'])) {
             // phpcs:ignore Generic.Files.LineLength.MaxExceeded
-            $block['attrs']['cover_type'] = Utils\Constants::OLD_COVER_TYPES[ $block['attrs']['cover_type'] ];
+            $block['attrs']['cover_type'] = Utils\Constants::OLD_COVER_TYPES[$block['attrs']['cover_type']];
         }
 
         // Skip non campaign cover style blocks.

--- a/src/Migration/Migrations/M036RemoveEnFormOptions.php
+++ b/src/Migration/Migrations/M036RemoveEnFormOptions.php
@@ -37,7 +37,7 @@ class M036RemoveEnFormOptions extends MigrationScript
 
         // Unset ENForm feature flag.
         $features = get_option('planet4_features');
-        unset($features[ 'feature_engaging_networks' ]);
+        unset($features['feature_engaging_networks']);
         update_option('planet4_features', $features);
 
         // Unset ENForm credentials.

--- a/src/Search/Filters/ActionTypes.php
+++ b/src/Search/Filters/ActionTypes.php
@@ -44,7 +44,7 @@ class ActionTypes
         $filters = [];
 
         foreach ($types as $type) {
-            $filters[ $type->term_id ] = [
+            $filters[$type->term_id] = [
                 'id' => $type->term_id,
                 'slug' => $type->slug,
                 'name' => $type->name,

--- a/src/Search/Filters/Categories.php
+++ b/src/Search/Filters/Categories.php
@@ -36,7 +36,7 @@ class Categories
                 continue;
             }
 
-            $filters[ $category->term_id ] = [
+            $filters[$category->term_id] = [
                 'id' => $category->term_id,
                 'slug' => $category->slug,
                 'name' => $category->name,

--- a/src/Search/Filters/ContentTypes.php
+++ b/src/Search/Filters/ContentTypes.php
@@ -45,7 +45,7 @@ class ContentTypes
         return array_filter(
             $types,
             function ($type) use ($config) {
-                return isset($config[ $type->name ]);
+                return isset($config[$type->name]);
             }
         );
     }
@@ -72,12 +72,12 @@ class ContentTypes
                 continue;
             }
 
-            $type_data = $config[ $type->name ] ?? null;
+            $type_data = $config[$type->name] ?? null;
             if (! $type_data) {
                 continue;
             }
 
-            $filters[ $type_data['id'] ] = [
+            $filters[$type_data['id']] = [
                 'id' => $type_data['id'],
                 'slug' => $type_data['slug'],
                 'name' => $type_data['label'],

--- a/src/Search/Filters/PostTypes.php
+++ b/src/Search/Filters/PostTypes.php
@@ -50,7 +50,7 @@ class PostTypes
         $filters = [];
 
         foreach ($post_types as $post_type) {
-            $filters[ $post_type->term_id ] = [
+            $filters[$post_type->term_id] = [
                 'id' => $post_type->term_id,
                 'slug' => $post_type->slug,
                 'name' => $post_type->name,

--- a/src/Search/Filters/Tags.php
+++ b/src/Search/Filters/Tags.php
@@ -43,7 +43,7 @@ class Tags
         $filters = [];
 
         foreach ($tags as $tag) {
-            $filters[ $tag->term_id ] = [
+            $filters[$tag->term_id] = [
                 'id' => $tag->term_id,
                 'slug' => $tag->slug,
                 'name' => $tag->name,

--- a/src/Settings/Features.php
+++ b/src/Settings/Features.php
@@ -134,7 +134,7 @@ class Features
     {
         $features = get_option(self::OPTIONS_KEY);
 
-        $active = isset($features[ $name ]) && $features[ $name ];
+        $active = isset($features[$name]) && $features[$name];
 
         // Filter to allow setting a feature from code, to avoid chicken and egg problem when releasing adaptions to a
         // new feature.

--- a/src/Spreadsheet.php
+++ b/src/Spreadsheet.php
@@ -63,7 +63,7 @@ final class Spreadsheet
         $rows = array_filter(
             $this->rows,
             function ($row) use ($column_index, $expected) {
-                $value = $row['cells'][ $column_index ]['value'];
+                $value = $row['cells'][$column_index]['value'];
 
                 return $value === $expected;
             }
@@ -85,7 +85,7 @@ final class Spreadsheet
         usort(
             $rows,
             function ($row1, $row2) use ($column_index) {
-                return $row1['cells'][ $column_index ] <=> $row2['cells'][ $column_index ];
+                return $row1['cells'][$column_index] <=> $row2['cells'][$column_index];
             }
         );
         return new self($this->columns, $rows);
@@ -102,7 +102,7 @@ final class Spreadsheet
     {
         return array_map(
             function ($row) use ($column_index) {
-                return $row['cells'][ $column_index ]['value'];
+                return $row['cells'][$column_index]['value'];
             },
             $this->rows
         );
@@ -126,9 +126,9 @@ final class Spreadsheet
                     $row['cells'],
                     function ($carry, $cell) use ($columns, &$cell_index) {
                         if (array_key_exists($cell_index, $columns)) {
-                            $export_name = $columns[ $cell_index ];
+                            $export_name = $columns[$cell_index];
 
-                            $carry[ $export_name ] = $cell['value'] ?? null;
+                            $carry[$export_name] = $cell['value'] ?? null;
                         }
                         ++$cell_index;
 


### PR DESCRIPTION
### Summary

This practically adds 3 rules

- No spacing around array keys
- No spacing around logical operators
- No spacing around function arguments (declarations and calling)

It also fixes all pending syntax errors raised by `phpcs` after this change.

Ref: https://greenpeace-planet4.atlassian.net/browse/PLANET-8184

---

### Testing

I intentionally split the changes in to two commits for easier testing. After applying just the `phpcs` changes you'll see all the changes in the second commit being flagged as errors.

```
npm run shell:php
cd wp-content/themes/planet4-master-theme
vendor/bin/phpcs .
```