### PR TITLE
Fix fatal error in the `remove_no_post_text` function

### DIFF
--- a/src/Blocks/QueryLoopExtension.php
+++ b/src/Blocks/QueryLoopExtension.php
@@ -320,7 +320,8 @@ class QueryLoopExtension
     public static function remove_no_post_text(string $block_content, array $block): string
     {
         $classes = $block['attrs']['className'] ?? '';
-        if (!str_contains($classes, 'p4-query-loop')) {
+
+        if (!str_contains($classes, 'p4-query-loop') || trim($block_content) === '') {
             return $block_content;
         }
 


### PR DESCRIPTION
### Summary

This PR fixes the fatal error produced by the `remove_no_post_text` function when the block content is empty.

---

Ref: 
- https://greenpeace.slack.com/archives/C014UMRC4AJ/p1782817999206469
- https://grafana.greenpeace.org/goto/ffqp0wdjkyoe8c?orgId=1

### Testing

1. Install the Greek website on your local environment.
2. Switch to the `main` branch.
3. Visit page 58595. A fatal error should occur.
4. Switch to this PR branch.
5. Visit page 58595. No fatal error should be there.

<hr>

1. Run the default development website on your local environment.
2. Add a new page with an Actions List block.
3. Add this line of code at the beginning of the `QueryLoopExtension::remove_no_post_text` function to mimic the error: `$block_content = '';`
4. Switch to the `main` branch.
5. Visit the page created in step 2. A fatal error should occur.
6. Switch to this PR branch.
7. Visit the page created in step 2. No fatal error should be there.
