### PR TITLE
PLANET-8053 E2E Test for Actions List block with Carousel layout

### DIFF
--- a/tests/e2e/blocks/actions-list.spec.js
+++ b/tests/e2e/blocks/actions-list.spec.js
@@ -5,6 +5,7 @@ import {
   checkActionsListBlock,
   addActionsListBlockWithManualOverride,
   checkActionsListBlockWithManualOverride,
+  checkActionsListBlockCarouselLayout,
 } from '../tools/lib/actions-list.js';
 import {isNewIAEnabled} from '../tools/lib/check-new-ia.js';
 
@@ -78,5 +79,18 @@ test.describe('Test Actions List block', () => {
 
     // Check that the block displays correctly in the frontend.
     await checkActionsListBlockWithManualOverride(page, actionTitles);
+  });
+
+  test('Test the Carousel layout', async ({page, admin, editor}) => {
+    await createPostWithFeaturedImage({page, admin, editor}, {title: 'Test Actions List, Carousel Layout', postType: 'page'});
+
+    // Add a Actions List block with the Carousel layout.
+    await addActionsListBlock(page, 'Carousel');
+
+    // Publish page.
+    await publishPostAndVisit({page, editor});
+
+    // Test that the block is displayed as expected in the frontend.
+    await checkActionsListBlockCarouselLayout(page);
   });
 });

--- a/tests/e2e/tools/lib/actions-list.js
+++ b/tests/e2e/tools/lib/actions-list.js
@@ -1,4 +1,5 @@
 import {addListBlock, addListBlockWithManualOverride, checkListBlock} from './query-loop-utils.js';
+import {expect} from './test-utils.js';
 
 const BLOCK_NAME = 'Actions List';
 const TEST_TITLE = 'Campaigns';
@@ -8,8 +9,8 @@ const MANUAL_OVERRIDE_TITLE = 'Actions';
 /**
  * Adds the Actions List block to the page.
  *
- * @param {import('@playwright/test').Page} page   - The Playwright page instance.
- * @param {string}                          layout - The layout of the block.
+ * @param {{Page}} page   - The Playwright page instance.
+ * @param {string} layout - The layout of the block.
  */
 export async function addActionsListBlock(page, layout) {
   await addListBlock(page, BLOCK_NAME, 2, {layout, category: TEST_CATEGORY, title: TEST_TITLE});
@@ -18,8 +19,8 @@ export async function addActionsListBlock(page, layout) {
 /**
  * Adds the Actions List block to the page with the Manual Override posts selected.
  *
- * @param {import('@playwright/test').Page} page         - The Playwright page instance.
- * @param {string[]}                        actionTitles - The titles of the actions to include in the block to override the default ones.
+ * @param {{Page}}   page         - The Playwright page instance.
+ * @param {string[]} actionTitles - The titles of the actions to include in the block to override the default ones.
  */
 export async function addActionsListBlockWithManualOverride(page, actionTitles) {
   await addListBlockWithManualOverride(page, BLOCK_NAME, actionTitles, MANUAL_OVERRIDE_TITLE);
@@ -29,11 +30,12 @@ export async function addActionsListBlockWithManualOverride(page, actionTitles) 
 /**
  * Validate the Actions List block tests.
  *
- * @param {import('@playwright/test').Page} page - The Playwright page instance.
+ * @param {{Page}} page   - The Playwright page instance.
+ * @param {string} layout - The layout of the block.
  */
-export async function checkActionsListBlock(page) {
+export async function checkActionsListBlock(page, layout) {
   await checkListBlock(page, {
-    layout: 'grid',
+    layout,
     title: TEST_TITLE,
     count: 2,
     category: TEST_CATEGORY,
@@ -43,8 +45,8 @@ export async function checkActionsListBlock(page) {
 /**
  * Validate the Actions List block tests with manual override.
  *
- * @param {import('@playwright/test').Page} page         - The Playwright page instance.
- * @param {string[]}                        actionTitles - The titles of the actions to include in the block to override the default ones.
+ * @param {{Page}}   page         - The Playwright page instance.
+ * @param {string[]} actionTitles - The titles of the actions to include in the block to override the default ones.
  */
 export async function checkActionsListBlockWithManualOverride(page, actionTitles) {
   await checkListBlock(page, {
@@ -53,4 +55,17 @@ export async function checkActionsListBlockWithManualOverride(page, actionTitles
     count: actionTitles.length,
     postTitles: actionTitles,
   });
+}
+
+/**
+ * Validate the Actions List block tests with carousel layout.
+ *
+ * @param {{Page}} page - The Playwright page instance.
+ */
+export async function checkActionsListBlockCarouselLayout(page) {
+  await checkActionsListBlock(page, 'carousel');
+
+  const block = page.locator('.p4-query-loop');
+  await expect(block.locator('.carousel.slide')).toBeVisible();
+  await expect(block.locator('.carousel-item.active')).toBeVisible();
 }


### PR DESCRIPTION
### Summary

Expanding Actions List block test scenarios to include carousel layout.

<!-- Please provide a brief summary of the change introduced in this Pull Request. -->

---

<!-- Please add a reference link to the ticket, if one exists. -->
Ref: https://greenpeace-planet4.atlassian.net/browse/PLANET-8053

### Testing

<!-- Please add the steps required to test the changes in this Pull Request. -->
 - Login to the Admin Panel.

 - Create a new Page.

 - Add a Actions List block:

    - Pick the Carousel layout

   - Set the Actions per page value to 2

   - Filter actions by category "Energy"

 - Change block title to "Campaigns"

 - Publish the page.

 - Navigate to the frontend view of that Page and verify that all of the above properties are working as expected.

    - Block title

    - All posts are from the "Energy" category

    - Assess carousel layout

    - There are 2 actions displayed
