### PR TITLE
Fix missing accessible names and decorative image alts

### DIFF
--- a/templates/404.twig
+++ b/templates/404.twig
@@ -3,7 +3,8 @@
 {% block content %}
     <div class="page-header">
         <div class="page-header-background">
-            <img src="{{ page_notfound_image }}" class="page-header-image img-fluid" />
+            {# No need for an alt text here since the image is decorative #}
+            <img src="{{ page_notfound_image }}" class="page-header-image img-fluid" alt="" role="presentation" />
         </div>
         <div class="container">
             <div class="speech-bubble">
@@ -15,7 +16,7 @@
                     <form class="form search-form" action="{{ data_nav_bar.home_url }}">
                         {% set search = __( 'Search', 'planet4-master-theme' ) %}
                         <input class="form-control" placeholder="{{ search|e( 'html_attr' ) }}" name="s" aria-label="{{ search|e( 'html_attr' ) }}" type="text">
-                        <button class="search-form-btn" type="submit">
+                        <button class="search-form-btn" type="submit" aria-label="{{ search|e( 'html_attr' ) }}">
                             {{ 'search'|svgicon }}
                         </button>
                     </form>

--- a/templates/404.twig
+++ b/templates/404.twig
@@ -3,7 +3,7 @@
 {% block content %}
     <div class="page-header">
         <div class="page-header-background">
-            <img src="{{ page_notfound_image }}" class="page-header-image img-fluid" />
+            <img src="{{ page_notfound_image }}" class="page-header-image img-fluid" alt="" role="presentation" />
         </div>
         <div class="container">
             <div class="speech-bubble">
@@ -15,7 +15,7 @@
                     <form class="form search-form" action="{{ data_nav_bar.home_url }}">
                         {% set search = __( 'Search', 'planet4-master-theme' ) %}
                         <input class="form-control" placeholder="{{ search|e( 'html_attr' ) }}" name="s" aria-label="{{ search|e( 'html_attr' ) }}" type="text">
-                        <button class="search-form-btn" type="submit">
+                        <button class="search-form-btn" type="submit" aria-label="{{ search|e( 'html_attr' ) }}">
                             {{ 'search'|svgicon }}
                         </button>
                     </form>

--- a/templates/blocks/header.twig
+++ b/templates/blocks/header.twig
@@ -7,7 +7,9 @@
                     {% if ( background_image_srcset ) %}
                         srcset="{{ background_image_srcset }}"
                      {% endif %}
-                     class="page-header-image" />
+                     class="page-header-image"
+                     alt=""
+                     role="presentation" />
             </div>
         {% endif %}
         <div class="container">

--- a/templates/cookies/cookies_settings.twig
+++ b/templates/cookies/cookies_settings.twig
@@ -9,7 +9,7 @@
     class="d-none cookies-settings"
     role="dialog"
     aria-modal="true"
-    aria-labelledby={{__('Cookies Settings', 'planet4-master-theme')}}
+    aria-label="{{ __('Cookies Settings', 'planet4-master-theme')|e('html_attr') }}"
     tabindex="-1"
 >
     <div class="cookies-settings-header">

--- a/templates/cookies/cookies_settings.twig
+++ b/templates/cookies/cookies_settings.twig
@@ -9,7 +9,7 @@
     class="d-none cookies-settings"
     role="dialog"
     aria-modal="true"
-    aria-labelledby={{__('Cookies Settings', 'planet4-master-theme')}}
+    aria-label="{{__('Cookies Settings', 'planet4-master-theme')|e('html_attr')}}"
     tabindex="-1"
 >
     <div class="cookies-settings-header">

--- a/templates/search.twig
+++ b/templates/search.twig
@@ -30,7 +30,7 @@
                     <div class="search-bar">
                         <form id="search_form_inner" role="search" class="form d-md-flex" action="{{ data_nav_bar.home_url }}">
                             <div class="search-input-container w-100">
-                                <input type="search" id="search-page-input" class="form-control" placeholder="{{ search_label }}" value="{{ search_query|e('wp_kses_post') }}" name="s" aria-label="Search">
+                                <input type="search" id="search-page-input" class="form-control" placeholder="{{ search_label }}" value="{{ search_query|e('wp_kses_post') }}" name="s" aria-label="{{ __( 'Search input', 'planet4-master-theme' )|e('html_attr') }}">
                                 <input type="hidden" name="orderby" value="{{ selected_sort ?? default_sort }}" />
                                 <button
                                     class="clear-search"
@@ -63,16 +63,16 @@
                                 {{ __( 'Filters', 'planet4-master-theme' ) }}
                             </button>
                         </div>
-                        <div class="modal fade filter-modal" id="filtermodal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
+                        <div class="modal fade filter-modal" id="filtermodal" tabindex="-1" role="dialog" aria-labelledby="filtermodal-title" aria-hidden="true">
                             <div class="modal-dialog modal-lg" role="document">
                                 <div class="modal-content">
                                     <div class="modal-body">
                                         <div class="row">
                                             <div class="col-9">
-                                                <h4 class="modal-title">{{ __( 'Refine your search', 'planet4-master-theme' ) }}</h4>
+                                                <h4 class="modal-title" id="filtermodal-title">{{ __( 'Refine your search', 'planet4-master-theme' ) }}</h4>
                                             </div>
                                             <div class="col-3 text-end">
-                                                <button type="button" class="closebtn" data-bs-dismiss="modal">
+                                                <button type="button" class="closebtn" data-bs-dismiss="modal" aria-label="{{ __( 'Close', 'planet4-master-theme' )|e('html_attr') }}">
                                                     {{ 'times'|svgicon }}
                                                 </button>
                                             </div>

--- a/templates/search.twig
+++ b/templates/search.twig
@@ -30,7 +30,7 @@
                     <div class="search-bar">
                         <form id="search_form_inner" role="search" class="form d-md-flex" action="{{ data_nav_bar.home_url }}">
                             <div class="search-input-container w-100">
-                                <input type="search" id="search-page-input" class="form-control" placeholder="{{ search_label }}" value="{{ search_query|e('wp_kses_post') }}" name="s" aria-label="Search">
+                                <input type="search" id="search-page-input" class="form-control" placeholder="{{ search_label }}" value="{{ search_query|e('wp_kses_post') }}" name="s" aria-label="{{__('Search input', 'planet4-master-theme')|e('html_attr')}}">
                                 <input type="hidden" name="orderby" value="{{ selected_sort ?? default_sort }}" />
                                 <button
                                     class="clear-search"
@@ -63,16 +63,16 @@
                                 {{ __( 'Filters', 'planet4-master-theme' ) }}
                             </button>
                         </div>
-                        <div class="modal fade filter-modal" id="filtermodal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
+                        <div class="modal fade filter-modal" id="filtermodal" tabindex="-1" role="dialog" aria-labelledby="filtermodal-title" aria-hidden="true">
                             <div class="modal-dialog modal-lg" role="document">
                                 <div class="modal-content">
                                     <div class="modal-body">
                                         <div class="row">
                                             <div class="col-9">
-                                                <h4 class="modal-title">{{ __( 'Refine your search', 'planet4-master-theme' ) }}</h4>
+                                                <h4 class="modal-title" id="filtermodal-title">{{ __( 'Refine your search', 'planet4-master-theme' ) }}</h4>
                                             </div>
                                             <div class="col-3 text-end">
-                                                <button type="button" class="closebtn" data-bs-dismiss="modal">
+                                                <button type="button" class="closebtn" data-bs-dismiss="modal" aria-label="{{__('Close', 'planet4-master-theme')|e('html_attr')}}">
                                                     {{ 'times'|svgicon }}
                                                 </button>
                                             </div>

--- a/templates/tease-post.twig
+++ b/templates/tease-post.twig
@@ -4,6 +4,7 @@
     <h2 class="h2"><a href="{{ post.link }}">{{ post.title|raw }}</a></h2>
         <p>{{ post.excerpt()|truncate( 25, true )|raw }}</p>
         {% if ( post.thumbnail.src ) %}
-            <img data-src="{{ post.thumbnail.src }}" loading="lazy">
+            {# No need for an alt text here since the image is decorative and the post title is already a link #}
+            <img data-src="{{ post.thumbnail.src }}" loading="lazy" alt="" role="presentation">
         {% endif %}
 {% endblock %}

--- a/templates/tease-post.twig
+++ b/templates/tease-post.twig
@@ -4,6 +4,6 @@
     <h2 class="h2"><a href="{{ post.link }}">{{ post.title|raw }}</a></h2>
         <p>{{ post.excerpt()|truncate( 25, true )|raw }}</p>
         {% if ( post.thumbnail.src ) %}
-            <img data-src="{{ post.thumbnail.src }}" loading="lazy">
+            <img data-src="{{ post.thumbnail.src }}" loading="lazy" alt="" role="presentation">
         {% endif %}
 {% endblock %}

--- a/templates/tease.twig
+++ b/templates/tease.twig
@@ -3,7 +3,8 @@
         <h2 class="h2"><a href="{{ post.link }}">{{ post.title|raw }}</a></h2>
         <p>{{ post.excerpt()|truncate( 25, true )|raw }}</p>
         {% if ( post.get_thumbnail ) %}
-            <img src="{{ post.thumbnail.src }}" />
+            {# No need for an alt text here since the image is decorative and the post title is already a link #}
+            <img src="{{ post.thumbnail.src }}" alt="" role="presentation" />
         {% endif %}
     {% endblock %}
 </article>

--- a/templates/tease.twig
+++ b/templates/tease.twig
@@ -3,7 +3,7 @@
         <h2 class="h2"><a href="{{ post.link }}">{{ post.title|raw }}</a></h2>
         <p>{{ post.excerpt()|truncate( 25, true )|raw }}</p>
         {% if ( post.get_thumbnail ) %}
-            <img src="{{ post.thumbnail.src }}" />
+            <img src="{{ post.thumbnail.src }}" alt="" role="presentation" />
         {% endif %}
     {% endblock %}
 </article>


### PR DESCRIPTION
### Summary

Two dialogs, two icon-only buttons and four images currently reach assistive technology with no usable name. Each fix follows a pattern already used elsewhere in the theme.

**`templates/cookies/cookies_settings.twig`** had an unquoted attribute value:

```twig
aria-labelledby={{__('Cookies Settings', 'planet4-master-theme')}}
```

Once Twig renders that, the browser parses it as `aria-labelledby="Cookies"` plus a stray `Settings` attribute. Separately, `aria-labelledby` expects an element id rather than literal text, so the reference resolved to nothing either way. The element is `role="dialog" aria-modal="true"`, so it shipped nameless. Switched to a quoted, escaped `aria-label`.

**`templates/search.twig`** filter modal pointed at `aria-labelledby="exampleModalLabel"`. That id appears exactly once in the whole repository, on the reference itself, so it is leftover Bootstrap boilerplate and the dialog was nameless. The modal already renders a `<h4 class="modal-title">`, so I gave that an id and pointed the reference at it.

**Icon-only buttons.** The filter modal close button and the 404 search submit button each contain only `{{ 'icon'|svgicon }}`. The `svgicon` filter (`src/TimberSettings.php`) emits `<svg><use/></svg>` with no title, role or label, so neither button had an accessible name. Added `aria-label` to both, matching how `nav-search-btn` and `clear-search` are already labelled in `search-form.twig`. Note the 404 page's `<input>` one line above the button already had an `aria-label`, so only the button was missing.

**Decorative images.** `404.twig`, `blocks/header.twig`, `tease.twig` and `tease-post.twig` had `<img>` elements with no `alt` at all. I audited every `<img>` under `templates/` and these were the only four. They are decorative, and in the tease cases the post title beside them is already a link to the same destination, so they take `alt=""` with `role="presentation"`. This mirrors `tease-search.twig`, the sibling template included from the same `{% include %}` array, down to the explanatory comment.

Also swapped a hardcoded `aria-label="Search"` on the search page input for the translated `Search input` string already used for the same field in `search-form.twig`.

I used `aria-label` alone rather than also adding a `visually-hidden` span. Some existing buttons do both; happy to match that if you would rather be consistent with them.

**Heads up on overlap:** `templates/search.twig` is also touched by open PR #3051, but in a different hunk (the `#select_order` class, around line 130). These should merge cleanly, though I wanted to flag it rather than have you find it.

No visual or behavioural changes.

---

Ref:

### Testing

1. Open the cookies settings dialog and inspect it. It now exposes an accessible name via `aria-label` instead of rendering a malformed `aria-labelledby` attribute.
2. On the search page at a narrow viewport, open the Filters modal. A screen reader now announces it as "Refine your search" rather than an unnamed dialog, and the close button announces as "Close".
3. On a 404 page, tab to the search submit button. It now announces "Search" instead of being an unnamed button.
4. Inspect the page header images, the 404 header image and post teases. Each decorative image now carries `alt=""` and `role="presentation"`, so screen readers skip them instead of announcing a filename.
5. Confirm nothing changed visually on those pages.

Build and lint are unchanged from `main`: 92 build warnings, 47 lint warnings, 0 errors in both. `vendor/bin/phpcs src/` is clean. No test references any of the touched markup.
