### PR TITLE
Fix media-replacer test

### DIFF
--- a/assets/src/blocks/Spreadsheet/spreadsheet.js
+++ b/assets/src/blocks/Spreadsheet/spreadsheet.js
@@ -15,6 +15,33 @@ const placeholderData = {
   ],
 };
 
+/**
+ * Normalizes the spreadsheet REST response into a consistent { header, rows }
+ * shape, since the endpoint sometimes returns it flat and sometimes nested
+ * under a `data` key.
+ *
+ * @param {Object} rawData - Raw response from get-spreadsheet-data.
+ * @return {{header: Array, rows: Array}|null} Normalized data, or null if unusable.
+ */
+function normalizeSpreadsheetData(rawData) {
+  if (!rawData) {
+    return null;
+  }
+
+  const source = Array.isArray(rawData?.data?.header) || Array.isArray(rawData?.data?.rows) ?
+    rawData.data :
+    rawData;
+
+  if (!Array.isArray(source.header) || !Array.isArray(source.rows)) {
+    return null;
+  }
+
+  return {
+    header: source.header,
+    rows: source.rows,
+  };
+}
+
 export const SpreadsheetFrontend = ({
   url,
   color,
@@ -67,7 +94,7 @@ export const SpreadsheetFrontend = ({
           await apiFetch({path: addQueryArgs('planet4/v1/get-spreadsheet-data', args)});
 
         setLoading(false);
-        setSpreadsheetData(newSpreadsheetData);
+        setSpreadsheetData(normalizeSpreadsheetData(newSpreadsheetData));
       } else {
         if (setInvalidSheetId) {
           setInvalidSheetId(true);

--- a/tests/e2e/media-replacer.spec.js
+++ b/tests/e2e/media-replacer.spec.js
@@ -140,7 +140,9 @@ test('Replace Media file (PDF) in WordPress', async ({page, admin, requestUtils}
     // --- Replace the media file ---
     await replaceMediaFile(page, newFile);
 
-    const successNotice = page.locator('.notice-success');
+    const successNotice = page.locator('.notice-success').filter({
+      hasText: 'These files were successfully replaced:',
+    });
     await expect(successNotice).toContainText('These files were successfully replaced:', {timeout: 20000});
 
     // --- Download the new file for hashing ---


### PR DESCRIPTION
### Summary

On test instances, the media replacer test gets two success messages when a file is replaced, one for the replacer and the other for cache, this fix ensures the right message is picked up so the tests don't fail. 

Also the data returned by the spreadsheet block in my testing is not consistent, it some times returns `data: {header, rows} `and other times `{header, rows}`, so this fix normalizes the data to `{header, rows}` so it is more consistent.

<!-- Please provide a brief summary of the change introduced in this Pull Request. -->

---

<!-- Please add a reference link to the ticket, if one exists. -->

### Testing
All tests should pass now with no issues.
<!-- Please add the steps required to test the changes in this Pull Request. -->

