### PR TITLE
PLANET-8209 Cache navbar and donate menus

### DIFF
--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -366,25 +366,13 @@ class MasterSite extends \Timber\Site
         $context['foo'] = 'bar'; // For unit test purposes.
 
         if (has_nav_menu('navigation-bar-menu')) {
-            $menu = Timber::get_menu('navigation-bar-menu');
-            $menu_items = $menu->get_items();
-            $context['navbar_menu'] = $menu;
-            $context['navbar_menu_items'] = array_filter(
-                $menu_items,
-                function ($item) {
-                    return !in_array('wpml-ls-item', $item->classes ?? [], true);
-                }
-            );
+            $context['navbar_menu_items'] = NavMenus::navbar_menu_items();
         }
 
         // Check if the menu has been created.
-        if (has_nav_menu('donate-menu')) {
-            $donate_menu = Timber::get_menu('donate-menu');
-
-            // Check if it has at least 1 item added into the menu.
-            if (!empty($donate_menu->get_items())) {
-                $context['donate_menu_items'] = $donate_menu->get_items();
-            }
+        $donate_menu_items = NavMenus::donate_menu_items();
+        if (!empty($donate_menu_items)) {
+            $context['donate_menu_items'] = $donate_menu_items;
         }
 
         $languages = function_exists('icl_get_languages') ? icl_get_languages() : [];

--- a/src/NavMenus.php
+++ b/src/NavMenus.php
@@ -10,7 +10,9 @@ use Timber\Timber;
  *
  * Centralises nav-menus functionality for the theme:
  *  - registers the 5 menu locations (top nav, donate, 3x footer)
- *  - serves footer-menu items from a 24h Timber transient, with invalidation on any menu mutation
+ *  - serves menu items from 24h Timber transients, with invalidation on any menu mutation
+ *  - resets per-request current-page state on the top nav and donate menu so cached items track the page being rendered
+ *  - varies cache keys by language on WPML sites
  *  - applies the transparent-nav body class on the front page
  */
 class NavMenus
@@ -18,12 +20,27 @@ class NavMenus
     private const FOOTER_SOCIAL_KEY = 'p4_footer_social_menu';
     private const FOOTER_PRIMARY_KEY = 'p4_footer_primary_menu';
     private const FOOTER_SECONDARY_KEY = 'p4_footer_secondary_menu';
+    private const NAVBAR_KEY = 'p4_navbar_menu_items';
+    private const DONATE_KEY = 'p4_donate_menu_items';
+
+    /**
+     * CSS classes that reflect per-request "current page" state on menu items. Stripped from cached entries and re-added
+     * at read time by recompute_current_state() based on the URL being rendered.
+     */
+    private const STALE_CURRENT_CLASSES = [
+        'current-menu-item',
+        'current-menu-parent',
+        'current-menu-ancestor',
+        'current_page_item',
+        'current_page_parent',
+        'current_page_ancestor',
+    ];
 
     public function __construct()
     {
         add_action('after_setup_theme', [self::class, 'register_locations'], 0);
 
-        $invalidate = [self::class, 'invalidate_footer_cache'];
+        $invalidate = [self::class, 'invalidate_menu_cache'];
         add_action('wp_update_nav_menu', $invalidate);
         add_action('wp_update_nav_menu_item', $invalidate);
         add_action('wp_delete_nav_menu', $invalidate);
@@ -71,17 +88,54 @@ class NavMenus
     }
 
     /**
-     * Delete all footer-menu transients. Called on any nav-menu mutation.
+     * Cached Timber\MenuItem[] for the navigation-bar-menu location.
+     *
+     * The wpml-ls-item language switcher entries are stripped at cache-write time. Current-menu-item state is stripped
+     * from the cache and recomputed per request in recompute_current_state() so the active highlight tracks the page
+     * being rendered, not the page that warmed the cache.
+     */
+    public static function navbar_menu_items(): array
+    {
+        $items = self::cached_timber_menu_items(
+            self::NAVBAR_KEY,
+            'navigation-bar-menu',
+            static fn(array $items): array => array_values(array_filter(
+                $items,
+                static fn($item) => !in_array('wpml-ls-item', $item->classes ?? [], true)
+            ))
+        );
+
+        self::recompute_current_state($items);
+
+        return $items;
+    }
+
+    /**
+     * Cached Timber\MenuItem[] for the donate-menu location.
+     *
+     * Current-menu-item state is stripped from the cache and recomputed per request in recompute_current_state().
+     */
+    public static function donate_menu_items(): array
+    {
+        $items = self::cached_timber_menu_items(self::DONATE_KEY, 'donate-menu');
+        self::recompute_current_state($items);
+        return $items;
+    }
+
+    /**
+     * Delete every nav-menu transient. Called on any nav-menu mutation.
      *
      * On multilingual sites each language has its own cache entry, so we enumerate active language codes and delete
      * every variant. Also deletes the un-suffixed base keys for safety on sites where the plugin is inactive.
      */
-    public static function invalidate_footer_cache(): void
+    public static function invalidate_menu_cache(): void
     {
         $base_keys = [
             self::FOOTER_SOCIAL_KEY,
             self::FOOTER_PRIMARY_KEY,
             self::FOOTER_SECONDARY_KEY,
+            self::NAVBAR_KEY,
+            self::DONATE_KEY,
         ];
 
         $suffixes = array_merge([''], array_map(
@@ -115,8 +169,7 @@ class NavMenus
      */
     private static function cached_items(string $cache_key, string $location, string $fallback): array
     {
-        $lang = self::current_language_code();
-        $key = $lang !== '' ? $cache_key . '_' . $lang : $cache_key;
+        $key = self::localised_key($cache_key);
 
         $items = TimberHelper::transient(
             $key,
@@ -125,6 +178,150 @@ class NavMenus
         );
 
         return is_array($items) ? $items : [];
+    }
+
+    /**
+     * Fetch and cache fully-wrapped Timber\MenuItem[] for a menu location. Used for the navigation-bar-menu and
+     * donate-menu, whose templates rely on Timber\MenuItem accessors (`.link`, `.children`, `.title`) that a plain
+     * WP_Post array doesn't provide.
+     *
+     * The optional $post_filter runs once at cache-write time and is responsible for stripping items that shouldn't
+     * be persisted (e.g. the WPML language switcher entries on the top nav).
+     *
+     * @param callable(array):array|null $post_filter
+     */
+    private static function cached_timber_menu_items(
+        string $cache_key,
+        string $location,
+        ?callable $post_filter = null
+    ): array {
+        $key = self::localised_key($cache_key);
+
+        $items = TimberHelper::transient(
+            $key,
+            static function () use ($location, $post_filter): array {
+                if (!has_nav_menu($location)) {
+                    return [];
+                }
+                $menu = Timber::get_menu($location);
+                if (!$menu) {
+                    return [];
+                }
+                $items = $menu->get_items();
+                if (!is_array($items)) {
+                    return [];
+                }
+
+                if ($post_filter !== null) {
+                    $items = $post_filter($items);
+                }
+
+                // Strip per-request state so the cached copy is safe to return on any URL.
+                // recompute_current_state() reapplies it at read time.
+                self::strip_current_state($items);
+
+                return $items;
+            },
+            DAY_IN_SECONDS
+        );
+
+        return is_array($items) ? $items : [];
+    }
+
+    /**
+     * Zero out the ->current / ->current_item_* flags and remove the current-menu-* CSS classes before caching, so no
+     * page-specific state leaks into the cached representation.
+     *
+     * @param array $items Timber\MenuItem-like objects (recursed via ->children).
+     */
+    private static function strip_current_state(array $items): void
+    {
+        foreach ($items as $item) {
+            if (!is_object($item)) {
+                continue;
+            }
+
+            $item->current = false;
+            $item->current_item_ancestor = false;
+            $item->current_item_parent = false;
+
+            if (isset($item->classes) && is_array($item->classes)) {
+                $item->classes = array_values(array_diff($item->classes, self::STALE_CURRENT_CLASSES));
+            }
+
+            if (!empty($item->children) && is_array($item->children)) {
+                self::strip_current_state($item->children);
+            }
+        }
+    }
+
+    /**
+     * Reapply current-menu-* state on cached items based on the URL being rendered. Matches item URL against the
+     * current request URL; ancestor / parent detection is left to Twig template logic (Planet4 templates only use
+     * ->current for the active class).
+     *
+     * @param array $items Timber\MenuItem-like objects (recursed via ->children).
+     */
+    private static function recompute_current_state(array $items): void
+    {
+        if (empty($items)) {
+            return;
+        }
+
+        global $wp;
+        $current_url = isset($wp->request)
+            ? untrailingslashit(home_url($wp->request))
+            : untrailingslashit(home_url((string) ($_SERVER['REQUEST_URI'] ?? '')));
+
+        foreach ($items as $item) {
+            if (!is_object($item)) {
+                continue;
+            }
+
+            $item_url = self::item_url($item);
+            $is_current = $item_url !== '' && untrailingslashit($item_url) === $current_url;
+
+            $item->current = $is_current;
+            if ($is_current) {
+                $item->classes = isset($item->classes) && is_array($item->classes)
+                    ? array_values(array_unique(array_merge($item->classes, ['current-menu-item'])))
+                    : ['current-menu-item'];
+            }
+
+            if (!empty($item->children) && is_array($item->children)) {
+                self::recompute_current_state($item->children);
+            }
+        }
+    }
+
+    /**
+     * Best-effort URL accessor for a Timber\MenuItem-like object. Timber exposes both ->link (method) and ->url
+     * (property) depending on version; fall back to either.
+     */
+    private static function item_url(object $item): string
+    {
+        if (isset($item->url) && is_string($item->url) && $item->url !== '') {
+            return $item->url;
+        }
+        if (method_exists($item, 'link')) {
+            $link = $item->link();
+            if (is_string($link) && $link !== '') {
+                return $link;
+            }
+        }
+        if (isset($item->link) && is_string($item->link) && $item->link !== '') {
+            return $item->link;
+        }
+        return '';
+    }
+
+    /**
+     * Append the current language code to a base cache key so each language on a WPML site has its own entry.
+     */
+    private static function localised_key(string $base_key): string
+    {
+        $lang = self::current_language_code();
+        return $lang !== '' ? $base_key . '_' . $lang : $base_key;
     }
 
     /**
@@ -153,11 +350,10 @@ class NavMenus
     }
 
     /**
-     * Fetch items as a cache-safe stdClass array.
+     * Fetch footer-menu items as a cache-safe stdClass array.
      *
-     * Casts WP_Post to stdClass so the dynamic props from
-     * wp_setup_nav_menu_item() (url, title, target, classes) survive
-     * serialize() - WP_Post::__sleep() would otherwise drop them.
+     * Casts WP_Post to stdClass so the dynamic props from wp_setup_nav_menu_item() (url, title, target, classes)
+     * survive serialize() — WP_Post::__sleep() would otherwise drop them.
      */
     private static function resolve_items(string $location, string $fallback): array
     {

--- a/src/NavMenus.php
+++ b/src/NavMenus.php
@@ -24,8 +24,8 @@ class NavMenus
     private const DONATE_KEY = 'p4_donate_menu_items';
 
     /**
-     * CSS classes that reflect per-request "current page" state on menu items. Stripped from cached entries and re-added
-     * at read time by recompute_current_state() based on the URL being rendered.
+     * CSS classes that reflect per-request "current page" state on menu items. Stripped from cached entries and
+     * re-added at read time by recompute_current_state() based on the URL being rendered.
      */
     private const STALE_CURRENT_CLASSES = [
         'current-menu-item',
@@ -249,9 +249,11 @@ class NavMenus
                 $item->classes = array_values(array_diff($item->classes, self::STALE_CURRENT_CLASSES));
             }
 
-            if (!empty($item->children) && is_array($item->children)) {
-                self::strip_current_state($item->children);
+            if (empty($item->children) || !is_array($item->children)) {
+                continue;
             }
+
+            self::strip_current_state($item->children);
         }
     }
 
@@ -288,9 +290,11 @@ class NavMenus
                     : ['current-menu-item'];
             }
 
-            if (!empty($item->children) && is_array($item->children)) {
-                self::recompute_current_state($item->children);
+            if (empty($item->children) || !is_array($item->children)) {
+                continue;
             }
+
+            self::recompute_current_state($item->children);
         }
     }
 


### PR DESCRIPTION
### Summary

Cache the navigation-bar-menu and donate-menu Timber\MenuItem arrays. Per-request "current page" state(->current + current-menu-* classes) is stripped before caching and recomputed on read against the URL being rendered, so the active-item highlight follows the page being served.

---

Ref: 
https://greenpeace-planet4.atlassian.net/browse/PLANET-8209

### Testing

1. **Baseline** : checkout `main` branch, load `/`, `/about-us-2/`, `/news-stories/`,  and any story page. Reload each once (warm cache). Note the Query Monitor totals: **queries**, **DB time**, **memory**.

2. **This PR** : checkout `PLANET-8209_optimize_nav_menu_query` branch, reload each URL twice (first populates transients, second is warm). Record the same totals.

3. **Active-item highlighting** : visit `/take-action/` => "Take Action" underlined. Then `/get-informed/` => "The issues we work on" underlined. Confirms the current-state recompute follows the URL and doesn't freeze to the page that warmed the cache.

Additionally also inspect the transients directly using below wp cli commands -
```
wp transient list --search='p4_footer_*'
wp transient list --search='p4_navbar_*'
wp transient list --search='p4_donate_*'
```
