### PR TITLE
PLANET-8189: implement automation for importing external landing pages with redirection

### DIFF
--- a/admin/js/action_importer.js
+++ b/admin/js/action_importer.js
@@ -8,6 +8,6 @@ document.addEventListener('DOMContentLoaded', () => {
     actionImportButton.href = 'edit.php?post_type=p4_action&page=import-action';
     actionImportButton.className = 'add-new-h2';
     actionImportButton.textContent = 'Import Action';
-    pageTitleAction.insertAdjacentElement('afterend', actionImportButton);
+    pageTitleAction.after(actionImportButton);
   }
 });

--- a/admin/js/action_importer.js
+++ b/admin/js/action_importer.js
@@ -1,0 +1,13 @@
+// Adds a link to the Import Action page.
+
+document.addEventListener('DOMContentLoaded', () => {
+  const pageTitleAction = document.querySelector('.wp-admin.post-type-p4_action .page-title-action');
+
+  if(pageTitleAction) {
+    const actionImportButton = document.createElement('a');
+    actionImportButton.href = 'edit.php?post_type=p4_action&page=import-action';
+    actionImportButton.className = 'add-new-h2';
+    actionImportButton.textContent = 'Import Action';
+    pageTitleAction.insertAdjacentElement('afterend', actionImportButton);
+  }
+});

--- a/functions.php
+++ b/functions.php
@@ -384,20 +384,6 @@ add_action(
     3
 );
 
-// Update Core Post Author block with P4 custom block
-// P4 custom block has author override value
-add_filter(
-    'render_block',
-    function ($block_content, $block): string {
-        if ($block['blockName'] === 'core/post-author-name') {
-            return render_block(['blockName' => 'p4/post-author-name']);
-        }
-        return $block_content;
-    },
-    10,
-    2
-);
-
 // Remove the user email from the notification email sent to editors
 // when a new comment is added to a post.
 // phpcs:disable SlevomatCodingStandard.Functions.UnusedParameter

--- a/src/BlockRenderOverrides.php
+++ b/src/BlockRenderOverrides.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace P4\MasterTheme;
+
+/**
+ * Class BlockRenderOverrides
+ */
+class BlockRenderOverrides
+{
+    public function __construct()
+    {
+
+        add_filter('render_block', [$this, 'apply_wpautop_to_non_block_content'], 10, 2);
+        add_filter('render_block', [$this, 'replace_core_author_block'], 10, 2);
+        add_filter('render_block_core/post-template', [$this, 'remove_empty_elements_from_template'], 10, 1);
+    }
+
+    /**
+     * Apply wpautop to non-block content.
+     * @link https://wordpress.stackexchange.com/q/321662/26317
+     */
+    public function apply_wpautop_to_non_block_content(string $block_content, array $block): string
+    {
+        if (is_null($block['blockName'])) {
+            return wpautop($block_content);
+        }
+        return $block_content;
+    }
+
+    /**
+     * Update Core Post Author block with P4 custom block.
+     * P4 custom block has author override value.
+     */
+    public function replace_core_author_block(string $block_content, array $block): string
+    {
+        if ($block['blockName'] === 'core/post-author-name') {
+            return render_block(['blockName' => 'p4/post-author-name']);
+        }
+        return $block_content;
+    }
+
+    /**
+     * Remove from the Core Post Template the Taxonomy Breadcrumb inner block if empty.
+     * Remove from the Core Post Template the Post Terms inner block if empty.
+     */
+    public function remove_empty_elements_from_template(string $block_content): string
+    {
+        $block_content = preg_replace(
+            '/<div class="wrapper-post-term">\s*<\/div>/',
+            '',
+            $block_content
+        );
+        $block_content = preg_replace(
+            '/<div class="wrapper-post-tag">\s*<\/div>/',
+            '',
+            $block_content
+        );
+        return $block_content;
+    }
+}

--- a/src/CustomPostType/ActionImporter.php
+++ b/src/CustomPostType/ActionImporter.php
@@ -32,7 +32,7 @@ class ActionImporter
         }
 
         add_action('admin_menu', [ $this, 'add_options_page' ], 99);
-        add_action('admin_init', [ $this, 'maybe_handle_submission' ]);
+        add_action('admin_init', [ $this, 'init_import' ]);
     }
 
     /**
@@ -50,13 +50,40 @@ class ActionImporter
         );
     }
 
+    public function init_import(): void
+    {
+        $redirect_args = [
+            'post_type' => 'p4_action',
+            'page'      => 'import-action',
+        ];
+
+        $url = $this->maybe_handle_submission($redirect_args);
+
+        if ($url === null) {
+            return;
+        }
+
+        $post_id = $this->import_from_url($url);
+
+        if (is_wp_error($post_id)) {
+            $redirect_args['action_importer_error'] = rawurlencode($post_id->get_error_message());
+            $this->redirect_back($redirect_args);
+        }
+
+        $this->create_redirection_to_source($post_id, $url);
+        $this->sync_elasticpress($post_id);
+
+        $redirect_args['action_importer_success'] = $post_id;
+        $this->redirect_back($redirect_args);
+    }
+
     /**
      * Handle the form submission on admin_init, before any output.
      */
-    public function maybe_handle_submission(): void
+    private function maybe_handle_submission(array $redirect_args): string|null
     {
         if (empty($_POST['import_url'])) {
-            return;
+            return null;
         }
 
         check_admin_referer(self::NONCE_ACTION);
@@ -66,10 +93,6 @@ class ActionImporter
         }
 
         $url = esc_url_raw(wp_unslash($_POST['import_url']));
-        $redirect_args = [
-            'post_type' => 'p4_action',
-            'page'      => 'import-action',
-        ];
 
         if (!$url || !filter_var($url, FILTER_VALIDATE_URL)) {
             $redirect_args['action_importer_error'] = rawurlencode(
@@ -95,15 +118,18 @@ class ActionImporter
             $this->redirect_back($redirect_args);
         }
 
-        $post_id = $this->import_from_url($url);
+        return $url;
+    }
 
-        if (is_wp_error($post_id)) {
-            $redirect_args['action_importer_error'] = rawurlencode($post_id->get_error_message());
-            $this->redirect_back($redirect_args);
-        }
-
-        $redirect_args['action_importer_success'] = $post_id;
-        $this->redirect_back($redirect_args);
+    /**
+     * Redirect back to the import page with status query args, then exit.
+     *
+     * @param array<string,mixed> $args Query args to append.
+     */
+    private function redirect_back(array $args): void
+    {
+        wp_safe_redirect(add_query_arg($args, admin_url('edit.php')));
+        exit;
     }
 
     /**
@@ -219,9 +245,6 @@ class ActionImporter
         if ($og['image']) {
             $this->set_featured_image_from_url($post_id, $og['image'], $og['title']);
         }
-
-        $this->create_redirection_to_source($post_id, $url);
-        $this->sync_elasticpress($post_id);
 
         return $post_id;
     }
@@ -410,17 +433,6 @@ class ActionImporter
         if (!is_wp_error($media_id)) {
             set_post_thumbnail($post_id, $media_id);
         }
-    }
-
-    /**
-     * Redirect back to the import page with status query args, then exit.
-     *
-     * @param array<string,mixed> $args Query args to append.
-     */
-    private function redirect_back(array $args): void
-    {
-        wp_safe_redirect(add_query_arg($args, admin_url('edit.php')));
-        exit;
     }
 
     /**

--- a/src/CustomPostType/ActionImporter.php
+++ b/src/CustomPostType/ActionImporter.php
@@ -4,15 +4,35 @@ namespace P4\MasterTheme\CustomPostType;
 
 /**
  * Class ActionImporter
+ *
+ * Lets an admin/editor paste an external URL. On submit, PHP fetches the
+ * page server-side, extracts its Open Graph data, and publishes a
+ * p4_action post from it directly (no client-side preview step). URLs
+ * that have already been imported are rejected.
  */
 class ActionImporter
 {
+    private const NONCE_ACTION = 'import_action';
+
     /**
-     * Constructor
+     * Constructor.
      */
     public function __construct()
     {
+        $this->hooks();
+    }
+
+    /**
+     * Hooks actions and filters.
+     */
+    public function hooks(): void
+    {
+        if (!current_user_can('manage_options') && !current_user_can('editor')) {
+            return;
+        }
+
         add_action('admin_menu', [ $this, 'add_options_page' ], 99);
+        add_action('admin_init', [ $this, 'maybe_handle_submission' ]);
     }
 
     /**
@@ -30,29 +50,361 @@ class ActionImporter
         );
     }
 
+    /**
+     * Handle the form submission on admin_init, before any output.
+     */
+    public function maybe_handle_submission(): void
+    {
+        if (empty($_POST['import_url'])) {
+            return;
+        }
+
+        check_admin_referer(self::NONCE_ACTION);
+
+        if (!current_user_can('manage_options') && !current_user_can('editor')) {
+            wp_die(esc_html__('You are not allowed to do this.', 'planet4-master-theme-backend'));
+        }
+
+        $url = esc_url_raw(wp_unslash($_POST['import_url']));
+        $redirect_args = [
+            'post_type' => 'p4_action',
+            'page'      => 'import-action',
+        ];
+
+        if (!$url || !filter_var($url, FILTER_VALIDATE_URL)) {
+            $redirect_args['action_importer_error'] = rawurlencode(
+                __('Please provide a valid URL.', 'planet4-master-theme-backend')
+            );
+            $this->redirect_back($redirect_args);
+        }
+
+        $existing_post_id = $this->find_existing_post_by_url($url);
+
+        if ($existing_post_id) {
+            $redirect_args['action_importer_error'] = rawurlencode(
+                __('This URL has already been imported.', 'planet4-master-theme-backend')
+            );
+            $redirect_args['action_importer_existing'] = $existing_post_id;
+            $this->redirect_back($redirect_args);
+        }
+
+        $post_id = $this->import_from_url($url);
+
+        if (is_wp_error($post_id)) {
+            $redirect_args['action_importer_error'] = rawurlencode($post_id->get_error_message());
+            $this->redirect_back($redirect_args);
+        }
+
+        $redirect_args['action_importer_success'] = $post_id;
+        $this->redirect_back($redirect_args);
+    }
+
+    /**
+     * Look up whether a post has already been imported from a given URL.
+     *
+     * @param string $url URL to check.
+     * @return int Post ID if found, 0 otherwise.
+     */
+    private function find_existing_post_by_url(string $url): int
+    {
+        $existing = get_posts([
+            'post_type'      => 'p4_action',
+            'post_status'    => 'any',
+            'posts_per_page' => 1,
+            'fields'         => 'ids',
+            'meta_query'     => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+                [
+                    'key'   => 'action_importer_source_url',
+                    'value' => $url,
+                ],
+            ],
+        ]);
+
+        return !empty($existing) ? (int) $existing[0] : 0;
+    }
+
+    /**
+     * Derive a post slug from the last path segment of a URL.
+     *
+     * e.g. https://act.greenpeace.org.au/stop-big-gas -> "stop-big-gas"
+     *
+     * @param string $url Source URL.
+     * @return string Sanitized slug, or empty string if none could be derived
+     *                (wp_insert_post() will then fall back to the title).
+     */
+    private function slug_from_url(string $url): string
+    {
+        $path = (string) wp_parse_url($url, PHP_URL_PATH);
+        $path = trim($path, '/');
+
+        if ($path === '') {
+            return '';
+        }
+
+        $segments = explode('/', $path);
+        $last     = end($segments);
+
+        return sanitize_title($last);
+    }
+
+    /**
+     * Fetch a URL, parse its Open Graph tags, and create a published post.
+     *
+     * @param string $url External URL to import.
+     * @return int|\WP_Error Post ID on success, WP_Error on failure.
+     */
+    private function import_from_url(string $url)
+    {
+        $response = wp_remote_get($url, [
+            'timeout'    => 12,
+            'user-agent' => 'Planet4 Action Importer',
+        ]);
+
+        if (is_wp_error($response)) {
+            return $response;
+        }
+
+        $code = wp_remote_retrieve_response_code($response);
+        if ($code < 200 || $code >= 300) {
+            return new \WP_Error(
+                'action_importer_http_error',
+                sprintf(
+                    /* translators: %d is an HTTP status code. */
+                    __('The remote server responded with status %d.', 'planet4-master-theme-backend'),
+                    $code
+                )
+            );
+        }
+
+        $body = wp_remote_retrieve_body($response);
+
+        if (trim($body) === '') {
+            return new \WP_Error(
+                'action_importer_empty_body',
+                __('The remote page returned no content.', 'planet4-master-theme-backend')
+            );
+        }
+
+        $og = $this->parse_og_tags($body, $url);
+
+        if (empty($og['title']) && empty($og['description'])) {
+            return new \WP_Error(
+                'action_importer_no_og_data',
+                __('No Open Graph data could be found on that page.', 'planet4-master-theme-backend')
+            );
+        }
+
+        $post_id = wp_insert_post([
+            'post_type'    => 'p4_action',
+            'post_title'   => $og['title'] ?: __('(No title found)', 'planet4-master-theme-backend'),
+            'post_content' => $og['description'],
+            'post_status'  => 'publish',
+            'post_name'    => $this->slug_from_url($url),
+            'meta_input'   => [
+                'action_importer_source_url' => $url,
+            ],
+        ], true);
+
+        if (is_wp_error($post_id)) {
+            return $post_id;
+        }
+
+        if ($og['image']) {
+            $this->set_featured_image_from_url($post_id, $og['image'], $og['title']);
+        }
+
+        return $post_id;
+    }
+
+    /**
+     * Parse Open Graph meta tags out of an HTML string.
+     *
+     * @param string $html       Raw HTML.
+     * @param string $source_url Original URL, used as a fallback for og:url.
+     * @return array{title:string, description:string, image:string, url:string}
+     */
+    private function parse_og_tags(string $html, string $source_url): array
+    {
+        $og = [
+            'title'       => '',
+            'description' => '',
+            'image'       => '',
+            'url'         => $source_url,
+        ];
+
+        // Guard against the PHP 8 ValueError thrown by loadHTML() on an empty string.
+        if (trim($html) === '') {
+            return $og;
+        }
+
+        $dom = new \DOMDocument();
+
+        $previous_setting = libxml_use_internal_errors(true);
+        $loaded            = $dom->loadHTML($html, LIBXML_NOERROR | LIBXML_NOWARNING);
+        libxml_clear_errors();
+        libxml_use_internal_errors($previous_setting);
+
+        if (!$loaded) {
+            return $og;
+        }
+
+        $metas = $dom->getElementsByTagName('meta');
+
+        foreach ($metas as $meta) {
+            /** @var \DOMElement $meta */
+            $property = $meta->getAttribute('property') ?: $meta->getAttribute('name');
+            $content  = $meta->getAttribute('content');
+
+            if (!$property || $content === '') {
+                continue;
+            }
+
+            switch ($property) {
+                case 'og:title':
+                    $og['title'] = $content;
+                    break;
+                case 'og:description':
+                    $og['description'] = $content;
+                    break;
+                case 'og:image':
+                case 'og:image:secure_url':
+                    if (empty($og['image'])) {
+                        $og['image'] = $content;
+                    }
+                    break;
+                case 'og:url':
+                    $og['url'] = $content;
+                    break;
+            }
+        }
+
+        // Fall back to <title> if og:title is missing.
+        if (empty($og['title'])) {
+            $titles = $dom->getElementsByTagName('title');
+            if ($titles->length > 0) {
+                $og['title'] = $titles->item(0)->textContent;
+            }
+        }
+
+        $og['title']       = sanitize_text_field($og['title']);
+        $og['description'] = sanitize_text_field($og['description']);
+        $og['url']          = esc_url_raw($og['url']);
+        $og['image']        = esc_url_raw($og['image']);
+
+        return $og;
+    }
+
+    /**
+     * Sideload a remote image and set it as the post's featured image.
+     *
+     * @param int    $post_id   Target post ID.
+     * @param string $image_url Remote image URL.
+     * @param string $desc      Image description / alt text.
+     */
+    private function set_featured_image_from_url(int $post_id, string $image_url, string $desc): void
+    {
+        if (!function_exists('media_sideload_image')) {
+            require_once ABSPATH . 'wp-admin/includes/media.php';
+            require_once ABSPATH . 'wp-admin/includes/file.php';
+            require_once ABSPATH . 'wp-admin/includes/image.php';
+        }
+
+        $media_id = media_sideload_image($image_url, $post_id, $desc, 'id');
+
+        if (!is_wp_error($media_id)) {
+            set_post_thumbnail($post_id, $media_id);
+        }
+    }
+
+    /**
+     * Redirect back to the import page with status query args, then exit.
+     *
+     * @param array<string,mixed> $args Query args to append.
+     */
+    private function redirect_back(array $args): void
+    {
+        wp_safe_redirect(add_query_arg($args, admin_url('edit.php')));
+        exit;
+    }
+
+    /**
+     * Render the admin page markup, including any success/error notice.
+     */
     public function admin_page_display(): void
     {
-        echo '<h2>Import Action</h2>' . "\n"; ?>
+        ?>
+        <div class="wrap">
+            <h2><?php echo esc_html__('Import Action', 'planet4-master-theme-backend'); ?></h2>
 
-        <form method="post">
-            <?php wp_nonce_field('import_action'); ?>
-            <table class="form-table">
-                <tr>
-                    <th><?php echo __('URL', 'planet4-master-theme-backend'); ?></th>
-                    <td>
-                        <input
-                            type="url"
-                            name="import_url"
-                            class="regular-text"
-                            required
-                            placeholder="https://act.greenpeace.org/landing-page"
-                        />
-                        <p>Verify the results on submission. This feature has mostly been tested with Hubspot landing pages.</p>
-                    </td>
-                </tr>
-            </table>
-            <?php submit_button(__('Import Action', 'planet4-master-theme-backend')); ?>
-        </form>
+            <?php $this->maybe_render_notice(); ?>
+
+            <form method="post">
+                <?php wp_nonce_field(self::NONCE_ACTION); ?>
+                <table class="form-table">
+                    <tr>
+                        <th><?php echo esc_html__('URL', 'planet4-master-theme-backend'); ?></th>
+                        <td>
+                            <input
+                                type="url"
+                                name="import_url"
+                                class="regular-text"
+                                required
+                                placeholder="https://act.greenpeace.org/landing-page"
+                            />
+                            <p>
+                                <?php echo esc_html__(
+                                    'Verify the results on submission. This feature has mostly been tested with Hubspot landing pages.',
+                                    'planet4-master-theme-backend'
+                                ); ?>
+                            </p>
+                        </td>
+                    </tr>
+                </table>
+                <?php submit_button(__('Import Action', 'planet4-master-theme-backend')); ?>
+            </form>
+        </div>
         <?php
+    }
+
+    /**
+     * Print a success/error admin notice based on the redirect query args.
+     */
+    private function maybe_render_notice(): void
+    {
+        if (!empty($_GET['action_importer_error'])) {
+            $message = sanitize_text_field(wp_unslash($_GET['action_importer_error']));
+
+            if (!empty($_GET['action_importer_existing'])) {
+                $existing_id  = absint($_GET['action_importer_existing']);
+                $existing_url = get_edit_post_link($existing_id, 'raw');
+                printf(
+                    '<div class="notice notice-error"><p>%s <a href="%s">%s</a></p></div>',
+                    esc_html($message),
+                    esc_url($existing_url),
+                    esc_html__('View existing post', 'planet4-master-theme-backend')
+                );
+                return;
+            }
+
+            printf(
+                '<div class="notice notice-error"><p>%s</p></div>',
+                esc_html($message)
+            );
+            return;
+        }
+
+        if (!empty($_GET['action_importer_success'])) {
+            $post_id   = absint($_GET['action_importer_success']);
+            $edit_url  = get_edit_post_link($post_id, 'raw');
+            $view_url  = get_permalink($post_id);
+            printf(
+                '<div class="notice notice-success"><p>%s <a href="%s">%s</a> &middot; <a href="%s">%s</a></p></div>',
+                esc_html__('Post published.', 'planet4-master-theme-backend'),
+                esc_url($view_url),
+                esc_html__('View it', 'planet4-master-theme-backend'),
+                esc_url($edit_url),
+                esc_html__('Edit it', 'planet4-master-theme-backend')
+            );
+        }
     }
 }

--- a/src/CustomPostType/ActionImporter.php
+++ b/src/CustomPostType/ActionImporter.php
@@ -78,6 +78,13 @@ class ActionImporter
             $this->redirect_back($redirect_args);
         }
 
+        if (wp_parse_url($url, PHP_URL_SCHEME) !== 'https') {
+            $redirect_args['action_importer_error'] = rawurlencode(
+                __('Only HTTPS URLs are allowed.', 'planet4-master-theme-backend')
+            );
+            $this->redirect_back($redirect_args);
+        }
+
         $existing_post_id = $this->find_existing_post_by_url($url);
 
         if ($existing_post_id) {
@@ -349,6 +356,8 @@ class ActionImporter
                                 name="import_url"
                                 class="regular-text"
                                 required
+                                pattern="https://.+"
+                                title="<?php echo esc_attr__('Please enter a URL starting with https://', 'planet4-master-theme-backend'); ?>"
                                 placeholder="https://act.greenpeace.org/landing-page"
                             />
                             <p>

--- a/src/CustomPostType/ActionImporter.php
+++ b/src/CustomPostType/ActionImporter.php
@@ -359,7 +359,13 @@ class ActionImporter
             'group_id'    => $group_id,
         ]);
 
-        $redirect_id = $this->extract_redirect_id($redirect);
+        if ($redirect instanceof \Red_Item) {
+            $redirect_id = (int) $redirect->get_id();
+        } else if (is_array($redirect) && !empty($redirect['id'])) {
+            $redirect_id = (int) $redirect['id'];
+        } else {
+            $redirect_id = 0;
+        }
 
         if ($redirect_id) {
             update_post_meta($post_id, self::REDIRECT_ID_META_KEY, $redirect_id);
@@ -367,56 +373,36 @@ class ActionImporter
     }
 
     /**
-     * Normalize the return value of Red_Item::create() into a redirect ID.
-     *
-     * Different versions of the Redirection plugin return either a
-     * Red_Item instance or an array from create(); handle both.
-     *
-     * @param mixed $redirect Return value from Red_Item::create().
-     * @return int Redirect ID, or 0 if it couldn't be determined.
-     */
-    private function extract_redirect_id($redirect): int
-    {
-        if ($redirect instanceof \Red_Item) {
-            return (int) $redirect->get_id();
-        }
-
-        if (is_array($redirect) && !empty($redirect['id'])) {
-            return (int) $redirect['id'];
-        }
-
-        return 0;
-    }
-
-    /**
      * Disable the redirection when a p4_action post is moved to Trash.
-     * The redirect itself is preserved (not deleted) so it can be
-     * re-enabled if the post is restored.
-     *
-     * @param int $post_id Post ID being trashed.
      */
     public function disable_redirection_on_trash(int $post_id): void
     {
-        $this->set_redirection_status($post_id, false);
+        $this->set_redirection_status($post_id, 'disable');
     }
 
     /**
      * Re-enable the redirection when a p4_action post is restored from Trash.
-     *
-     * @param int $post_id Post ID being restored.
      */
     public function enable_redirection_on_untrash(int $post_id): void
     {
-        $this->set_redirection_status($post_id, true);
+        $this->set_redirection_status($post_id, 'enable');
+    }
+
+    /**
+     * Remove the redirection associated with a p4_action post when that post is permanently deleted.
+     */
+    public function remove_redirection_on_delete(int $post_id): void
+    {
+        $this->set_redirection_status($post_id, 'delete');
     }
 
     /**
      * Enable or disable the redirection associated with a p4_action post.
      *
      * @param int  $post_id Post ID.
-     * @param bool $enable  True to enable the redirect, false to disable it.
+     * @param string $action The type of action to be executed.
      */
-    private function set_redirection_status(int $post_id, bool $enable): void
+    private function set_redirection_status(int $post_id, string $action): void
     {
         $post = get_post($post_id);
 
@@ -441,44 +427,11 @@ class ActionImporter
                 return;
             }
 
-            if ($enable) {
+            if ($action === 'enable') {
                 $item->enable();
-            } else {
+            } else if ($action === 'disable') {
                 $item->disable();
-            }
-        } catch (\Exception $e) {
-            function_exists('\Sentry\captureException') && \Sentry\captureException($e);
-        }
-    }
-
-    /**
-     * Remove the redirection associated with a p4_action post when that
-     * post is permanently deleted (fires on force-delete or emptying the
-     * trash — not on moving a post to trash).
-     *
-     * @param int      $post_id Post ID being deleted.
-     * @param \WP_Post $post    Post object being deleted.
-     */
-    public function remove_redirection_on_delete(int $post_id, \WP_Post $post): void
-    {
-        if ($post->post_type !== self::POST_TYPE) {
-            return;
-        }
-
-        if (!class_exists('Red_Item')) {
-            return;
-        }
-
-        $redirect_id = (int) get_post_meta($post_id, self::REDIRECT_ID_META_KEY, true);
-
-        if (!$redirect_id) {
-            return;
-        }
-
-        try {
-            $item = \Red_Item::get_by_id($redirect_id);
-
-            if ($item instanceof \Red_Item) {
+            } else if ($action === 'delete') {
                 $item->delete();
             }
         } catch (\Exception $e) {

--- a/src/CustomPostType/ActionImporter.php
+++ b/src/CustomPostType/ActionImporter.php
@@ -27,14 +27,6 @@ class ActionImporter
      */
     public function __construct()
     {
-        $this->hooks();
-    }
-
-    /**
-     * Hooks actions and filters.
-     */
-    public function hooks(): void
-    {
         add_action('before_delete_post', [ $this, 'remove_redirection_on_delete' ], 10, 2);
         add_action('wp_trash_post', [ $this, 'disable_redirection_on_trash' ]);
         add_action('untrashed_post', [ $this, 'enable_redirection_on_untrash' ]);
@@ -87,7 +79,7 @@ class ActionImporter
         try {
             $redirect_args = [
                 'post_type' => self::POST_TYPE,
-                'page'      => self::PAGE_NAME,
+                'page' => self::PAGE_NAME,
             ];
 
             $url = $this->maybe_handle_submission($redirect_args);
@@ -189,13 +181,13 @@ class ActionImporter
     {
         try {
             $existing = get_posts([
-                'post_type'      => self::POST_TYPE,
-                'post_status'    => 'any',
+                'post_type' => self::POST_TYPE,
+                'post_status' => 'any',
                 'posts_per_page' => 1,
-                'fields'         => 'ids',
-                'meta_query'     => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+                'fields' => 'ids',
+                'meta_query' => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
                     [
-                        'key'   => 'action_importer_source_url',
+                        'key' => 'action_importer_source_url',
                         'value' => $url,
                     ],
                 ],
@@ -228,7 +220,7 @@ class ActionImporter
             }
 
             $segments = explode('/', $path);
-            $last     = end($segments);
+            $last = end($segments);
 
             return sanitize_title($last);
         } catch (\Throwable $e) {
@@ -244,7 +236,7 @@ class ActionImporter
     {
         try {
             $response = wp_remote_get($url, [
-                'timeout'    => 12,
+                'timeout' => 12,
                 'user-agent' => 'Planet4 Action Importer',
             ]);
 
@@ -283,12 +275,12 @@ class ActionImporter
             }
 
             $post_id = wp_insert_post([
-                'post_type'    => self::POST_TYPE,
-                'post_title'   => $og['title'] ?: __('(No title found)', 'planet4-master-theme-backend'),
+                'post_type' => self::POST_TYPE,
+                'post_title' => $og['title'] ?: __('(No title found)', 'planet4-master-theme-backend'),
                 'post_content' => $og['description'],
-                'post_status'  => 'publish',
-                'post_name'    => $this->slug_from_url($url),
-                'meta_input'   => [
+                'post_status' => 'publish',
+                'post_name' => $this->slug_from_url($url),
+                'meta_input' => [
                     'action_importer_source_url' => $url,
                 ],
             ], true);
@@ -305,9 +297,9 @@ class ActionImporter
         } catch (\Throwable $e) {
             function_exists('\Sentry\captureException') && \Sentry\captureException($e);
             return new \WP_Error(
-                    'action_importer_catch_error',
-                    __($e, 'planet4-master-theme-backend')
-                );
+                'action_importer_catch_error',
+                __('There was an error trying to import the remote page data.', 'planet4-master-theme-backend')
+            );
         }
     }
 
@@ -342,10 +334,10 @@ class ActionImporter
             global $wpdb;
 
             $group_name = 'Actions';
-            $table      = $wpdb->prefix . 'redirection_groups';
+            $table = $wpdb->prefix . 'redirection_groups';
 
             $existing = $wpdb->get_var($wpdb->prepare(
-                "SELECT id FROM $table WHERE name = %s", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+                "SELECT id FROM $table WHERE name = %s",
                 $group_name
             ));
 
@@ -387,26 +379,26 @@ class ActionImporter
             }
 
             $group_id = $this->get_or_create_actions_group();
-            $source   = wp_parse_url(get_permalink($post_id), PHP_URL_PATH);
+            $source = wp_parse_url(get_permalink($post_id), PHP_URL_PATH);
 
             if (!$source) {
                 return;
             }
 
             $redirect = \Red_Item::create([
-                'url'         => $source,
+                'url' => $source,
                 'action_type' => 'url',
                 'action_code' => 301,
-                'match_type'  => 'url',
+                'match_type' => 'url',
                 'action_data' => [
                     'url' => $target_url,
                 ],
-                'group_id'    => $group_id,
+                'group_id' => $group_id,
             ]);
 
             if ($redirect instanceof \Red_Item) {
                 $redirect_id = (int) $redirect->get_id();
-            } else if (is_array($redirect) && !empty($redirect['id'])) {
+            } elseif (is_array($redirect) && !empty($redirect['id'])) {
                 $redirect_id = (int) $redirect['id'];
             } else {
                 $redirect_id = 0;
@@ -477,9 +469,9 @@ class ActionImporter
 
             if ($action === 'enable') {
                 $item->enable();
-            } else if ($action === 'disable') {
+            } elseif ($action === 'disable') {
                 $item->disable();
-            } else if ($action === 'delete') {
+            } elseif ($action === 'delete') {
                 $item->delete();
             }
         } catch (\Throwable $e) {
@@ -497,10 +489,10 @@ class ActionImporter
     private function parse_og_tags(string $html, string $source_url): array
     {
         $og = [
-            'title'       => '',
+            'title' => '',
             'description' => '',
-            'image'       => '',
-            'url'         => $source_url,
+            'image' => '',
+            'url' => $source_url,
         ];
 
         try {
@@ -512,7 +504,7 @@ class ActionImporter
             $dom = new \DOMDocument();
 
             $previous_setting = libxml_use_internal_errors(true);
-            $loaded            = $dom->loadHTML($html, LIBXML_NOERROR | LIBXML_NOWARNING);
+            $loaded = $dom->loadHTML($html, LIBXML_NOERROR | LIBXML_NOWARNING);
             libxml_clear_errors();
             libxml_use_internal_errors($previous_setting);
 
@@ -525,7 +517,7 @@ class ActionImporter
             foreach ($metas as $meta) {
                 /** @var \DOMElement $meta */
                 $property = $meta->getAttribute('property') ?: $meta->getAttribute('name');
-                $content  = $meta->getAttribute('content');
+                $content = $meta->getAttribute('content');
 
                 if (!$property || $content === '') {
                     continue;
@@ -558,10 +550,10 @@ class ActionImporter
                 }
             }
 
-            $og['title']       = sanitize_text_field($og['title']);
+            $og['title'] = sanitize_text_field($og['title']);
             $og['description'] = sanitize_text_field($og['description']);
-            $og['url']          = esc_url_raw($og['url']);
-            $og['image']        = esc_url_raw($og['image']);
+            $og['url'] = esc_url_raw($og['url']);
+            $og['image'] = esc_url_raw($og['image']);
 
             return $og;
         } catch (\Throwable $e) {
@@ -601,7 +593,7 @@ class ActionImporter
      */
     public function admin_page_display(): void
     {
-        ?>
+        // phpcs:disable Generic.Files.LineLength.MaxExceeded ?>
         <div class="wrap">
             <h2><?php echo esc_html__('Import Action', 'planet4-master-theme-backend'); ?></h2>
 
@@ -624,7 +616,8 @@ class ActionImporter
                             />
                             <p>
                                 <?php echo esc_html__(
-                                    'Verify the results on submission. This feature has mostly been tested with Hubspot landing pages.',
+                                    'Verify the results on submission.
+                                    This feature has mostly been tested with Hubspot landing pages.',
                                     'planet4-master-theme-backend'
                                 ); ?>
                             </p>
@@ -634,7 +627,7 @@ class ActionImporter
                 <?php submit_button(__('Import Action', 'planet4-master-theme-backend')); ?>
             </form>
         </div>
-        <?php
+        <?php // phpcs:enable Generic.Files.LineLength.MaxExceeded
     }
 
     /**
@@ -646,7 +639,7 @@ class ActionImporter
             $message = sanitize_text_field(wp_unslash($_GET[self::REDIRECT_ARG_ERROR]));
 
             if (!empty($_GET[self::REDIRECT_ARG_EXISTING])) {
-                $existing_id  = absint($_GET[self::REDIRECT_ARG_EXISTING]);
+                $existing_id = absint($_GET[self::REDIRECT_ARG_EXISTING]);
                 $existing_url = get_edit_post_link($existing_id, 'raw');
                 printf(
                     '<div class="notice notice-error"><p>%s <a href="%s">%s</a></p></div>',
@@ -664,18 +657,20 @@ class ActionImporter
             return;
         }
 
-        if (!empty($_GET[self::REDIRECT_ARG_SUCCESS])) {
-            $post_id   = absint($_GET[self::REDIRECT_ARG_SUCCESS]);
-            $edit_url  = get_edit_post_link($post_id, 'raw');
-            $view_url  = get_permalink($post_id);
-            printf(
-                '<div class="notice notice-success"><p>%s <a href="%s">%s</a> &middot; <a href="%s">%s</a></p></div>',
-                esc_html__('Post published.', 'planet4-master-theme-backend'),
-                esc_url($view_url),
-                esc_html__('View it', 'planet4-master-theme-backend'),
-                esc_url($edit_url),
-                esc_html__('Edit it', 'planet4-master-theme-backend')
-            );
+        if (empty($_GET[self::REDIRECT_ARG_SUCCESS])) {
+            return;
         }
+
+        $post_id = absint($_GET[self::REDIRECT_ARG_SUCCESS]);
+        $edit_url = get_edit_post_link($post_id, 'raw');
+        $view_url = get_permalink($post_id);
+        printf(
+            '<div class="notice notice-success"><p>%s <a href="%s">%s</a> &middot; <a href="%s">%s</a></p></div>',
+            esc_html__('Post published.', 'planet4-master-theme-backend'),
+            esc_url($view_url),
+            esc_html__('View it', 'planet4-master-theme-backend'),
+            esc_url($edit_url),
+            esc_html__('Edit it', 'planet4-master-theme-backend')
+        );
     }
 }

--- a/src/CustomPostType/ActionImporter.php
+++ b/src/CustomPostType/ActionImporter.php
@@ -221,8 +221,28 @@ class ActionImporter
         }
 
         $this->create_redirection_to_source($post_id, $url);
+        $this->sync_elasticpress($post_id);
 
         return $post_id;
+    }
+
+    /**
+     * Queue the newly imported post for ElasticPress indexing.
+     *
+     * @param int $post_id Post ID to sync.
+     */
+    private function sync_elasticpress(int $post_id): void
+    {
+        if (!class_exists('\ElasticPress\Indexables')) {
+            return;
+        }
+
+        try {
+            $indexable = \ElasticPress\Indexables::factory()->get('post');
+            $indexable->sync_manager->add_to_queue($post_id);
+        } catch (\Exception $e) {
+            function_exists('\Sentry\captureException') && \Sentry\captureException($e);
+        }
     }
 
     /**

--- a/src/CustomPostType/ActionImporter.php
+++ b/src/CustomPostType/ActionImporter.php
@@ -220,7 +220,76 @@ class ActionImporter
             $this->set_featured_image_from_url($post_id, $og['image'], $og['title']);
         }
 
+        $this->create_redirection_to_source($post_id, $url);
+
         return $post_id;
+    }
+
+    /**
+     * Get (or create) the "Actions" redirection group.
+     *
+     * @return int Group ID. Falls back to the default group (1) if the
+     *             Redirection plugin isn't active or group creation fails.
+     */
+    private function get_or_create_actions_group(): int
+    {
+        global $wpdb;
+
+        $group_name = 'Actions';
+        $table      = $wpdb->prefix . 'redirection_groups';
+
+        $existing = $wpdb->get_var($wpdb->prepare(
+            "SELECT id FROM $table WHERE name = %s", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+            $group_name
+        ));
+
+        if ($existing) {
+            return (int) $existing;
+        }
+
+        if (!class_exists('Red_Group')) {
+            return 1;
+        }
+
+        $group = \Red_Group::create($group_name, 1, true);
+
+        if ($group instanceof \Red_Group) {
+            return (int) $group->get_id();
+        }
+
+        return 1;
+    }
+
+    /**
+     * Create a 301 redirect from the new post's permalink to the original
+     * external URL it was imported from, inside the "Actions" group.
+     *
+     * @param int    $post_id    Newly created post ID.
+     * @param string $target_url Original external URL.
+     */
+    private function create_redirection_to_source(int $post_id, string $target_url): void
+    {
+        if (!class_exists('Red_Item')) {
+            return;
+        }
+
+        $group_id = $this->get_or_create_actions_group();
+        $source   = wp_parse_url(get_permalink($post_id), PHP_URL_PATH);
+
+        if (!$source) {
+            return;
+        }
+
+        \Red_Item::create([
+            'url'         => $source,
+            'action_type' => 'url',
+            'action_code' => 301,
+            'match_type'  => 'url',
+            'action_data' => [
+                'url' => $target_url,
+            ],
+            'group_id'    => $group_id,
+        ]);
     }
 
     /**

--- a/src/CustomPostType/ActionImporter.php
+++ b/src/CustomPostType/ActionImporter.php
@@ -18,6 +18,8 @@ class ActionImporter
     private const REDIRECT_ARG_SUCCESS = 'action_importer_success';
     private const REDIRECT_ARG_ERROR = 'action_importer_error';
     private const REDIRECT_ARG_EXISTING = 'action_importer_existing';
+    private const REDIRECT_ARG_WARNING = 'action_importer_redirect_warning';
+    private const NOTICE_TRANSIENT_PREFIX = 'action_importer_notice_';
 
     /**
      * Constructor.
@@ -27,6 +29,7 @@ class ActionImporter
         add_action('before_delete_post', [ $this, 'remove_redirection_on_delete' ], 10, 2);
         add_action('wp_trash_post', [ $this, 'disable_redirection_on_trash' ]);
         add_action('untrashed_post', [ $this, 'enable_redirection_on_untrash' ]);
+        add_action('admin_notices', [ $this, 'render_queued_admin_notice' ]);
 
         if (!current_user_can('manage_options') && !current_user_can('editor')) {
             return;
@@ -48,7 +51,8 @@ class ActionImporter
             __('Import Action', 'planet4-master-theme-backend'),
             'manage_options',
             self::PAGE_NAME,
-            [ $this, 'admin_page_display' ]
+            [ $this, 'admin_page_display' ],
+            2
         );
     }
 
@@ -77,7 +81,7 @@ class ActionImporter
                 'page' => self::PAGE_NAME,
             ];
 
-            $url = $this->maybe_handle_submission($redirect_args);
+            $url = $this->handle_submission($redirect_args);
 
             if ($url === null) {
                 return;
@@ -90,10 +94,15 @@ class ActionImporter
                 $this->redirect_back($redirect_args);
             }
 
-            $this->create_redirection_to_source($post_id, $url);
+            $redirect_created = $this->create_redirection_to_source($post_id, $url);
             $this->sync_elasticpress($post_id);
 
             $redirect_args[self::REDIRECT_ARG_SUCCESS] = $post_id;
+
+            if (!$redirect_created) {
+                $redirect_args[self::REDIRECT_ARG_WARNING] = 1;
+            }
+
             $this->redirect_back($redirect_args);
         } catch (\Throwable $e) {
             function_exists('\Sentry\captureException') && \Sentry\captureException($e);
@@ -101,9 +110,9 @@ class ActionImporter
     }
 
     /**
-     * Validate the form submission on admin_init, before any output.
+     * Validate the form submission.
      */
-    private function maybe_handle_submission(array $redirect_args): string|null
+    private function handle_submission(array $redirect_args): mixed
     {
         try {
             if (empty($_POST[self::FORM_ACTION])) {
@@ -145,6 +154,10 @@ class ActionImporter
             return $url;
         } catch (\Throwable $e) {
             function_exists('\Sentry\captureException') && \Sentry\captureException($e);
+            $redirect_args[self::REDIRECT_ARG_ERROR] = rawurlencode(
+                __('Something went wrong validating that URL. Please try again.', 'planet4-master-theme-backend')
+            );
+            $this->redirect_back($redirect_args);
             return null;
         }
     }
@@ -163,25 +176,20 @@ class ActionImporter
      */
     private function find_existing_post_by_url(string $url): int
     {
-        try {
-            $existing = get_posts([
-                'post_type' => self::POST_TYPE,
-                'post_status' => 'any',
-                'posts_per_page' => 1,
-                'fields' => 'ids',
-                'meta_query' => [
-                    [
-                        'key' => 'action_importer_source_url',
-                        'value' => $url,
-                    ],
+        $existing = get_posts([
+            'post_type' => self::POST_TYPE,
+            'post_status' => 'any',
+            'posts_per_page' => 1,
+            'fields' => 'ids',
+            'meta_query' => [
+                [
+                    'key' => 'action_importer_source_url',
+                    'value' => $url,
                 ],
-            ]);
+            ],
+        ]);
 
-            return !empty($existing) ? (int) $existing[0] : 0;
-        } catch (\Throwable $e) {
-            function_exists('\Sentry\captureException') && \Sentry\captureException($e);
-            return 0;
-        }
+        return !empty($existing) ? (int) $existing[0] : 0;
     }
 
     /**
@@ -255,8 +263,9 @@ class ActionImporter
 
             $post_id = wp_insert_post([
                 'post_type' => self::POST_TYPE,
-                'post_title' => $og['title'] ?: __('(No title found)', 'planet4-master-theme-backend'),
+                'post_title' => $og['title'] ?: __('No title found', 'planet4-master-theme-backend'),
                 'post_content' => $og['description'],
+                'post_excerpt' => $og['description'],
                 'post_status' => 'publish',
                 'post_name' => $this->slug_from_url($url),
                 'meta_input' => [
@@ -340,18 +349,18 @@ class ActionImporter
      * Create a 301 redirect from the new post's permalink to the original
      * external URL it was imported from, inside the "Actions" group.
      */
-    private function create_redirection_to_source(int $post_id, string $target_url): void
+    private function create_redirection_to_source(int $post_id, string $target_url): bool
     {
         try {
             if (!class_exists('Red_Item')) {
-                return;
+                return false;
             }
 
             $group_id = $this->get_or_create_actions_group();
             $source = wp_parse_url(get_permalink($post_id), PHP_URL_PATH);
 
             if (!$source) {
-                return;
+                return false;
             }
 
             $redirect = \Red_Item::create([
@@ -373,11 +382,15 @@ class ActionImporter
                 $redirect_id = 0;
             }
 
-            if ($redirect_id) {
-                update_post_meta($post_id, self::REDIRECT_ID_META_KEY, $redirect_id);
+            if (!$redirect_id) {
+                return false;
             }
+
+            update_post_meta($post_id, self::REDIRECT_ID_META_KEY, $redirect_id);
+            return true;
         } catch (\Throwable $e) {
             function_exists('\Sentry\captureException') && \Sentry\captureException($e);
+            return false;
         }
     }
 
@@ -430,6 +443,12 @@ class ActionImporter
             $item = \Red_Item::get_by_id($redirect_id);
 
             if (!$item instanceof \Red_Item) {
+                $this->queue_admin_notice(sprintf(
+                    /* translators: 1: post ID, 2: redirect ID */
+                    __('Could not find redirection #%2$d for post #%1$d.', 'planet4-master-theme-backend'),
+                    $post_id,
+                    $redirect_id
+                ));
                 return;
             }
 
@@ -442,7 +461,40 @@ class ActionImporter
             }
         } catch (\Throwable $e) {
             function_exists('\Sentry\captureException') && \Sentry\captureException($e);
+            $this->queue_admin_notice(sprintf(
+                /* translators: %d is a post ID. */
+                __('Could not update the redirection for post #%d.', 'planet4-master-theme-backend'),
+                $post_id
+            ));
         }
+    }
+
+    /**
+     * Queue a one-time admin notice message for the current user.
+     */
+    private function queue_admin_notice(string $message): void
+    {
+        set_transient(self::NOTICE_TRANSIENT_PREFIX . get_current_user_id(), $message, MINUTE_IN_SECONDS);
+    }
+
+    /**
+     * Render and clear any queued admin notice for the current user.
+     */
+    public function render_queued_admin_notice(): void
+    {
+        $key = self::NOTICE_TRANSIENT_PREFIX . get_current_user_id();
+        $message = get_transient($key);
+
+        if (!$message) {
+            return;
+        }
+
+        delete_transient($key);
+
+        printf(
+            '<div class="notice notice-warning is-dismissible"><p>%s</p></div>',
+            esc_html($message)
+        );
     }
 
     /**
@@ -476,7 +528,6 @@ class ActionImporter
             $metas = $dom->getElementsByTagName('meta');
 
             foreach ($metas as $meta) {
-                /** @var \DOMElement $meta */
                 $property = $meta->getAttribute('property') ?: $meta->getAttribute('name');
                 $content = $meta->getAttribute('content');
 
@@ -559,7 +610,7 @@ class ActionImporter
                 <?php wp_nonce_field(self::NONCE_ACTION); ?>
                 <table class="form-table">
                     <tr>
-                        <th><?php echo esc_html__('URL', 'planet4-master-theme-backend'); ?></th>
+                        <th><?php echo esc_html__('External URL', 'planet4-master-theme-backend'); ?></th>
                         <td>
                             <input
                                 type="url"
@@ -627,6 +678,18 @@ class ActionImporter
             esc_html__('View it', 'planet4-master-theme-backend'),
             esc_url($edit_url),
             esc_html__('Edit it', 'planet4-master-theme-backend')
+        );
+
+        if (empty($_GET[self::REDIRECT_ARG_WARNING])) {
+            return;
+        }
+
+        printf(
+            '<div class="notice notice-warning"><p>%s</p></div>',
+            esc_html__(
+                'Note: the redirect to the original URL could not be created.',
+                'planet4-master-theme-backend'
+            )
         );
     }
 }

--- a/src/CustomPostType/ActionImporter.php
+++ b/src/CustomPostType/ActionImporter.php
@@ -20,6 +20,7 @@ class ActionImporter
     private const REDIRECT_ARG_EXISTING = 'action_importer_existing';
     private const REDIRECT_ARG_WARNING = 'action_importer_redirect_warning';
     private const NOTICE_TRANSIENT_PREFIX = 'action_importer_notice_';
+    private const SENTRY_EXCEPTION = '\Sentry\captureException';
 
     /**
      * Constructor.
@@ -105,7 +106,7 @@ class ActionImporter
 
             $this->redirect_back($redirect_args);
         } catch (\Throwable $e) {
-            function_exists('\Sentry\captureException') && \Sentry\captureException($e);
+            function_exists(self::SENTRY_EXCEPTION) && \Sentry\captureException($e);
         }
     }
 
@@ -153,7 +154,7 @@ class ActionImporter
 
             return $url;
         } catch (\Throwable $e) {
-            function_exists('\Sentry\captureException') && \Sentry\captureException($e);
+            function_exists(self::SENTRY_EXCEPTION) && \Sentry\captureException($e);
             $redirect_args[self::REDIRECT_ARG_ERROR] = rawurlencode(
                 __('Something went wrong validating that URL. Please try again.', 'planet4-master-theme-backend')
             );
@@ -211,7 +212,7 @@ class ActionImporter
 
             return sanitize_title($last);
         } catch (\Throwable $e) {
-            function_exists('\Sentry\captureException') && \Sentry\captureException($e);
+            function_exists(self::SENTRY_EXCEPTION) && \Sentry\captureException($e);
             return '';
         }
     }
@@ -283,7 +284,7 @@ class ActionImporter
 
             return $post_id;
         } catch (\Throwable $e) {
-            function_exists('\Sentry\captureException') && \Sentry\captureException($e);
+            function_exists(self::SENTRY_EXCEPTION) && \Sentry\captureException($e);
             return new \WP_Error(
                 'action_importer_catch_error',
                 __('There was an error trying to import the remote page data.', 'planet4-master-theme-backend')
@@ -304,7 +305,7 @@ class ActionImporter
             $indexable = \ElasticPress\Indexables::factory()->get('post');
             $indexable->sync_manager->add_to_queue($post_id);
         } catch (\Throwable $e) {
-            function_exists('\Sentry\captureException') && \Sentry\captureException($e);
+            function_exists(self::SENTRY_EXCEPTION) && \Sentry\captureException($e);
         }
     }
 
@@ -340,7 +341,7 @@ class ActionImporter
 
             return 1;
         } catch (\Throwable $e) {
-            function_exists('\Sentry\captureException') && \Sentry\captureException($e);
+            function_exists(self::SENTRY_EXCEPTION) && \Sentry\captureException($e);
             return 1;
         }
     }
@@ -389,7 +390,7 @@ class ActionImporter
             update_post_meta($post_id, self::REDIRECT_ID_META_KEY, $redirect_id);
             return true;
         } catch (\Throwable $e) {
-            function_exists('\Sentry\captureException') && \Sentry\captureException($e);
+            function_exists(self::SENTRY_EXCEPTION) && \Sentry\captureException($e);
             return false;
         }
     }
@@ -460,7 +461,7 @@ class ActionImporter
                 $item->delete();
             }
         } catch (\Throwable $e) {
-            function_exists('\Sentry\captureException') && \Sentry\captureException($e);
+            function_exists(self::SENTRY_EXCEPTION) && \Sentry\captureException($e);
             $this->queue_admin_notice(sprintf(
                 /* translators: %d is a post ID. */
                 __('Could not update the redirection for post #%d.', 'planet4-master-theme-backend'),
@@ -503,74 +504,117 @@ class ActionImporter
     private function parse_og_tags(string $html, string $source_url): array
     {
         $og = [
-            'title' => '',
-            'description' => '',
-            'image' => '',
-            'url' => $source_url,
+           'title' => '',
+           'description' => '',
+           'image' => '',
+           'url' => $source_url,
         ];
 
         try {
-            if (trim($html) === '') {
-                return $og;
+            $dom = $this->load_html_dom($html);
+
+            if ($dom === null) {
+                 return $og;
             }
 
-            $dom = new \DOMDocument();
 
-            $previous_setting = libxml_use_internal_errors(true);
-            $loaded = $dom->loadHTML($html, LIBXML_NOERROR | LIBXML_NOWARNING);
-            libxml_clear_errors();
-            libxml_use_internal_errors($previous_setting);
+            $og = $this->extract_og_from_dom($dom, $og);
+            $og = $this->apply_title_fallback($dom, $og);
 
-            if (!$loaded) {
-                return $og;
-            }
-
-            $metas = $dom->getElementsByTagName('meta');
-
-            foreach ($metas as $meta) {
-                $property = $meta->getAttribute('property') ?: $meta->getAttribute('name');
-                $content = $meta->getAttribute('content');
-
-                if (!$property || $content === '') {
-                    continue;
-                }
-
-                switch ($property) {
-                    case 'og:title':
-                        $og['title'] = $content;
-                        break;
-                    case 'og:description':
-                        $og['description'] = $content;
-                        break;
-                    case 'og:image':
-                    case 'og:image:secure_url':
-                        if (empty($og['image'])) {
-                            $og['image'] = $content;
-                        }
-                        break;
-                    case 'og:url':
-                        $og['url'] = $content;
-                        break;
-                }
-            }
-
-            if (empty($og['title'])) {
-                $titles = $dom->getElementsByTagName('title');
-                if ($titles->length > 0) {
-                    $og['title'] = $titles->item(0)->textContent;
-                }
-            }
-
-            $og['title'] = sanitize_text_field($og['title']);
-            $og['description'] = sanitize_text_field($og['description']);
-            $og['url'] = esc_url_raw($og['url']);
-            $og['image'] = esc_url_raw($og['image']);
-
-            return $og;
+            return $this->sanitize_og_data($og);
         } catch (\Throwable $e) {
             function_exists('\Sentry\captureException') && \Sentry\captureException($e);
             return $og;
         }
+    }
+
+    /**
+     * Load a new DOM Document.
+     */
+    private function load_html_dom(string $html): ?\DOMDocument
+    {
+        if (trim($html) === '') {
+            return null;
+        }
+
+        $dom = new \DOMDocument();
+
+        $previous_setting = libxml_use_internal_errors(true);
+        $loaded = $dom->loadHTML($html, LIBXML_NOERROR | LIBXML_NOWARNING);
+        libxml_clear_errors();
+        libxml_use_internal_errors($previous_setting);
+
+        return $loaded ? $dom : null;
+    }
+
+    /**
+     * Extract the Open Graph meta tags using DOM Document.
+     */
+    private function extract_og_from_dom(\DOMDocument $dom, array $og): array
+    {
+        $metas = $dom->getElementsByTagName('meta');
+
+        foreach ($metas as $meta) {
+            $property = $meta->getAttribute('property') ?: $meta->getAttribute('name');
+            $content = $meta->getAttribute('content');
+
+            if (!$property || $content === '') {
+                continue;
+            }
+
+            switch ($property) {
+                case 'og:title':
+                    $og['title'] = $content;
+                    break;
+                case 'og:description':
+                    $og['description'] = $content;
+                    break;
+                case 'og:image':
+                case 'og:image:secure_url':
+                    if (empty($og['image'])) {
+                        $og['image'] = $content;
+                    }
+                    break;
+                case 'og:url':
+                    $og['url'] = $content;
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        return $og;
+    }
+
+    /**
+     * Apply a fallback title if no one was extracted from the Open Graph data.
+     */
+    private function apply_title_fallback(\DOMDocument $dom, array $og): array
+    {
+        if (!empty($og['title'])) {
+            return $og;
+        }
+
+        $titles = $dom->getElementsByTagName('title');
+
+        if ($titles->length > 0) {
+            $og['title'] = $titles->item(0)->textContent;
+        }
+
+        return $og;
+    }
+
+    /**
+     * Sanitize the Open Graph data.
+     */
+    private function sanitize_og_data(array $og): array
+    {
+        $og['title'] = sanitize_text_field($og['title']);
+        $og['description'] = sanitize_text_field($og['description']);
+        $og['url'] = esc_url_raw($og['url']);
+        $og['image'] = esc_url_raw($og['image']);
+
+        return $og;
     }
 
     /**
@@ -591,7 +635,7 @@ class ActionImporter
                 set_post_thumbnail($post_id, $media_id);
             }
         } catch (\Throwable $e) {
-            function_exists('\Sentry\captureException') && \Sentry\captureException($e);
+            function_exists(self::SENTRY_EXCEPTION) && \Sentry\captureException($e);
         }
     }
 

--- a/src/CustomPostType/ActionImporter.php
+++ b/src/CustomPostType/ActionImporter.php
@@ -45,6 +45,7 @@ class ActionImporter
 
         add_action('admin_menu', [ $this, 'add_options_page' ], 99);
         add_action('admin_init', [ $this, 'init_import' ]);
+        add_action('admin_enqueue_scripts', [ $this, 'enqueue_admin_assets' ]);
     }
 
     /**
@@ -59,6 +60,20 @@ class ActionImporter
             'manage_options',
             self::PAGE_NAME,
             [ $this, 'admin_page_display' ]
+        );
+    }
+
+    /**
+     * Load admin assets.
+     */
+    public function enqueue_admin_assets(): void
+    {
+        wp_enqueue_script(
+            'action-importer-script',
+            get_template_directory_uri() . "/admin/js/action_importer.js",
+            [],
+            \P4\MasterTheme\Loader::theme_file_ver('admin/js/action_importer.js'),
+            true
         );
     }
 

--- a/src/CustomPostType/ActionImporter.php
+++ b/src/CustomPostType/ActionImporter.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace P4\MasterTheme\CustomPostType;
+
+/**
+ * Class ActionImporter
+ */
+class ActionImporter
+{
+    /**
+     * Constructor
+     */
+    public function __construct()
+    {
+        add_action('admin_menu', [ $this, 'add_options_page' ], 99);
+    }
+
+    /**
+     * Add menu options page.
+     */
+    public function add_options_page(): void
+    {
+        add_submenu_page(
+            'edit.php?post_type=p4_action',
+            __('Import Action', 'planet4-master-theme-backend'),
+            __('Import Action', 'planet4-master-theme-backend'),
+            'manage_options',
+            'import-action',
+            [ $this, 'admin_page_display' ]
+        );
+    }
+
+    public function admin_page_display(): void
+    {
+        echo '<h2>Import Action</h2>' . "\n"; ?>
+
+        <form method="post">
+            <?php wp_nonce_field('import_action'); ?>
+            <table class="form-table">
+                <tr>
+                    <th><?php echo __('URL', 'planet4-master-theme-backend'); ?></th>
+                    <td>
+                        <input
+                            type="url"
+                            name="import_url"
+                            class="regular-text"
+                            required
+                            placeholder="https://act.greenpeace.org/landing-page"
+                        />
+                        <p>Verify the results on submission. This feature has mostly been tested with Hubspot landing pages.</p>
+                    </td>
+                </tr>
+            </table>
+            <?php submit_button(__('Import Action', 'planet4-master-theme-backend')); ?>
+        </form>
+        <?php
+    }
+}

--- a/src/CustomPostType/ActionImporter.php
+++ b/src/CustomPostType/ActionImporter.php
@@ -69,29 +69,33 @@ class ActionImporter
      */
     public function init_import(): void
     {
-        $redirect_args = [
-            'post_type' => self::POST_TYPE,
-            'page'      => self::PAGE_NAME,
-        ];
+        try {
+            $redirect_args = [
+                'post_type' => self::POST_TYPE,
+                'page'      => self::PAGE_NAME,
+            ];
 
-        $url = $this->maybe_handle_submission($redirect_args);
+            $url = $this->maybe_handle_submission($redirect_args);
 
-        if ($url === null) {
-            return;
-        }
+            if ($url === null) {
+                return;
+            }
 
-        $post_id = $this->import_from_url($url);
+            $post_id = $this->import_from_url($url);
 
-        if (is_wp_error($post_id)) {
-            $redirect_args[self::REDIRECT_ARG_ERROR] = rawurlencode($post_id->get_error_message());
+            if (is_wp_error($post_id)) {
+                $redirect_args[self::REDIRECT_ARG_ERROR] = rawurlencode($post_id->get_error_message());
+                $this->redirect_back($redirect_args);
+            }
+
+            $this->create_redirection_to_source($post_id, $url);
+            $this->sync_elasticpress($post_id);
+
+            $redirect_args[self::REDIRECT_ARG_SUCCESS] = $post_id;
             $this->redirect_back($redirect_args);
+        } catch (\Throwable $e) {
+            function_exists('\Sentry\captureException') && \Sentry\captureException($e);
         }
-
-        $this->create_redirection_to_source($post_id, $url);
-        $this->sync_elasticpress($post_id);
-
-        $redirect_args[self::REDIRECT_ARG_SUCCESS] = $post_id;
-        $this->redirect_back($redirect_args);
     }
 
     /**
@@ -105,43 +109,48 @@ class ActionImporter
      */
     private function maybe_handle_submission(array $redirect_args): string|null
     {
-        if (empty($_POST[self::FORM_ACTION])) {
+        try {
+            if (empty($_POST[self::FORM_ACTION])) {
+                return null;
+            }
+
+            check_admin_referer(self::NONCE_ACTION);
+
+            if (!current_user_can('manage_options') && !current_user_can('editor')) {
+                wp_die(esc_html__('You are not allowed to do this.', 'planet4-master-theme-backend'));
+            }
+
+            $url = esc_url_raw(wp_unslash($_POST[self::FORM_ACTION]));
+
+            if (!$url || !filter_var($url, FILTER_VALIDATE_URL)) {
+                $redirect_args[self::REDIRECT_ARG_ERROR] = rawurlencode(
+                    __('Please provide a valid URL.', 'planet4-master-theme-backend')
+                );
+                $this->redirect_back($redirect_args);
+            }
+
+            if (wp_parse_url($url, PHP_URL_SCHEME) !== 'https') {
+                $redirect_args[self::REDIRECT_ARG_ERROR] = rawurlencode(
+                    __('Only HTTPS URLs are allowed.', 'planet4-master-theme-backend')
+                );
+                $this->redirect_back($redirect_args);
+            }
+
+            $existing_post_id = $this->find_existing_post_by_url($url);
+
+            if ($existing_post_id) {
+                $redirect_args[self::REDIRECT_ARG_ERROR] = rawurlencode(
+                    __('This URL has already been imported.', 'planet4-master-theme-backend')
+                );
+                $redirect_args[self::REDIRECT_ARG_EXISTING] = $existing_post_id;
+                $this->redirect_back($redirect_args);
+            }
+
+            return $url;
+        } catch (\Throwable $e) {
+            function_exists('\Sentry\captureException') && \Sentry\captureException($e);
             return null;
         }
-
-        check_admin_referer(self::NONCE_ACTION);
-
-        if (!current_user_can('manage_options') && !current_user_can('editor')) {
-            wp_die(esc_html__('You are not allowed to do this.', 'planet4-master-theme-backend'));
-        }
-
-        $url = esc_url_raw(wp_unslash($_POST[self::FORM_ACTION]));
-
-        if (!$url || !filter_var($url, FILTER_VALIDATE_URL)) {
-            $redirect_args[self::REDIRECT_ARG_ERROR] = rawurlencode(
-                __('Please provide a valid URL.', 'planet4-master-theme-backend')
-            );
-            $this->redirect_back($redirect_args);
-        }
-
-        if (wp_parse_url($url, PHP_URL_SCHEME) !== 'https') {
-            $redirect_args[self::REDIRECT_ARG_ERROR] = rawurlencode(
-                __('Only HTTPS URLs are allowed.', 'planet4-master-theme-backend')
-            );
-            $this->redirect_back($redirect_args);
-        }
-
-        $existing_post_id = $this->find_existing_post_by_url($url);
-
-        if ($existing_post_id) {
-            $redirect_args[self::REDIRECT_ARG_ERROR] = rawurlencode(
-                __('This URL has already been imported.', 'planet4-master-theme-backend')
-            );
-            $redirect_args[self::REDIRECT_ARG_EXISTING] = $existing_post_id;
-            $this->redirect_back($redirect_args);
-        }
-
-        return $url;
     }
 
     /**
@@ -163,20 +172,25 @@ class ActionImporter
      */
     private function find_existing_post_by_url(string $url): int
     {
-        $existing = get_posts([
-            'post_type'      => self::POST_TYPE,
-            'post_status'    => 'any',
-            'posts_per_page' => 1,
-            'fields'         => 'ids',
-            'meta_query'     => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
-                [
-                    'key'   => 'action_importer_source_url',
-                    'value' => $url,
+        try {
+            $existing = get_posts([
+                'post_type'      => self::POST_TYPE,
+                'post_status'    => 'any',
+                'posts_per_page' => 1,
+                'fields'         => 'ids',
+                'meta_query'     => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+                    [
+                        'key'   => 'action_importer_source_url',
+                        'value' => $url,
+                    ],
                 ],
-            ],
-        ]);
+            ]);
 
-        return !empty($existing) ? (int) $existing[0] : 0;
+            return !empty($existing) ? (int) $existing[0] : 0;
+        } catch (\Throwable $e) {
+            function_exists('\Sentry\captureException') && \Sentry\captureException($e);
+            return 0;
+        }
     }
 
     /**
@@ -190,86 +204,96 @@ class ActionImporter
      */
     private function slug_from_url(string $url): string
     {
-        $path = (string) wp_parse_url($url, PHP_URL_PATH);
-        $path = trim($path, '/');
+        try {
+            $path = (string) wp_parse_url($url, PHP_URL_PATH);
+            $path = trim($path, '/');
 
-        if ($path === '') {
+            if ($path === '') {
+                return '';
+            }
+
+            $segments = explode('/', $path);
+            $last     = end($segments);
+
+            return sanitize_title($last);
+        } catch (\Throwable $e) {
+            function_exists('\Sentry\captureException') && \Sentry\captureException($e);
             return '';
         }
-
-        $segments = explode('/', $path);
-        $last     = end($segments);
-
-        return sanitize_title($last);
     }
 
     /**
      * Fetch a URL, parse its Open Graph tags, and create a published post.
-     *
-     * @param string $url External URL to import.
-     * @return int|\WP_Error Post ID on success, WP_Error on failure.
      */
-    private function import_from_url(string $url)
+    private function import_from_url(string $url): int|\WP_Error
     {
-        $response = wp_remote_get($url, [
-            'timeout'    => 12,
-            'user-agent' => 'Planet4 Action Importer',
-        ]);
+        try {
+            $response = wp_remote_get($url, [
+                'timeout'    => 12,
+                'user-agent' => 'Planet4 Action Importer',
+            ]);
 
-        if (is_wp_error($response)) {
-            return $response;
-        }
+            if (is_wp_error($response)) {
+                return $response;
+            }
 
-        $code = wp_remote_retrieve_response_code($response);
-        if ($code < 200 || $code >= 300) {
-            return new \WP_Error(
-                'action_importer_http_error',
-                sprintf(
-                    /* translators: %d is an HTTP status code. */
-                    __('The remote server responded with status %d.', 'planet4-master-theme-backend'),
-                    $code
-                )
-            );
-        }
+            $code = wp_remote_retrieve_response_code($response);
+            if ($code < 200 || $code >= 300) {
+                return new \WP_Error(
+                    'action_importer_http_error',
+                    sprintf(
+                        /* translators: %d is an HTTP status code. */
+                        __('The remote server responded with status %d.', 'planet4-master-theme-backend'),
+                        $code
+                    )
+                );
+            }
 
-        $body = wp_remote_retrieve_body($response);
+            $body = wp_remote_retrieve_body($response);
 
-        if (trim($body) === '') {
-            return new \WP_Error(
-                'action_importer_empty_body',
-                __('The remote page returned no content.', 'planet4-master-theme-backend')
-            );
-        }
+            if (trim($body) === '') {
+                return new \WP_Error(
+                    'action_importer_empty_body',
+                    __('The remote page returned no content.', 'planet4-master-theme-backend')
+                );
+            }
 
-        $og = $this->parse_og_tags($body, $url);
+            $og = $this->parse_og_tags($body, $url);
 
-        if (empty($og['title']) && empty($og['description'])) {
-            return new \WP_Error(
-                'action_importer_no_og_data',
-                __('No Open Graph data could be found on that page.', 'planet4-master-theme-backend')
-            );
-        }
+            if (empty($og['title']) && empty($og['description'])) {
+                return new \WP_Error(
+                    'action_importer_no_og_data',
+                    __('No Open Graph data could be found on that page.', 'planet4-master-theme-backend')
+                );
+            }
 
-        $post_id = wp_insert_post([
-            'post_type'    => self::POST_TYPE,
-            'post_title'   => $og['title'] ?: __('(No title found)', 'planet4-master-theme-backend'),
-            'post_content' => $og['description'],
-            'post_status'  => 'publish',
-            'post_name'    => $this->slug_from_url($url),
-            'meta_input'   => [
-                'action_importer_source_url' => $url,
-            ],
-        ], true);
+            $post_id = wp_insert_post([
+                'post_type'    => self::POST_TYPE,
+                'post_title'   => $og['title'] ?: __('(No title found)', 'planet4-master-theme-backend'),
+                'post_content' => $og['description'],
+                'post_status'  => 'publish',
+                'post_name'    => $this->slug_from_url($url),
+                'meta_input'   => [
+                    'action_importer_source_url' => $url,
+                ],
+            ], true);
 
-        if (is_wp_error($post_id)) {
+            if (is_wp_error($post_id)) {
+                return $post_id;
+            }
+
+            if ($og['image']) {
+                $this->set_featured_image_from_url($post_id, $og['image'], $og['title']);
+            }
+
             return $post_id;
+        } catch (\Throwable $e) {
+            function_exists('\Sentry\captureException') && \Sentry\captureException($e);
+            return new \WP_Error(
+                    'action_importer_catch_error',
+                    __($e, 'planet4-master-theme-backend')
+                );
         }
-
-        if ($og['image']) {
-            $this->set_featured_image_from_url($post_id, $og['image'], $og['title']);
-        }
-
-        return $post_id;
     }
 
     /**
@@ -286,7 +310,7 @@ class ActionImporter
         try {
             $indexable = \ElasticPress\Indexables::factory()->get('post');
             $indexable->sync_manager->add_to_queue($post_id);
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             function_exists('\Sentry\captureException') && \Sentry\captureException($e);
         }
     }
@@ -299,31 +323,36 @@ class ActionImporter
      */
     private function get_or_create_actions_group(): int
     {
-        global $wpdb;
+        try {
+            global $wpdb;
 
-        $group_name = 'Actions';
-        $table      = $wpdb->prefix . 'redirection_groups';
+            $group_name = 'Actions';
+            $table      = $wpdb->prefix . 'redirection_groups';
 
-        $existing = $wpdb->get_var($wpdb->prepare(
-            "SELECT id FROM $table WHERE name = %s", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-            $group_name
-        ));
+            $existing = $wpdb->get_var($wpdb->prepare(
+                "SELECT id FROM $table WHERE name = %s", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+                $group_name
+            ));
 
-        if ($existing) {
-            return (int) $existing;
-        }
+            if ($existing) {
+                return (int) $existing;
+            }
 
-        if (!class_exists('Red_Group')) {
+            if (!class_exists('Red_Group')) {
+                return 1;
+            }
+
+            $group = \Red_Group::create($group_name, 1, true);
+
+            if ($group instanceof \Red_Group) {
+                return (int) $group->get_id();
+            }
+
+            return 1;
+        } catch (\Throwable $e) {
+            function_exists('\Sentry\captureException') && \Sentry\captureException($e);
             return 1;
         }
-
-        $group = \Red_Group::create($group_name, 1, true);
-
-        if ($group instanceof \Red_Group) {
-            return (int) $group->get_id();
-        }
-
-        return 1;
     }
 
     /**
@@ -337,38 +366,42 @@ class ActionImporter
      */
     private function create_redirection_to_source(int $post_id, string $target_url): void
     {
-        if (!class_exists('Red_Item')) {
-            return;
-        }
+        try {
+            if (!class_exists('Red_Item')) {
+                return;
+            }
 
-        $group_id = $this->get_or_create_actions_group();
-        $source   = wp_parse_url(get_permalink($post_id), PHP_URL_PATH);
+            $group_id = $this->get_or_create_actions_group();
+            $source   = wp_parse_url(get_permalink($post_id), PHP_URL_PATH);
 
-        if (!$source) {
-            return;
-        }
+            if (!$source) {
+                return;
+            }
 
-        $redirect = \Red_Item::create([
-            'url'         => $source,
-            'action_type' => 'url',
-            'action_code' => 301,
-            'match_type'  => 'url',
-            'action_data' => [
-                'url' => $target_url,
-            ],
-            'group_id'    => $group_id,
-        ]);
+            $redirect = \Red_Item::create([
+                'url'         => $source,
+                'action_type' => 'url',
+                'action_code' => 301,
+                'match_type'  => 'url',
+                'action_data' => [
+                    'url' => $target_url,
+                ],
+                'group_id'    => $group_id,
+            ]);
 
-        if ($redirect instanceof \Red_Item) {
-            $redirect_id = (int) $redirect->get_id();
-        } else if (is_array($redirect) && !empty($redirect['id'])) {
-            $redirect_id = (int) $redirect['id'];
-        } else {
-            $redirect_id = 0;
-        }
+            if ($redirect instanceof \Red_Item) {
+                $redirect_id = (int) $redirect->get_id();
+            } else if (is_array($redirect) && !empty($redirect['id'])) {
+                $redirect_id = (int) $redirect['id'];
+            } else {
+                $redirect_id = 0;
+            }
 
-        if ($redirect_id) {
-            update_post_meta($post_id, self::REDIRECT_ID_META_KEY, $redirect_id);
+            if ($redirect_id) {
+                update_post_meta($post_id, self::REDIRECT_ID_META_KEY, $redirect_id);
+            }
+        } catch (\Throwable $e) {
+            function_exists('\Sentry\captureException') && \Sentry\captureException($e);
         }
     }
 
@@ -434,7 +467,7 @@ class ActionImporter
             } else if ($action === 'delete') {
                 $item->delete();
             }
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             function_exists('\Sentry\captureException') && \Sentry\captureException($e);
         }
     }
@@ -455,66 +488,71 @@ class ActionImporter
             'url'         => $source_url,
         ];
 
-        // Guard against the PHP 8 ValueError thrown by loadHTML() on an empty string.
-        if (trim($html) === '') {
+        try {
+            // Guard against the PHP 8 ValueError thrown by loadHTML() on an empty string.
+            if (trim($html) === '') {
+                return $og;
+            }
+
+            $dom = new \DOMDocument();
+
+            $previous_setting = libxml_use_internal_errors(true);
+            $loaded            = $dom->loadHTML($html, LIBXML_NOERROR | LIBXML_NOWARNING);
+            libxml_clear_errors();
+            libxml_use_internal_errors($previous_setting);
+
+            if (!$loaded) {
+                return $og;
+            }
+
+            $metas = $dom->getElementsByTagName('meta');
+
+            foreach ($metas as $meta) {
+                /** @var \DOMElement $meta */
+                $property = $meta->getAttribute('property') ?: $meta->getAttribute('name');
+                $content  = $meta->getAttribute('content');
+
+                if (!$property || $content === '') {
+                    continue;
+                }
+
+                switch ($property) {
+                    case 'og:title':
+                        $og['title'] = $content;
+                        break;
+                    case 'og:description':
+                        $og['description'] = $content;
+                        break;
+                    case 'og:image':
+                    case 'og:image:secure_url':
+                        if (empty($og['image'])) {
+                            $og['image'] = $content;
+                        }
+                        break;
+                    case 'og:url':
+                        $og['url'] = $content;
+                        break;
+                }
+            }
+
+            // Fall back to <title> if og:title is missing.
+            if (empty($og['title'])) {
+                $titles = $dom->getElementsByTagName('title');
+                if ($titles->length > 0) {
+                    $og['title'] = $titles->item(0)->textContent;
+                }
+            }
+
+            $og['title']       = sanitize_text_field($og['title']);
+            $og['description'] = sanitize_text_field($og['description']);
+            $og['url']          = esc_url_raw($og['url']);
+            $og['image']        = esc_url_raw($og['image']);
+
+            return $og;
+        } catch (\Throwable $e) {
+            function_exists('\Sentry\captureException') && \Sentry\captureException($e);
             return $og;
         }
-
-        $dom = new \DOMDocument();
-
-        $previous_setting = libxml_use_internal_errors(true);
-        $loaded            = $dom->loadHTML($html, LIBXML_NOERROR | LIBXML_NOWARNING);
-        libxml_clear_errors();
-        libxml_use_internal_errors($previous_setting);
-
-        if (!$loaded) {
-            return $og;
-        }
-
-        $metas = $dom->getElementsByTagName('meta');
-
-        foreach ($metas as $meta) {
-            /** @var \DOMElement $meta */
-            $property = $meta->getAttribute('property') ?: $meta->getAttribute('name');
-            $content  = $meta->getAttribute('content');
-
-            if (!$property || $content === '') {
-                continue;
-            }
-
-            switch ($property) {
-                case 'og:title':
-                    $og['title'] = $content;
-                    break;
-                case 'og:description':
-                    $og['description'] = $content;
-                    break;
-                case 'og:image':
-                case 'og:image:secure_url':
-                    if (empty($og['image'])) {
-                        $og['image'] = $content;
-                    }
-                    break;
-                case 'og:url':
-                    $og['url'] = $content;
-                    break;
-            }
-        }
-
-        // Fall back to <title> if og:title is missing.
-        if (empty($og['title'])) {
-            $titles = $dom->getElementsByTagName('title');
-            if ($titles->length > 0) {
-                $og['title'] = $titles->item(0)->textContent;
-            }
-        }
-
-        $og['title']       = sanitize_text_field($og['title']);
-        $og['description'] = sanitize_text_field($og['description']);
-        $og['url']          = esc_url_raw($og['url']);
-        $og['image']        = esc_url_raw($og['image']);
-
-        return $og;
     }
 
     /**
@@ -526,16 +564,20 @@ class ActionImporter
      */
     private function set_featured_image_from_url(int $post_id, string $image_url, string $desc): void
     {
-        if (!function_exists('media_sideload_image')) {
-            require_once ABSPATH . 'wp-admin/includes/media.php';
-            require_once ABSPATH . 'wp-admin/includes/file.php';
-            require_once ABSPATH . 'wp-admin/includes/image.php';
-        }
+        try {
+            if (!function_exists('media_sideload_image')) {
+                require_once ABSPATH . 'wp-admin/includes/media.php';
+                require_once ABSPATH . 'wp-admin/includes/file.php';
+                require_once ABSPATH . 'wp-admin/includes/image.php';
+            }
 
-        $media_id = media_sideload_image($image_url, $post_id, $desc, 'id');
+            $media_id = media_sideload_image($image_url, $post_id, $desc, 'id');
 
-        if (!is_wp_error($media_id)) {
-            set_post_thumbnail($post_id, $media_id);
+            if (!is_wp_error($media_id)) {
+                set_post_thumbnail($post_id, $media_id);
+            }
+        } catch (\Throwable $e) {
+            function_exists('\Sentry\captureException') && \Sentry\captureException($e);
         }
     }
 

--- a/src/CustomPostType/ActionImporter.php
+++ b/src/CustomPostType/ActionImporter.php
@@ -13,8 +13,14 @@ namespace P4\MasterTheme\CustomPostType;
  */
 class ActionImporter
 {
+    private const POST_TYPE = 'p4_action';
+    private const PAGE_NAME = 'import-action';
     private const NONCE_ACTION = 'import_action';
+    private const FORM_ACTION = 'import_url';
     private const REDIRECT_ID_META_KEY = 'action_importer_redirect_id';
+    private const REDIRECT_ARG_SUCCESS = 'action_importer_success';
+    private const REDIRECT_ARG_ERROR = 'action_importer_error';
+    private const REDIRECT_ARG_EXISTING = 'action_importer_existing';
 
     /**
      * Constructor.
@@ -47,11 +53,11 @@ class ActionImporter
     public function add_options_page(): void
     {
         add_submenu_page(
-            'edit.php?post_type=p4_action',
+            'edit.php?post_type=' . self::POST_TYPE,
             __('Import Action', 'planet4-master-theme-backend'),
             __('Import Action', 'planet4-master-theme-backend'),
             'manage_options',
-            'import-action',
+            self::PAGE_NAME,
             [ $this, 'admin_page_display' ]
         );
     }
@@ -64,8 +70,8 @@ class ActionImporter
     public function init_import(): void
     {
         $redirect_args = [
-            'post_type' => 'p4_action',
-            'page'      => 'import-action',
+            'post_type' => self::POST_TYPE,
+            'page'      => self::PAGE_NAME,
         ];
 
         $url = $this->maybe_handle_submission($redirect_args);
@@ -77,14 +83,14 @@ class ActionImporter
         $post_id = $this->import_from_url($url);
 
         if (is_wp_error($post_id)) {
-            $redirect_args['action_importer_error'] = rawurlencode($post_id->get_error_message());
+            $redirect_args[self::REDIRECT_ARG_ERROR] = rawurlencode($post_id->get_error_message());
             $this->redirect_back($redirect_args);
         }
 
         $this->create_redirection_to_source($post_id, $url);
         $this->sync_elasticpress($post_id);
 
-        $redirect_args['action_importer_success'] = $post_id;
+        $redirect_args[self::REDIRECT_ARG_SUCCESS] = $post_id;
         $this->redirect_back($redirect_args);
     }
 
@@ -99,7 +105,7 @@ class ActionImporter
      */
     private function maybe_handle_submission(array $redirect_args): string|null
     {
-        if (empty($_POST['import_url'])) {
+        if (empty($_POST[self::FORM_ACTION])) {
             return null;
         }
 
@@ -109,17 +115,17 @@ class ActionImporter
             wp_die(esc_html__('You are not allowed to do this.', 'planet4-master-theme-backend'));
         }
 
-        $url = esc_url_raw(wp_unslash($_POST['import_url']));
+        $url = esc_url_raw(wp_unslash($_POST[self::FORM_ACTION]));
 
         if (!$url || !filter_var($url, FILTER_VALIDATE_URL)) {
-            $redirect_args['action_importer_error'] = rawurlencode(
+            $redirect_args[self::REDIRECT_ARG_ERROR] = rawurlencode(
                 __('Please provide a valid URL.', 'planet4-master-theme-backend')
             );
             $this->redirect_back($redirect_args);
         }
 
         if (wp_parse_url($url, PHP_URL_SCHEME) !== 'https') {
-            $redirect_args['action_importer_error'] = rawurlencode(
+            $redirect_args[self::REDIRECT_ARG_ERROR] = rawurlencode(
                 __('Only HTTPS URLs are allowed.', 'planet4-master-theme-backend')
             );
             $this->redirect_back($redirect_args);
@@ -128,10 +134,10 @@ class ActionImporter
         $existing_post_id = $this->find_existing_post_by_url($url);
 
         if ($existing_post_id) {
-            $redirect_args['action_importer_error'] = rawurlencode(
+            $redirect_args[self::REDIRECT_ARG_ERROR] = rawurlencode(
                 __('This URL has already been imported.', 'planet4-master-theme-backend')
             );
-            $redirect_args['action_importer_existing'] = $existing_post_id;
+            $redirect_args[self::REDIRECT_ARG_EXISTING] = $existing_post_id;
             $this->redirect_back($redirect_args);
         }
 
@@ -158,7 +164,7 @@ class ActionImporter
     private function find_existing_post_by_url(string $url): int
     {
         $existing = get_posts([
-            'post_type'      => 'p4_action',
+            'post_type'      => self::POST_TYPE,
             'post_status'    => 'any',
             'posts_per_page' => 1,
             'fields'         => 'ids',
@@ -245,7 +251,7 @@ class ActionImporter
         }
 
         $post_id = wp_insert_post([
-            'post_type'    => 'p4_action',
+            'post_type'    => self::POST_TYPE,
             'post_title'   => $og['title'] ?: __('(No title found)', 'planet4-master-theme-backend'),
             'post_content' => $og['description'],
             'post_status'  => 'publish',
@@ -414,7 +420,7 @@ class ActionImporter
     {
         $post = get_post($post_id);
 
-        if (!$post || $post->post_type !== 'p4_action') {
+        if (!$post || $post->post_type !== self::POST_TYPE) {
             return;
         }
 
@@ -455,7 +461,7 @@ class ActionImporter
      */
     public function remove_redirection_on_delete(int $post_id, \WP_Post $post): void
     {
-        if ($post->post_type !== 'p4_action') {
+        if ($post->post_type !== self::POST_TYPE) {
             return;
         }
 
@@ -599,7 +605,7 @@ class ActionImporter
                         <td>
                             <input
                                 type="url"
-                                name="import_url"
+                                name="<?php echo self::FORM_ACTION; ?>"
                                 class="regular-text"
                                 required
                                 pattern="https://.+"
@@ -626,11 +632,11 @@ class ActionImporter
      */
     private function maybe_render_notice(): void
     {
-        if (!empty($_GET['action_importer_error'])) {
-            $message = sanitize_text_field(wp_unslash($_GET['action_importer_error']));
+        if (!empty($_GET[self::REDIRECT_ARG_ERROR])) {
+            $message = sanitize_text_field(wp_unslash($_GET[self::REDIRECT_ARG_ERROR]));
 
-            if (!empty($_GET['action_importer_existing'])) {
-                $existing_id  = absint($_GET['action_importer_existing']);
+            if (!empty($_GET[self::REDIRECT_ARG_EXISTING])) {
+                $existing_id  = absint($_GET[self::REDIRECT_ARG_EXISTING]);
                 $existing_url = get_edit_post_link($existing_id, 'raw');
                 printf(
                     '<div class="notice notice-error"><p>%s <a href="%s">%s</a></p></div>',
@@ -648,8 +654,8 @@ class ActionImporter
             return;
         }
 
-        if (!empty($_GET['action_importer_success'])) {
-            $post_id   = absint($_GET['action_importer_success']);
+        if (!empty($_GET[self::REDIRECT_ARG_SUCCESS])) {
+            $post_id   = absint($_GET[self::REDIRECT_ARG_SUCCESS]);
             $edit_url  = get_edit_post_link($post_id, 'raw');
             $view_url  = get_permalink($post_id);
             printf(

--- a/src/CustomPostType/ActionImporter.php
+++ b/src/CustomPostType/ActionImporter.php
@@ -5,11 +5,8 @@ namespace P4\MasterTheme\CustomPostType;
 /**
  * Class ActionImporter
  *
- * Lets an admin/editor paste an external URL. On submit, PHP fetches the
- * page server-side, extracts its Open Graph data, and publishes a
- * p4_action post from it directly (no client-side preview step). URLs
- * that have already been imported are rejected. When an imported post is
- * permanently deleted, its associated redirection is removed too.
+ * Lets an admin/editor paste an external URL. On submit, PHP fetches the page server-side,
+ * extracts its Open Graph data, and publishes a p4_action post from it directly.
  */
 class ActionImporter
 {
@@ -70,9 +67,7 @@ class ActionImporter
     }
 
     /**
-     * Orchestrates the import: validate submission, create the post,
-     * wire up its side effects (redirect, search indexing), and redirect
-     * back to the admin screen with a success/error notice.
+     * Orchestrates the import.
      */
     public function init_import(): void
     {
@@ -107,12 +102,6 @@ class ActionImporter
 
     /**
      * Validate the form submission on admin_init, before any output.
-     *
-     * @param array<string,mixed> $redirect_args Base redirect query args
-     *                                            (post_type, page) used for
-     *                                            any error redirects.
-     * @return string|null The validated URL, or null if there was no
-     *                      submission to handle.
      */
     private function maybe_handle_submission(array $redirect_args): string|null
     {
@@ -161,9 +150,7 @@ class ActionImporter
     }
 
     /**
-     * Redirect back to the import page with status query args, then exit.
-     *
-     * @param array<string,mixed> $args Query args to append.
+     * Redirect back to the import page with status query args.
      */
     private function redirect_back(array $args): void
     {
@@ -173,9 +160,6 @@ class ActionImporter
 
     /**
      * Look up whether a post has already been imported from a given URL.
-     *
-     * @param string $url URL to check.
-     * @return int Post ID if found, 0 otherwise.
      */
     private function find_existing_post_by_url(string $url): int
     {
@@ -185,7 +169,7 @@ class ActionImporter
                 'post_status' => 'any',
                 'posts_per_page' => 1,
                 'fields' => 'ids',
-                'meta_query' => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+                'meta_query' => [
                     [
                         'key' => 'action_importer_source_url',
                         'value' => $url,
@@ -202,12 +186,7 @@ class ActionImporter
 
     /**
      * Derive a post slug from the last path segment of a URL.
-     *
-     * e.g. https://act.greenpeace.org.au/stop-big-gas -> "stop-big-gas"
-     *
-     * @param string $url Source URL.
-     * @return string Sanitized slug, or empty string if none could be derived
-     *                (wp_insert_post() will then fall back to the title).
+     * e.g. https://act.greenpeace.org.au/stop-big-gas ---> "stop-big-gas"
      */
     private function slug_from_url(string $url): string
     {
@@ -305,8 +284,6 @@ class ActionImporter
 
     /**
      * Queue the newly imported post for ElasticPress indexing.
-     *
-     * @param int $post_id Post ID to sync.
      */
     private function sync_elasticpress(int $post_id): void
     {
@@ -323,10 +300,7 @@ class ActionImporter
     }
 
     /**
-     * Get (or create) the "Actions" redirection group.
-     *
-     * @return int Group ID. Falls back to the default group (1) if the
-     *             Redirection plugin isn't active or group creation fails.
+     * Get or create the "Actions" redirection group.
      */
     private function get_or_create_actions_group(): int
     {
@@ -364,12 +338,7 @@ class ActionImporter
 
     /**
      * Create a 301 redirect from the new post's permalink to the original
-     * external URL it was imported from, inside the "Actions" group. The
-     * created redirect's ID is stored as post meta so it can be cleaned up
-     * later if the post is deleted.
-     *
-     * @param int    $post_id    Newly created post ID.
-     * @param string $target_url Original external URL.
+     * external URL it was imported from, inside the "Actions" group.
      */
     private function create_redirection_to_source(int $post_id, string $target_url): void
     {
@@ -437,10 +406,7 @@ class ActionImporter
     }
 
     /**
-     * Enable or disable the redirection associated with a p4_action post.
-     *
-     * @param int  $post_id Post ID.
-     * @param string $action The type of action to be executed.
+     * Enable, disable, or delete the redirection associated with a p4_action post.
      */
     private function set_redirection_status(int $post_id, string $action): void
     {
@@ -481,10 +447,6 @@ class ActionImporter
 
     /**
      * Parse Open Graph meta tags out of an HTML string.
-     *
-     * @param string $html       Raw HTML.
-     * @param string $source_url Original URL, used as a fallback for og:url.
-     * @return array{title:string, description:string, image:string, url:string}
      */
     private function parse_og_tags(string $html, string $source_url): array
     {
@@ -496,7 +458,6 @@ class ActionImporter
         ];
 
         try {
-            // Guard against the PHP 8 ValueError thrown by loadHTML() on an empty string.
             if (trim($html) === '') {
                 return $og;
             }
@@ -542,7 +503,6 @@ class ActionImporter
                 }
             }
 
-            // Fall back to <title> if og:title is missing.
             if (empty($og['title'])) {
                 $titles = $dom->getElementsByTagName('title');
                 if ($titles->length > 0) {
@@ -563,11 +523,7 @@ class ActionImporter
     }
 
     /**
-     * Sideload a remote image and set it as the post's featured image.
-     *
-     * @param int    $post_id   Target post ID.
-     * @param string $image_url Remote image URL.
-     * @param string $desc      Image description / alt text.
+     * Load a remote image and set it as the post's featured image.
      */
     private function set_featured_image_from_url(int $post_id, string $image_url, string $desc): void
     {
@@ -589,7 +545,7 @@ class ActionImporter
     }
 
     /**
-     * Render the admin page markup, including any success/error notice.
+     * Render the admin page markup.
      */
     public function admin_page_display(): void
     {

--- a/src/CustomPostType/ActionImporter.php
+++ b/src/CustomPostType/ActionImporter.php
@@ -8,11 +8,13 @@ namespace P4\MasterTheme\CustomPostType;
  * Lets an admin/editor paste an external URL. On submit, PHP fetches the
  * page server-side, extracts its Open Graph data, and publishes a
  * p4_action post from it directly (no client-side preview step). URLs
- * that have already been imported are rejected.
+ * that have already been imported are rejected. When an imported post is
+ * permanently deleted, its associated redirection is removed too.
  */
 class ActionImporter
 {
     private const NONCE_ACTION = 'import_action';
+    private const REDIRECT_ID_META_KEY = 'action_importer_redirect_id';
 
     /**
      * Constructor.
@@ -27,6 +29,10 @@ class ActionImporter
      */
     public function hooks(): void
     {
+        add_action('before_delete_post', [ $this, 'remove_redirection_on_delete' ], 10, 2);
+        add_action('wp_trash_post', [ $this, 'disable_redirection_on_trash' ]);
+        add_action('untrashed_post', [ $this, 'enable_redirection_on_untrash' ]);
+
         if (!current_user_can('manage_options') && !current_user_can('editor')) {
             return;
         }
@@ -50,6 +56,11 @@ class ActionImporter
         );
     }
 
+    /**
+     * Orchestrates the import: validate submission, create the post,
+     * wire up its side effects (redirect, search indexing), and redirect
+     * back to the admin screen with a success/error notice.
+     */
     public function init_import(): void
     {
         $redirect_args = [
@@ -78,7 +89,13 @@ class ActionImporter
     }
 
     /**
-     * Handle the form submission on admin_init, before any output.
+     * Validate the form submission on admin_init, before any output.
+     *
+     * @param array<string,mixed> $redirect_args Base redirect query args
+     *                                            (post_type, page) used for
+     *                                            any error redirects.
+     * @return string|null The validated URL, or null if there was no
+     *                      submission to handle.
      */
     private function maybe_handle_submission(array $redirect_args): string|null
     {
@@ -305,7 +322,9 @@ class ActionImporter
 
     /**
      * Create a 301 redirect from the new post's permalink to the original
-     * external URL it was imported from, inside the "Actions" group.
+     * external URL it was imported from, inside the "Actions" group. The
+     * created redirect's ID is stored as post meta so it can be cleaned up
+     * later if the post is deleted.
      *
      * @param int    $post_id    Newly created post ID.
      * @param string $target_url Original external URL.
@@ -323,7 +342,7 @@ class ActionImporter
             return;
         }
 
-        \Red_Item::create([
+        $redirect = \Red_Item::create([
             'url'         => $source,
             'action_type' => 'url',
             'action_code' => 301,
@@ -333,6 +352,132 @@ class ActionImporter
             ],
             'group_id'    => $group_id,
         ]);
+
+        $redirect_id = $this->extract_redirect_id($redirect);
+
+        if ($redirect_id) {
+            update_post_meta($post_id, self::REDIRECT_ID_META_KEY, $redirect_id);
+        }
+    }
+
+    /**
+     * Normalize the return value of Red_Item::create() into a redirect ID.
+     *
+     * Different versions of the Redirection plugin return either a
+     * Red_Item instance or an array from create(); handle both.
+     *
+     * @param mixed $redirect Return value from Red_Item::create().
+     * @return int Redirect ID, or 0 if it couldn't be determined.
+     */
+    private function extract_redirect_id($redirect): int
+    {
+        if ($redirect instanceof \Red_Item) {
+            return (int) $redirect->get_id();
+        }
+
+        if (is_array($redirect) && !empty($redirect['id'])) {
+            return (int) $redirect['id'];
+        }
+
+        return 0;
+    }
+
+    /**
+     * Disable the redirection when a p4_action post is moved to Trash.
+     * The redirect itself is preserved (not deleted) so it can be
+     * re-enabled if the post is restored.
+     *
+     * @param int $post_id Post ID being trashed.
+     */
+    public function disable_redirection_on_trash(int $post_id): void
+    {
+        $this->set_redirection_status($post_id, false);
+    }
+
+    /**
+     * Re-enable the redirection when a p4_action post is restored from Trash.
+     *
+     * @param int $post_id Post ID being restored.
+     */
+    public function enable_redirection_on_untrash(int $post_id): void
+    {
+        $this->set_redirection_status($post_id, true);
+    }
+
+    /**
+     * Enable or disable the redirection associated with a p4_action post.
+     *
+     * @param int  $post_id Post ID.
+     * @param bool $enable  True to enable the redirect, false to disable it.
+     */
+    private function set_redirection_status(int $post_id, bool $enable): void
+    {
+        $post = get_post($post_id);
+
+        if (!$post || $post->post_type !== 'p4_action') {
+            return;
+        }
+
+        if (!class_exists('Red_Item')) {
+            return;
+        }
+
+        $redirect_id = (int) get_post_meta($post_id, self::REDIRECT_ID_META_KEY, true);
+
+        if (!$redirect_id) {
+            return;
+        }
+
+        try {
+            $item = \Red_Item::get_by_id($redirect_id);
+
+            if (!$item instanceof \Red_Item) {
+                return;
+            }
+
+            if ($enable) {
+                $item->enable();
+            } else {
+                $item->disable();
+            }
+        } catch (\Exception $e) {
+            function_exists('\Sentry\captureException') && \Sentry\captureException($e);
+        }
+    }
+
+    /**
+     * Remove the redirection associated with a p4_action post when that
+     * post is permanently deleted (fires on force-delete or emptying the
+     * trash — not on moving a post to trash).
+     *
+     * @param int      $post_id Post ID being deleted.
+     * @param \WP_Post $post    Post object being deleted.
+     */
+    public function remove_redirection_on_delete(int $post_id, \WP_Post $post): void
+    {
+        if ($post->post_type !== 'p4_action') {
+            return;
+        }
+
+        if (!class_exists('Red_Item')) {
+            return;
+        }
+
+        $redirect_id = (int) get_post_meta($post_id, self::REDIRECT_ID_META_KEY, true);
+
+        if (!$redirect_id) {
+            return;
+        }
+
+        try {
+            $item = \Red_Item::get_by_id($redirect_id);
+
+            if ($item instanceof \Red_Item) {
+                $item->delete();
+            }
+        } catch (\Exception $e) {
+            function_exists('\Sentry\captureException') && \Sentry\captureException($e);
+        }
     }
 
     /**

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -78,6 +78,7 @@ final class Loader
             Cookies::class,
             DevReport::class,
             TimberSettings::class,
+            BlockRenderOverrides::class,
             MasterSite::class,
             NavMenus::class,
             HeadManager::class,

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -71,6 +71,7 @@ final class Loader
             CustomPostType\PostCampaign::class,
             CustomPostType\PostArchive::class,
             CustomPostType\ActionPage::class,
+            CustomPostType\ActionImporter::class,
             Settings::class,
             Features::class,
             PostReportController::class,

--- a/src/MasterSite.php
+++ b/src/MasterSite.php
@@ -108,26 +108,6 @@ class MasterSite extends \Timber\Site
             }
         );
 
-        /**
-         * Apply wpautop to non-block content.
-         *
-         * @link https://wordpress.stackexchange.com/q/321662/26317
-         *
-         * @param string $block_content The HTML generated for the block.
-         * @param array  $block         The block.
-         */
-        add_filter(
-            'render_block',
-            function ($block_content, $block) {
-                if (is_null($block['blockName'])) {
-                    return wpautop($block_content);
-                }
-                return $block_content;
-            },
-            10,
-            2
-        );
-
         // Disable WordPress(WP5.5) Block Directory.
         $this->disable_block_directory();
 


### PR DESCRIPTION
### Summary

This PR implements a mechanism to automate the import of external landing pages, turn them into Actions, and add redirects to the source URL.

---

Ref: https://greenpeace-planet4.atlassian.net/browse/PLANET-8189

### Testing

1. Go to the website admin area.
2. Look at the sidebar and check that a link labeled "Import Action" exists under "Actions".
3. Go to "Actions" and check that a button labeled "Import Action" exists next to "Add Action".
4. Go to "Import Action".
5. Add an external non-secure URL (http instead of https) and submit the form. An error message should be shown.
6. Add a non-valid URL and submit the form. An error message should be shown.
7. Add a valid and secure external URL and submit the form. A success message should be shown.
8. Add the same URL used in the previous step and submit the form. An error message should be shown.
9. Go to "Actions" and check that a new action exists with data from the external URL: title, description, featured image, and excerpt.
10. Go to "Tools" > "Redirections" and check that a new group called "Actions" exists.
11. Check that a new redirection from the recently created action to the source URL exists.
12. Move the recently created action to the trash and check that the linked redirection is suspended.
13. Completely delete the recently created action and check that the linked redirection is removed.
14. Verify that the Action is shown in all relevant places: Actions List block, Listing pages, Search page.