### PR TITLE
PLANET-8182 Update codebase for WordPress 7.0.1 upgrade

### DIFF
--- a/assets/src/scss/editorStyle.scss
+++ b/assets/src/scss/editorStyle.scss
@@ -40,8 +40,6 @@
 @import "blocks/HappyPoint/HappyPointEditorStyle";
 @import "blocks/TakeActionBoxout/TakeActionBoxoutEditorStyle";
 @import "blocks/Timeline/TimelineEditorStyle";
-
-// Beta blocks editor styles
 @import "blocks/PostsList/PostsListEditorStyle";
 @import "blocks/ActionsList/ActionsListEditorStyle";
 

--- a/functions.php
+++ b/functions.php
@@ -132,6 +132,38 @@ function hide_wp_update_nag(): void
 
 add_action('admin_menu', 'hide_wp_update_nag');
 
+/**
+ * Remove Connectors settings menu page, at least until we are ready to discuss AI in P4.
+ */
+add_action('admin_init', function (): void {
+    remove_submenu_page('options-general.php', 'options-connectors.php');
+    /**
+     * Redirects the new Settings > Connectors AI screen back to the main
+     * Dashboard so the URL can't be accessed directly.
+     */
+    global $pagenow;
+    if ('options-connectors.php' === $pagenow) {
+        wp_safe_redirect(admin_url('/'), 301);
+        exit;
+    }
+});
+
+/**
+ * Remove Theme Editor menu page.
+ */
+add_action('admin_init', function (): void {
+    remove_submenu_page('themes.php', 'theme-editor.php');
+    /**
+     * Redirects the Appearance > Theme Editor screen back to the main
+     * Dashboard so the URL can't be accessed directly.
+     */
+    global $pagenow;
+    if ('theme-editor.php' === $pagenow) {
+        wp_safe_redirect(admin_url('/'), 301);
+        exit;
+    }
+});
+
 require_once 'load-class-aliases.php';
 
 Loader::get_instance();

--- a/src/Blocks/Accordion.php
+++ b/src/Blocks/Accordion.php
@@ -88,7 +88,9 @@ class Accordion extends BaseBlock
             ]
         );
 
-        add_action('enqueue_block_editor_assets', [ self::class, 'enqueue_editor_assets' ]);
+        if (is_admin()) {
+            add_action('enqueue_block_assets', [ self::class, 'enqueue_editor_assets' ]);
+        }
         add_action('wp_enqueue_scripts', [ self::class, 'enqueue_frontend_assets' ]);
     }
 

--- a/src/Blocks/CarouselHeader.php
+++ b/src/Blocks/CarouselHeader.php
@@ -95,7 +95,9 @@ class CarouselHeader extends BaseBlock
             ]
         );
 
-        add_action('enqueue_block_editor_assets', [ self::class, 'enqueue_editor_assets' ]);
+        if (is_admin()) {
+            add_action('enqueue_block_assets', [ self::class, 'enqueue_editor_assets' ]);
+        }
         add_action('wp_enqueue_scripts', [ self::class, 'enqueue_frontend_assets' ]);
     }
 

--- a/src/Blocks/Counter.php
+++ b/src/Blocks/Counter.php
@@ -65,7 +65,9 @@ class Counter extends BaseBlock
             ]
         );
 
-        add_action('enqueue_block_editor_assets', [ self::class, 'enqueue_editor_assets' ]);
+        if (is_admin()) {
+            add_action('enqueue_block_assets', [ self::class, 'enqueue_editor_assets' ]);
+        }
         add_action('wp_enqueue_scripts', [ self::class, 'enqueue_frontend_assets' ]);
     }
 

--- a/src/Blocks/Gallery.php
+++ b/src/Blocks/Gallery.php
@@ -104,7 +104,9 @@ class Gallery extends BaseBlock
             ]
         );
 
-        add_action('enqueue_block_editor_assets', [ self::class, 'enqueue_editor_assets' ]);
+        if (is_admin()) {
+            add_action('enqueue_block_assets', [ self::class, 'enqueue_editor_assets' ]);
+        }
         add_action('wp_enqueue_scripts', [ self::class, 'enqueue_frontend_assets' ]);
         add_action('rest_api_init', [ self::class, 'register_endpoint' ]);
     }

--- a/src/Blocks/SecondaryNavigation.php
+++ b/src/Blocks/SecondaryNavigation.php
@@ -55,7 +55,9 @@ class SecondaryNavigation extends BaseBlock
             ]
         );
 
-        add_action('enqueue_block_editor_assets', [ self::class, 'enqueue_editor_assets' ]);
+        if (is_admin()) {
+            add_action('enqueue_block_assets', [ self::class, 'enqueue_editor_assets' ]);
+        }
         add_action('wp_enqueue_scripts', [ self::class, 'enqueue_frontend_assets' ]);
     }
 

--- a/src/Blocks/SocialMedia.php
+++ b/src/Blocks/SocialMedia.php
@@ -86,7 +86,9 @@ class SocialMedia extends BaseBlock
             ]
         );
 
-        add_action('enqueue_block_editor_assets', [ self::class, 'enqueue_editor_assets' ]);
+        if (is_admin()) {
+            add_action('enqueue_block_assets', [ self::class, 'enqueue_editor_assets' ]);
+        }
         add_action('wp_enqueue_scripts', [ self::class, 'enqueue_frontend_assets' ]);
     }
 

--- a/src/Blocks/Timeline.php
+++ b/src/Blocks/Timeline.php
@@ -112,7 +112,9 @@ class Timeline extends BaseBlock
             );
         }
 
-        add_action('enqueue_block_editor_assets', [ self::class, 'enqueue_editor_assets' ]);
+        if (is_admin()) {
+            add_action('enqueue_block_assets', [ self::class, 'enqueue_editor_assets' ]);
+        }
         add_action('wp_enqueue_scripts', [ self::class, 'enqueue_frontend_assets' ]);
     }
 

--- a/src/MasterBlocks.php
+++ b/src/MasterBlocks.php
@@ -71,7 +71,9 @@ class MasterBlocks
         add_filter('render_block_data', [$this, 'empty_string_to_false_in_link_new_tab_in_columns_blocks']);
 
         // Admin scripts.
-        add_action('enqueue_block_editor_assets', [ $this, 'enqueue_block_editor_script' ]);
+        if (is_admin()) {
+            add_action('enqueue_block_assets', [ $this, 'enqueue_block_editor_script' ]);
+        }
 
         // Frontend scripts.
         add_action('wp_enqueue_scripts', [$this, 'enqueue_block_public_assets']);

--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -89,7 +89,9 @@ class MasterSite extends \Timber\Site
         add_action('init', [$this, 'register_oembed_provider']);
         add_action('admin_menu', [$this, 'add_post_revisions_setting']);
         // Load the editor scripts only enqueuing editor scripts while in context of the editor.
-        add_action('enqueue_block_editor_assets', [$this, 'enqueue_editor_assets']);
+        if (is_admin()) {
+            add_action('enqueue_block_assets', [$this, 'enqueue_editor_assets']);
+        }
         // Load main theme assets before any child theme.
         add_action('wp_enqueue_scripts', [PublicAssets::class, 'enqueue_css'], 0);
         add_action('wp_enqueue_scripts', [PublicAssets::class, 'enqueue_js']);

--- a/tests/e2e/author-override.spec.js
+++ b/tests/e2e/author-override.spec.js
@@ -1,11 +1,13 @@
 import {test, expect} from './tools/lib/test-utils.js';
 import {updatePost} from './tools/lib/post.js';
+import {openMetaBoxesTab, closeMetaBoxesTab} from './tools/lib/editor.js';
 
 const AUTHOR_NAME = 'Alternative Author';
 
 test.useAdminLoggedIn();
 
 test('Test Author override', async ({page, requestUtils}) => {
+  // Create a new post for the test.
   const newPost = await requestUtils.rest({
     path: '/wp/v2/posts',
     method: 'POST',
@@ -17,19 +19,27 @@ test('Test Author override', async ({page, requestUtils}) => {
       categories: [1, 2, 3],
     },
   });
-  const editUrl = `./wp-admin/post.php?post=${newPost.id}&action=edit`;
-  const postUrl = newPost.link;
 
+  // Go to the edit page for the new post.
+  const editUrl = `./wp-admin/post.php?post=${newPost.id}&action=edit`;
   await page.goto(editUrl, {waitUntil: 'domcontentloaded'}); // Default is waituntil: 'load' but that doesn't work for Webkit
 
+  // Fill in the author override.
+  await openMetaBoxesTab({page});
   const overrideControl = page.locator('.edit-post-layout__metaboxes').locator('#p4_author_override');
+  await overrideControl.scrollIntoViewIfNeeded();
   await expect(overrideControl).toBeVisible();
   await overrideControl.fill(AUTHOR_NAME);
+  await page.waitForTimeout(1000); // letting metabox post query finish
+  await closeMetaBoxesTab({page});
 
+  // Update the post.
   await page.waitForTimeout(1000);
   await updatePost({page});
+  const postUrl = newPost.link;
   await page.goto(postUrl);
 
+  // Make sure the new author name is properly displayed in the frontend.
   const authorLocator = page.locator('.single-post-author');
   expect(authorLocator).toBeVisible();
   expect(await authorLocator.innerText()).toBe(AUTHOR_NAME);

--- a/tests/e2e/blocks/actions-list.spec.js
+++ b/tests/e2e/blocks/actions-list.spec.js
@@ -18,7 +18,7 @@ test.describe('Test Actions List block', () => {
     await createPostWithFeaturedImage({page, admin, editor}, {title: 'Test Actions List Grid Layout', postType: 'page'});
 
     // Add Actions List block.
-    await addActionsListBlock(page);
+    await addActionsListBlock({page, editor});
 
     // Publish page.
     await publishPostAndVisit({page, editor});
@@ -72,7 +72,7 @@ test.describe('Test Actions List block', () => {
     await createPostWithFeaturedImage({page, admin, editor}, {title: 'Test Actions List, Manual Override', postType: 'page'});
 
     // Add a Actions List block using the Manual Override to select the actions created above.
-    await addActionsListBlockWithManualOverride(page, actionTitles);
+    await addActionsListBlockWithManualOverride({page, editor}, actionTitles);
 
     // Publish page.
     await publishPostAndVisit({page, editor});
@@ -85,7 +85,7 @@ test.describe('Test Actions List block', () => {
     await createPostWithFeaturedImage({page, admin, editor}, {title: 'Test Actions List, Carousel Layout', postType: 'page'});
 
     // Add a Actions List block with the Carousel layout.
-    await addActionsListBlock(page, 'Carousel');
+    await addActionsListBlock({page, editor}, 'Carousel');
 
     // Publish page.
     await publishPostAndVisit({page, editor});

--- a/tests/e2e/blocks/audio-video.spec.js
+++ b/tests/e2e/blocks/audio-video.spec.js
@@ -42,11 +42,11 @@ const TEST_MEDIA = [
  * @param {string} mediaType - The type of media added (Audio or Video).
  * @param {string} mediaLink - The media file link (can be YouTube, Vimeo, mp4, mp3, SoundCloud).
  */
-const addVideoOrAudioBlock = async ({page}, mediaType, mediaLink) => {
+const addVideoOrAudioBlock = async ({page, editor}, mediaType, mediaLink) => {
   await searchAndInsertBlock({page}, mediaType, mediaType);
 
   // Make sure the block has been added.
-  const insertUrl = await page.getByRole('button', {name: 'Insert from URL'});
+  const insertUrl = await editor.canvas.getByRole('button', {name: 'Insert from URL'});
   await expect(insertUrl).toBeVisible();
 
   // We should close the sidebar before editing the block.
@@ -64,7 +64,7 @@ test.useAdminLoggedIn();
 TEST_MEDIA.forEach(({type, format, url, selector}) => {
   test(`check the ${type} block with format ${format}`, async ({page, admin, editor}) => {
     await createPostWithFeaturedImage({page, admin, editor}, {title: `Test ${type} block`});
-    await addVideoOrAudioBlock({page}, type, url);
+    await addVideoOrAudioBlock({page, editor}, type, url);
     await publishPostAndVisit({page, editor});
     await expect(page.locator(selector)).toBeVisible();
   });

--- a/tests/e2e/blocks/carousel-header.spec.js
+++ b/tests/e2e/blocks/carousel-header.spec.js
@@ -17,9 +17,9 @@ const slides = [
  * @param {{Page, Editor}} options - Page and Editor object
  */
 const addSlide = async (slide, {index, addNext}, {page, editor}) => {
-  await page.locator('[aria-label="Enter title"][contenteditable="true"]').nth(index).fill(`My test Header ${index + 1}`);
-  await page.locator('[aria-label="Enter description"][contenteditable="true"]').nth(index).fill(`Testing carousel description ${index + 1}`);
-  await page.locator('[aria-label="Enter CTA text"][contenteditable="true"]').nth(index).fill(`Read more ${index + 1}`);
+  await editor.canvas.locator('[aria-label="Enter title"][contenteditable="true"]').nth(index).fill(`My test Header ${index + 1}`);
+  await editor.canvas.locator('[aria-label="Enter description"][contenteditable="true"]').nth(index).fill(`Testing carousel description ${index + 1}`);
+  await editor.canvas.locator('[aria-label="Enter CTA text"][contenteditable="true"]').nth(index).fill(`Read more ${index + 1}`);
 
   // Check if sidebar is not visible
   await editor.openDocumentSettingsSidebar();
@@ -33,7 +33,7 @@ const addSlide = async (slide, {index, addNext}, {page, editor}) => {
   // Close sidebar before interacting with the carousel item
   await page.getByRole('button', {name: 'Close Settings'}).click();
 
-  const activeSlide = page.locator('.carousel-item.active');
+  const activeSlide = editor.canvas.locator('.carousel-item.active');
 
   const editButton = activeSlide.locator('.carousel-header-editor-controls button');
 

--- a/tests/e2e/blocks/columns-icons.spec.js
+++ b/tests/e2e/blocks/columns-icons.spec.js
@@ -8,7 +8,7 @@ test('Test Columns block with Icons style', async ({page, admin, editor}) => {
   await createPostWithFeaturedImage({page, admin, editor}, {title: 'Test Columns block', postType: 'page'});
 
   // Add Columns block.
-  await addColumnsBlock(page, 'Icons');
+  await addColumnsBlock(page, editor, 'Icons');
 
   // Publish page.
   await publishPostAndVisit({page, editor});

--- a/tests/e2e/blocks/columns-images.spec.js
+++ b/tests/e2e/blocks/columns-images.spec.js
@@ -9,7 +9,7 @@ test('Test Columns block with Images style', async ({page, editor, admin}) => {
   await createPostWithFeaturedImage({page, admin, editor}, {title: 'Test Columns block', postType: 'page'});
 
   // Add Columns block.
-  await addColumnsBlock(page, 'Images');
+  await addColumnsBlock(page, editor, 'Images');
 
   // Publish page.
   await publishPostAndVisit({page, editor});

--- a/tests/e2e/blocks/columns-no-image.spec.js
+++ b/tests/e2e/blocks/columns-no-image.spec.js
@@ -8,7 +8,7 @@ test('Test Columns block with No Image style', async ({page, editor, admin}) => 
   await createPostWithFeaturedImage({page, admin, editor}, {title: 'Test Columns block', postType: 'page'});
 
   // Add Columns block.
-  await addColumnsBlock(page);
+  await addColumnsBlock(page, editor);
 
   // Publish page.
   await publishPostAndVisit({page, editor});

--- a/tests/e2e/blocks/columns-tasks.spec.js
+++ b/tests/e2e/blocks/columns-tasks.spec.js
@@ -8,7 +8,7 @@ test('Test Columns block with Tasks style', async ({page, admin, editor}) => {
   await createPostWithFeaturedImage({page, admin, editor}, {title: 'Test Columns block', postType: 'page'});
 
   // Add Columns block.
-  await addColumnsBlock(page, 'Tasks');
+  await addColumnsBlock(page, editor, 'Tasks');
 
   // Publish page.
   await publishPostAndVisit({page, editor});

--- a/tests/e2e/blocks/counter.spec.js
+++ b/tests/e2e/blocks/counter.spec.js
@@ -1,6 +1,6 @@
 import {test, expect} from '../tools/lib/test-utils.js';
 import {publishPostAndVisit, createPostWithFeaturedImage} from '../tools/lib/post.js';
-import {searchAndInsertBlock} from '../tools/lib/editor.js';
+import {searchAndInsertBlock, pickBlockStyle} from '../tools/lib/editor.js';
 
 const COUNTER_URL = 'https://counter.greenpeace.org/signups?id=testcounter';
 const COUNTER_GOAL = 10000;
@@ -15,18 +15,17 @@ test('Test Counter block', async ({page, admin, editor, request}) => {
   // Add Counter block.
   await searchAndInsertBlock({page}, 'Counter');
 
-  // Pick the "Progress Bar" style.
-  const stylePicker = page.locator('.block-editor-block-styles__variants');
-  await stylePicker.locator('button[aria-label="Progress Bar"]').click();
-
   // Change the block settings.
   await page.getByLabel('API URL for Goal Reached').fill(COUNTER_URL);
   await page.getByLabel('Goal', {exact: true}).fill(`${COUNTER_GOAL}`);
   await page.getByPlaceholder('e.g. "signatures collected of').fill('Signatures collected: %completed% from %target%. (%remaining% remaining)');
 
+  // Pick the "Progress Bar" style.
+  await pickBlockStyle({page}, 'Progress Bar');
+
   // Change block title and description.
-  await page.getByRole('textbox', {name: 'Enter title'}).fill(COUNTER_TITLE);
-  await page.getByRole('textbox', {name: 'Enter description'}).fill(COUNTER_DESCRIPTION);
+  await editor.canvas.getByRole('textbox', {name: 'Enter title'}).fill(COUNTER_TITLE);
+  await editor.canvas.getByRole('textbox', {name: 'Enter description'}).fill(COUNTER_DESCRIPTION);
 
   // Publish page.
   await publishPostAndVisit({page, editor});

--- a/tests/e2e/blocks/gallery.spec.js
+++ b/tests/e2e/blocks/gallery.spec.js
@@ -1,6 +1,6 @@
-import {test, expect} from './tools/lib/test-utils.js';
-import {publishPostAndVisit, createPostWithFeaturedImage} from './tools/lib/post.js';
-import {searchAndInsertBlock} from './tools/lib/editor.js';
+import {test, expect} from '../tools/lib/test-utils.js';
+import {publishPostAndVisit, createPostWithFeaturedImage} from '../tools/lib/post.js';
+import {searchAndInsertBlock} from '../tools/lib/editor.js';
 
 test.useAdminLoggedIn();
 
@@ -21,7 +21,7 @@ test('Test Gallery basic functionalities', async ({page, admin, editor}) => {
     await route.continue();
   });
 
-  await page.getByRole('button', {name: 'Media Library'}).click();
+  await editor.canvas.getByRole('button', {name: 'Media Library'}).click();
 
   const imageModal = page.getByRole('dialog', {name: 'Create gallery'});
   await imageModal.getByRole('tab', {name: 'Media Library'}).click();

--- a/tests/e2e/blocks/posts-list.spec.js
+++ b/tests/e2e/blocks/posts-list.spec.js
@@ -16,7 +16,7 @@ test.describe('Test Posts List block', () => {
     await createPostWithFeaturedImage({page, admin, editor}, {title: 'Test Posts List, List Layout', postType: 'page'});
 
     // Add a Posts List block with the wanted attributes.
-    await addPostsListBlock(page);
+    await addPostsListBlock({page, editor});
 
     // Publish page.
     await publishPostAndVisit({page, editor});
@@ -29,7 +29,7 @@ test.describe('Test Posts List block', () => {
     await createPostWithFeaturedImage({page, admin, editor}, {title: 'Test Posts List, Carousel Layout', postType: 'page'});
 
     // Add a Posts List block with the Carousel layout.
-    await addPostsListBlock(page, 'Carousel');
+    await addPostsListBlock({page, editor}, 'Carousel');
 
     // Publish page.
     await publishPostAndVisit({page, editor});
@@ -42,7 +42,7 @@ test.describe('Test Posts List block', () => {
     await createPostWithFeaturedImage({page, admin, editor}, {title: 'Test Posts List, Grid Layout', postType: 'page'});
 
     // Add a Posts List block with the wanted attributes.
-    await addPostsListBlock(page, 'Grid');
+    await addPostsListBlock({page, editor}, 'Grid');
 
     // Publish page.
     await publishPostAndVisit({page, editor});
@@ -72,7 +72,7 @@ test.describe('Test Posts List block', () => {
     await createPostWithFeaturedImage({page, admin, editor}, {title: 'Test Posts List, Manual Override', postType: 'page'});
 
     // Add a Posts List block using the Manual Override to select the 4 posts created above.
-    await addPostsListBlockWithManualOverride(page, postTitles);
+    await addPostsListBlockWithManualOverride({page, editor}, postTitles);
 
     // Publish page.
     await publishPostAndVisit({page, editor});

--- a/tests/e2e/blocks/secondary-navigation.spec.js
+++ b/tests/e2e/blocks/secondary-navigation.spec.js
@@ -39,15 +39,15 @@ test('Test Secondary Navigation block', async ({page, admin, editor}) => {
   await closeBlockInserter({page});
 
   // Make sure it displays the empty message at first.
-  await expect(page.locator('.EmptyMessage')).toBeVisible();
+  await expect(editor.canvas.locator('.EmptyMessage')).toBeVisible();
 
   let i = 0;
 
   // Add content (headings and paragraphs).
   for (let index = 0; index < HEADINGS.length; index++) {
-    await addHeadingOrParagraph({page}, 'Heading', 'h2', i, HEADINGS[index]);
+    await addHeadingOrParagraph({page, editor}, 'Heading', 'h2', i, HEADINGS[index]);
     // For the paragraphs, we need to use i + 1 because there is a paragraph in the Page Header.
-    await addHeadingOrParagraph({page}, 'Paragraph', 'p', i + 1, PARAGRAPH_CONTENT);
+    await addHeadingOrParagraph({page, editor}, 'Paragraph', 'p', i + 1, PARAGRAPH_CONTENT);
 
     i++;
   };

--- a/tests/e2e/blocks/spreadsheet.spec.js
+++ b/tests/e2e/blocks/spreadsheet.spec.js
@@ -14,7 +14,7 @@ test('Test Spreadsheet block', async ({page, admin, editor}) => {
   await searchAndInsertBlock({page}, 'Spreadsheet');
 
   // Check that the "empty URL" warning is displayed.
-  const warning = page.locator('.block-edit-mode-warning');
+  const warning = editor.canvas.locator('.block-edit-mode-warning');
   await expect(warning).toBeVisible();
   await expect(warning).toHaveText('No URL has been specified. Please edit the block and provide a Spreadsheet URL using the sidebar.');
 
@@ -42,7 +42,7 @@ test('Test Spreadsheet block', async ({page, admin, editor}) => {
   await expect(warning).toBeHidden();
 
   // Test that the data is properly displayed in the editor.
-  const editorTable = page.locator('table.spreadsheet-table');
+  const editorTable = editor.canvas.locator('table.spreadsheet-table');
   await expect(editorTable.locator('thead th:first-child button')).toHaveText('Some 30x30 commitment');
   await expect(editorTable.locator('tbody tr:first-child td:first-child')).toHaveText('Albania');
 

--- a/tests/e2e/blocks/take-action-boxout.spec.js
+++ b/tests/e2e/blocks/take-action-boxout.spec.js
@@ -15,7 +15,7 @@ test.describe('Test Take Action Boxout block', () => {
       page.waitForResponse(r =>
         r.url().includes('/planet4/v1/action-pages')
       ),
-      page.waitForSelector('.boxout-heading[contenteditable="true"]'),
+      await expect(editor.canvas.locator('.boxout-heading[contenteditable="true"]')).toBeVisible(),
     ]);
 
   });
@@ -23,35 +23,29 @@ test.describe('Test Take Action Boxout block', () => {
   test('Take Action Boxout with existing page', async ({page, editor}) => {
     test.slow();
     // Select the first page option.
-    await page.getByRole('region', {name: 'Editor settings'})
-      .getByRole('combobox', {name: 'Select Take Action Page'})
-      .selectOption({index: 1});
+    await page.getByRole('combobox', {name: 'Select Take Action Page'}).selectOption({index: 1});
 
     // Save boxout data to make sure it shows in the frontend.
-    const boxoutTitle = await page.innerHTML('.boxout-heading');
+    const boxoutTitle = await editor.canvas.locator('.boxout-heading').innerText();
 
     // Publish post.
     await publishPostAndVisit({page, editor});
 
     // Make sure block shows as expected in the frontend.
-    expect((await page.innerHTML('.boxout-heading')).trim()).toBe(boxoutTitle);
+    await expect(page.locator('.boxout-heading')).toHaveText(boxoutTitle);
   });
 
   test('Take Action Boxout with custom fields', async ({page, editor}) => {
     // Fill in boxout fields.
-    await page.locator('.boxout-heading').click();
-    await page.locator('.boxout-heading').fill('The boxout title');
-    await page.locator('.boxout-excerpt').click();
-    await page.locator('.boxout-excerpt').fill('The boxout excerpt');
+    await editor.canvas.locator('.boxout-heading').fill('The boxout title');
+    await editor.canvas.locator('.boxout-excerpt').fill('The boxout excerpt');
 
     // Publish post.
     await publishPostAndVisit({page, editor});
 
     // Make sure block shows as expected in the frontend.
-    const boxoutTitle = (await page.innerHTML('.boxout-heading')).trim();
-    const boxoutExcerpt = await page.innerHTML('.boxout-excerpt');
-    expect(boxoutTitle).toBe('The boxout title');
-    expect(boxoutExcerpt).toBe('The boxout excerpt');
+    await expect(page.locator('.boxout-heading')).toHaveText('The boxout title');
+    await expect(page.locator('.boxout-excerpt')).toHaveText('The boxout excerpt');
   });
 });
 

--- a/tests/e2e/related-posts.spec.js
+++ b/tests/e2e/related-posts.spec.js
@@ -1,5 +1,6 @@
 import {test, expect} from './tools/lib/test-utils.js';
 import {updatePost} from './tools/lib/post.js';
+import {openMetaBoxesTab, closeMetaBoxesTab} from './tools/lib/editor.js';
 
 test.useAdminLoggedIn();
 
@@ -19,24 +20,30 @@ test('Test Related Posts block', async ({page, requestUtils}) => {
   const editUrl = `./wp-admin/post.php?post=${newPost.id}&action=edit`;
   const postUrl = newPost.link;
 
-  // Related posts enabled
+  // Related posts enabled.
   await page.goto(editUrl, {waitUntil: 'domcontentloaded'}); // Default is waituntil: 'load' but that doesn't work for Webkit
+  await openMetaBoxesTab({page});
   await page.locator('.edit-post-layout__metaboxes').getByRole('combobox', {name: 'Include Related Posts'}).selectOption('Yes');
   await page.waitForTimeout(1000); // letting metabox post query finish
+  await closeMetaBoxesTab({page});
   await updatePost({page});
 
+  // Check the frontend.
   await page.goto(postUrl);
   const relatedSection = page.locator('.p4-query-loop');
   await relatedSection.scrollIntoViewIfNeeded();
   relatedSection.locator('.wp-block-post-template');
   await expect(relatedSection.locator('.wp-block-post-template')).not.toHaveCount(0);
 
-  // Related posts disabled
+  // Related posts disabled.
   await page.goto(editUrl);
+  await openMetaBoxesTab({page});
   await page.locator('.edit-post-layout__metaboxes').getByRole('combobox', {name: 'Include Related Posts'}).selectOption('No');
-  await updatePost({page});
   await page.waitForTimeout(1000); // letting metabox post query finish
+  await closeMetaBoxesTab({page});
+  await updatePost({page});
 
+  // Check the frontend.
   await page.goto(postUrl);
   await expect(page.locator('.p4-query-loop')).toHaveCount(0);
 });

--- a/tests/e2e/tools/lib/actions-list.js
+++ b/tests/e2e/tools/lib/actions-list.js
@@ -9,21 +9,21 @@ const MANUAL_OVERRIDE_TITLE = 'Actions';
 /**
  * Adds the Actions List block to the page.
  *
- * @param {{Page}} page   - The Playwright page instance.
- * @param {string} layout - The layout of the block.
+ * @param {{Page, Editor}} options - Page and Editor object
+ * @param {string}         layout  - The layout of the block.
  */
-export async function addActionsListBlock(page, layout) {
-  await addListBlock(page, BLOCK_NAME, 2, {layout, category: TEST_CATEGORY, title: TEST_TITLE});
+export async function addActionsListBlock({page, editor}, layout) {
+  await addListBlock({page, editor}, BLOCK_NAME, 2, {layout, category: TEST_CATEGORY, title: TEST_TITLE});
 }
 
 /**
  * Adds the Actions List block to the page with the Manual Override posts selected.
  *
- * @param {{Page}}   page         - The Playwright page instance.
- * @param {string[]} actionTitles - The titles of the actions to include in the block to override the default ones.
+ * @param {{Page, Editor}} options      - Page and Editor object
+ * @param {string[]}       actionTitles - The titles of the actions to include in the block to override the default ones.
  */
-export async function addActionsListBlockWithManualOverride(page, actionTitles) {
-  await addListBlockWithManualOverride(page, BLOCK_NAME, actionTitles, MANUAL_OVERRIDE_TITLE);
+export async function addActionsListBlockWithManualOverride({page, editor}, actionTitles) {
+  await addListBlockWithManualOverride({page, editor}, BLOCK_NAME, actionTitles, MANUAL_OVERRIDE_TITLE);
 }
 
 

--- a/tests/e2e/tools/lib/columns.js
+++ b/tests/e2e/tools/lib/columns.js
@@ -1,17 +1,11 @@
-import {searchAndInsertBlock} from './editor.js';
+import {searchAndInsertBlock, pickBlockStyle} from './editor.js';
 import {expect} from './test-utils.js';
 
 const TEST_LINKS = ['/act', '/explore', '/'];
 
-async function addColumnsBlock(page, style) {
+async function addColumnsBlock(page, editor, style) {
   // Add Columns block.
   await searchAndInsertBlock({page}, 'Planet 4 Columns', 'planet4-blocks-columns');
-
-  // Select the style if needed.
-  if (style) {
-    const stylePicker = page.locator('.block-editor-block-styles__variants');
-    await stylePicker.locator(`button[aria-label^=${style}]`).click();
-  }
 
   // Fill in the Columns links.
   for (const index in TEST_LINKS) {
@@ -19,8 +13,14 @@ async function addColumnsBlock(page, style) {
       .fill(TEST_LINKS[index]);
   }
 
+  // Select the style if needed.
+  if (style) {
+    await pickBlockStyle({page}, style);
+  }
+
+
   // Fill in the other fields.
-  const backendColumns = await page.locator('.column-wrap').all();
+  const backendColumns = await editor.canvas.locator('.column-wrap').all();
   for (const [index, column] of backendColumns.entries()) {
     await column.locator(style === 'Tasks' ? 'h5' : 'h3').fill(`Column ${index + 1}`);
     await column.locator('p').fill(`Description ${index + 1}`);

--- a/tests/e2e/tools/lib/editor.js
+++ b/tests/e2e/tools/lib/editor.js
@@ -100,12 +100,59 @@ const searchAndInsertPattern = async ({page}, id) => {
  * @param {number} number
  * @param {string} text
  */
-const addHeadingOrParagraph = async ({page}, blockName, blockTag, number, text) => {
+const addHeadingOrParagraph = async ({page, editor}, blockName, blockTag, number, text) => {
   await searchAndInsertBlock({page}, blockName, blockName.toLowerCase());
-  const newBlock = page.getByRole('region', {name: 'Editor content'}).locator(blockTag).nth(number);
+  const newBlock = editor.canvas.locator(blockTag).nth(number);
   await expect(newBlock).toBeVisible();
   await closeBlockInserter({page});
   await newBlock.fill(text);
 };
 
-export {openComponentPanel, searchAndInsertBlock, searchAndInsertPattern, closeBlockInserter, addHeadingOrParagraph};
+/**
+ * Pick a specific block style from the sidebar.
+ *
+ * @param {{Page}} page
+ * @param {string} style - The style that needs to be selected.
+ */
+const pickBlockStyle = async ({page}, style) => {
+  await page.getByRole('tab', {name: 'Styles'}).click();
+  const stylePicker = page.locator('.block-editor-block-styles__variants');
+  await stylePicker.locator(`button[aria-label^="${style}"]`).click();
+};
+
+/**
+ * Open the "Meta Boxes" tab at the bottom of the editor if needed.
+ *
+ * @param {{Page}} page
+ */
+const openMetaBoxesTab = async ({page}) => {
+  const metaBoxesTab = page.getByRole('button', {name: 'Meta Boxes'});
+  if (await metaBoxesTab.getAttribute('aria-expanded') === 'false') {
+    await metaBoxesTab.locator('svg').click();
+    await expect(metaBoxesTab).toHaveAttribute('aria-expanded', 'true');
+  }
+};
+
+/**
+ * Close the "Meta Boxes" tab at the bottom of the editor if needed.
+ *
+ * @param {{Page}} page
+ */
+const closeMetaBoxesTab = async ({page}) => {
+  const metaBoxesTab = page.getByRole('button', {name: 'Meta Boxes'});
+  if (await metaBoxesTab.getAttribute('aria-expanded') === 'true') {
+    await metaBoxesTab.locator('svg').click();
+    await expect(metaBoxesTab).toHaveAttribute('aria-expanded', 'false');
+  }
+};
+
+export {
+  openComponentPanel,
+  searchAndInsertBlock,
+  searchAndInsertPattern,
+  closeBlockInserter,
+  addHeadingOrParagraph,
+  pickBlockStyle,
+  openMetaBoxesTab,
+  closeMetaBoxesTab,
+};

--- a/tests/e2e/tools/lib/posts-list.js
+++ b/tests/e2e/tools/lib/posts-list.js
@@ -9,21 +9,21 @@ const MANUAL_OVERRIDE_TITLE = 'Posts';
 /**
  * Adds the Posts List block to the page.
  *
- * @param {import('@playwright/test').Page} page   - The Playwright page instance.
- * @param {string}                          layout - The layout of the block.
+ * @param {{Page, Editor}} options - Page and Editor object.
+ * @param {string}         layout  - The layout of the block.
  */
-export async function addPostsListBlock(page, layout) {
-  await addListBlock(page, BLOCK_NAME, 4, {layout, category: TEST_CATEGORY, title: TEST_TITLE});
+export async function addPostsListBlock({page, editor}, layout) {
+  await addListBlock({page, editor}, BLOCK_NAME, 4, {layout, category: TEST_CATEGORY, title: TEST_TITLE});
 }
 
 /**
  * Adds the Posts List block to the page with the Manual Override posts selected.
  *
- * @param {import('@playwright/test').Page} page       - The Playwright page instance.
- * @param {string[]}                        postTitles - The titles of the posts to include in the block to override the default ones.
+ * @param {{Page, Editor}} options    - Page and Editor object
+ * @param {string[]}       postTitles - The titles of the posts to include in the block to override the default ones.
  */
-export async function addPostsListBlockWithManualOverride(page, postTitles) {
-  await addListBlockWithManualOverride(page, BLOCK_NAME, postTitles, MANUAL_OVERRIDE_TITLE);
+export async function addPostsListBlockWithManualOverride({page, editor}, postTitles) {
+  await addListBlockWithManualOverride({page, editor}, BLOCK_NAME, postTitles, MANUAL_OVERRIDE_TITLE);
 }
 
 /**

--- a/tests/e2e/tools/lib/query-loop-utils.js
+++ b/tests/e2e/tools/lib/query-loop-utils.js
@@ -4,12 +4,12 @@ import {expect} from './test-utils.js';
 /**
  * Adds and configures a Query List block in the block editor.
  *
- * @param {import('@playwright/test').Page} page         - The Playwright page instance.
- * @param {string}                          blockName    - The name of the block to search for and insert.
- * @param {number}                          itemsPerPage - The number of items to display per page.
- * @param {Object}                          [config={}]  - Optional configuration settings for the block.
+ * @param {{Page, Editor}} options      - Page and Editor object
+ * @param {string}         blockName    - The name of the block to search for and insert.
+ * @param {number}         itemsPerPage - The number of items to display per page.
+ * @param {Object}         [config={}]  - Optional configuration settings for the block.
  */
-export async function addListBlock(page, blockName, itemsPerPage, config = {}) {
+export async function addListBlock({page, editor}, blockName, itemsPerPage, config = {}) {
   await searchAndInsertBlock({page}, blockName);
 
   if (config.layout) {
@@ -22,7 +22,7 @@ export async function addListBlock(page, blockName, itemsPerPage, config = {}) {
     const editorSettings = page.getByRole('region', {name: 'Editor settings'});
     await editorSettings.getByRole('button', {name: 'Filters options'}).click();
     await page.getByLabel('Show Taxonomies').click();
-    await editorSettings.getByLabel('Categories').fill(config.category);
+    await editorSettings.getByRole('combobox', {name: 'Categories', exact: true}).fill(config.category);
     await editorSettings.locator(
       '.components-form-token-field__suggestion', {hasText: config.category}
     ).click();
@@ -32,19 +32,19 @@ export async function addListBlock(page, blockName, itemsPerPage, config = {}) {
   }
 
   if (config.title) {
-    await page.getByRole('document', {name: 'Block: Heading'}).fill(config.title);
+    await editor.canvas.getByRole('document', {name: 'Block: Heading 2'}).fill(config.title);
   }
 }
 
 /**
  * Updates the existing Query Loop block with a Manual Override to select specific posts and override the default ones.
  *
- * @param {import('@playwright/test').Page} page          - The Playwright page instance.
- * @param {string}                          blockName     - The name of the block to search for and insert.
- * @param {string[]}                        titles        - New Post titles to override existing ones.
- * @param {string}                          overrideTitle - New Page title to override the default.
+ * @param {{Page, Editor}} options       - Page and Editor object
+ * @param {string}         blockName     - The name of the block to search for and insert.
+ * @param {string[]}       titles        - New Post titles to override existing ones.
+ * @param {string}         overrideTitle - New Page title to override the default.
  */
-export async function addListBlockWithManualOverride(page, blockName, titles, overrideTitle) {
+export async function addListBlockWithManualOverride({page, editor}, blockName, titles, overrideTitle) {
   await searchAndInsertBlock({page}, blockName);
 
   await page.getByRole('spinbutton', {name: 'Items per page'}).fill('4');
@@ -65,7 +65,7 @@ export async function addListBlockWithManualOverride(page, blockName, titles, ov
     ).toBeVisible();
   }
 
-  await page.getByRole('document', {name: 'Block: Heading'}).fill(overrideTitle);
+  await editor.canvas.getByRole('document', {name: 'Block: Heading 2'}).fill(overrideTitle);
 }
 
 /**


### PR DESCRIPTION
### Summary

- The UI is a bit different now and therefore some of the e2e tests need to be updated. Most of the changes come down to the fact that now we need to use `editor.canvas.locator` instead of `page.locator` to update WYSIWYG blocks. I've also created a few editor functions (`pickBlockStyle`, `closeMetaBoxesTab` & `openMetaBoxesTab`) that remove a little bit of code duplication.
- This PR also removes the new [Connectors settings page](https://make.wordpress.org/core/2026/05/14/wordpress-7-0-field-guide/#ai-connectors-screen), so that we disable AI in our sites for now.
- In addition we remove the Theme Editor because we don't want this enabled, even on local.
- I had to change the way that we enqueue editor styles, because now we are using the iframe. `enqueue_block_editor_assets` should be used to style the editor itself, not its content (blocks etc). More details [here](https://developer.wordpress.org/block-editor/how-to-guides/enqueueing-assets-in-the-editor/#editor-content-scripts-and-styles).

Ref: [PLANET-8182](https://greenpeace-planet4.atlassian.net/browse/PLANET-8182)

### Testing

- Run the e2e tests on local after upgrading to WordPress 7.0.1, and make sure that they all pass.
- Make sure that the blocks now using `enqueue_block_assets` for editor styles still behave as expected.
- Make sure that you cannot access the Connectors page (`/wp-admin/options-connectors.php`) and that the corresponding menu item is missing from Settings.
<img width="324" height="375" alt="Screenshot 2026-06-30 at 09 41 46" src="https://github.com/user-attachments/assets/f25d516c-a7f9-46d4-9034-1cbee37258fe" />

- Make sure that you cannot access the Theme Editor page (`/wp-admin/theme-editor.php`) and that the corresponding menu item is missing from Appearance.
<img width="322" height="200" alt="Screenshot 2026-06-30 at 09 41 35" src="https://github.com/user-attachments/assets/7a132404-3ad4-48fa-843f-c3436737130f" />


[PLANET-8182]: https://greenpeace-planet4.atlassian.net/browse/PLANET-8182?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ