### PR TITLE
Experiment with customizable select HTML

### DIFF
--- a/assets/src/scss/pages/search/_sort-filter.scss
+++ b/assets/src/scss/pages/search/_sort-filter.scss
@@ -56,9 +56,32 @@ div.search-filter-results {
     }
   }
 
-  select {
+
+  select,
+  ::picker(select) {
+    appearance: base-select;
     width: 151px;
-    display: inline-block;
+    vertical-align: top;
+    padding: $sp-1x $sp-2;
+    font-family: var(--font-family-tertiary);
+    font-size: var(--font-size-m--font-family-tertiary);
+    border-radius: 4px;
+
+    &:focus {
+      box-shadow: 0 0 0 2px var(--gp-green-800);
+      border-color: transparent;
+      background-color: white;
+      outline: 0;
+    }
+
+    &::picker-icon {
+      content: url("../../images/select-arrow.svg");
+      transition: 0.4s rotate;
+    }
+
+    &:open::picker-icon {
+      rotate: 180deg;
+    }
 
     @include small-and-up {
       width: 210px;

--- a/templates/search.twig
+++ b/templates/search.twig
@@ -130,7 +130,6 @@
                                 <label for="select_order">{{ __('Sort by', 'planet4-master-theme' ) }}</label>
                                 <select
                                         id="select_order"
-                                        class="form-select"
                                         name="select_order"
                                         data-ga-category="Search Page"
                                         data-ga-action="Sort By Filter"


### PR DESCRIPTION
### Summary

This would have the benefit to let us also style the options and not only the select component

[Docs](https://developer.mozilla.org/en-US/docs/Learn_web_development/Extensions/Forms/Customizable_select)

**Note:** this is currently not supported by all browsers (Firefox for example) but I've tested on Chrome and there it works fine.

### Testing

You can see the new version of the select component on the search page, for the sorting options.

- Current version: &nbsp; <img width="416" height="141" alt="Screenshot 2026-07-24 at 11 31 57" src="https://github.com/user-attachments/assets/4b3cf2db-6a79-4079-a6a8-71f57537faf4" />

- New version: &nbsp; <img width="399" height="183" alt="Screenshot 2026-07-24 at 11 32 10" src="https://github.com/user-attachments/assets/1f164b2f-5270-4ca0-b4ed-1f1e33ddb072" />
