### PR TITLE
PLANET-8249 Add hidden H2 to featured articles

### DIFF
--- a/templates/featured-posts.twig
+++ b/templates/featured-posts.twig
@@ -1,5 +1,6 @@
 {% if featured_posts|length == sticky_posts_to_show %}
 <section id="featured-posts">
+    <h2 tabindex="0" class="visually-hidden">{{__( 'Featured articles', 'planet4-master-theme' )}}</h2>
     <div class="container">
         <!-- wp:query {"query":{"inherit":false,"postIn":{{ featured_posts|json_encode }}}} -->
         <div id="featured-posts-content" class="wp-block-query wp-block-query--list">


### PR DESCRIPTION
### Summary

Ref: [PLANET-8249](https://greenpeace-planet4.atlassian.net/browse/PLANET-8249)

**Requirements**
- Add a visually hidden `<h2>` element before the “Featured Articles” block.
- The text of the `<h2>` should be "Featured articles".

### Testing

On local:
1. Run `npx wp-env run cli wp timber clear_cache`.
2. Make sure you have 4 sticky Posts.
3. Go to the News & Stories page, see that you have the "Featured Articles" block but you don't see the new heading.
4. Activate your screen reader.
5. Navigate the page with tabs and make sure that the hidden heading is announced.

Alternatively you can check out the tavros instance [News & Stories page](https://www-dev.greenpeace.org/test-tavros/news-stories/), which will be used for UAT.

[PLANET-8249]: https://greenpeace-planet4.atlassian.net/browse/PLANET-8249?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ