### PR TITLE
PLANET-8263 Allow secure Websockets connections

### DIFF
--- a/src/HttpHeaders.php
+++ b/src/HttpHeaders.php
@@ -41,6 +41,7 @@ class HttpHeaders
 
         $directives = [
             "default-src 'self' https: 'unsafe-inline'",
+            "connect-src 'self' https: wss:",
             "img-src 'self' https: data:",
             "frame-ancestors " . implode(' ', $allowed_frame_ancestors),
         ];


### PR DESCRIPTION
### Summary

Adds `connect-src` to CSP headers to allow (secure) Websockets connections.

This was allowed before the recent change to `default-src`, but adding an explicit reference to `https:` is currently blocking those connections.

---

Ref: https://greenpeace-planet4.atlassian.net/browse/PLANET-8263

#### Testing

On the CSP headers you should be able to see this new directive

<img width="394" height="121" alt="Screenshot 2026-08-17 at 13 01 10" src="https://github.com/user-attachments/assets/2b25d00f-667f-4109-bca2-1468bcddc95b" />
