### PR TITLE
PLANET-7630: Fix special characters for Open Graph

### DIFF
--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -4,8 +4,6 @@ namespace P4\MasterTheme;
 
 use P4\MasterTheme\Features\Dev\CoreBlockPatterns;
 use Timber\Timber;
-use Twig\Extension\StringLoaderExtension;
-use Twig\Markup;
 use WP_Error;
 
 /**
@@ -80,7 +78,6 @@ class MasterSite extends \Timber\Site
         add_post_type_support('page', 'excerpt'); // Added excerpt option to pages.
 
         add_filter('timber/context', [$this, 'add_to_context']);
-        add_filter('timber/twig', [$this, 'add_to_twig']);
         add_action('init', [$this, 'register_taxonomies'], 2);
         add_action('init', [$this, 'register_oembed_provider']);
         add_action('admin_menu', [$this, 'add_post_revisions_setting']);
@@ -535,33 +532,6 @@ class MasterSite extends \Timber\Site
         }
 
         return $context;
-    }
-
-    /**
-     * Add your own functions to Twig.
-     *
-     * @param Twig_ExtensionInterface $twig The Twig object that implements the Twig_ExtensionInterface.
-     *
-     * @return mixed
-     */
-    public function add_to_twig(\Twig\Environment $twig)
-    {
-        $twig->addExtension(new StringLoaderExtension());
-        $twig->addFilter(new \Twig\TwigFilter('svgicon', [$this, 'svgicon']));
-        return $twig;
-    }
-
-    /**
-     * SVG Icon helper
-     *
-     * @param string $name Icon name.
-     */
-    public function svgicon(string $name): Markup
-    {
-        $svg_icon_template = '<svg viewBox="0 0 32 32" class="icon"><use xlink:href="'
-            . $this->theme_dir . '/assets/build/sprite.symbol.svg#'
-            . $name . '"></use></svg>';
-        return new Markup($svg_icon_template, 'UTF-8');
     }
 
     /**

--- a/src/TimberSettings.php
+++ b/src/TimberSettings.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace P4\MasterTheme;
 
+use Twig\Extension\StringLoaderExtension;
+use Twig\Markup;
+
 /**
  * Class TimberSettings
  *
@@ -24,6 +27,8 @@ class TimberSettings
      */
     public function hooks(): void
     {
+        add_filter('timber/twig', [$this, 'add_to_twig']);
+
         // Map post types to custom Timber post class.
         add_filter('timber/post/classmap', function ($classmap) {
             $custom_classmap = [
@@ -46,5 +51,38 @@ class TimberSettings
             $options['cache'] = defined('WP_DEBUG') ? !WP_DEBUG : true;
             return $options;
         });
+    }
+
+    /**
+     * Add your own functions to Twig.
+     *
+     * @param Twig_ExtensionInterface $twig The Twig object that implements the Twig_ExtensionInterface.
+     *
+     * @return mixed
+     */
+    public function add_to_twig(\Twig\Environment $twig)
+    {
+        $twig->addExtension(new StringLoaderExtension());
+
+        $twig->addFilter(new \Twig\TwigFilter('svgicon', [$this, 'svgicon']));
+
+        $twig->addFilter(new \Twig\TwigFilter('decode_entities', function ($str) {
+            return html_entity_decode($str, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+        }));
+
+        return $twig;
+    }
+
+    /**
+     * SVG Icon helper
+     *
+     * @param string $name Icon name.
+     */
+    public function svgicon(string $name): Markup
+    {
+        $svg_icon_template = '<svg viewBox="0 0 32 32" class="icon"><use xlink:href="'
+            . get_template_directory_uri() . '/assets/build/sprite.symbol.svg#'
+            . $name . '"></use></svg>';
+        return new Markup($svg_icon_template, 'UTF-8');
     }
 }

--- a/templates/blocks/meta_fields.twig
+++ b/templates/blocks/meta_fields.twig
@@ -23,15 +23,15 @@
     <meta name="description" content="{{ meta_description }}">
 
     {% if og_title %}
-        {% set title = og_title|raw~' - '~site.name %}
+        {% set title = og_title|decode_entities~' - '~site.name %}
     {% elseif wp_title %}
-        {% set title = wp_title|raw~' - '~site.name %}
+        {% set title = wp_title|decode_entities~' - '~site.name %}
     {% else %}
         {% set title = site.name %}
     {% endif %}
 
-    <meta name="title" content="{{ title|e('html_attr')|raw }}"/>
-    <meta property="og:title" content="{{ title|e('html_attr')|raw }}" />
+    <meta name="title" content="{{ title }}"/>
+    <meta property="og:title" content="{{ title }}" />
     <meta property="og:url" content="{{ current_url }}" />
     {% if (og_type) %}
         <meta property="og:type" content="{{ og_type }}" />
@@ -48,6 +48,7 @@
         <meta property="og:image:width" content="{{ og_image_data['width'] }}" />
         <meta property="og:image:height" content="{{ og_image_data['height'] }}" />
     {% endif %}
+
     <meta property="og:site_name" content="{{ site.name }}" />
 
     {% if facebook_page_id %}
@@ -56,9 +57,10 @@
 
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:site" content="{{ site.name }}" />
-    <meta name="twitter:title" content="{{ title|e('html_attr')|raw }}">
+    <meta name="twitter:title" content="{{ title }}">
+
     {% if (og_description) %}
-        <meta name="twitter:description" content="{{ og_description|e('html_attr')|raw }}">
+        <meta name="twitter:description" content="{{ og_description|striptags }}">
     {% endif %}
 
     {% if (meta_twitter_creator is defined) %}


### PR DESCRIPTION
### Summary

This PR prevents the special characters from being wrongly rendered on social sharing.
It also moves the code related to Twig from the `MasterSite` class to the `TimberSettings` class.

---

Ref: https://greenpeace-planet4.atlassian.net/browse/PLANET-7630

### Testing

1. Create a new page in the [test instance](https://www-dev.greenpeace.org/test-nix/wp-admin/).
2. For the new page, use a title with several special characters (especially the ones reported in the [ticket](https://greenpeace-planet4.atlassian.net/browse/PLANET-7630))
3. Validate that the characters are rendered correctly on social sharing (you can use testing tools [like](https://www.opengraph.xyz/) this or [this](https://debug.iframely.com/))
4. Check that the characters also work when data is added to the Open Graph/Social Fields fields in the sidebar of the page editor.
5. Compare the results with another test instance.