### PR TITLE
News & Stories: change Post Type filter label for consistency

### DIFF
--- a/templates/listing-page-filters.twig
+++ b/templates/listing-page-filters.twig
@@ -1,7 +1,7 @@
 <div class="listing-page-filters">
      <div class="listing-page-select">
         <label for="post-type" class="listing-page-select-label">
-            {{__('Content type', 'planet4-master-theme')}}
+            {{__('Post Type', 'planet4-master-theme')}}
         </label>
         <select class="form-select" id="post-type">
             <option value="">{{__('All posts', 'planet4-master-theme')}}</option>


### PR DESCRIPTION
## Summary

For consistency, replacing “Content” for “Post” in the filters of the News & Stories page, so that the terms match to the ones in the search page.

Also used the same capitalization as the search page.

---

Ref: https://greenpeace-planet4.atlassian.net/browse/PLANET-8232

### Testing

Open the News & Stories page. The first filter label should now be "Post Type". You may need to clear Timber cache first (`npx wp-env run cli wp timber clear-cache`).