### PR TITLE
PLANET-8208 New Timeline Block: Add support for DisplayDate Column

### DIFF
--- a/assets/src/blocks/Timeline/NewTimelineFrontend.js
+++ b/assets/src/blocks/Timeline/NewTimelineFrontend.js
@@ -191,11 +191,15 @@ export const NewTimelineFrontend = ({attributes}) => {
       return acc;
     }, {});
 
-    const result = Object.entries(grouped)
-      .map(([year, list]) => ({
+    const result = Object.entries(grouped).map(([year, list]) => {
+      const displayDate = list.find(item => item.anchor_label?.trim())?.anchor_label?.trim();
+
+      return {
         year,
+        displayColumn: displayDate || year,
         list,
-      }));
+      };
+    });
 
     setProcessedSheetData(result);
   }, [sheetData]);
@@ -241,12 +245,20 @@ export const NewTimelineFrontend = ({attributes}) => {
         {!!description && !isEditing &&
           <p className="page-section-description text-center" dangerouslySetInnerHTML={{__html: description}} />
         }
-
-        <YearsNavigation isEditing={isEditing} years={processedSheetData.map(({year}) => year)} timelineId={timeline_id} />
+        <YearsNavigation
+          isEditing={isEditing}
+          years={processedSheetData.map(({year, displayColumn}) => ({
+            year,
+            displayDate: displayColumn,
+          }))}
+          timelineId={timeline_id}
+        />
         <fieldset className="timeline-group">
-          {processedSheetData.map(({year, list}) => (
+          {processedSheetData.map(({year, displayColumn, list}) => (
             <div className="timeline-block-year-group" id={`${timeline_id}-${year}`} key={`${timeline_id}-${year}`}>
-              <p className="timeline-block-year">{year}</p>
+              <p className="timeline-block-year">
+                <span>{displayColumn}</span>
+              </p>
               <ul className="timeline-block-events">
                 {list.map((event, index) => (
                   <TimelineEvent

--- a/assets/src/blocks/Timeline/YearsNavigation.js
+++ b/assets/src/blocks/Timeline/YearsNavigation.js
@@ -103,7 +103,7 @@ export const YearsNavigation = ({years, isEditing, timelineId}) => {
 
     const observer = new IntersectionObserver(observerCallback, observerOptions);
 
-    years.forEach(year => {
+    years.forEach(({year}) => {
       const link = document.getElementById(`${timelineId}-${year}`);
       if (link) {observer.observe(link);}
     });
@@ -176,7 +176,7 @@ export const YearsNavigation = ({years, isEditing, timelineId}) => {
         className={`years-navigation-items d-flex ${showLeftArrow || showRightArrow ? 'with-gradient' : ''}`}
         ref={yearsListRef}
       >
-        {years.map(year => (
+        {years.map(({year, displayDate}) => (
           <li key={`nav-${timelineId}-${year}`}>
             <a
               href={`#${timelineId}-${year}`}
@@ -184,7 +184,7 @@ export const YearsNavigation = ({years, isEditing, timelineId}) => {
               data-target={`${timelineId}-${year}`}
               className={`${!isEditing && activeYear === `${timelineId}-${year}` ? 'active': ''}`}
             >
-              {year}
+              {displayDate}
             </a>
           </li>
         ))}

--- a/assets/src/scss/blocks/Timeline/TimelineStyle.scss
+++ b/assets/src/scss/blocks/Timeline/TimelineStyle.scss
@@ -347,18 +347,32 @@
 
   .timeline-block-year {
     text-align: center;
-    width: 78px;
-    border-radius: $sp-x;
-    background-color: var(--white);
-    margin: $sp-6 auto;
-    padding: $sp-1;
-    box-shadow: 0 $sp-x $sp-1x rgba(0, 0, 0, 0.15);
     position: relative;
+    margin: $sp-6 auto;
     z-index: 1;
+
+    span {
+      border-radius: $sp-x;
+      background-color: var(--white);
+      padding: $sp-1;
+      box-shadow: 0 $sp-x $sp-1x rgba(0, 0, 0, 0.15);
+    }
+
+    @include medium-and-less {
+      max-width: 340px;
+
+      span {
+        display: inline-block;
+        max-width: 100%;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+    }
   }
 
   .timeline-block-year-group {
-    scroll-margin-top: 100px;
+    scroll-margin-top: 120px;
   }
 
   .timeline-block-event-day,
@@ -672,6 +686,7 @@
 
     li {
       margin: $sp-x $sp-2;
+      flex-shrink: 0;
 
       &:first-child {
         margin-inline-start: 0;


### PR DESCRIPTION
### Summary
Our [sheet template](https://docs.google.com/spreadsheets/d/1JSY5DMFu9axpgjw2nOZMDF7C3ZpzYbM7DoSAR_WWx_k/edit?gid=0#gid=0) for the Timeline block has a DisplayDate column, that we ignore in the current implementation. Ideally we should support it.

<!-- Please provide a brief summary of the change introduced in this Pull Request. -->

---

<!-- Please add a reference link to the ticket, if one exists. -->
Ref: https://greenpeace-planet4.atlassian.net/browse/PLANET-8208

### Testing

<!-- Please add the steps required to test the changes in this Pull Request. -->
 - Continue ordering and grouping items per date fields. ✅ 
 - Use that column for the navigation on top. ✅ 
 - Default to the `DisplayDate` column if it’s being set for just one item of the same year. ✅ 
 - Ignore other values for the same year. ✅ 
 - If `DisplayDate` column is not set, we default to the year column. ✅

You can use this [sheet](https://docs.google.com/spreadsheets/d/1EhkSuDPdz8ZCo-DYksW-eOxE0H9mgu7Eed1xOIMBRFg/edit?gid=0#gid=0) for testing.

Test [Page](https://www-dev.greenpeace.org/test-venus/timeline-block-test/)
