### PR TITLE
PLANET-8197: Improve file organization in the src/ folder

### DIFF
--- a/load-class-aliases.php
+++ b/load-class-aliases.php
@@ -17,7 +17,7 @@ class_alias(\P4\MasterTheme\Context::class, 'P4_Context');
 class_alias(\P4\MasterTheme\ControlPanel::class, 'P4_Control_Panel');
 class_alias(\P4\MasterTheme\CustomTaxonomy::class, 'P4_Custom_Taxonomy');
 class_alias(\P4\MasterTheme\DevReport::class, 'P4_Dev_Report');
-class_alias(\P4\MasterTheme\ImageCompression::class, 'P4_Image_Compression');
+class_alias(\P4\MasterTheme\Images\ImageCompression::class, 'P4_Image_Compression');
 class_alias(\P4\MasterTheme\Loader::class, 'P4_Loader');
 class_alias(\P4\MasterTheme\MetaboxRegister::class, 'P4_Metabox_Register');
 class_alias(\P4\MasterTheme\Post::class, 'P4_Post');

--- a/src/Images/BreakpointsImageSizes.php
+++ b/src/Images/BreakpointsImageSizes.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace P4\MasterTheme;
+namespace P4\MasterTheme\Images;
 
 use WP_Block;
 

--- a/src/Images/ImageCompression.php
+++ b/src/Images/ImageCompression.php
@@ -1,6 +1,6 @@
 <?php // phpcs:disable PSR1.Files.SideEffects.FoundWithSymbols
 
-namespace P4\MasterTheme;
+namespace P4\MasterTheme\Images;
 
 use Exception;
 use Imagick;

--- a/src/Images/ImageHandler.php
+++ b/src/Images/ImageHandler.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace P4\MasterTheme;
+namespace P4\MasterTheme\Images;
 
 use WP_HTML_Tag_Processor;
 

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -91,7 +91,7 @@ final class Loader
             CommentFormCustomizer::class,
             CronJob::class,
             DashboardNotice::class,
-            ImageHandler::class,
+            Images\ImageHandler::class,
             Cloudflare\CloudflareTurnstileHandler::class,
             Sentry::class,
             PostFunctionsHandler::class,

--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -240,7 +240,7 @@ class MasterSite extends \Timber\Site
         add_action('wpml_after_startup', $remove_rtl_fix, 10, 0);
 
         AuthorPage::hooks();
-        BreakpointsImageSizes::hooks();
+        Images\BreakpointsImageSizes::hooks();
         QueryLoopPagination::hooks();
         Search\Search::hooks();
         Sendgrid::hooks();

--- a/src/MediaReplacer.php
+++ b/src/MediaReplacer.php
@@ -3,6 +3,7 @@
 namespace P4\MasterTheme;
 
 use WP_Post;
+use P4\MasterTheme\Images\ImageHandler;
 
 /**
  * Class MediaReplacer.


### PR DESCRIPTION
### Summary

This PR improves the file organization in the `src` folder by moving all image-related elements to the `src/Images` subfolder. In summary:

- The class `BreakpointsImageSizes` was moved to the `src/Images` folder.
- The class `ImageCompression` was moved to the `src/Images` folder.
- The class `ImageHandler` was moved to the `src/Images` folder.

---

Ref: https://greenpeace-planet4.atlassian.net/browse/PLANET-8197

### Testing

1. Check that all image functionalities still work correctly.
4. Check all the calls to any of the affected classes made from other repositories, so they can be informed and adjusted (check this [example](https://github.com/search?q=org%3Agreenpeace+ImageHandler&type=code)).