### PR TITLE
PLANET-8226 Add support for "Open in a new tab" setting when a P4 action page is selected in TAB block

### DIFF
--- a/assets/src/blocks/TakeActionBoxout/TakeActionBoxoutEditor.js
+++ b/assets/src/blocks/TakeActionBoxout/TakeActionBoxoutEditor.js
@@ -219,16 +219,13 @@ export const TakeActionBoxoutEditor = ({
               }
             }}
           />}
-          {!takeActionPageSelected &&
-            <CheckboxControl
-              __nextHasNoMarginBottom
-              label={__('Open in a new tab', 'planet4-master-theme-backend')}
-              value={newTab}
-              checked={newTab}
-              onChange={toAttribute('newTab')}
-              disabled={takeActionPageSelected}
-            />
-          }
+          <CheckboxControl
+            __nextHasNoMarginBottom
+            label={__('Open in a new tab', 'planet4-master-theme-backend')}
+            value={newTab}
+            checked={newTab}
+            onChange={toAttribute('newTab')}
+          />
           {!takeActionPageSelected &&
             <MediaUploadCheck>
               <MediaUpload

--- a/src/Blocks/TakeActionBoxout.php
+++ b/src/Blocks/TakeActionBoxout.php
@@ -170,7 +170,7 @@ class TakeActionBoxout extends BaseBlock
                 'title' => null === $page ? '' : $page->post_title,
                 'excerpt' => null === $page ? '' : $page->post_excerpt,
                 'link' => null === $page ? '' : get_permalink($page),
-                'new_tab' => false,
+                'new_tab' => $fields['newTab'] ?? false,
                 'link_text' => $cover_button_text,
                 'image' => $image ?? '',
                 'image_alt' => $image_alt ?? '',


### PR DESCRIPTION
Ref. https://greenpeace-planet4.atlassian.net/browse/PLANET-8226

### Testing

1. Create or edit a page and add a "Take Action Boxout" block.
2. In the block sidebar, under **Settings => Select Take Action Page**, choose an actual Planet4 action page (not "None (custom)").
3. Confirm the "Open in a new tab" checkbox is now visible (previously it only appeared for "None (custom)").
4. Enable the checkbox and save/publish the page.
5. View the page on the front end and click the boxout image, title, and button, each should open the action page in a new tab (`target="_blank"`).
6. Uncheck "Open in a new tab", save, and verify the links now open in the same tab.
7. Select "None (custom)", set a custom link, and confirm the "Open in a new tab" toggle still works as before.
