### PR TITLE
Fix "P4\MasterTheme\Cloudflare\Loader" not found

### DIFF
--- a/src/Cloudflare/CloudflareTurnstileHandler.php
+++ b/src/Cloudflare/CloudflareTurnstileHandler.php
@@ -3,6 +3,7 @@
 namespace P4\MasterTheme\Cloudflare;
 
 use P4\MasterTheme\Settings\CloudflareTurnstile;
+use P4\MasterTheme\Loader;
 
 /**
  * Handles Cloudflare Turnstile integration for WordPress comment forms.


### PR DESCRIPTION
### Summary

This PR fixes the fatal error introduced by https://github.com/greenpeace/planet4-master-theme/pull/3013 as the namespace context changed for the `CloudflareTurnstileHandler` class, so the reference to the `Loader` class has to be updated.

---

Ref: 
- https://github.com/greenpeace/planet4-master-theme/pull/3013
- https://grafana.greenpeace.org/d/aehhgob3tgw74f/planet4-logs?orgId=1&from=now-3h&to=now&timezone=browser&var-env=test&var-target=gutenberg
- https://greenpeace-gpi.slack.com/archives/C0160MX64AG/p1782286744973619

### Testing

1. Run your local instance using the `main` branch
2. Go to the website admin panel > Settings > Discussions.
3. Activate the option "Cloudflare Turnstile".
4. Visit the website front. Everything should be okay.
5. Edit the `CloudflareTurnstileHandler` class by removing the early return of the constructor (lines 25-27).
6. Visit the website front again. A fatal error should be seen, as the `P4\MasterTheme\Cloudflare\Loader` class is missing.
7. Switch to this PR branch (`fix-cloudflare-loader-not-found`).
8. Visit the website front again. A different error should be seen, as the problem with the `P4\MasterTheme\Cloudflare\Loader` class is fixed.
9. If the `CloudflareTurnstileHandler` class is edited by replacing the constant `TURNSTILE_SECRET_KEY` with any string, the website should be back to normal.