### PR TITLE
Use new blocks visibility feature for carousel controls

### DIFF
--- a/assets/src/blocks/ActionsList/index.js
+++ b/assets/src/blocks/ActionsList/index.js
@@ -22,6 +22,14 @@ const carouselButtons = [
     tagName: 'nav',
     className: 'carousel-controls',
     ariaLabel: __('Actions List carousel controls', 'planet4-master-theme-backend'),
+    metadata: {
+      blockVisibility: {
+        viewport: {
+          tablet: false,
+          mobile: false,
+        },
+      },
+    },
   },
   [
     [

--- a/assets/src/blocks/PostsList/index.js
+++ b/assets/src/blocks/PostsList/index.js
@@ -26,6 +26,14 @@ const carouselButtons = ['core/buttons', {
   className: 'carousel-controls',
   lock: {move: true},
   layout: {type: 'flex', justifyContent: 'space-between', orientation: 'horizontal', flexWrap: 'nowrap'},
+  metadata: {
+    blockVisibility: {
+      viewport: {
+        tablet: false,
+        mobile: false,
+      },
+    },
+  },
 }, [
   ['core/button',
     {

--- a/assets/src/scss/blocks/ActionsList/ActionsListStyle.scss
+++ b/assets/src/scss/blocks/ActionsList/ActionsListStyle.scss
@@ -37,7 +37,6 @@
     position: relative;
   }
 
-  .carousel-controls,
   .carousel-indicators {
     display: none;
   }

--- a/assets/src/scss/blocks/PostsList/PostsListStyle.scss
+++ b/assets/src/scss/blocks/PostsList/PostsListStyle.scss
@@ -1,7 +1,6 @@
 .posts-list {
   margin-bottom: $sp-4;
 
-  .carousel-controls,
   .carousel-indicators {
     display: none;
   }
@@ -134,8 +133,13 @@
       margin-top: -$sp-5;
     }
 
-    .carousel-item-wrapper li {
-      height: $posts-list-container-height;
+    .carousel-item-wrapper {
+      list-style: none;
+      padding: 0;
+
+      li {
+        height: $posts-list-container-height;
+      }
     }
 
     // We don't show tags in this layout because they often break the design.

--- a/assets/src/scss/layout/_query-loop-overrides.scss
+++ b/assets/src/scss/layout/_query-loop-overrides.scss
@@ -59,7 +59,6 @@
       }
 
       .carousel-controls {
-        display: flex;
         position: absolute;
         height: 48px;
         width: calc(100% + calc($sp-3 * 2));


### PR DESCRIPTION
### Summary

This is to play around with WordPress 7.0 new features, as part of Experimentation Day. If we want to go on with this implementation we would need a migration to update existing blocks.

