### PR TITLE
PLANET-8195 Add USE_MEDIA_ARCHIVE capability to author role

### DIFF
--- a/src/Role/Campaigner.php
+++ b/src/Role/Campaigner.php
@@ -56,6 +56,7 @@ class Campaigner
             'publish_campaigns',
             'delete_published_campaigns',
             'edit_published_campaigns',
+            Capability::USE_MEDIA_ARCHIVE,
         ],
         'contributor' => [
             'edit_campaign',


### PR DESCRIPTION
**Requirements**
- Reveal the Greenpeace Media option in the sidebar for Authors
- Allow Authors to use the Greenpeace Media functionality

---

Ref. https://greenpeace-planet4.atlassian.net/browse/PLANET-8195

### Testing:

1. Create a new user with the Author role and log in using the newly created user's credentials.
2. Check the Greenpeace Media functionality. The Greenpeace Media menu item under the Media sidebar should not be available.
3. On local environment, check out the `PLANET-8195_GP_media_allow_author_to_import` branch and repeat the previous step.
4. Verify that the Greenpeace Media menu item is now available to the Author user, and importing media from Greenpeace Media within Posts and Pages works as expected.
5. You can also test this fix on the [test-atlas](https://www-dev.greenpeace.org/test-atlas/wp-admin/users.php) instance.

**Note:**
After checking out the `PLANET-8195_GP_media_allow_author_to_import` branch locally, run the following command:
```npx wp-env run cli wp cap add author use_media_archive```
This is required because the `register_role_and_add_capabilities()` method runs only during theme activation/setup, so the new capability will not be added automatically on an existing local environment.