### PR TITLE
PLANET-8229 New Timeline block: Added heading to ToC block

### DIFF
--- a/assets/src/blocks/TableOfContents/TableOfContentsFrontend.js
+++ b/assets/src/blocks/TableOfContents/TableOfContentsFrontend.js
@@ -2,9 +2,28 @@ import {getTableOfContentsStyle} from './getTableOfContentsStyle';
 import {TableOfContentsItems} from './TableOfContentsItems';
 import {makeHierarchical} from './makeHierarchical';
 import {getHeadingsFromDom} from '../../functions/getHeadingsFromDom';
+import {observeTimelineHeadings} from '../../functions/timelineObserver';
+
+const {useState, useEffect} = wp.element;
 
 export const TableOfContentsFrontend = ({title, className, levels, submenu_style}) => {
-  const headings = getHeadingsFromDom(levels);
+
+  const [headings, setHeadings] = useState([]);
+
+  useEffect(() => {
+    const updateHeadings = () => {
+      setHeadings(getHeadingsFromDom(levels));
+    };
+
+    updateHeadings();
+
+    const observer = observeTimelineHeadings(updateHeadings);
+
+    return () => {
+      observer?.();
+    };
+  }, [levels]);
+
   const menuItems = makeHierarchical(headings);
   const style = getTableOfContentsStyle(className, submenu_style);
 

--- a/assets/src/functions/getHeadingsFromBlocks.js
+++ b/assets/src/functions/getHeadingsFromBlocks.js
@@ -5,6 +5,7 @@ import {unescape} from './unescape';
 // Then we can also filter those to include them in the menu.
 const blockTypesWithHeadings = [
   {name: 'core/query', fieldName: 'core/heading', level: 4},
+  {name: 'planet4-blocks/timeline', fieldName: 'timeline_title', level: 2},
 ];
 
 // Naive regex to remove html tags. Don't use anywhere else as it's too limited, but for the expected HTML in heading
@@ -98,12 +99,20 @@ export const getHeadingsFromBlocks = (blocks, selectedLevels) => {
       const {fieldName, level} = blockType;
       const levelConfig = selectedLevels.find(selected => selected.heading === level);
 
-      if (!levelConfig) {
+      if (!levelConfig || !block.attributes[fieldName]) {
         return;
       }
+
+      const content = unescape(stripTags(block.attributes[fieldName]));
+      const anchor = block.attributes.anchor || generateAnchor(content, headings.map(h => h.anchor));
+
+
       headings.push({
         level,
-        content: block.attributes[fieldName],
+        content,
+        anchor,
+        style: levelConfig.style,
+        shouldLink: levelConfig.link,
       });
     }
   });

--- a/assets/src/functions/getHeadingsFromDom.js
+++ b/assets/src/functions/getHeadingsFromDom.js
@@ -4,32 +4,46 @@ const getHeadingLevel = heading => Number(heading.tagName.replace('H', ''));
 
 export const getHeadingsFromDom = selectedLevels => {
   const container = document.querySelector('.page-content');
+
   if (!container || !selectedLevels) {
     return [];
   }
 
   // Get all heading tags that we need to query
-  const headingsSelector = selectedLevels.map(
-    level => `:not(.table-of-contents-block):not(.secondary-navigation-block) > h${level.heading}`
-  );
+  const headingsSelector = selectedLevels.map(({heading}) => `h${heading}`).join(',');
 
   const usedAnchors = [];
 
-  return [...container.querySelectorAll(headingsSelector)].map(heading => {
-    const levelConfig = selectedLevels.find(selected => selected.heading === getHeadingLevel(heading));
+  return [...container.querySelectorAll(headingsSelector)]
+    .filter(heading => (
+      !heading.closest('.table-of-contents-block') &&
+      !heading.closest('.secondary-navigation-block')
+    ))
+    .map(heading => {
+      const levelConfig = selectedLevels.find(
+        selected => selected.heading === getHeadingLevel(heading)
+      );
 
-    if (!heading.id) {
-      heading.id = generateAnchor(heading.textContent, usedAnchors);
-    }
+      if (!levelConfig) {
+        return null;
+      }
 
-    usedAnchors.push(heading.id);
+      if (!heading.id) {
+        heading.id = generateAnchor(
+          heading.textContent,
+          usedAnchors
+        );
+      }
 
-    return ({
-      content: heading.textContent,
-      level: levelConfig.heading,
-      style: levelConfig.style,
-      shouldLink: levelConfig.link,
-      anchor: heading.id,
-    });
-  });
+      usedAnchors.push(heading.id);
+
+      return {
+        content: heading.textContent,
+        level: levelConfig.heading,
+        style: levelConfig.style,
+        shouldLink: levelConfig.link,
+        anchor: heading.id,
+      };
+    })
+    .filter(Boolean);
 };

--- a/assets/src/functions/timelineObserver.js
+++ b/assets/src/functions/timelineObserver.js
@@ -1,0 +1,63 @@
+export const observeTimelineHeadings = callback => {
+  const timelineSelector = '[class*="timeline"]';
+
+  let timelineObserver;
+
+  const startTimelineObserver = timelineBlock => {
+
+    const existingHeading = timelineBlock.querySelector('h2');
+
+    if (existingHeading) {
+      callback();
+      return;
+    }
+
+    // eslint-disable-next-line no-unused-vars
+    timelineObserver = new MutationObserver(mutations => {
+
+      const heading = timelineBlock.querySelector('h2');
+
+      if (heading) {
+        callback();
+        timelineObserver.disconnect();
+      }
+    });
+
+    timelineObserver.observe(timelineBlock, {
+      childList: true,
+      subtree: true,
+    });
+  };
+
+
+  const timelineBlock = document.querySelector(timelineSelector);
+
+  if (timelineBlock) {
+    startTimelineObserver(timelineBlock);
+  } else {
+    const bodyObserver = new MutationObserver(() => {
+      const timelineObserverBlock = document.querySelector(timelineSelector);
+
+      if (timelineObserverBlock) {
+
+        bodyObserver.disconnect();
+
+        startTimelineObserver(timelineObserverBlock);
+      }
+    });
+
+    bodyObserver.observe(document.body, {
+      childList: true,
+      subtree: true,
+    });
+
+    return () => {
+      bodyObserver.disconnect();
+      timelineObserver?.disconnect();
+    };
+  }
+
+  return () => {
+    timelineObserver?.disconnect();
+  };
+};


### PR DESCRIPTION
### Summary
Ideally we want the block headings to be picked up by the Table of Contents block. To achieve that, we probably need to make the block heading be actual heading blocks. Same as Posts/Actions Lists blocks.

<!-- Please provide a brief summary of the change introduced in this Pull Request. -->

---

<!-- Please add a reference link to the ticket, if one exists. -->
Ref: https://greenpeace-planet4.atlassian.net/browse/PLANET-8229

### Testing

<!-- Please add the steps required to test the changes in this Pull Request. -->

- Add a new page with some blocks that have headings and also add the timeline block. Also add the Table of Contents block to the page.
- Use the same markup we currently use (h2) ✅ 
- Verify the Timeline block title is being picked up by the ToC block ✅ 

Test [Page](https://www-dev.greenpeace.org/test-oberon/test-title)
