### PR TITLE
Hide GA Login plugin advertisement notice

### DIFF
--- a/admin/css/notices.css
+++ b/admin/css/notices.css
@@ -4,7 +4,8 @@
 - Gravity Forms
 - ElasticPress
 - GF plugins recommendation
-- WordPress upgrade */
+- WordPress upgrade
+- Google Login plugin */
 
 .stateless-admin-notice,
 #admin_banner_about_automatic_media_detection,
@@ -12,6 +13,7 @@
 [data-ep-notice],
 .otgs-installer-notice-plugin-recommendation,
 .welcome-panel-content,
-div.error:has(a[href*="gpavatars_list_options"]) {
+div.error:has(a[href*="gpavatars_list_options"]),
+div.updated:has(a[href*="wp-glogin.com"]) {
   display: none;
 }

--- a/src/ControlPanel.php
+++ b/src/ControlPanel.php
@@ -253,6 +253,7 @@ class ControlPanel
 
         $this->load_dashboard_assets();
         $this->load_wpml_assets();
+        $this->load_admin_notices_styles();
     }
 
     /**
@@ -273,6 +274,7 @@ class ControlPanel
             [],
             Loader::theme_file_ver('admin/css/dashboard.css')
         );
+
         wp_enqueue_script(
             'dashboard-script',
             "$theme_uri/admin/js/dashboard.js",
@@ -299,6 +301,23 @@ class ControlPanel
             "$theme_uri/admin/css/wpml.css",
             [],
             Loader::theme_file_ver('admin/css/wpml.css')
+        );
+    }
+
+    /**
+     * Load admin notices styles.
+     */
+    public function load_admin_notices_styles(): void
+    {
+        if (!defined('WP_APP_ENV') || !in_array(WP_APP_ENV, ['production', 'staging'], true)) {
+            return;
+        }
+
+        wp_enqueue_style(
+            'admin-notices-style',
+            get_template_directory_uri() . '/admin/css/notices.css',
+            [],
+            Loader::theme_file_ver('admin/css/notices.css')
         );
     }
 }

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -874,16 +874,6 @@ class Settings
         );
         wp_enqueue_style('options-style');
 
-        /* Load additional styles for production environments. */
-        if (defined('WP_APP_ENV') && in_array(WP_APP_ENV, ['production', 'staging'], true)) {
-            wp_enqueue_style(
-                'admin-notices-style',
-                get_template_directory_uri() . '/admin/css/notices.css',
-                [],
-                Loader::theme_file_ver('admin/css/notices.css')
-            );
-        }
-
         wp_enqueue_script(
             'options-script',
             get_template_directory_uri() . '/admin/js/options.js',


### PR DESCRIPTION
### Summary

The plugin is injecting an advertisement for its paid version.

<img width="1303" height="124" alt="Screenshot 2026-06-23 at 11 58 50" src="https://github.com/user-attachments/assets/4e04913f-df62-4e40-8f4a-1bc26bdfba6d" />

Also moved the relevant css file to the proper place so it's loaded across all admin panel screens.

### Testing

<!-- Please add the steps required to test the changes in this Pull Request. -->
1. Browsing on the Users page you should see the notice.
2. Stop the develop environment. 
3. Open `.wp-env.override.json` and change `WP_APP_ENV` to `production`.
4. Start the develop environment.
5. The notice should no longer be visible.
