### PR TITLE
PLANET-7915 Add GP Media use to P4 Columns block

### DIFF
--- a/assets/src/blocks/Columns/ColumnsEditor.js
+++ b/assets/src/blocks/Columns/ColumnsEditor.js
@@ -7,7 +7,7 @@ import {getStyleFromClassName} from '../../functions/getStyleFromClassName';
 const {useSelect} = wp.data;
 const {InspectorControls, RichText} = wp.blockEditor;
 const {CheckboxControl, PanelBody, RangeControl} = wp.components;
-const {useEffect} = wp.element;
+const {useEffect, useCallback} = wp.element;
 const {__, sprintf} = wp.i18n;
 
 const renderEdit = (attributes, toAttribute, setAttributes, isSelected) => {
@@ -99,6 +99,9 @@ export const ColumnsEditor = ({isSelected, attributes, setAttributes}) => {
     isExample,
     exampleColumns,
   } = attributes;
+  const updateCurrentImageIndex = useCallback(index => {
+    setAttributes({currentImageIndex: index});
+  }, [setAttributes]);
 
   // Add className for existing blocks, based on columns_block_style attribute
   useEffect(() => {
@@ -128,9 +131,10 @@ export const ColumnsEditor = ({isSelected, attributes, setAttributes}) => {
     const columnImages = [];
     columns.forEach(column => {
       if (column.attachment && column.attachment > 0) {
-        const media_details = select('core').getMedia(column.attachment);
-        if (media_details) {
-          columnImages[column.attachment] = select('core').getMedia(column.attachment).source_url;
+        const media = select('core').getMedia(column.attachment);
+
+        if (media?.source_url) {
+          columnImages[column.attachment] = media.source_url;
         }
       }
     });
@@ -190,6 +194,7 @@ export const ColumnsEditor = ({isSelected, attributes, setAttributes}) => {
           columns_block_style={columns_block_style}
           toAttribute={toAttribute}
           columnImages={columnImages}
+          updateCurrentImageIndex={updateCurrentImageIndex}
         />
       }
     </section>

--- a/assets/src/blocks/Columns/EditableColumns.js
+++ b/assets/src/blocks/Columns/EditableColumns.js
@@ -12,12 +12,16 @@ export const EditableColumns = ({
   columns,
   isCampaign,
   columnImages,
+  updateCurrentImageIndex,
 }) => {
   const getImageOrButton = (openMediaModal, index) => {
     if ((0 < columns[index].attachment)) {
       return <div className="columns-image-container">
         <ImageHoverControls
-          onEdit={openMediaModal}
+          onEdit={() => {
+            openMediaModal();
+            updateCurrentImageIndex(index);
+          }}
           onRemove={() => toAttribute('attachment', index)(0)}
           isCompact={columns_block_style === LAYOUT_ICONS}
         />
@@ -27,7 +31,10 @@ export const EditableColumns = ({
 
     if (columns_block_style === LAYOUT_TASKS) {
       return <Button
-        onClick={openMediaModal}
+        onClick={() => {
+          openMediaModal();
+          updateCurrentImageIndex(index);
+        }}
         icon="plus-alt2"
         isPrimary
         className="tasks-image-button"
@@ -42,7 +49,10 @@ export const EditableColumns = ({
         height={columns_block_style !== LAYOUT_ICONS ? 250 : 100}
       />
       <Button
-        onClick={openMediaModal}
+        onClick={() => {
+          openMediaModal();
+          updateCurrentImageIndex(index);
+        }}
         icon="plus-alt2"
         isPrimary
         className="image-placeholder-button"

--- a/assets/src/js/Components/ArchivePicker/ArchivePicker.js
+++ b/assets/src/js/Components/ArchivePicker/ArchivePicker.js
@@ -11,6 +11,7 @@ import {
   updateCarouselBlockAttributes,
   updateCoverBlockAttributes,
   updateTopicLinkBlockAttributes,
+  updateColumnslBlockAttributes,
 } from './blockUpdateFunctions';
 
 const {Spinner} = wp.components;
@@ -29,6 +30,7 @@ const acceptedBlockTypes = new Map([
   ['planet4-blocks/carousel-header', updateCarouselBlockAttributes],
   ['core/media-text', updateMediaAndTextAttributes],
   ['planet4-blocks/topic-link', updateTopicLinkBlockAttributes],
+  ['planet4-blocks/columns', updateColumnslBlockAttributes],
 ]);
 
 const acceptedBlockTypesView = [...acceptedBlockTypes.keys(), 'planet4-blocks/happypoint'];
@@ -313,24 +315,11 @@ export default function ArchivePicker({view = ADMIN_VIEW}) {
 
   const currentBlock = wp.data.select('core/block-editor').getSelectedBlock();
 
-  const getImageDetails = useCallback(async id => {
-    try {
-      // On first try wp returns undefined, so need to make call again to get image details.
-      for (let retries = 0; retries < 2; ++retries) {
-        const newImageUploaded = await wp.data.select('core').getMedia(id);
-        if (newImageUploaded) {
-          return newImageUploaded;
-        }
-
-        await timeout(3000);
-      }
-    } catch (err) {
-      dispatch({type: ACTIONS.ADD_IMAGE_TO_POST_ERROR, payload: err});
-    }
-  }, []);
-
   const processImageForBlock = async (imageID, updateAttributeFunction) => {
-    const uploadedImage = await getImageDetails(imageID);
+    const uploadedImage = await wp.data.resolveSelect('core').getMedia(imageID);
+    if (!uploadedImage) {
+      dispatch({type: ACTIONS.ADD_IMAGE_TO_POST_ERROR, payload: 'No image returned from WordPress for the given ID.'});
+    }
     const updatedAttributes = updateAttributeFunction(uploadedImage, currentBlock);
     await wp.data.dispatch('core/block-editor').updateBlock(currentBlock.clientId, updatedAttributes);
   };

--- a/assets/src/js/Components/ArchivePicker/blockUpdateFunctions.js
+++ b/assets/src/js/Components/ArchivePicker/blockUpdateFunctions.js
@@ -92,8 +92,7 @@ export const updateMediaAndTextAttributes = (image, currentBlock) => {
  * @return {Object} An object containing updated block attributes.
  */
 export const updateCarouselBlockAttributes = (image, currentBlock) => {
-  const slides = currentBlock.attributes.slides;
-  const currentImageIndex = currentBlock.attributes.currentImageIndex;
+  const {slides, currentImageIndex} = currentBlock.attributes;
   const {thumbnail, medium_large, medium, large, full} = image.media_details.sizes;
   const imageSrcSet = `
   ${thumbnail.source_url} ${thumbnail.width}w,
@@ -103,13 +102,23 @@ export const updateCarouselBlockAttributes = (image, currentBlock) => {
   ${full.source_url} ${full.width}w,
   `;
 
-  slides[currentImageIndex].image = image.id;
-  slides[currentImageIndex].image_url = image.source_url;
-  slides[currentImageIndex].image_srcset = imageSrcSet;
+  const updatedSlides = slides.map((slide, index) => {
+    if (index !== currentImageIndex) {
+      return slide;
+    }
+
+    return {
+      ...slide,
+      image: image.id,
+      image_url: image.source_url,
+      image_srcset: imageSrcSet,
+    };
+  });
+
 
   return {
     attributes: {
-      slides,
+      slides: updatedSlides,
     },
   };
 };
@@ -164,6 +173,39 @@ export const updateTopicLinkBlockAttributes = image => {
       imageId: id,
       imageAlt: alt_text,
       imageUrl: source_url,
+    },
+  };
+};
+
+/**
+ * Updates the attributes of the P4 Columns block with new image data at the current slide index.
+ *
+ * This function modifies the `columns` array of the current Columns block, updating the slide
+ * at the `currentImageIndex` with a new image ID.
+ *
+ * @param {Object} image        - The image data object.
+ *
+ * @param {Object} currentBlock - The current carousel block object.
+ *
+ * @return {Object} An object containing updated block attributes.
+ */
+export const updateColumnslBlockAttributes = (image, currentBlock) => {
+  const {columns, currentImageIndex} = currentBlock.attributes;
+
+  const updatedColumns = columns.map((column, index) => {
+    if (index !== currentImageIndex) {
+      return column;
+    }
+
+    return {
+      ...column,
+      attachment: image.id,
+    };
+  });
+
+  return {
+    attributes: {
+      columns: updatedColumns,
     },
   };
 };


### PR DESCRIPTION
### Summary
Currently it’s not possible for editors to upload  images directly from Greenpeace Media, through the Images Style Block of the Planet 4 Columns Block.

<!-- Please provide a brief summary of the change introduced in this Pull Request. -->

---

<!-- Please add a reference link to the ticket, if one exists. -->
Ref: https://greenpeace-planet4.atlassian.net/browse/PLANET-7915

### Testing

<!-- Please add the steps required to test the changes in this Pull Request. -->
You can upload images in the Columns block now through GP Media
