### PR TITLE
PLANET-8268 Fix navigation menu z-index layering

### DIFF
--- a/assets/src/blocks/SecondaryNavigation/SecondaryNavigationFrontend.js
+++ b/assets/src/blocks/SecondaryNavigation/SecondaryNavigationFrontend.js
@@ -19,16 +19,15 @@ export const SecondaryNavigationFrontend = ({levels}) => {
   const toggleRef = useRef(null);
   const visibleRef = useRef([]);
   const isRTL = document.dir === 'rtl';
-  const pageHeader = document.querySelector('.is-pattern-p4-page-header');
 
   useEffect(() => {
     const block = document.querySelector('div[data-render="planet4-blocks/secondary-navigation"]');
 
-    if (!pageHeader || !block) {return;}
+    if (!block) {return;}
 
     document.body.classList.add('secondary-nav-class');
     document.body.classList.add('overflow-visible');
-  }, [pageHeader]);
+  }, []);
 
   // Check runs to confirm if we are on mobile
   useEffect(() => {
@@ -41,7 +40,6 @@ export const SecondaryNavigationFrontend = ({levels}) => {
   // This runs to auto update the URL and active header class for the Secondary Navigation
   // Works on scroll
   useEffect(() => {
-    if (!pageHeader) {return;}
     const observerOptions = {
       root: null,
       rootMargin: '0px',
@@ -102,7 +100,7 @@ export const SecondaryNavigationFrontend = ({levels}) => {
     setTimeout(() => hasLoaded.current = true, 500);
 
     return () => observer.disconnect();
-  }, [activeLink, headings, pageHeader]);
+  }, [activeLink, headings]);
 
   // On mobile we update the navbar with the current active element
   // Does not run if there isn't one

--- a/assets/src/scss/base/_body.scss
+++ b/assets/src/scss/base/_body.scss
@@ -1,13 +1,13 @@
 html,
 body {
-  overflow-x: hidden;
+  overflow-x: clip;
   scroll-behavior: smooth;
   scroll-padding-top: 4rem;
 }
 
 body {
   position: relative;
-  overflow-y: hidden;
+  overflow-y: visible;
 
   &.search {
     font-family: var(--font-family-heading);

--- a/assets/src/scss/layout/_navbar.scss
+++ b/assets/src/scss/layout/_navbar.scss
@@ -22,7 +22,7 @@
   position: fixed;
   top: 0;
   width: 100%;
-  z-index: 99;
+  z-index: 1000;
 
   .admin-bar & {
     top: 46px;


### PR DESCRIPTION
### Summary

**Current Behavior:** Main navigation items are currently being hidden behind the secondary navigation while the secondary nav is visible.  To replicate this you just need to hover on any item on the main nav that has a submenu while the secondary nav is visible.

**Expected Behavior:** The intended UX is for main navigation elements to remain on top. 

---

<!-- Please add a reference link to the ticket, if one exists. -->
Ref. https://greenpeace-planet4.atlassian.net/browse/PLANET-8268

### Testing

- Please check the main navigation menu's submenu remain top of secondary menu.
[eg.](https://www-dev.greenpeace.org/test-nix/test-navigation-menu/)

-------------
## Amendment to PR

This PR also includes a [fix](https://github.com/greenpeace/planet4-master-theme/pull/3075/changes/a432eab7dc8aabf02503d84d95e770d7686ea1d6) for an issue where the secondary navigation menu was not sticking to the header when scrolling the page.

Please test this use case as well.
