### PR TITLE
Add Sentry error logging when GP Media connection fails

### DIFF
--- a/assets/src/js/Components/ArchivePicker/ArchivePicker.js
+++ b/assets/src/js/Components/ArchivePicker/ArchivePicker.js
@@ -1,3 +1,4 @@
+/* global Sentry */
 import classNames from 'classnames';
 import ArchivePickerList from './ArchivePickerList';
 import SingleSidebar from './SingleSidebar';
@@ -285,9 +286,26 @@ export default function ArchivePicker({view = ADMIN_VIEW}) {
       }});
     } catch (err) {
       if (err.name !== 'AbortError') {
+        const errorMessage = err instanceof Error ? err.message : String(err);
+        const sentryError = err instanceof Error ? err : new Error(`ArchivePicker fetch error: ${errorMessage}`);
+
+        if (typeof Sentry !== 'undefined' && typeof Sentry.captureException === 'function') {
+          Sentry.captureException(sentryError, {
+            tags: {
+              feature: 'archive-picker',
+              action: 'fetch-images',
+            },
+            extra: {
+              pageNumber,
+              searchText,
+              originalError: err,
+            },
+          });
+        }
+
         dispatch({type: 'SET_ERROR', payload: {
           type: ACTIONS.FETCH_IMAGES,
-          error: err.message,
+          error: errorMessage,
         }});
       }
     }


### PR DESCRIPTION
### Summary

When the API call to GP Media fails we currently are just seeing a 500 error in the web console. With this change we will also get a Sentry issue.

### Testing

We are having a connection issue at the moment. So this branch change is [already visible in Sentry](https://greenpeace-international.sentry.io/issues/?environment=development&project=4508408819417088&query=is%3Aunresolved%20archivepicker&referrer=issue-list&statsPeriod=7d).

<img width="562" height="82" alt="image" src="https://github.com/user-attachments/assets/f61b8cdb-0673-4053-a288-8f8901a447d3" />
