### PR TITLE
PLANET-8023_optimize-query-db-single-posts

### DIFF
--- a/src/CustomPostType/ActionPage.php
+++ b/src/CustomPostType/ActionPage.php
@@ -521,7 +521,7 @@ class ActionPage
 
         // Check if Action has a action type term assigned to it and if none assigned,
         // assign the default p4 action type term.
-        $terms = wp_get_object_terms($post->ID, self::TAXONOMY);
+        $terms = get_the_terms($post->ID, self::TAXONOMY);
         if (is_wp_error($terms)) {
             return;
         }
@@ -666,7 +666,7 @@ class ActionPage
         }
 
         // Get action's taxonomy terms.
-        $terms = wp_get_object_terms($post->ID, self::TAXONOMY);
+        $terms = get_the_terms($post->ID, self::TAXONOMY);
 
         if (! is_wp_error($terms) && ! empty($terms) && is_object($terms[0])) {
             $taxonomy_slug = $terms[0]->slug;

--- a/src/CustomTaxonomy.php
+++ b/src/CustomTaxonomy.php
@@ -127,7 +127,7 @@ class CustomTaxonomy
         }
 
         // Get post's taxonomy terms.
-        $terms = wp_get_object_terms($post->ID, self::TAXONOMY);
+        $terms = get_the_terms($post->ID, self::TAXONOMY);
         $all_terms = self::get_terms();
 
         // Assign story slug if the taxonomy does not have any terms.

--- a/src/Post.php
+++ b/src/Post.php
@@ -48,6 +48,7 @@ class Post extends \Timber\Post
         $post = parent::build($wp_post);
         $post->set_page_types();
         $post->set_author();
+        $post->post_meta = get_post_meta($post->ID);
 
         return $post;
     }
@@ -240,6 +241,15 @@ class Post extends \Timber\Post
         }
     }
 
+    public function get_meta(string $key, int|null $index = null): string
+    {
+        if (null !== $index) {
+            return $this->post_meta[$key][$index] ?? '';
+        }
+
+        return $this->post_meta[$key] ?? '';
+    }
+
     /**
      * Get post/page custom planet4 type.
      * ACTION, DOCUMENT, PAGE, POST
@@ -256,7 +266,7 @@ class Post extends \Timber\Post
      */
     public function get_og_title(): string
     {
-        return get_post_meta($this->id, 'p4_og_title', true);
+        return $this->get_meta('p4_og_title', 0);
     }
 
     /**
@@ -265,7 +275,7 @@ class Post extends \Timber\Post
      */
     public function get_og_description(): string
     {
-        $og_desc = get_post_meta($this->id, 'p4_og_description', true);
+        $og_desc = $this->get_meta('p4_og_description', 0);
 
         if ('' === $og_desc) {
             return $this->post_excerpt;
@@ -280,12 +290,12 @@ class Post extends \Timber\Post
      */
     public function get_og_image(): array
     {
-        $meta = get_post_meta($this->id);
         $image_id = null;
         $image_metas = ['p4_og_image_id', '_thumbnail_id', 'background_image_id'];
         foreach ($image_metas as $image_meta) {
-            if (!empty($meta[$image_meta][0])) {
-                $image_id = $meta[$image_meta][0];
+            $image_meta_id = $this->get_meta($image_meta, 0);
+            if (!empty($image_meta_id)) {
+                $image_id = $image_meta_id;
                 break;
             }
         }
@@ -312,8 +322,8 @@ class Post extends \Timber\Post
      */
     public function share_meta(): array
     {
-        $og_title = get_post_meta($this->id, 'p4_og_title', true);
-        $og_description = get_post_meta($this->id, 'p4_og_description', true);
+        $og_title = $this->get_og_title();
+        $og_description = $this->get_og_description();
         $link = get_permalink($this->id);
 
         if (('' === $og_title) && '' !== $this->post_title) {
@@ -364,7 +374,7 @@ class Post extends \Timber\Post
      */
     public function get_author_override(): bool
     {
-        return !empty(get_post_meta($this->id, 'p4_author_override', true));
+        return (bool) $this->get_meta('p4_author_override', 0);
     }
 
     /**
@@ -372,10 +382,10 @@ class Post extends \Timber\Post
      */
     public function set_author(): void
     {
-        $author_override = get_post_meta($this->id, 'p4_author_override', true);
+        $author_override = $this->get_author_override();
         $real_author = Timber::get_user((int) $this->post_author);
 
-        if ('' !== $author_override) {
+        if (true !== $author_override) {
             $fake_user = $real_author;
             $fake_user->display_name = $author_override;
             $this->author = $fake_user;

--- a/src/Post.php
+++ b/src/Post.php
@@ -46,7 +46,6 @@ class Post extends \Timber\Post
     /**
      * Post meta data.
      *
-     * @var array $post_meta
      */
     public array $post_meta = [];
 

--- a/src/Post.php
+++ b/src/Post.php
@@ -43,6 +43,13 @@ class Post extends \Timber\Post
      */
     public array $data_layer;
 
+    /**
+     * Post meta data.
+     *
+     * @var array $post_meta
+     */
+    public array $post_meta = [];
+
     public static function build(\WP_Post $wp_post): self
     {
         $post = parent::build($wp_post);
@@ -364,7 +371,7 @@ class Post extends \Timber\Post
      */
     public function get_author_override(): bool
     {
-        return array_key_exists('p4_author_override', $this->post_meta);
+        return ! empty($this->post_meta['p4_author_override'][0]);
     }
 
     /**

--- a/src/Post.php
+++ b/src/Post.php
@@ -46,9 +46,9 @@ class Post extends \Timber\Post
     public static function build(\WP_Post $wp_post): self
     {
         $post = parent::build($wp_post);
+        $post->post_meta = get_post_meta($post->ID);
         $post->set_page_types();
         $post->set_author();
-        $post->post_meta = get_post_meta($post->ID);
 
         return $post;
     }
@@ -361,11 +361,10 @@ class Post extends \Timber\Post
 
     /**
      * Get post's author override status.
-     *
      */
     public function get_author_override(): bool
     {
-        return (bool) $this->post_meta['p4_author_override'][0] ?? false;
+        return array_key_exists('p4_author_override', $this->post_meta);
     }
 
     /**
@@ -373,12 +372,11 @@ class Post extends \Timber\Post
      */
     public function set_author(): void
     {
-        $author_override = $this->get_author_override();
         $real_author = Timber::get_user((int) $this->post_author);
 
-        if (true !== $author_override) {
+        if (true === $this->get_author_override()) {
             $fake_user = $real_author;
-            $fake_user->display_name = $author_override;
+            $fake_user->display_name = $this->post_meta['p4_author_override'][0];
             $this->author = $fake_user;
         } else {
             $this->author = $real_author;

--- a/src/Post.php
+++ b/src/Post.php
@@ -241,15 +241,6 @@ class Post extends \Timber\Post
         }
     }
 
-    public function get_meta(string $key, int|null $index = null): string
-    {
-        if (null !== $index) {
-            return $this->post_meta[$key][$index] ?? '';
-        }
-
-        return $this->post_meta[$key] ?? '';
-    }
-
     /**
      * Get post/page custom planet4 type.
      * ACTION, DOCUMENT, PAGE, POST
@@ -266,7 +257,7 @@ class Post extends \Timber\Post
      */
     public function get_og_title(): string
     {
-        return $this->get_meta('p4_og_title', 0);
+        return $this->post_meta['p4_og_title'][0] ?? '';
     }
 
     /**
@@ -275,7 +266,7 @@ class Post extends \Timber\Post
      */
     public function get_og_description(): string
     {
-        $og_desc = $this->get_meta('p4_og_description', 0);
+        $og_desc = $this->post_meta['p4_og_description'][0] ?? '';
 
         if ('' === $og_desc) {
             return $this->post_excerpt;
@@ -293,7 +284,7 @@ class Post extends \Timber\Post
         $image_id = null;
         $image_metas = ['p4_og_image_id', '_thumbnail_id', 'background_image_id'];
         foreach ($image_metas as $image_meta) {
-            $image_meta_id = $this->get_meta($image_meta, 0);
+            $image_meta_id = $this->post_meta[$image_meta][0] ?? '';
             if (!empty($image_meta_id)) {
                 $image_id = $image_meta_id;
                 break;
@@ -374,7 +365,7 @@ class Post extends \Timber\Post
      */
     public function get_author_override(): bool
     {
-        return (bool) $this->get_meta('p4_author_override', 0);
+        return (bool) $this->post_meta['p4_author_override'][0] ?? false;
     }
 
     /**

--- a/src/PostFunctionsHandler.php
+++ b/src/PostFunctionsHandler.php
@@ -232,7 +232,7 @@ class PostFunctionsHandler
         }
 
         // Check if post has an assigned term to it.
-        $terms = wp_get_object_terms($post_id, CustomTaxonomy::TAXONOMY);
+        $terms = get_the_terms($post_id, CustomTaxonomy::TAXONOMY);
         if (is_wp_error($terms)) {
             return;
         }

--- a/tests/test-action-type-custom-taxonomy.php
+++ b/tests/test-action-type-custom-taxonomy.php
@@ -38,7 +38,7 @@ class ActionTypeCustomTaxonomyTest extends P4TestCase
             ]
         );
 
-        $terms = wp_get_object_terms($post_id, 'action-type');
+        $terms = get_the_terms($post_id, 'action-type');
 
         // Assert that the action has been assigned with a action-type term.
         $this->assertCount(1, $terms);
@@ -73,7 +73,7 @@ class ActionTypeCustomTaxonomyTest extends P4TestCase
             ]
         );
 
-        $terms = wp_get_object_terms($post_id, 'action-type');
+        $terms = get_the_terms($post_id, 'action-type');
         // Assert that the Action has been assigned with a single action-type term.
         $this->assertCount(1, $terms);
         $this->assertEquals('contest', $terms[0]->slug);

--- a/tests/test-custom-taxonomy.php
+++ b/tests/test-custom-taxonomy.php
@@ -37,7 +37,7 @@ class CustomTaxonomyTest extends P4TestCase
             ]
         );
 
-        $terms = wp_get_object_terms($post_id, 'p4-page-type');
+        $terms = get_the_terms($post_id, 'p4-page-type');
 
         // Assert that the post has been assigned with a p4-page-type term.
         $this->assertEquals(1, count($terms));
@@ -71,7 +71,7 @@ class CustomTaxonomyTest extends P4TestCase
             ]
         );
 
-        $terms = wp_get_object_terms($post_id, 'p4-page-type');
+        $terms = get_the_terms($post_id, 'p4-page-type');
         // Assert that the post has been assigned with a single p4-page-type term.
         $this->assertEquals(1, count($terms));
         $this->assertEquals('publication', $terms[0]->slug);


### PR DESCRIPTION
### Summary
While working on Query DB perfomance ticket I've noticed that the official WP stack exchange request to `wp_get_object_terms` with `get_the_terms`.

> get_the_terms relies on the object cache. This gives a scaling boost and a speed boost. This means WP won't fetch the data a second time and reuses the results from the first time. Why grab a post from the database a second time? Store it in a variable to optimise performance!
> Unless you have a permanent object cache installed, the object cache only exists for that request though. If you have a permanent object cache set up this boost increases speed dramatically by storing this data in external software instead of variables, e.g. Redis/Memcached.

Ref: https://wordpress.stackexchange.com/questions/313114/when-to-not-to-use-wp-get-post-terms-vs-get-the-terms

---

<!-- Please add a reference link to the ticket, if one exists. -->
Ref: https://greenpeace-planet4.atlassian.net/browse/PLANET-8023

### Testing
<!-- Please add the steps required to test the changes in this Pull Request. -->
1. It should work the same
