### PR TITLE
Hubspot reverse proxy: add reference to the Handbook

### DIFF
--- a/src/Settings.php
+++ b/src/Settings.php
@@ -597,7 +597,10 @@ class Settings
                 'fields' => [
                     [
                         'name' => __('Reverse Proxy', 'planet4-master-theme-backend'),
-                        'desc' => __('Enables reverse proxy for Hubspot hosted content.', 'planet4-master-theme-backend'),
+                        'desc' => __(
+                            'Enables reverse proxy for Hubspot hosted content. (<a href="https://planet4.greenpeace.org/manage/form-builder/hubspot-pages-under-planet-4/" target="_blank">read more</a>)',
+                            'planet4-master-theme-backend'
+                        ),
                         'id' => 'hubspot_reverse_proxy',
                         'type' => 'checkbox',
                     ],


### PR DESCRIPTION
## Summary

Adds a link to the relevant Handbook page.

### Testing

1. Browse in the Admin Panel: _Planet 4 > Hubspot_.
2. Verify the link it's visible and working as expected.