### PR TITLE
Fix carousel image upload resolution

### DIFF
--- a/assets/src/blocks/CarouselHeader/CarouselHeaderEditor.js
+++ b/assets/src/blocks/CarouselHeader/CarouselHeaderEditor.js
@@ -6,7 +6,7 @@ import {CarouselControls} from './CarouselControls';
 
 // Carousel Header Editor
 import {Sidebar} from './Sidebar';
-import {EditableBackground, getLargestSizeUrl} from './EditableBackground';
+import {EditableBackground, getLargestSizeUrl, getSrcSetSizes} from './EditableBackground';
 
 const {useSelect} = wp.data;
 const {useCallback, useMemo, useRef} = wp.element;
@@ -81,7 +81,8 @@ export const CarouselHeaderEditor = ({setAttributes, attributes}) => {
     if (!image) {
       return slide;
     }
-    const image_srcset = toSrcSet(Object.values(image.media_details.sizes));
+    const image_srcset = toSrcSet(getSrcSetSizes(image.media_details.sizes));
+
     // Prefer a registered resized size over the original full-resolution upload.
     const image_url = getLargestSizeUrl(image);
     return ({...slide, image_url, image_srcset, image_alt: image.alt_text});

--- a/assets/src/blocks/CarouselHeader/CarouselHeaderEditor.js
+++ b/assets/src/blocks/CarouselHeader/CarouselHeaderEditor.js
@@ -6,9 +6,8 @@ import {CarouselControls} from './CarouselControls';
 
 // Carousel Header Editor
 import {Sidebar} from './Sidebar';
-import {EditableBackground, getLargestSizeUrl, getSrcSetSizes} from './EditableBackground';
+import {EditableBackground} from './EditableBackground';
 
-const {useSelect} = wp.data;
 const {useCallback, useMemo, useRef} = wp.element;
 
 export const toSrcSet = sizes => {
@@ -66,28 +65,6 @@ export const CarouselHeaderEditor = ({setAttributes, attributes}) => {
     goToSlide({newSlide: currentSlide > lastSlide ? 0 : currentSlide, forceCurrentSlide: true});
   }, [currentSlide, goToSlide, setAttributes, slides]);
 
-  const needsMigration = slides.some(slide => !!slide.image && !slide.image_srcset);
-  const migratedSlides = useSelect(select => slides && slides.map(slide => {
-    if (!needsMigration) {
-      return null;
-    }
-    let attempt = 0;
-    let image;
-    // Run a loop as this could return undefined the first time.
-    while (!image && attempt++ < 100) {
-      image = select('core').getMedia(slide.image);
-    }
-    // Didn't see this case occur but catch it anyway.
-    if (!image) {
-      return slide;
-    }
-    const image_srcset = toSrcSet(getSrcSetSizes(image.media_details.sizes));
-
-    // Prefer a registered resized size over the original full-resolution upload.
-    const image_url = getLargestSizeUrl(image);
-    return ({...slide, image_url, image_srcset, image_alt: image.alt_text});
-  }), [needsMigration, slides]);
-
   return useMemo(() => (
     <section className={`block block-header alignfull carousel-header ${className ?? ''}`}>
       <Sidebar
@@ -98,12 +75,6 @@ export const CarouselHeaderEditor = ({setAttributes, attributes}) => {
         changeSlideAttribute={changeSlideAttribute}
         goToSlide={goToSlide}
       />
-      { needsMigration && <button
-        title={'This block was created before WYSIWYG, press this to fetch data the new version uses.'}
-        onClick={() => {
-          setAttributes({slides: migratedSlides});
-        }}
-      >Migrate image data</button>}
       <div className="carousel-wrapper-header">
         <ul className="carousel-inner" role="listbox">
           {slides?.map((slide, index) => (
@@ -157,8 +128,6 @@ export const CarouselHeaderEditor = ({setAttributes, attributes}) => {
     goToSlide,
     goToPrevSlide,
     goToNextSlide,
-    migratedSlides,
-    needsMigration,
     setAttributes,
     addSlide,
     changeSlideAttribute,

--- a/assets/src/blocks/CarouselHeader/EditableBackground.js
+++ b/assets/src/blocks/CarouselHeader/EditableBackground.js
@@ -25,6 +25,18 @@ export const getLargestSizeUrl = image => {
   );
 };
 
+// Check if an image is very large.
+const isValidSize = key =>
+  key !== 'full' &&
+  key !== 'scaled' &&
+  key !== 'original';
+
+// Remove very large images from the SRC set.
+export const getSrcSetSizes = (sizes = {}) =>
+  Object.entries(sizes)
+    .filter(([key, value]) => isValidSize(key) && value?.source_url)
+    .map(([, value]) => value);
+
 export const EditableBackground = ({
   image_url,
   image_alt,
@@ -57,7 +69,7 @@ export const EditableBackground = ({
 
         // Use the largest registered size instead of the original image so we never serve a multi-MB upload to the front end.
         const resizedUrl = getLargestSizeUrl(image);
-        changeSlideImage(index, id, resizedUrl, alt_text, toSrcSet(Object.values(sizes)));
+        changeSlideImage(index, id, resizedUrl, alt_text, toSrcSet(getSrcSetSizes(sizes)));
       }}
       allowedTypes={ALLOWED_MIME_TYPES}
       value={image_id}

--- a/assets/src/blocks/CarouselHeader/EditableBackground.js
+++ b/assets/src/blocks/CarouselHeader/EditableBackground.js
@@ -1,5 +1,6 @@
 import {ImagePlaceholder} from './ImagePlaceholder';
 import {toSrcSet} from './CarouselHeaderEditor';
+import {logDataInSentry} from '../../functions/logDataInSentry';
 
 const {MediaUpload, MediaUploadCheck} = wp.blockEditor;
 const {Button, Dropdown} = wp.components;
@@ -53,9 +54,17 @@ export const EditableBackground = ({
   <MediaUploadCheck>
     <MediaUpload
       onSelect={async image => {
-        const imageRecord = await wp.data.resolveSelect('core').getMedia(image.id);
-        const {id, alt_text} = image;
-        const mimeType = image?.mime ?? image?.mime_type ?? (image?.subtype && `image/${image.subtype}`) ?? '';
+        let imageRecord;
+        try {
+          imageRecord = await wp.data.resolveSelect('core').getMedia(image.id);
+        } catch (error) {
+          logDataInSentry(error);
+          // eslint-disable-next-line no-alert
+          window.alert(__('There was an error retrieving the image from the Media Library. Please try again.', 'planet4-master-theme-backend'));
+          return;
+        }
+        const {id, alt_text} = imageRecord;
+        const mimeType = imageRecord?.mime ?? imageRecord?.mime_type ?? (imageRecord?.subtype && `image/${imageRecord.subtype}`) ?? '';
 
         // Reject anything that is not JPG / WebP. Defends against PNGs and other types that can slip in
         // via drag-and-drop, the Upload tab, or pre-existing entries in the Media Library.

--- a/assets/src/blocks/CarouselHeader/EditableBackground.js
+++ b/assets/src/blocks/CarouselHeader/EditableBackground.js
@@ -20,8 +20,8 @@ export const getLargestSizeUrl = image => {
     pickUrl(sizes.medium_large) ||
     pickUrl(sizes.medium) ||
     // As a last resort use the original URL so the slide is not left empty.
-    image?.url ||
-    image?.source_url
+    image?.source_url ||
+    image?.url
   );
 };
 
@@ -52,8 +52,9 @@ export const EditableBackground = ({
 }) => (
   <MediaUploadCheck>
     <MediaUpload
-      onSelect={image => {
-        const {id, alt_text, sizes} = image;
+      onSelect={async image => {
+        const imageRecord = await wp.data.resolveSelect('core').getMedia(image.id);
+        const {id, alt_text} = image;
         const mimeType = image?.mime ?? image?.mime_type ?? (image?.subtype && `image/${image.subtype}`) ?? '';
 
         // Reject anything that is not JPG / WebP. Defends against PNGs and other types that can slip in
@@ -68,8 +69,8 @@ export const EditableBackground = ({
         }
 
         // Use the largest registered size instead of the original image so we never serve a multi-MB upload to the front end.
-        const resizedUrl = getLargestSizeUrl(image);
-        changeSlideImage(index, id, resizedUrl, alt_text, toSrcSet(getSrcSetSizes(sizes)));
+        const resizedUrl = getLargestSizeUrl(imageRecord);
+        changeSlideImage(index, id, resizedUrl, alt_text, toSrcSet(getSrcSetSizes(imageRecord.media_details?.sizes)));
       }}
       allowedTypes={ALLOWED_MIME_TYPES}
       value={image_id}


### PR DESCRIPTION
### Summary
The Carousel Header block currently enforces images under 1MB by switching the image source to a smaller WordPress-generated size instead of the original file URL.

<!-- Please provide a brief summary of the change introduced in this Pull Request. -->

---

<!-- Please add a reference link to the ticket, if one exists. -->
Ref: https://greenpeace-planet4.atlassian.net/browse/PLANET-8214
Original PR: https://github.com/greenpeace/planet4-master-theme/pull/3009

### Testing

<!-- Please add the steps required to test the changes in this Pull Request. -->
Images uploaded from your device to the Carousel Header block now use the right attributes for `sizes` and `srcsets` as we now pull this image attributes from the WP media library for that image