### PR TITLE
PLANET-8238 Use contextual accessible names for mobile submenus

### DIFF
--- a/templates/burger-menu-items.twig
+++ b/templates/burger-menu-items.twig
@@ -41,7 +41,7 @@
         <nav
             id="menu-{{ targetId }}"
             class="nav-subitems accordion-collapse collapse"
-            aria-label="Mobile submenu {{ key }}"
+            aria-label="{{ __( item.title ~ ' submenu', 'planet4-master-theme' ) }}"
             data-bs-parent="#accordion-list"
         >
             <ul>

--- a/templates/navigation-submenu.twig
+++ b/templates/navigation-submenu.twig
@@ -1,4 +1,4 @@
-<nav id="submenu-{{ key }}" class='nav-submenu' aria-label="Sub menu {{ key }}" hidden>
+<nav id="submenu-{{ key }}" class='nav-submenu' aria-label="{{ __( menu.title ~ ' submenu', 'planet4-master-theme' ) }}" hidden>
     <ul>
     {% for key,item in menu.children %}
         <li class="nav-item {{ item.class }} {{ item == item.current ? 'active' : '' }}">


### PR DESCRIPTION
### Summary

It was noted that the mobile submenu containers are currently using a generic, sequential naming convention that is exposed to screen readers (e.g., "mobile submenu_0_nav", "mobile submenu_1_nav". We need to replace these generic labels with descriptive ones based on their parent topics (e.g., "Issues we work on submenu", "Get involved submenu").

**Requirements**

- Update the accessible name of each submenu container to a clear label that matches its parent navigation item(e.g., "Issues we work on submenu", "Get involved submenu").

---

<!-- Please add a reference link to the ticket, if one exists. -->
Ref. https://greenpeace-planet4.atlassian.net/browse/PLANET-8238

### Testing

- Please check the submenu on mobile view, it should have accessible name of each submenu container.

 [example](https://www-dev.greenpeace.org/test-janus)

--------
### Amendment to PR

- This PR also includes a [fix](https://github.com/greenpeace/planet4-master-theme/pull/3078/changes/ef0c8230a9706651898e527fee0dcd49b17d16cf) for desktop submenus. It was discussed in JIRA ticket UAT comments.

Please test for desktop submenus as well.