### PR TITLE
PLANET-8173 Carousel Header accessibility: Fixed off-screen focus issue

### DIFF
--- a/assets/src/blocks/CarouselHeader/CarouselHeaderFrontend.js
+++ b/assets/src/blocks/CarouselHeader/CarouselHeaderFrontend.js
@@ -48,16 +48,21 @@ export const CarouselHeaderFrontend = ({slides, carousel_autoplay, className, de
       ) : null}
       <div className="carousel-wrapper-header">
         <ul className="carousel-inner" role="listbox">
-          {slides.map((slide, index) => <Slide
-            key={index}
-            active={currentSlide === index}
-            focusable={currentSlide === index}
-            ref={element => slidesRef ? slidesRef.current[index] = element : null}
-            handleUserInteraction={handleUserInteraction}
-          >
-            <SlideBackground decoding={decoding} slide={slide} />
-            <StaticCaption slide={slide} focusable={currentSlide === index} />
-          </Slide>)
+          {slides.map((slide, index) => {
+            const isActive = currentSlide === index;
+
+            return (
+              <Slide
+                key={index}
+                active={isActive}
+                focusable={isActive}
+                ref={element => slidesRef ? slidesRef.current[index] = element : null}
+                handleUserInteraction={handleUserInteraction}
+              >
+                <SlideBackground decoding={decoding} slide={slide} />
+                <StaticCaption slide={slide} focusable={isActive} />
+              </Slide>);
+          })
           }
         </ul>
       </div>

--- a/assets/src/blocks/CarouselHeader/Slide.js
+++ b/assets/src/blocks/CarouselHeader/Slide.js
@@ -9,7 +9,8 @@ export const SlideWithRef = ({
   <li
     className={`carousel-item ${active ? 'active' : ''}`}
     tabIndex={focusable ? 0 : -1}
-    aria-hidden={focusable ? 'false' : 'true'}
+    aria-hidden={focusable ? undefined : true}
+    inert={focusable ? undefined : true}
     ref={ref}
     role="tabpanel"
     alt=""

--- a/tests/e2e/blocks/carousel-header.spec.js
+++ b/tests/e2e/blocks/carousel-header.spec.js
@@ -33,7 +33,12 @@ const addSlide = async (slide, {index, addNext}, {page, editor}) => {
   // Close sidebar before interacting with the carousel item
   await page.getByRole('button', {name: 'Close Settings'}).click();
 
-  await page.locator('.carousel-item.active .components-button.is-primary').click();
+  const activeSlide = page.locator('.carousel-item.active');
+
+  const editButton = activeSlide.locator('.carousel-header-editor-controls button');
+
+  await expect(editButton).toBeVisible();
+  await editButton.click();
   await page.getByRole('button', {name: 'Add image'}).click();
   await page.getByRole('tab', {name: 'Media Library'}).click();
   await page.getByRole('checkbox', {name: slide.image}).click();
@@ -44,7 +49,7 @@ const addSlide = async (slide, {index, addNext}, {page, editor}) => {
 
   // Next Slide
   if (addNext) {
-    await page.locator('.carousel-item.active .components-button.is-primary').click();
+    await editButton.click();
     await page.getByRole('button', {name: 'Add slide'}).click();
   }
 };


### PR DESCRIPTION
### Summary

On mobile. when a user navigates through the Carousel Header, the focus moves to the off-screen slides, and the screen reader announces the content of these hidden slides.

<!-- Please provide a brief summary of the change introduced in this Pull Request. -->

---

<!-- Please add a reference link to the ticket, if one exists. -->
Ref: https://greenpeace-planet4.atlassian.net/browse/PLANET-8173

### Testing

<!-- Please add the steps required to test the changes in this Pull Request. -->
On mobile, non visible slides and its elements should not receive any focus.
