### PR TITLE
PLANET-8264 Add sidebar options for customizing meta tags

### DIFF
--- a/assets/src/block-editor/Sidebar/SearchEngineOptimizationsSidebar.js
+++ b/assets/src/block-editor/Sidebar/SearchEngineOptimizationsSidebar.js
@@ -3,20 +3,46 @@ import {URLInput} from '../URLInput/URLInput';
 const {PluginDocumentSettingPanel} = wp.editor;
 const {useDispatch, useSelect} = wp.data;
 const {__} = wp.i18n;
+const {TextControl, TextareaControl, ExternalLink} = wp.components;
+const {createInterpolateElement} = wp.element;
 
 const CANONICAL_URL = 'p4_seo_canonical_url';
+const META_TITLE = 'p4_seo_meta_title';
+const META_DESCRIPTION = 'p4_seo_meta_description';
 
 export const SearchEngineOptimizationsSidebar = {
   getId: () => 'planet4-seo-sidebar',
   render: () => {
     const meta = useSelect(select => select('core/editor').getEditedPostAttribute('meta'), []);
-    const {editPost} = useDispatch('core/editor', [meta[CANONICAL_URL]]);
+    const {editPost} = useDispatch('core/editor');
 
     return (
       <PluginDocumentSettingPanel
         name="planet4-search-engine-optimizations"
         title={__('Search Engine Optimizations', 'planet4-master-theme-backend')}
       >
+        <p className="components-base-control__help">
+          {createInterpolateElement(
+            __('Check optimal length at <a>SERP Snippet Generator</a>.', 'planet4-master-theme-backend'),
+            {
+              a: (
+                <ExternalLink href="https://app.sistrix.com/en/serp-snippet-generator" />
+              ),
+            }
+          )}
+        </p>
+        <TextControl
+          label={__('Meta Title', 'planet4-master-theme-backend')}
+          value={meta[META_TITLE] || ''}
+          onChange={value => editPost({meta: {[META_TITLE]: value}})}
+          help={__('Leave empty to use the Open Graph Title (if set) or the Post Title.', 'planet4-master-theme-backend')}
+        />
+        <TextareaControl
+          label={__('Meta Description', 'planet4-master-theme-backend')}
+          value={meta[META_DESCRIPTION] || ''}
+          onChange={value => editPost({meta: {[META_DESCRIPTION]: value}})}
+          help={__('Leave empty to use Open Graph Description (if set) or the Post Excerpt.', 'planet4-master-theme-backend')}
+        />
         <URLInput
           label={__('Canonical link', 'planet4-master-theme-backend')}
           value={meta[CANONICAL_URL]}

--- a/assets/src/block-editor/Sidebar/SearchEngineOptimizationsSidebar.js
+++ b/assets/src/block-editor/Sidebar/SearchEngineOptimizationsSidebar.js
@@ -21,34 +21,36 @@ export const SearchEngineOptimizationsSidebar = {
         name="planet4-search-engine-optimizations"
         title={__('Search Engine Optimizations', 'planet4-master-theme-backend')}
       >
-        <p className="components-base-control__help">
-          {createInterpolateElement(
-            __('Check optimal length at <a>SERP Snippet Generator</a>.', 'planet4-master-theme-backend'),
-            {
-              a: (
-                <ExternalLink href="https://app.sistrix.com/en/serp-snippet-generator" />
-              ),
-            }
-          )}
-        </p>
-        <TextControl
-          label={__('Meta Title', 'planet4-master-theme-backend')}
-          value={meta[META_TITLE] || ''}
-          onChange={value => editPost({meta: {[META_TITLE]: value}})}
-          help={__('Leave empty to use the Open Graph Title (if set) or the Post Title.', 'planet4-master-theme-backend')}
-        />
-        <TextareaControl
-          label={__('Meta Description', 'planet4-master-theme-backend')}
-          value={meta[META_DESCRIPTION] || ''}
-          onChange={value => editPost({meta: {[META_DESCRIPTION]: value}})}
-          help={__('Leave empty to use Open Graph Description (if set) or the Post Excerpt.', 'planet4-master-theme-backend')}
-        />
-        <URLInput
-          label={__('Canonical link', 'planet4-master-theme-backend')}
-          value={meta[CANONICAL_URL]}
-          onChange={value => editPost({meta: {[CANONICAL_URL]: value}})}
-          help={__('If emtpy a self-reference canonical link will be used', 'planet4-master-theme-backend')}
-        />
+        <div className="planet4-seo-sidebar">
+          <p className="components-base-control__help">
+            {createInterpolateElement(
+              __('Check optimal length at <a>SERP Snippet Generator</a>.', 'planet4-master-theme-backend'),
+              {
+                a: (
+                  <ExternalLink href="https://app.sistrix.com/en/serp-snippet-generator" />
+                ),
+              }
+            )}
+          </p>
+          <TextControl
+            label={__('Meta Title', 'planet4-master-theme-backend')}
+            value={meta[META_TITLE] || ''}
+            onChange={value => editPost({meta: {[META_TITLE]: value}})}
+            help={__('Leave empty to use the Open Graph Title (if set) or the Post Title.', 'planet4-master-theme-backend')}
+          />
+          <TextareaControl
+            label={__('Meta Description', 'planet4-master-theme-backend')}
+            value={meta[META_DESCRIPTION] || ''}
+            onChange={value => editPost({meta: {[META_DESCRIPTION]: value}})}
+            help={__('Leave empty to use Open Graph Description (if set) or the Post Excerpt.', 'planet4-master-theme-backend')}
+          />
+          <URLInput
+            label={__('Canonical link', 'planet4-master-theme-backend')}
+            value={meta[CANONICAL_URL]}
+            onChange={value => editPost({meta: {[CANONICAL_URL]: value}})}
+            help={__('If emtpy a self-reference canonical link will be used', 'planet4-master-theme-backend')}
+          />
+        </div>
       </PluginDocumentSettingPanel>
     );
   },

--- a/assets/src/scss/editorStyle.scss
+++ b/assets/src/scss/editorStyle.scss
@@ -93,3 +93,8 @@
     margin-left: 115px;
   }
 }
+
+// Search Engine Optimizations sidebar: even vertical spacing between fields.
+.planet4-seo-sidebar > * + * {
+  margin-top: $sp-2;
+}

--- a/src/Context.php
+++ b/src/Context.php
@@ -52,6 +52,8 @@ class Context
         $context['og_title'] = $post->get_og_title();
         $context['og_description'] = $post->get_og_description();
         $context['og_image_data'] = $post->get_og_image();
+        $context['seo_meta_title'] = $post->get_meta_title();
+        $context['seo_meta_description'] = $post->get_meta_description();
     }
 
     /**

--- a/src/CustomPostType/ActionPage.php
+++ b/src/CustomPostType/ActionPage.php
@@ -24,6 +24,8 @@ class ActionPage
         'p4_og_image',
         'p4_og_image_id',
         'p4_seo_canonical_url',
+        'p4_seo_meta_title',
+        'p4_seo_meta_description',
         'p4_campaign_name',
         'p4_local_project',
         'p4_basket_name',

--- a/src/CustomPostType/PostCampaign.php
+++ b/src/CustomPostType/PostCampaign.php
@@ -34,6 +34,8 @@ class PostCampaign
         'p4_og_image',
         'p4_og_image_id',
         'p4-seo-canonical-url',
+        'p4_seo_meta_title',
+        'p4_seo_meta_description',
     ];
 
     /**

--- a/src/PageMeta.php
+++ b/src/PageMeta.php
@@ -24,6 +24,8 @@ class PageMeta
         'p4_og_image',
         'p4_og_image_id',
         'p4_seo_canonical_url',
+        'p4_seo_meta_title',
+        'p4_seo_meta_description',
         'p4_campaign_name',
         'p4_local_project',
         'p4_basket_name',

--- a/src/Post.php
+++ b/src/Post.php
@@ -282,6 +282,24 @@ class Post extends \Timber\Post
     }
 
     /**
+     * Get the meta title.
+     *
+     */
+    public function get_meta_title(): string
+    {
+        return $this->post_meta['p4_seo_meta_title'][0] ?? '';
+    }
+
+    /**
+     * Get the meta description.
+     *
+     */
+    public function get_meta_description(): string
+    {
+        return $this->post_meta['p4_seo_meta_description'][0] ?? '';
+    }
+
+    /**
      * Get image data for open graph image meta.
      *
      */

--- a/src/PostMeta.php
+++ b/src/PostMeta.php
@@ -19,6 +19,8 @@ class PostMeta
         'p4_og_image',
         'p4_og_image_id',
         'p4_seo_canonical_url',
+        'p4_seo_meta_title',
+        'p4_seo_meta_description',
         'p4_campaign_name',
         'p4_local_project',
         'p4_basket_name',

--- a/templates/blocks/meta_fields.twig
+++ b/templates/blocks/meta_fields.twig
@@ -36,6 +36,10 @@
 
     {% if seo_meta_title %}
         {% set meta_title = seo_meta_title|decode_entities~' - '~site.name %}
+    {% elseif og_title %}
+        {% set meta_title = og_title|decode_entities~' - '~site.name %}
+    {% elseif wp_title %}
+        {% set meta_title = wp_title|decode_entities~' - '~site.name %}
     {% else %}
         {% set meta_title = site.name %}
     {% endif %}

--- a/templates/blocks/meta_fields.twig
+++ b/templates/blocks/meta_fields.twig
@@ -2,7 +2,11 @@
 {% set is_news_page = page_category == 'News' %}
 
 {% if (post and (1 != fn('post_password_required', post))) or is_listing_page or is_news_page %}
-    {% if (author.description is defined and author.description) %}
+    {% if (seo_meta_description) %}
+        {% set meta_description = seo_meta_description|striptags %}
+    {% elseif (og_description) %}
+        {% set meta_description = og_description|striptags %}
+    {% elseif (author.description is defined and author.description) %}
         {% set meta_description = author.description|striptags %}
     {% elseif (post.post_excerpt is defined and post.post_excerpt) %}
         {% set meta_description = post.post_excerpt|striptags %}
@@ -30,7 +34,13 @@
         {% set title = site.name %}
     {% endif %}
 
-    <meta name="title" content="{{ title }}"/>
+    {% if seo_meta_title %}
+        {% set meta_title = seo_meta_title|decode_entities~' - '~site.name %}
+    {% else %}
+        {% set meta_title = site.name %}
+    {% endif %}
+
+    <meta name="title" content="{{ meta_title }}"/>
     <meta property="og:title" content="{{ title }}" />
     <meta property="og:url" content="{{ current_url }}" />
     {% if (og_type) %}

--- a/templates/blocks/title.twig
+++ b/templates/blocks/title.twig
@@ -12,6 +12,10 @@
     {% elseif search_query and page_category == 'Search Page' %}
         {{ __('%d search results found for %s', 'planet4-master-theme') | format(found_posts, search_query) }}
 
+    {# If the current page/post has a custom meta (SEO) title: #}
+    {% elseif seo_meta_title %}
+        {{ seo_meta_title|e('esc_html')|raw }} - {{ site.name }}
+
     {# If the current page/post contains an OG title: #}
     {% elseif og_title %}
         {{ og_title|e('esc_html')|raw }} - {{ site.name }}


### PR DESCRIPTION
### Summary

Editors should be able to override the meta tags (title and description) independently. Currently, the Open Graph/Social fields define the meta title and the Excerpt defines the meta description.

The meta description serves a different purpose from Open Graph standards. It is intended for search engines, is typically around 120–160 characters, and should be written to encourage users to click on the page in search results, not as a summary of the article.

### Requirements

- Add two new options in the sidebar, inside the Search Engines Optimizations section.
  - One input text field. Title: Meta Title. Help Text: Leave empty to use the Open Graph Title (if set) or the Post Title.
  - One textarea field: Title: Meta Description. Help Text: Leave empty to use Open Graph Description (if set) or the Post Excerpt.
- Add an additional help text above both fields: Check optimal length at [SERP Snippet Generator](https://app.sistrix.com/en/serp-snippet-generator).
- Both fields should be above the Canonical URL option (see screenshot).
- Precedence requirements for meta tags:
  - Meta Title tag: Meta Title > Open Graph Title > Post Title
  - Meta Description tag: Meta Description > Open Graph Description > Post Excerpt

---

<!-- Please add a reference link to the ticket, if one exists. -->
Ref. https://greenpeace-planet4.atlassian.net/browse/PLANET-8264

### Testing
1. Check out this branch on local and rebuild the editor assets(`npm run build`)
2. Edit published Post or Page, open the "Search Engine Optimizations" panel in the sidebar
3. Confirm the panel now shows, in this order - 
    - A help line: "Check optimal length at SERP Snippet Generator
    - Meta Title
    - Meta Description
    - Canonical link

4. Repeat on a Page, an Action and  Campaign, the two new fields should appear on all four post types
5. Enter values in Meta Title and Meta Description, Update, reload the editor, Confirm both values persisted
6. Check Meta Title precedence: Meta Title > OG Title > Post Title
7. Check Meta Description precedence: Meta Description > OG Description > Post Excerpt
