### PR TITLE
PLANET-8197: Improve file organization in the src/ folder

### DIFF
--- a/src/Cloudflare/CloudflarePurger.php
+++ b/src/Cloudflare/CloudflarePurger.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace P4\MasterTheme;
+namespace P4\MasterTheme\Cloudflare;
 
 use Cloudflare\APO\Integration\DefaultConfig;
 use Cloudflare\APO\Integration\DefaultIntegration;

--- a/src/Cloudflare/CloudflareTurnstileHandler.php
+++ b/src/Cloudflare/CloudflareTurnstileHandler.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace P4\MasterTheme;
+namespace P4\MasterTheme\Cloudflare;
 
 use P4\MasterTheme\Settings\CloudflareTurnstile;
 

--- a/src/Commands/CloudflarePurge.php
+++ b/src/Commands/CloudflarePurge.php
@@ -2,7 +2,7 @@
 
 namespace P4\MasterTheme\Commands;
 
-use P4\MasterTheme\CloudflarePurger;
+use P4\MasterTheme\Cloudflare\CloudflarePurger;
 use P4\MasterTheme\Features;
 use WP_CLI;
 

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -92,7 +92,7 @@ final class Loader
             CronJob::class,
             DashboardNotice::class,
             ImageHandler::class,
-            CloudflareTurnstileHandler::class,
+            Cloudflare\CloudflareTurnstileHandler::class,
             Sentry::class,
             PostFunctionsHandler::class,
             HtmlPostProcessor::class,

--- a/src/MediaReplacer.php
+++ b/src/MediaReplacer.php
@@ -11,7 +11,7 @@ use WP_Post;
  */
 class MediaReplacer
 {
-    private CloudflarePurger $cf;
+    private Cloudflare\CloudflarePurger $cf;
     private array $replacement_status;
     private array $cache_purge_status;
     private string $bucket_name;
@@ -75,7 +75,7 @@ class MediaReplacer
 
     private function set_variables(): void
     {
-        $this->cf = new CloudflarePurger();
+        $this->cf = new Cloudflare\CloudflarePurger();
 
         $this->bucket_name = $this->stateless->get('sm.bucket');
 


### PR DESCRIPTION
### Summary

This PR improves the file organization in the `src` folder by moving all the elements related to Clouflare to the subfolder `src/Clouflare`. In summary:

- The class `CloudflarePurger` was moved to the `src/Clouflare` folder.
- The class `CloudflareTurnstileHandler` was moved to the `src/Clouflare` folder.

---

Ref: https://greenpeace-planet4.atlassian.net/browse/PLANET-8197

### Testing

1. Check that all Clouflare's functionalities still work correctly.
4. Check all the calls to any of the affected classes made from other repositories, so they can be informed and adjusted (check this [example](https://github.com/search?q=org%3Agreenpeace+CloudflareTurnstileHandler&type=code)).