### PR TITLE
PLANET-8151: Adjust CSP Headers to more strict configuration

### DIFF
--- a/src/HttpHeaders.php
+++ b/src/HttpHeaders.php
@@ -40,8 +40,9 @@ class HttpHeaders
         }
 
         $directives = [
-            'default-src * \'self\' data: \'unsafe-inline\' \'unsafe-eval\'',
-            'frame-ancestors ' . implode(' ', $allowed_frame_ancestors),
+            "default-src 'self' https: 'unsafe-inline'",
+            "img-src 'self' https: data:",
+            "frame-ancestors " . implode(' ', $allowed_frame_ancestors),
         ];
 
         // Add VWO exception to CSP list
@@ -49,18 +50,6 @@ class HttpHeaders
         if ($enable_vwo) {
             // phpcs:disable Generic.Files.LineLength.MaxExceeded
             $directives[0] = $directives[0] . ' blob: *.visualwebsiteoptimizer.com app.vwo.com useruploads.vwo.io';
-        }
-
-        // Add CSP exceptions from Social settings.
-        $csp_exceptions = planet4_get_option('csp_headers_exceptions') ?? '';
-        if ($csp_exceptions) {
-            $exceptions = array_filter(
-                array_map('trim', explode("\n", $csp_exceptions)),
-                fn($line) => str_starts_with($line, 'https://')
-            );
-            if ($exceptions) {
-                $directives[0] .= ' ' . implode(' ', $exceptions);
-            }
         }
 
         $csp_header = implode('; ', $directives);

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -430,18 +430,6 @@ class Settings
                         ],
                     ],
                     [
-                        'name' => __('CSP headers exceptions', 'planet4-master-theme-backend'),
-                        'desc' => __(
-                            'Add the list of resources (one per line) provided by the vendor as required exceptions. All resources should start with https.',
-                            'planet4-master-theme-backend'
-                        ),
-                        'id' => 'csp_headers_exceptions',
-                        'type' => 'textarea',
-                        'attributes' => [
-                            'type' => 'text',
-                        ],
-                    ],
-                    [
                         'name' => __('Choose social sharing options', 'planet4-master-theme-backend'),
                         'id' => 'social_share_options',
                         'type' => 'social_share_checkboxes',


### PR DESCRIPTION
### Summary
- Revert #2896 
- Apply the Pentest changes
> Requirements
> Add a new textarea option under Planet 4 > Social 
> Title: CSP headers exceptions
> Description: Add the list of resources (one per line) provided by the vendor as required exceptions. All resources should start with https.
> Append those values to our default-src directive.
> Only add the values that start with https://.



<!-- Please provide a brief summary of the change introduced in this Pull Request. -->

---

<!-- Please add a reference link to the ticket, if one exists. -->
Ref: https://greenpeace-planet4.atlassian.net/browse/PLANET-8151

### Testing

<!-- Please add the steps required to test the changes in this Pull Request. -->
1. CSP headers exceptions input should not be available on Planet 4 > Social
2. Open P4 website's frontend page, open Developer Tools (F12), and navigate to the Network tab. Refresh the page, click on the main document request, and look for the Content-Security-Policy header under Response Headers. it should show the same as requested as Pentest.

```php
        $directives = [
            "default-src 'self' https: 'unsafe-inline'",
            "img-src 'self' https: data:",
            "frame-ancestors " . implode(' ', $allowed_frame_ancestors),
        ];
```

As a first sight, it seems to be working as requested:

#### Before
`content-security-policy default-src * 'self' data: 'unsafe-inline' 'unsafe-eval'; frame-ancestors 'self'`

<img width="654" height="281" alt="Screenshot 2026-08-03 at 4 47 02 PM" src="https://github.com/user-attachments/assets/a47cdc17-3181-4dc6-a540-72bbf1235efe" />

#### After
`content-security-policy default-src 'self' https: 'unsafe-inline'; img-src 'self' https: data:; frame-ancestors 'self'`

<img width="679" height="200" alt="Screenshot 2026-08-03 at 4 55 20 PM" src="https://github.com/user-attachments/assets/d702c5af-fa36-4238-9082-e8717365f840" />
