### PR TITLE
GF test: Update the default confirmation text in the hidden textarea as well

### DIFF
--- a/tests/e2e/gravity-forms.spec.js
+++ b/tests/e2e/gravity-forms.spec.js
@@ -71,7 +71,17 @@ test.describe('Gravity Forms tests', () => {
     await tinymceBody.click();
     await tinymceBody.fill(CONFIRMATION_MESSAGE);
 
-    // Verify the content is actually in the editor before saving
+    // Update the form's default confirmation text in the hidden textarea as well.
+    const confirmationTextarea = page.locator('#_gform_setting_message');
+    if (await confirmationTextarea.count()) {
+      await confirmationTextarea.evaluate((element, value) => {
+        element.value = value;
+        element.dispatchEvent(new Event('input', {bubbles: true}));
+        element.dispatchEvent(new Event('change', {bubbles: true}));
+      }, CONFIRMATION_MESSAGE);
+    }
+
+    // Verify the content is actually in the editor before saving.
     await expect(tinymceBody).toContainText(CONFIRMATION_MESSAGE);
 
     await page.getByRole('button', {name: 'Save Confirmation'}).click();

--- a/tests/e2e/tools/lib/gravity-forms.js
+++ b/tests/e2e/tools/lib/gravity-forms.js
@@ -121,7 +121,8 @@ const changeConfirmationType = async ({page, admin}, formId, label) => {
   await expect(typeRadio).toBeVisible();
 
   // Click the radio button and wait for the UI to update
-  await typeRadio.click();
+  await typeRadio.check();
+  await expect(typeRadio).toBeChecked();
 };
 
 export {toggleRestAPI, createForm, fillAndSubmitForm, checkEntry, changeConfirmationType};


### PR DESCRIPTION
Make Gravity Forms confirmation text test more reliable by syncing the hidden field before save.

- The change locates the hidden confirmation field the TinyMCE editor.
- Then update its value directly in the page DOM.
- Then dispatch input and change events so the form reacts as if it was a user input.

I run this 2-3 times in the CI and test passed successfully 