### PR TITLE
PLANET-8207 Support multiple Timeline blocks

### DIFF
--- a/assets/src/blocks/Timeline/NewTimelineEditorScript.js
+++ b/assets/src/blocks/Timeline/NewTimelineEditorScript.js
@@ -5,9 +5,15 @@ import {getUniqueId} from '../../functions/getUniqueId';
 
 const {InspectorControls, RichText} = wp.blockEditor;
 const {PanelBody, Tooltip} = wp.components;
+import {select} from '@wordpress/data';
 const {debounce} = wp.compose;
 const {useCallback, useState, useEffect} = wp.element;
 const {__} = wp.i18n;
+
+const isTimelineIdReserved = timelineId => {
+  const timelines = select('core/editor').getBlocks().filter(block => block.name === 'planet4-blocks/timeline');
+  return timelines.some(timeline => timeline.attributes.timeline_id === timelineId);
+};
 
 const renderEdit = (
   sheetURL,
@@ -83,11 +89,9 @@ export const NewTimelineEditor = ({isSelected, attributes, setAttributes}) => {
 
   // Set a timeline id in the attributes, if it doesn't exist yet.
   useEffect(() => {
-    if (attributes.timeline_id) {
-      return;
+    if (!attributes.timeline_id || isTimelineIdReserved(attributes.timeline_id)) {
+      setAttributes({timeline_id: getUniqueId('tl')});
     }
-
-    setAttributes({timeline_id: getUniqueId('tl')});
   }, []);
 
   return (

--- a/assets/src/blocks/Timeline/NewTimelineEditorScript.js
+++ b/assets/src/blocks/Timeline/NewTimelineEditorScript.js
@@ -10,9 +10,28 @@ const {debounce} = wp.compose;
 const {useCallback, useState, useEffect} = wp.element;
 const {__} = wp.i18n;
 
+/**
+ * Get all blocks and inner blocks from a page.
+ *
+ * @param {Array} blocks - an array of blocks.
+ *
+ * @return {Array} All blocks from the page.
+ */
+const flattenBlocks = blocks => blocks.flatMap(block => [block, ...flattenBlocks(block.innerBlocks || [])]);
+
+/**
+ * Check if the given timeline id already exists on this page.
+ * This can happen if we duplicate a block for example.
+ *
+ * @param {string} timelineId - the Timeline block id.
+ *
+ * @return {boolean} Whether the timeline id is already given or not.
+ */
 const isTimelineIdReserved = timelineId => {
-  const timelines = select('core/editor').getBlocks().filter(block => block.name === 'planet4-blocks/timeline');
-  return timelines.some(timeline => timeline.attributes.timeline_id === timelineId);
+  const allBlocks = flattenBlocks(select('core/editor').getBlocks());
+  return allBlocks.some(
+    block => block.name === 'planet4-blocks/timeline' && block.attributes.timeline_id === timelineId
+  );
 };
 
 const renderEdit = (

--- a/assets/src/blocks/Timeline/NewTimelineEditorScript.js
+++ b/assets/src/blocks/Timeline/NewTimelineEditorScript.js
@@ -1,11 +1,12 @@
 import {URLInput} from '../../block-editor/URLInput/URLInput';
 import {NewTimelineFrontend} from './NewTimelineFrontend';
 import {URLDescriptionHelp} from './URLDescriptionHelp';
+import {getUniqueId} from '../../functions/getUniqueId';
 
 const {InspectorControls, RichText} = wp.blockEditor;
 const {PanelBody, Tooltip} = wp.components;
 const {debounce} = wp.compose;
-const {useCallback, useState} = wp.element;
+const {useCallback, useState, useEffect} = wp.element;
 const {__} = wp.i18n;
 
 const renderEdit = (
@@ -79,6 +80,15 @@ export const NewTimelineEditor = ({isSelected, attributes, setAttributes}) => {
   // Using a state to prevent the input losing the cursor position, a React issue reported multiple times
   const [sheetURL, setSheetURL] = useState(attributes.google_sheets_url);
   const debounceSheetURLUpdate = useCallback(debounce(toAttribute('google_sheets_url'), 300), []);
+
+  // Set a timeline id in the attributes, if it doesn't exist yet.
+  useEffect(() => {
+    if (attributes.timeline_id) {
+      return;
+    }
+
+    setAttributes({timeline_id: getUniqueId('tl')});
+  }, []);
 
   return (
     <>

--- a/assets/src/blocks/Timeline/NewTimelineFrontend.js
+++ b/assets/src/blocks/Timeline/NewTimelineFrontend.js
@@ -9,6 +9,11 @@ const getMonthName = monthNumber => {
     .format(new Date(2000, monthNumber - 1));
 };
 
+const uniqueId = () => {
+  const r = Math.floor(Math.random() * 10000);
+  return `timeline-${r}`;
+};
+
 const getLocalizedDate = (day, month) => {
   const locale = document.documentElement.lang || 'en';
 
@@ -50,6 +55,7 @@ export const NewTimelineFrontend = ({attributes}) => {
   const [loading, setLoading] = useState(false);
   const [sheetData, setSheetData] = useState(null);
   const [processedSheetData, setProcessedSheetData] = useState(null);
+  const [timelineId, setTimelineId] = useState('');
 
 
   const TimelineEvent = ({event}) => {
@@ -217,7 +223,9 @@ export const NewTimelineFrontend = ({attributes}) => {
     }
   }
 
-  if (loading || !processedSheetData) {
+  useEffect(() => setTimelineId(uniqueId()), []);
+
+  if (loading || !processedSheetData || !timelineId) {
     return null;
   }
 
@@ -231,7 +239,7 @@ export const NewTimelineFrontend = ({attributes}) => {
   );
 
   return (
-    <section className={`block timeline-block new-timeline-block ${className ?? ''} alignfull`} aria-label={summaryText}>
+    <section id={timelineId} className={`block timeline-block new-timeline-block ${className ?? ''} alignfull`} aria-label={summaryText}>
       <div className="container">
         {!!timeline_title && !isEditing &&
           <h2 className="page-section-header text-center">
@@ -242,15 +250,15 @@ export const NewTimelineFrontend = ({attributes}) => {
           <p className="page-section-description text-center" dangerouslySetInnerHTML={{__html: description}} />
         }
 
-        <YearsNavigation isEditing={isEditing} years={processedSheetData.map(({year}) => year)} />
+        <YearsNavigation isEditing={isEditing} years={processedSheetData.map(({year}) => year)} timelineId={timelineId} />
         <fieldset className="timeline-group">
           {processedSheetData.map(({year, list}) => (
-            <div className="timeline-block-year-group" id={year} key={year}>
+            <div className="timeline-block-year-group" id={`${timelineId}-${year}`} key={`${timelineId}-${year}`}>
               <p className="timeline-block-year">{year}</p>
               <ul className="timeline-block-events">
                 {list.map((event, index) => (
                   <TimelineEvent
-                    key={`row-${event.Day}-${index}`}
+                    key={`${timelineId}-event-${event.Day}-${index}`}
                     event={event}
                   />
                 ))}

--- a/assets/src/blocks/Timeline/NewTimelineFrontend.js
+++ b/assets/src/blocks/Timeline/NewTimelineFrontend.js
@@ -9,11 +9,6 @@ const getMonthName = monthNumber => {
     .format(new Date(2000, monthNumber - 1));
 };
 
-const uniqueId = () => {
-  const r = Math.floor(Math.random() * 10000);
-  return `timeline-${r}`;
-};
-
 const getLocalizedDate = (day, month) => {
   const locale = document.documentElement.lang || 'en';
 
@@ -51,12 +46,11 @@ export const NewTimelineFrontend = ({attributes}) => {
     className,
     google_sheets_url,
     isEditing,
+    timeline_id,
   } = attributes;
   const [loading, setLoading] = useState(false);
   const [sheetData, setSheetData] = useState(null);
   const [processedSheetData, setProcessedSheetData] = useState(null);
-  const [timelineId, setTimelineId] = useState('');
-
 
   const TimelineEvent = ({event}) => {
     const [expanded, setExpanded] = useState(false);
@@ -223,9 +217,7 @@ export const NewTimelineFrontend = ({attributes}) => {
     }
   }
 
-  useEffect(() => setTimelineId(uniqueId()), []);
-
-  if (loading || !processedSheetData || !timelineId) {
+  if (loading || !processedSheetData || !timeline_id) {
     return null;
   }
 
@@ -239,7 +231,7 @@ export const NewTimelineFrontend = ({attributes}) => {
   );
 
   return (
-    <section id={timelineId} className={`block timeline-block new-timeline-block ${className ?? ''} alignfull`} aria-label={summaryText}>
+    <section id={timeline_id} className={`block timeline-block new-timeline-block ${className ?? ''} alignfull`} aria-label={summaryText}>
       <div className="container">
         {!!timeline_title && !isEditing &&
           <h2 className="page-section-header text-center">
@@ -250,15 +242,15 @@ export const NewTimelineFrontend = ({attributes}) => {
           <p className="page-section-description text-center" dangerouslySetInnerHTML={{__html: description}} />
         }
 
-        <YearsNavigation isEditing={isEditing} years={processedSheetData.map(({year}) => year)} timelineId={timelineId} />
+        <YearsNavigation isEditing={isEditing} years={processedSheetData.map(({year}) => year)} timelineId={timeline_id} />
         <fieldset className="timeline-group">
           {processedSheetData.map(({year, list}) => (
-            <div className="timeline-block-year-group" id={`${timelineId}-${year}`} key={`${timelineId}-${year}`}>
+            <div className="timeline-block-year-group" id={`${timeline_id}-${year}`} key={`${timeline_id}-${year}`}>
               <p className="timeline-block-year">{year}</p>
               <ul className="timeline-block-events">
                 {list.map((event, index) => (
                   <TimelineEvent
-                    key={`${timelineId}-event-${event.Day}-${index}`}
+                    key={`${timeline_id}-event-${event.Day}-${index}`}
                     event={event}
                   />
                 ))}

--- a/assets/src/blocks/Timeline/TimelineBlock.js
+++ b/assets/src/blocks/Timeline/TimelineBlock.js
@@ -4,43 +4,44 @@ import {NewTimelineEditor} from './NewTimelineEditorScript';
 import {TimelineFrontend} from './TimelineFrontend';
 import {NewTimelineFrontend} from './NewTimelineFrontend';
 import {frontendRendered} from '../../functions/frontendRendered';
+import {getUniqueId} from '../../functions/getUniqueId';
 
 const BLOCK_NAME = 'planet4-blocks/timeline';
 
-const isNewTimelineEnabled = Boolean(window.p4_vars.features.new_timeline_block);
-
-const attributes = {
-  timeline_title: {
-    type: 'string',
-    default: '',
-  },
-  description: {
-    type: 'string',
-    default: '',
-  },
-  google_sheets_url: {
-    type: 'string',
-    default: '',
-  },
-  language: {
-    type: 'string',
-    default: 'en',
-  },
-  timenav_position: {
-    type: 'string',
-    default: '',
-  },
-  start_at_end: {
-    type: 'boolean',
-    default: false,
-  },
-};
+const newTimelineEnabled = Boolean(window.p4_vars.features.new_timeline_block);
 
 export const registerTimelineBlock = () => {
   const {registerBlockType} = wp.blocks;
   const {__} = wp.i18n;
   const {RawHTML} = wp.element;
   const {useBlockProps} = wp.blockEditor;
+
+  const blockAttributes = {
+    timeline_title: {
+      type: 'string',
+      default: '',
+    },
+    description: {
+      type: 'string',
+      default: '',
+    },
+    google_sheets_url: {
+      type: 'string',
+      default: '',
+    },
+    language: {
+      type: 'string',
+      default: 'en',
+    },
+    timenav_position: {
+      type: 'string',
+      default: '',
+    },
+    start_at_end: {
+      type: 'boolean',
+      default: false,
+    },
+  };
 
   registerBlockType(BLOCK_NAME, {
     title: 'Timeline',
@@ -50,10 +51,13 @@ export const registerTimelineBlock = () => {
     supports: {
       html: false, // Disable "Edit as HTMl" block option.
     },
-    attributes,
+    attributes: newTimelineEnabled ? {
+      ...blockAttributes,
+      timeline_id: {type: 'string', default: ''},
+    } : blockAttributes,
     edit: props => (
       <div {...useBlockProps()}>
-        {isNewTimelineEnabled ? <NewTimelineEditor {...props} /> : <TimelineEditor {...props} />}
+        {newTimelineEnabled ? <NewTimelineEditor {...props} /> : <TimelineEditor {...props} />}
       </div>
     ),
     save: props => {
@@ -62,14 +66,14 @@ export const registerTimelineBlock = () => {
           data-hydrate={BLOCK_NAME}
           data-attributes={JSON.stringify(props.attributes)}
         >
-          {isNewTimelineEnabled ? <NewTimelineFrontend {...props} /> : <TimelineFrontend {...props} />}
+          {newTimelineEnabled ? <NewTimelineFrontend {...props} /> : <TimelineFrontend {...props} />}
         </div>
       );
       return <RawHTML>{markup}</RawHTML>;
     },
     deprecated: [
-      isNewTimelineEnabled ? {
-        attributes,
+      newTimelineEnabled ? {
+        attributes: blockAttributes,
         edit: TimelineEditor,
         save: props => {
           const markup = renderToString(
@@ -82,13 +86,22 @@ export const registerTimelineBlock = () => {
           );
           return <RawHTML>{markup}</RawHTML>;
         },
+        isEligible(attributes) {
+          return !attributes.timeline_id;
+        },
+        migrate(attributes) {
+          return {
+            ...attributes,
+            timeline_id: getUniqueId('tl'),
+          };
+        },
       } : {},
       {
-        attributes,
+        attributes: blockAttributes,
         save: frontendRendered(BLOCK_NAME),
       },
       {
-        attributes,
+        attributes: blockAttributes,
         save() {
           return null;
         },

--- a/assets/src/blocks/Timeline/YearsNavigation.js
+++ b/assets/src/blocks/Timeline/YearsNavigation.js
@@ -1,7 +1,7 @@
 import {useState, useEffect, useRef} from '@wordpress/element';
 const {sprintf, __} = wp.i18n;
 
-export const YearsNavigation = ({years, isEditing}) => {
+export const YearsNavigation = ({years, isEditing, timelineId}) => {
   const [showLeftArrow, setShowLeftArrow] = useState(false);
   const [showRightArrow, setShowRightArrow] = useState(false);
   const [activeYear, setActiveYear] = useState('');
@@ -16,17 +16,17 @@ export const YearsNavigation = ({years, isEditing}) => {
     const isFirefox = navigator.userAgent.toLowerCase().includes('firefox');
 
     if (isFirefox) {
-      const target = document.getElementById(year);
+      const target = document.getElementById(`${timelineId}-${year}`);
       if (target) {
         target.scrollIntoView({behavior: 'smooth', block: 'start'});
       }
     }
 
     isClicking.current = true;
-    setActiveYear(year);
+    setActiveYear(`${timelineId}-${year}`);
 
     // Move focus to first element in the list for that year.
-    const yearDiv = document.getElementById(year);
+    const yearDiv = document.getElementById(`${timelineId}-${year}`);
     const firstElement = yearDiv.querySelector('.timeline-block-event');
     firstElement.focus();
 
@@ -90,7 +90,7 @@ export const YearsNavigation = ({years, isEditing}) => {
 
           // Make active year element visible
           setTimeout(() => {
-            const navItem = document.querySelector('.years-navigation-items a.active');
+            const navItem = document.querySelector(`#${timelineId} .years-navigation-items a.active`);
             navItem?.scrollIntoView({
               behavior: 'smooth',
               inline: 'center',
@@ -104,7 +104,7 @@ export const YearsNavigation = ({years, isEditing}) => {
     const observer = new IntersectionObserver(observerCallback, observerOptions);
 
     years.forEach(year => {
-      const link = document.getElementById(year);
+      const link = document.getElementById(`${timelineId}-${year}`);
       if (link) {observer.observe(link);}
     });
 
@@ -177,12 +177,12 @@ export const YearsNavigation = ({years, isEditing}) => {
         ref={yearsListRef}
       >
         {years.map(year => (
-          <li key={year}>
+          <li key={`nav-${timelineId}-${year}`}>
             <a
-              href={`#${year}`}
+              href={`#${timelineId}-${year}`}
               onClick={() => handleClick(year)}
-              data-target={year}
-              className={`${!isEditing && activeYear === year ? 'active': ''}`}
+              data-target={`${timelineId}-${year}`}
+              className={`${!isEditing && activeYear === `${timelineId}-${year}` ? 'active': ''}`}
             >
               {year}
             </a>

--- a/assets/src/functions/getUniqueId.js
+++ b/assets/src/functions/getUniqueId.js
@@ -1,0 +1,5 @@
+export const getUniqueId = prefix => {
+  const r = Math.floor(Math.random() * 10000);
+  const t = Date.now();
+  return `${prefix}-${t}-${r}`;
+};

--- a/assets/src/scss/blocks/Timeline/TimelineEditorStyle.scss
+++ b/assets/src/scss/blocks/Timeline/TimelineEditorStyle.scss
@@ -8,6 +8,9 @@ div[data-type="planet4-blocks/timeline"] {
 }
 
 .new-timeline-block {
+  max-height: 100%;
+  overflow: hidden;
+
   .page-section-header,
   .page-section-description {
     text-align: center;

--- a/src/Blocks/Timeline.php
+++ b/src/Blocks/Timeline.php
@@ -57,6 +57,40 @@ class Timeline extends BaseBlock
      */
     public function register_timeline_block(): void
     {
+        $attributes = [
+            'timeline_title' => [
+                'type' => 'string',
+                'default' => '',
+            ],
+            'description' => [
+                'type' => 'string',
+                'default' => '',
+            ],
+            'google_sheets_url' => [
+                'type' => 'string',
+                'default' => '',
+            ],
+            'language' => [
+                'type' => 'string',
+                'default' => 'en',
+            ],
+            'timenav_position' => [
+                'type' => 'string',
+                'default' => 'bottom',
+            ],
+            'start_at_end' => [
+                'type' => 'boolean',
+                'default' => false,
+            ],
+        ];
+
+        if (NewTimelineBlock::is_active()) {
+            $attributes['timeline_id'] = [
+                'type' => 'string',
+                'default' => '',
+            ];
+        }
+
         // - Register the block for the editor
         // in the PHP side.
         register_block_type(
@@ -66,32 +100,7 @@ class Timeline extends BaseBlock
                 'editor_script' => 'planet4-blocks',
                 // todo: Remove when all content is migrated.
                 'render_callback' => [ self::class, 'hydrate_frontend' ],
-                'attributes' => [
-                    'timeline_title' => [
-                        'type' => 'string',
-                        'default' => '',
-                    ],
-                    'description' => [
-                        'type' => 'string',
-                        'default' => '',
-                    ],
-                    'google_sheets_url' => [
-                        'type' => 'string',
-                        'default' => '',
-                    ],
-                    'language' => [
-                        'type' => 'string',
-                        'default' => 'en',
-                    ],
-                    'timenav_position' => [
-                        'type' => 'string',
-                        'default' => 'bottom',
-                    ],
-                    'start_at_end' => [
-                        'type' => 'boolean',
-                        'default' => false,
-                    ],
-                ],
+                'attributes' => $attributes,
             ]
         );
 


### PR DESCRIPTION
### Summary

Ref: [PLANET-8207](https://greenpeace-planet4.atlassian.net/browse/PLANET-8207)

### Testing

In the frontend, make sure that the years navigation and scrolling behaviour work as expected.

On local:
1. Enable the new design for the block via `Planet 4 > Features`.
2. Add at least 2 Timeline blocks (you can use [this sheet](https://docs.google.com/spreadsheets/d/1tYlLd_Fx0T_7ZEaf2y9dLfRnr5HzEOW_s0wELp5-j4s/) for example) to a page and save.

Alternatively, you can use [this page](https://www-dev.greenpeace.org/test-mars/timelines-2/) from the test instance.

[PLANET-8207]: https://greenpeace-planet4.atlassian.net/browse/PLANET-8207?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ