### PR TITLE
PLANET-8252 Fix blocks_report memory exhaustion and cache the report

### DIFF
--- a/src/BlockReportSearch/Block/BlockUsage.php
+++ b/src/BlockReportSearch/Block/BlockUsage.php
@@ -52,7 +52,7 @@ class BlockUsage
         if ($this->posts_ids === false) {
             $this->posts_ids = $this->search->get_posts($params);
             // Cache the data for next 24 hrs.
-            wp_cache_set('block_report_post_ids', $this->posts_ids, 'p4-cache-blocks-report', 86400);
+            wp_cache_set('block_report_post_ids', $this->posts_ids, 'p4-cache-blocks-report', DAY_IN_SECONDS);
         }
 
         return $this->get_filtered_blocks($this->posts_ids, $params);
@@ -64,7 +64,7 @@ class BlockUsage
      */
     private function get_filtered_blocks(array $posts_ids, Parameters $params): array
     {
-        $this->fetch_blocks($posts_ids, $params);
+        $this->fetch_blocks($posts_ids);
         $this->filter_blocks($params);
         $this->sort_blocks($params->order());
 
@@ -86,31 +86,130 @@ class BlockUsage
     }
 
     /**
-     * @param int[]      $posts_ids Posts IDs.
-     * @param Parameters $params Query parameters.
+     * Stream matching posts in memory-safe batches.
+     *
+     * Only the columns the parser needs are selected, and WP_Query's meta/term cache
+     * priming is bypassed, so peak memory stays flat regardless of how many posts match.
+     *
+     * @param int[] $posts_ids Posts IDs.
+     * @return \Generator<\WP_Post>
      */
-    private function fetch_blocks(array $posts_ids, Parameters $params): void
+    private function stream_posts(array $posts_ids): \Generator
     {
-        if (count($posts_ids) > 3500) {
-            // Limit the number of posts for the get_posts() function to 3.5k to reduce memory load.
-            $posts_ids = array_slice($posts_ids, 0, 3500);
+        global $wpdb;
+
+        foreach (array_chunk($posts_ids, 200) as $batch) {
+            $placeholders = implode(', ', array_fill(0, count($batch), '%d'));
+
+            // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+            $rows = $wpdb->get_results(
+                $wpdb->prepare(
+                    "SELECT ID, post_title, post_status, post_type, post_date, post_modified, guid, post_content
+                    FROM {$wpdb->posts}
+                    WHERE ID IN ($placeholders)",
+                    $batch
+                )
+            );
+
+            foreach ($rows as $row) {
+                yield new \WP_Post($row);
+            }
+
+            unset($rows);
+        }
+    }
+
+    /**
+     * @param int[]      $posts_ids Posts IDs.
+     */
+    private function fetch_blocks(array $posts_ids): void
+    {
+        $this->posts = [];
+        $this->blocks = [];
+
+        if (empty($posts_ids)) {
+            return;
         }
 
-        $posts_args = [
-            'include' => $posts_ids,
-            'orderby' => empty($params->order()) ? null : array_fill_keys($params->order(), 'ASC'),
-            'post_status' => $params->post_status(),
-            'post_type' => $params->post_type(),
-        ];
+        foreach ($this->stream_posts($posts_ids) as $post) {
+            foreach ($this->parse_post($post) as $block) {
+                $this->blocks[] = $block;
+            }
+        }
+    }
 
-        $this->posts = get_posts($posts_args) ?? [];
+    /**
+     * Count blocks by type and style without materialising every block.
+     *
+     * Streams matching posts and aggregates counts on the fly, so memory usage is
+     * bounded by the number of distinct block types rather than the total number of
+     * blocks on the site. Query-loop variations (Posts List / Actions List) are also
+     * counted under their block namespace, mirroring the report UI.
+     *
+     * @param Parameters $params Query parameters.
+     * @return array<string, array<string, mixed>>
+     */
+    public function count_blocks(Parameters $params): array
+    {
+        $posts_ids = $this->search->get_posts($params);
 
-        $block_listblock_list = [];
-        foreach ($this->posts as $post) {
-            $block_listblock_list = array_merge($block_listblock_list, $this->parse_post($post));
+        if (empty($posts_ids)) {
+            return [];
         }
 
-        $this->blocks = $block_listblock_list;
+        $blocks = [];
+
+        foreach ($this->stream_posts($posts_ids) as $post) {
+            foreach ($this->parse_post($post) as $block) {
+                $type = $block['block_type'];
+                $styles = empty($block['block_styles']) ? [ 'n/a' ] : $block['block_styles'];
+
+                $this->add_block_count($blocks, $type, $styles);
+
+                //phpcs:ignore SlevomatCodingStandard.ControlStructures.EarlyExit.EarlyExitNotUsed
+                if (
+                    $type === 'core/query'
+                    && isset($block['block_attrs']['namespace'])
+                    && in_array(
+                        $block['block_attrs']['namespace'],
+                        [ self::POSTS_LIST_NAME, self::ACTIONS_LIST_NAME ],
+                        true
+                    )
+                ) {
+                    $this->add_block_count($blocks, $block['block_attrs']['namespace'], $styles);
+                }
+            }
+        }
+
+        ksort($blocks);
+        foreach ($blocks as &$data) {
+            ksort($data['styles']);
+        }
+        unset($data);
+
+        return $blocks;
+    }
+
+    /**
+     * Increment the running count for a block type/style bucket.
+     *
+     * @param array    $blocks Running totals, passed by reference.
+     * @param string   $type   Block type.
+     * @param string[] $styles Block styles.
+     */
+    private function add_block_count(array &$blocks, string $type, array $styles): void
+    {
+        if (! isset($blocks[$type])) {
+            $blocks[$type] = [ 'total' => 0, 'styles' => [] ];
+        }
+
+        foreach ($styles as $style) {
+            if (! isset($blocks[$type]['styles'][$style])) {
+                $blocks[$type]['styles'][$style] = 0;
+            }
+            $blocks[$type]['styles'][$style]++;
+            $blocks[$type]['total']++;
+        }
     }
 
     /**

--- a/src/BlockReportSearch/Block/BlockUsageApi.php
+++ b/src/BlockReportSearch/Block/BlockUsageApi.php
@@ -19,9 +19,6 @@ class BlockUsageApi
 
     private Parameters $params;
 
-    // phpcs:ignore SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingAnyTypeHint
-    private $items;
-
     /**
      * Constructor
      */
@@ -41,86 +38,12 @@ class BlockUsageApi
     }
 
     /**
-     * Count blocks by type and style
+     * Count blocks by type and style.
      *
      * If style is not specified, an empty key 'n/a' is used.
      */
     public function get_count(): array
     {
-        if (null === $this->items) {
-            $this->fetch_items();
-        }
-
-        $posts_list_block = $this->usage->filter_query_blocks($this->items, $this->usage::POSTS_LIST_NAME);
-        $actions_list_block = $this->usage->filter_query_blocks($this->items, $this->usage::ACTIONS_LIST_NAME);
-
-        // Merge updated Posts/Actions List array with items array for API
-        $query_blocks = [
-            'posts_list_block' => $posts_list_block,
-            'actions_list_block' => $actions_list_block,
-        ];
-
-        foreach ($query_blocks as $block) {
-            if (empty($block)) {
-                continue;
-            }
-
-            $updated_block = $this->update_query_blocks($block);
-            $this->items = array_merge($this->items, $updated_block);
-        }
-
-        $types = array_unique(
-            array_column($this->items, 'block_type')
-        );
-        $blocks = array_fill_keys(
-            $types,
-            [
-                'total' => 0,
-                'styles' => [],
-            ]
-        );
-        ksort($blocks);
-
-        foreach ($this->items as $item) {
-            $styles = empty($item['block_styles']) ? [ 'n/a' ] : $item['block_styles'];
-            foreach ($styles as $style) {
-                $type = $item['block_type'];
-                if (! isset($blocks[$type]['styles'][$style])) {
-                    $blocks[$type]['styles'][$style] = 0;
-                }
-                $blocks[$type]['styles'][$style]++;
-                $blocks[$type]['total']++;
-            }
-            ksort($blocks[$type]['styles']);
-        }
-
-        return $blocks;
-    }
-
-    /**
-     * Fetch parsed blocks
-     */
-    private function fetch_items(): void
-    {
-        $this->items = $this->usage->get_blocks($this->params);
-    }
-
-    /**
-     * Function to update Query block block_type value
-     * With value of Posts/Actions list namespace
-     *
-     * @param array $blocks     array of blocks.
-     */
-    private function update_query_blocks(array $blocks): array
-    {
-        $updated = [];
-
-        foreach ($blocks as $key => $item) {
-            if (isset($item['block_attrs']['namespace'])) {
-                $item['block_type'] = $item['block_attrs']['namespace'];
-            }
-            $updated[$key] = $item;
-        }
-        return $updated;
+        return $this->usage->count_blocks($this->params);
     }
 }

--- a/src/Controllers/BlocksUsageController.php
+++ b/src/Controllers/BlocksUsageController.php
@@ -25,6 +25,11 @@ use P4\MasterTheme\View\View;
 class BlocksUsageController extends Controller
 {
     /**
+     * Cache key for the assembled blocks report.
+     */
+    private const REPORT_CACHE_KEY = 'p4_blocks_report_v3';
+
+    /**
      * Blocks_Usage_Controller constructor.
      *
      * @param View $view The view object.
@@ -41,6 +46,10 @@ class BlocksUsageController extends Controller
     private function hooks(): void
     {
         add_action('rest_api_init', [ $this, 'plugin_blocks_report_register_rest_route' ]);
+        add_action('save_post', [ $this, 'flush_report_cache_on_save' ], 10, 2);
+        add_action('deleted_post', [ $this, 'flush_report_cache' ]);
+        add_action('trashed_post', [ $this, 'flush_report_cache' ]);
+        add_action('untrashed_post', [ $this, 'flush_report_cache' ]);
         BlockUsageTable::set_hooks();
         PatternUsageTable::set_hooks();
     }
@@ -63,19 +72,32 @@ class BlocksUsageController extends Controller
 
     /**
      * Generates blocks/pages report.
+     *
+     * The assembled report is cached in a transient and invalidated whenever a
+     * post is created, updated, trashed or deleted, so the expensive scan only
+     * runs when the underlying content actually changes.
      */
     public function plugin_blocks_report_rest_api(): ?array
     {
-        global $wpdb;
-
-        $use_cache = ! current_user_can('manage_options');
-        $cache_key = 'plugin_blocks/v3/plugin_blocks_report';
-        if ($use_cache) {
-            $report = wp_cache_get($cache_key, 'api', false, $found);
-            if ($found) {
-                return $report;
-            }
+        $report = get_transient(self::REPORT_CACHE_KEY);
+        if (is_array($report)) {
+            return $report;
         }
+
+        $report = $this->generate_blocks_report();
+
+        // Cache the report data for next 24 hrs. content changes flush this proactively.
+        set_transient(self::REPORT_CACHE_KEY, $report, DAY_IN_SECONDS);
+
+        return $report;
+    }
+
+    /**
+     * Build the blocks/pages report from scratch (uncached).
+     */
+    private function generate_blocks_report(): array
+    {
+        global $wpdb;
 
         $types = \get_post_types(
             [
@@ -105,14 +127,40 @@ class BlocksUsageController extends Controller
         // Group results.
         $block_api = new BlockUsageApi();
         $pattern_api = new PatternUsageApi();
-        $report = [
+
+        return [
             'block_types' => $block_api->get_count(),
             'block_patterns' => $pattern_api->get_count(),
             'post_types' => $post_types,
         ];
-        wp_cache_set($cache_key, $report, 'api', 60 * 5);
+    }
 
-        return $report;
+    /**
+     * Flush the cached report when a post is created or updated.
+     *
+     * @param int      $post_id Post ID.
+     * @param \WP_Post $post    Post object.
+     */
+    public function flush_report_cache_on_save(int $post_id, \WP_Post $post): void
+    {
+        if (
+            wp_is_post_revision($post_id)
+            || wp_is_post_autosave($post_id)
+            || 'auto-draft' === $post->post_status
+        ) {
+            return;
+        }
+
+        $this->flush_report_cache();
+    }
+
+    /**
+     * Delete the cached blocks report.
+     */
+    public function flush_report_cache(): void
+    {
+        delete_transient(self::REPORT_CACHE_KEY);
+        wp_cache_delete('block_report_post_ids', 'p4-cache-blocks-report');
     }
 
     /**


### PR DESCRIPTION
This also fixes the empty blocks array issue in Report rest API endpoint

### Summary

The `plugin_blocks/v3/plugin_blocks_report` endpoint returned an empty `block_types` on large sites and fatally exhausted PHP's memory limit. It loaded every published post via `get_posts()` at once and materialised every parsed block before counting, which does not scale to sites with tens of thousands of posts.

- BlockUsage: `add stream_posts()`, a generator that pulls posts in batches of 200 straight from $wpdb, selecting only the columns the parser needs  and hydrating `WP_Post` by hand, so peak memory stays flat regardless of  post count.
- BlockUsage: add `count_blocks()` to aggregate block type/style counts while streaming, bounding memory by the number of distinct block types instead of the total number of blocks. Remove the 3,500-post [cap](https://github.com/greenpeace/planet4-master-theme/pull/2823/changes#diff-16cd2bffaedade07766d663b682a4da2aeea3cc6d2710c7460ac305c205f04e6R94).
- BlockUsage: `fetch_blocks()` now streams via `stream_posts()` and no longer retains full post objects.
- BlockUsageApi: `get_count()` delegates to `BlockUsage::count_blocks();` drop the unused items/fetch_items/update_query_blocks functions.
- BlocksUsageController: cache the assembled report in a transient and invalidate it on post save/trash/untrash/delete, replacing the non-persistent wp_cache layer so the scan only runs when content changes.

---

<!-- Please add a reference link to the ticket, if one exists. -->
Ref: https://greenpeace-planet4.atlassian.net/browse/PLANET-8252

### Testing

For local testing, please check the Block Report REST API endpoint:
http://www.planet4.test/wp-json/plugin_blocks/v3/plugin_blocks_report

The issue reported in the [JIRA ticket](https://greenpeace-planet4.atlassian.net/browse/PLANET-8252) only occurs on larger sites with more than 7,000 posts.

The issue is still reproducible on the GPI [prod](https://www.greenpeace.org/international/wp-json/plugin_blocks/v3/plugin_blocks_report) and [staging](https://www-stage.greenpeace.org/international/wp-json/plugin_blocks/v3/plugin_blocks_report) sites, where the `block_types` array is empty.

For testing purposes, I have pinned this branch to the GPI [dev](https://www-dev.greenpeace.org/international/wp-json/plugin_blocks/v3/plugin_blocks_report) site.

This PR also includes changes to the [Block Usage Report](http://www.planet4.test/wp-admin/admin.php?page=plugin_blocks_report) page in the WordPress admin. Please check that all backend Block Usage functionality and the Block Report REST API endpoints are working as expected.

The main purpose of this PR is to significantly optimize the memory intensive operations used by the Block Usage functionality.
