### PR TITLE
Add check for mobile donate button menu

### DIFF
--- a/templates/navigation-bar.twig
+++ b/templates/navigation-bar.twig
@@ -27,21 +27,23 @@
 
     {% include 'desktop-menu.twig' %}
 
-    <div class="d-flex align-items-center ms-auto">
-        <button
-            class="btn btn-donate d-lg-none"
-            onclick="window.location='{{ donate_menu_items[0].link }}';"
-            role="link"
-            target="{{ item.target }}"
-            data-ga-category="Menu Navigation"
-            data-ga-action="Donate"
-            data-ga-label="Mobile Header"
-        >
-            {{ donate_menu_items[0].title }}
-        </button>
+    {% if donate_menu_items is not empty %}
+        <div class="d-flex align-items-center ms-auto">
+            <button
+                class="btn btn-donate d-lg-none"
+                onclick="window.location='{{ donate_menu_items[0].link }}';"
+                role="link"
+                target="{{ item.target }}"
+                data-ga-category="Menu Navigation"
+                data-ga-action="Donate"
+                data-ga-label="Mobile Header"
+            >
+                {{ donate_menu_items[0].title }}
+            </button>
 
-        {% include 'navigation-search-btn.twig' with { show_for_medium: true } %}
-    </div>
+            {% include 'navigation-search-btn.twig' with { show_for_medium: true } %}
+        </div>
+    {% endif %}
 
     {% include 'search-form.twig' %}
 


### PR DESCRIPTION
## Summary

Some sites don't have a donate menu (or it's empty).

### Testing

<!-- Please add the steps required to test the changes in this Pull Request. -->
1. Go to _Appearance > Menu_ and select the Donate Menu
2. Delete all of its entries
3. In the `main` branch you'll see an empty button in mobile (like the screenshot below)
4. In this branch the button is hidden

You may need to clear Timber cache when switching between branches
` npx wp-env run cli wp timber clear-cache`

<img width="432" height="73" alt="image" src="https://github.com/user-attachments/assets/23cdf03f-188e-4224-b526-8a2d0796179a" />

