### PR TITLE
PLANET-8237 Make main nav dropdowns more accessible

### DIFF
--- a/assets/src/js/header/setupAccessibleNavMenu.js
+++ b/assets/src/js/header/setupAccessibleNavMenu.js
@@ -35,6 +35,7 @@ export const setupAccessibleNavMenu = () => {
         const accessibleLink = button.querySelector(ACCESSIBLE_NAV_LINK_CLASS);
         if (accessibleLink) {
           accessibleLink.classList.add('rotate');
+          accessibleLink.setAttribute('aria-expanded', 'true');
         }
       });
       button.addEventListener('mouseleave', () => {
@@ -47,6 +48,7 @@ export const setupAccessibleNavMenu = () => {
         const accessibleLink = button.querySelector(ACCESSIBLE_NAV_LINK_CLASS);
         if (accessibleLink) {
           accessibleLink.classList.remove('rotate');
+          accessibleLink.setAttribute('aria-expanded', 'false');
         }
       });
     });
@@ -63,10 +65,12 @@ export const setupAccessibleNavMenu = () => {
             submenu.style.display = 'flex';
             submenu.hidden = false;
             button.classList.add('rotate');
+            button.setAttribute('aria-expanded', 'true');
           } else {
             submenu.style.display = 'none';
             submenu.hidden = true;
             button.classList.remove('rotate');
+            button.setAttribute('aria-expanded', 'false');
           }
         }
       });
@@ -76,6 +80,7 @@ export const setupAccessibleNavMenu = () => {
 
         if (parentIsDonateBtn || parentHasChildren) {
           button.classList.remove('rotate');
+          button.setAttribute('aria-expanded', 'false');
           const submenu = button.closest(`${NAV_ITEM_CLASS}, ${NAV_DONATE_CLASS}`).querySelector(NAV_SUBMENU_CLASS);
           if (submenu) {
             submenu.style.display = 'none';
@@ -97,6 +102,7 @@ export const setupAccessibleNavMenu = () => {
           submenu.style.display = 'none';
           if (button) {
             button.classList.remove('rotate');
+            button.setAttribute('aria-expanded', 'false');
           }
         }
       });


### PR DESCRIPTION
### Summary

This is achieved by changing the aria-expanded attribute, which will be announced by screen readers.

Ref: [PLANET-8237](https://greenpeace-planet4.atlassian.net/browse/PLANET-8237)

### Testing

Using tabbing and a screen reader, close/open the main navigation dropdowns and make sure that the change is now announced.

[PLANET-8237]: https://greenpeace-planet4.atlassian.net/browse/PLANET-8237?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ