### PR TITLE
PLANET-7871 Add docs link to Details block

### DIFF
--- a/assets/src/block-editor/setupDetailsBlockExtension.js
+++ b/assets/src/block-editor/setupDetailsBlockExtension.js
@@ -135,6 +135,14 @@ const addStyleVariantsControls = wp.compose.createHigherOrderComponent(BlockEdit
             }
           </ButtonGroup>
         </PanelBody>
+        <PanelBody title={__('Learn more about this block ', 'planet4-master-theme-backend')} initialOpen={false}>
+          <p className="components-base-control__help">
+            <a target="_blank" href="https://planet4.greenpeace.org/content/blocks/details/" rel="noreferrer">
+              P4 Handbook Details block
+            </a>
+            {' '} &#129687;
+          </p>
+        </PanelBody>
       </InspectorControls>
     </>
   );

--- a/assets/src/blocks/Accordion/AccordionEditor.js
+++ b/assets/src/blocks/Accordion/AccordionEditor.js
@@ -161,7 +161,7 @@ const renderEdit = ({tabs}, setAttributes, updateTabAttribute) => {
           <a target="_blank" href="https://planet4.greenpeace.org/content/blocks/accordion/" rel="noreferrer">
             P4 Handbook Accordion
           </a>
-          {' '} &#11015;&#65039;
+          {' '} &#129687;
         </p>
       </PanelBody>
     </InspectorControls>


### PR DESCRIPTION
### Summary

Enable "Learn more about this Block" module in the Details Block sidebar of the backend, linking to the corresponding page of the Handbook. The link should say: "[P4 Handbook Details Block 🪗](https://planet4.greenpeace.org/content/blocks/details/)" (accordion emoji, or any other that displays a collapsable action).
I've also updated the Accordion block section to use the same emoji, since the two blocks are very similar.

Ref: [PLANET-7871](https://greenpeace-planet4.atlassian.net/browse/PLANET-7871)

### Testing

Add a Details block to a page, make sure that you see the new section in the sidebar and that the link is correct.


[PLANET-7871]: https://greenpeace-planet4.atlassian.net/browse/PLANET-7871?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ