### PR TITLE
Fix Cloudflare cache domain to work for other environments

### DIFF
--- a/src/Commands/SaveCloudflareKey.php
+++ b/src/Commands/SaveCloudflareKey.php
@@ -36,8 +36,8 @@ class SaveCloudflareKey extends Command
      * @param array|null $assoc_args Named arguments.
      *
      * @throws WP_CLI\ExitException If no hostname or Cloudflare key is not present.
-     * phpcs:disable SlevomatCodingStandard.Functions.UnusedParameter -- interface implementation
      */
+    // phpcs:ignore SlevomatCodingStandard.Functions.UnusedParameter
     public static function execute(?array $args, ?array $assoc_args): void
     {
         $hostname = $args[0] ?? null;
@@ -49,12 +49,12 @@ class SaveCloudflareKey extends Command
             WP_CLI::error('CLOUDFLARE_API_KEY constant is not set.');
         }
 
-        // Remove www from the hostname, since Cloudflare needs the apex domain.
-        $root_domain = str_replace('www.', '', $hostname);
+        // Remove www or other common subdomains from the hostname,
+        // since Cloudflare needs the apex domain.
+        $apex_domain = preg_replace('/^(www|www-stage|www-dev)\./i', '', trim($hostname));
 
         update_option('cloudflare_api_key', CLOUDFLARE_API_KEY);
         update_option('automatic_platform_optimization', [ 'value' => 1 ]);
-        update_option('cloudflare_cached_domain_name', $root_domain);
+        update_option('cloudflare_cached_domain_name', $apex_domain);
     }
-    // phpcs:enable SlevomatCodingStandard.Functions.UnusedParameter
 }


### PR DESCRIPTION
### Summary

Our current code only takes `www` into account.
So cache purging functionanily didn't work for dev/stage environments.

Switched to a more generic implementation to keep the apex domain.

### Testing

*Locally*

Test the new code snippet with different variations. You should always get the apex domain (eg. `greenpeace.org`). You can also test it in [php playhround](https://php-play.dev/?c=DwfgDgFmBQAkEHsDOAXAdgQwLYFMAEAvHgOQDu5AtACY4BuAdDgB7ZgA2O9AxglsQNzQ4GMMwD6VXhgCWaQnjAAnHAHMxy9hi44AFMQD0APR3lSAH1MVUGFTguUatAJQAdevunEANCW94UitJYOvDI6Ng4Tk6C0DhciHiwIuKSWDJo-EA&v=8.5&f=html)

*CircleCI*

Previous implementation failing. See `06-cloudflare.sh` on [post-deploy logs](https://app.circleci.com/pipelines/github/greenpeace/planet4-finland/4368/workflows/cbac023e-3e5d-47fd-ad52-aa4c6b6d6bd4/jobs/9920/parallel-runs/0/steps/0-107). Notice the Zone id missing from the API url (`/zone//purge_cache`).

<img width="729" height="140" alt="image" src="https://github.com/user-attachments/assets/5a34fcda-2cdc-4931-9d2b-fba2c7ec3805" />
<br><br>


Current one, check [logs](https://app.circleci.com/pipelines/github/greenpeace/planet4-finland/4369/workflows/b2055ae3-3ea5-4b62-b8f0-9324515c7cff/jobs/9922/parallel-runs/0/steps/0-107). Cache purging works.
