### PR TITLE
Experiment: Implement post-time-to-read native block

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -428,4 +428,23 @@ add_filter(
     10,
     2
 );
+
+add_filter(
+    'render_block_data',
+    'override_average_reading_speed',
+    10,
+    2
+);
+
+/**
+ * Overrides the averageReadingSpeed attribute
+ */
+function override_average_reading_speed( $parsed_block, $source_block ) {
+    if ( 'core/post-time-to-read' === $parsed_block['blockName'] ) {
+        $reading_time_wpm = $parsed_block['attrs']['averageReadingSpeed'];
+        $planet4_reading_time_wpm = get_option( 'planet4_reading_time_wpm', $reading_time_wpm);
+        $parsed_block['attrs']['averageReadingSpeed'] = $planet4_reading_time_wpm;
+    }
+    return $parsed_block;
+}
 // phpcs:enable SlevomatCodingStandard.Functions.UnusedParameter, Generic.Files.LineLength.MaxExceeded

--- a/templates/single.twig
+++ b/templates/single.twig
@@ -62,6 +62,13 @@
                             </address>
                         {% endif %}
                         <time class="single-post-time" pubdate>{{ post.post_date_gmt|date }}</time>
+
+                        <span class="single-post-meta-bullet" aria-hidden="true">&#8226;</span>
+                        <span class="single-post-meta-readtime">
+                            {% set time_to_read = fn('do_blocks', '<!-- wp:post-time-to-read {"displayAsRange":false} /-->')|striptags %}
+                            {{ __( '%s read', 'planet4-master-theme' )|format(time_to_read) }}
+                        </span>
+
                         {% set reading_time = post.reading_time_for_display %}
                         {% if reading_time %}
                             <span class="single-post-meta-bullet" aria-hidden="true">&#8226;</span>


### PR DESCRIPTION
### Summary
Test the Time To Read native block.

The Average Reading Speed by Wordpress is `189` by default, whereas we evaluate `265`by default.
- https://github.com/greenpeace/planet4-master-theme/blob/6d57cf43459fb2039acc734eb929535d6254022d/src/Post/ReadingTimeCalculator.php#L18.

As far as I investigated, WP don't take into account images and videos inserted into a page.

<!-- Please provide a brief summary of the change introduced in this Pull Request. -->

---

<!-- Please add a reference link to the ticket, if one exists. -->
Ref: No ticket needed

### Documentation
- https://github.com/WordPress/wordpress-develop/blob/5830b7cfcaa698f5136ffa0b19e8b555d800eef1/src/wp-includes/blocks/post-time-to-read.php#L28

### Testing

<!-- Please add the steps required to test the changes in this Pull Request. -->
1. Run WordPress >6.9 as mandatory
2. Enable All Blocks from features
