### PR TITLE
PLANET-8046 Move focus to Gravity Forms confirmation after successful…

### DIFF
--- a/src/GravityFormsExtensions.php
+++ b/src/GravityFormsExtensions.php
@@ -128,6 +128,7 @@ class GravityFormsExtensions
         add_action('gform_pre_render', [$this, 'enqueue_share_buttons'], 10, 2);
         add_action('admin_enqueue_scripts', [$this, 'enqueue_gf_custom_scripts']);
         add_action('wp_enqueue_scripts', [$this, 'dequeue_gf_scripts'], 999);
+        add_action('wp_enqueue_scripts', [$this, 'enqueue_confirmation_focus_script'], 10);
     }
 
     /**
@@ -1226,6 +1227,36 @@ class GravityFormsExtensions
             $result['message'] = "<span>{$result['message']}</span>";
         }
         return $result;
+    }
+
+    /**
+     * Enqueue a script to focus the confirmation message after form submission.
+     * This is important for accessibility, especially for screen reader users.
+     */
+    public function enqueue_confirmation_focus_script(): void
+    {
+        if (!class_exists('GFForms')) {
+            return;
+        }
+
+        wp_register_script('gform-confirmation-focus', '', ['jquery'], null, true);
+        wp_enqueue_script('gform-confirmation-focus');
+
+        $script = "
+            (function($) {
+                $(document).on('gform_confirmation_loaded', function(event, formId) {
+                    const wrapper = document.querySelector('#gform_confirmation_wrapper_' + formId)
+                        || document.querySelector('.gform_confirmation_wrapper');
+
+                    if (wrapper) {
+                        wrapper.setAttribute('tabindex', '-1');
+                        wrapper.focus();
+                    }
+                });
+            })(jQuery);
+        ";
+
+        wp_add_inline_script('gform-confirmation-focus', $script);
     }
     // @phpcs:enable SlevomatCodingStandard.Functions.UnusedParameter.UnusedParameter, SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint
 }


### PR DESCRIPTION
### Summary
After submitting the subscribe form, just above the footer ([example](https://www-dev.greenpeace.org/international/)), the focus is being reset and moved back to the top of the page (see video). The user doesn’t get to hear the confirmation message.

<!-- Please provide a brief summary of the change introduced in this Pull Request. -->

---

<!-- Please add a reference link to the ticket, if one exists. -->
Ref: https://greenpeace-planet4.atlassian.net/browse/PLANET-8046

### Testing

<!-- Please add the steps required to test the changes in this Pull Request. -->
1. The focus should stay in the confirmation message after form submission ✅ 
2. The screen reader should read the confirmation message ✅ 
