### PR TITLE
PLANET-8192 Fix patterns skipping the block editor validations

### DIFF
--- a/assets/src/block-editor/setupBlockEditorValidations.js
+++ b/assets/src/block-editor/setupBlockEditorValidations.js
@@ -2,6 +2,7 @@ const {__, sprintf} = wp.i18n;
 const {registerPlugin} = wp.plugins;
 const {useSelect, dispatch} = wp.data;
 const {useEffect, useRef} = wp.element;
+import {getAllBlocks} from '../functions/getAllBlocks';
 
 /**
  * Setup the block editor validation.
@@ -38,7 +39,7 @@ const getValidationState = select => {
   // template parts) They are design artifacts, not editorial content, so all checks
   // short-circuit to valid. New checks added below automatically respect this flag.
   const skip = !ALLOWED_POST_TYPES.includes(getCurrentPostType());
-  const allBlocks = getBlocks();
+  const allBlocks = getAllBlocks(getBlocks());
   const postTitle = skip || Boolean(getEditedPostAttribute('title'));
   const featuredImage = skip || Boolean(getEditedPostAttribute('featured_media'));
   const topicLink = skip || checkTopicLinks(allBlocks);

--- a/assets/src/blocks/Timeline/NewTimelineEditorScript.js
+++ b/assets/src/blocks/Timeline/NewTimelineEditorScript.js
@@ -2,6 +2,7 @@ import {URLInput} from '../../block-editor/URLInput/URLInput';
 import {NewTimelineFrontend} from './NewTimelineFrontend';
 import {URLDescriptionHelp} from './URLDescriptionHelp';
 import {getUniqueId} from '../../functions/getUniqueId';
+import {getAllBlocks} from '../../functions/getAllBlocks';
 
 const {InspectorControls, RichText} = wp.blockEditor;
 const {PanelBody, Tooltip} = wp.components;
@@ -9,15 +10,6 @@ import {select} from '@wordpress/data';
 const {debounce} = wp.compose;
 const {useCallback, useState, useEffect} = wp.element;
 const {__} = wp.i18n;
-
-/**
- * Get all blocks and inner blocks from a page.
- *
- * @param {Array} blocks - an array of blocks.
- *
- * @return {Array} All blocks from the page.
- */
-const flattenBlocks = blocks => blocks.flatMap(block => [block, ...flattenBlocks(block.innerBlocks || [])]);
 
 /**
  * Check if the given timeline id already exists on this page.
@@ -28,7 +20,7 @@ const flattenBlocks = blocks => blocks.flatMap(block => [block, ...flattenBlocks
  * @return {boolean} Whether the timeline id is already given or not.
  */
 const isTimelineIdReserved = timelineId => {
-  const allBlocks = flattenBlocks(select('core/editor').getBlocks());
+  const allBlocks = getAllBlocks(select('core/editor').getBlocks());
   return allBlocks.some(
     block => block.name === 'planet4-blocks/timeline' && block.attributes.timeline_id === timelineId
   );

--- a/assets/src/functions/getAllBlocks.js
+++ b/assets/src/functions/getAllBlocks.js
@@ -1,0 +1,8 @@
+/**
+ * Get all blocks and inner blocks from a page.
+ *
+ * @param {Array} blocks - an array of blocks.
+ *
+ * @return {Array} All blocks from the page.
+ */
+export const getAllBlocks = blocks => blocks.flatMap(block => [block, ...getAllBlocks(block.innerBlocks || [])]);


### PR DESCRIPTION
### Summary

Ref: [PLANET-8192](https://greenpeace-planet4.atlassian.net/browse/PLANET-8192)

### Testing

- Make sure that posts or pages using Gravity Form blocks through a pattern cannot be saved or published if no Global Project is selected.
- Make sure that posts using Topic Link blocks through a pattern cannot be saved or published if the blocks have no background image.

[PLANET-8192]: https://greenpeace-planet4.atlassian.net/browse/PLANET-8192?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ