### PR TITLE
Fix dead text domain and untranslated strings

### DIFF
--- a/assets/src/block-editor/setupImageBlockExtension.js
+++ b/assets/src/block-editor/setupImageBlockExtension.js
@@ -86,7 +86,7 @@ const addExtraControls = () => {
         <BlockEdit {...props} />
         <InspectorControls>
           <PanelBody
-            title={__('Planet4 Image Options')}
+            title={__('Planet4 Image Options', 'planet4-master-theme-backend')}
             initialOpen={true}
           >
             {/* eslint-disable-next-line jsx-a11y/label-has-for, jsx-a11y/label-has-associated-control */}

--- a/assets/src/blocks/CarouselHeader/CarouselHeaderFrontend.js
+++ b/assets/src/blocks/CarouselHeader/CarouselHeaderFrontend.js
@@ -27,7 +27,7 @@ export const CarouselHeaderFrontend = ({slides, carousel_autoplay, className, de
     <section
       className={`block block-header alignfull carousel-header ${className ?? ''}`}
       ref={containerRef}
-      aria-label={__('Greenpeace highlights', 'planet4-blocks')}
+      aria-label={__('Greenpeace highlights', 'planet4-master-theme')}
       aria-roledescription="carousel"
       onFocus={() => setAutoplay(false)}
       onTouchStart={() => setAutoplay(false)}

--- a/assets/src/blocks/Timeline/TimelineEvent.js
+++ b/assets/src/blocks/Timeline/TimelineEvent.js
@@ -101,7 +101,7 @@ export const TimelineEvent = ({event}) => {
           data-ga-label="n/a"
           type="button"
         >
-          {expanded ? __('Show less', 'planet4-blocks') : __('Show more', 'planet4-blocks')}
+          {expanded ? __('Show less', 'planet4-master-theme') : __('Show more', 'planet4-master-theme')}
         </button>
         {event.external_link && isValidHttpsUrl(event.external_link)  && (
           <div className="d-flex justify-content-end">
@@ -110,7 +110,7 @@ export const TimelineEvent = ({event}) => {
               href={event.external_link} rel="noreferrer"
               className="timeline-external-link"
             >
-              {__('Learn more', 'planet4-blocks')}
+              {__('Learn more', 'planet4-master-theme')}
             </a>
           </div>
         )}

--- a/assets/src/blocks/Timeline/TimelineFrontend.js
+++ b/assets/src/blocks/Timeline/TimelineFrontend.js
@@ -136,7 +136,7 @@ export const TimelineFrontend = ({attributes}) => {
             onClick={() => setExpanded(!expanded)}
             type="button"
           >
-            {expanded ? __('Show less', 'planet4-blocks') : __('Show more', 'planet4-blocks')}
+            {expanded ? __('Show less', 'planet4-master-theme') : __('Show more', 'planet4-master-theme')}
           </button>
           {event.external_link && isValidHttpsUrl(event.external_link)  && (
             <div className="d-flex justify-content-end">
@@ -145,7 +145,7 @@ export const TimelineFrontend = ({attributes}) => {
                 href={event.external_link} rel="noreferrer"
                 className="timeline-external-link"
               >
-                {__('Learn more', 'planet4-blocks')}
+                {__('Learn more', 'planet4-master-theme')}
               </a>
             </div>
           )}
@@ -247,7 +247,7 @@ export const TimelineFrontend = ({attributes}) => {
 
   const summaryText = sprintf(
   /* translators: 1: timeline title, 2: total items, 3: first date, 4: last date */
-    __('%1$s, %2$d items from %3$s to %4$s.', 'planet4-blocks'),
+    __('%1$s, %2$d items from %3$s to %4$s.', 'planet4-master-theme'),
     timeline_title,
     total,
     firstDate,

--- a/assets/src/blocks/Timeline/TimelineFrontend.js
+++ b/assets/src/blocks/Timeline/TimelineFrontend.js
@@ -155,7 +155,7 @@ export const TimelineFrontend = ({attributes}) => {
 
   const summaryText = sprintf(
   /* translators: 1: timeline title, 2: total items, 3: first date, 4: last date */
-    __('%1$s, %2$d items from %3$s to %4$s.', 'planet4-blocks'),
+    __('%1$s, %2$d items from %3$s to %4$s.', 'planet4-master-theme'),
     timeline_title,
     total,
     firstDate,

--- a/assets/src/blocks/Timeline/YearsNavigation.js
+++ b/assets/src/blocks/Timeline/YearsNavigation.js
@@ -165,7 +165,7 @@ export const YearsNavigation = ({years, isEditing, timelineId}) => {
       className={`years-navigation d-flex justify-content-center ${isEditing ? 'no-scroll' : ''}`}
       aria-label={sprintf(
       /* translators: 1: amount of years in the timeline */
-        __('Timeline, list with %1$d items', 'planet4-blocks'),
+        __('Timeline, list with %1$d items', 'planet4-master-theme'),
         years.length
       )}
     >

--- a/assets/src/js/Components/Paginator.js
+++ b/assets/src/js/Components/Paginator.js
@@ -114,7 +114,7 @@ function Paginator({currentPage, totalPages, onPageChange}) {
   const pageNumbers = getPageNumbers(currentPage, totalPages);
 
   return (
-    <nav className="wp-block-query-pagination is-layout-flex wp-block-query-pagination-is-layout-flex" aria-label="Pagination">
+    <nav className="wp-block-query-pagination is-layout-flex wp-block-query-pagination-is-layout-flex" aria-label={__('Pagination', 'planet4-master-theme')}>
       <a
         href="#"
         className={`wp-block-query-pagination-previous${isFirstPage ? ' disabled' : ''}`}

--- a/src/Exporter.php
+++ b/src/Exporter.php
@@ -32,7 +32,7 @@ class Exporter
         if (! empty($post_id) && 'export_data' === sanitize_text_field($_GET['action'])) {
             include get_template_directory() . '/exporter.php';
         } else {
-            wp_die('No post to export has been supplied!');
+            wp_die(esc_html__('No post to export has been supplied!', 'planet4-master-theme-backend'));
         }
     }
 


### PR DESCRIPTION
### Summary

Five frontend strings still pass `'planet4-blocks'` as their text domain, which no longer resolves. `greenpeace/planet4-plugin-gutenberg-blocks` was archived in March 2025, and `loco.xml` declares only `planet4-master-theme` and `planet4-master-theme-backend`, so there is no `planet4-blocks` catalog for these to load from. The files ship in the theme bundle and are registered to `planet4-master-theme` in `MasterBlocks.php`, so today they render untranslated in every locale.

Two of the five are `aria-label`s, so this affects assistive technology across all locales, not just visible copy.

The clearest symptom: `"Show more"` is already translated under `planet4-master-theme` (used by `templates/blocks/author_profile.twig`), so the Timeline button renders in English right next to an identically worded translated string.

| File | Strings |
|---|---|
| `assets/src/blocks/Timeline/TimelineEvent.js` | `Show less`, `Show more`, `Learn more` |
| `assets/src/blocks/Timeline/TimelineFrontend.js` | timeline summary |
| `assets/src/blocks/Timeline/YearsNavigation.js` | `Timeline, list with %1$d items` (aria-label) |
| `assets/src/blocks/CarouselHeader/CarouselHeaderFrontend.js` | `Greenpeace highlights` (aria-label) |

Also included, two strings that were never translatable at all:

- `assets/src/block-editor/setupImageBlockExtension.js` passed no domain for `Planet4 Image Options`, so it fell back to the core `default` domain where it does not exist
- `src/Exporter.php` called `wp_die()` with a raw English string and no escaping, while the same class already uses `__()` for the `Export` label

**Deliberately not changed:** `Medium`, `Left`, `Center` and `Right` in `setupImageBlockExtension.js` also pass no domain, but those are genuine WordPress core strings. Adding a theme domain there would drop the working core translations, so I left them as they are. Happy to split them out if you see it differently.

I did not regenerate the `.pot` files, assuming that is done by your own tooling. Let me know if you want them in this PR.

---

Ref:

### Testing

1. Load a page with a Timeline block in a non-English locale (any locale with a `planet4-master-theme` catalog). The `Show more` / `Show less` / `Learn more` labels now use the translated strings instead of English.
2. Inspect the Timeline years navigation and the Carousel Header section. Their `aria-label` attributes now resolve through `planet4-master-theme`.
3. In the block editor, select an Image block and confirm the `Planet4 Image Options` panel still renders, and that the Medium / Left / Center / Right labels are unchanged.

Build and lint are unchanged from `main`: 92 build warnings, 47 lint warnings, 0 errors in both. `vendor/bin/phpcs` is clean on `src/Exporter.php`.

