### PR TITLE
PLANET-8250 Add aria-label to footer social menu links

### DIFF
--- a/templates/footer_social_media.twig
+++ b/templates/footer_social_media.twig
@@ -14,6 +14,7 @@
               target="_blank"
               rel="noopener noreferrer"
             {% endif %}
+            aria-label="{{ site.name }} {{ social.title }}"
           >
             {{ social.icon|svgicon }}
             <span class="visually-hidden">{{ social.icon }}</span>
@@ -44,6 +45,8 @@
             {% else %}
               rel="me"
             {% endif %}
+
+            aria-label="{{ site.name }} {{ social.title }}"
           >
             {{ name|svgicon }}
             <span class="visually-hidden">{{ social.title }}</span>

--- a/templates/footer_social_media.twig
+++ b/templates/footer_social_media.twig
@@ -14,10 +14,9 @@
               target="_blank"
               rel="noopener noreferrer"
             {% endif %}
-            aria-label="{{ site.name }} {{ social.title }}"
           >
             {{ social.icon|svgicon }}
-            <span class="visually-hidden">{{ social.icon }}</span>
+            <span class="visually-hidden">{{ site.name }} {{ social.icon }}</span>
           </a>
         </li>
       {% endfor %}
@@ -45,11 +44,9 @@
             {% else %}
               rel="me"
             {% endif %}
-
-            aria-label="{{ site.name }} {{ social.title }}"
           >
             {{ name|svgicon }}
-            <span class="visually-hidden">{{ social.title }}</span>
+            <span class="visually-hidden">{{ site.name }} {{ social.title }}</span>
           </a>
         </li>
       {% endfor %}


### PR DESCRIPTION
### Summary

Currently, the screen reader announces the social media buttons without context, reading only the platform name. As a best practice, the screen reader should announce the Greenpeace accounts (e.g., “Greenpeace LinkedIn “).

**Requirements**
Update all social media anchor (\<a\>) tags to include both the organization and the platform in the accessible name (e.g., "Greenpeace International LinkedIn").

---

<!-- Please add a reference link to the ticket, if one exists. -->
Ref. https://greenpeace-planet4.atlassian.net/browse/PLANET-8250

### Testing

Please check the footer social menu links for their accessible labels. The label should include the NRO site name and the social media platform name.
