### PR TITLE
PLANET-8261 Add data attributes for timeline block

### DIFF
--- a/assets/src/blocks/Timeline/TimelineEvent.js
+++ b/assets/src/blocks/Timeline/TimelineEvent.js
@@ -94,6 +94,9 @@ export const TimelineEvent = ({event}) => {
           aria-expanded={expanded}
           aria-controls={contentId}
           onClick={() => setExpanded(!expanded)}
+          data-ga-category="Timeline"
+          data-ga-action="Show more"
+          data-ga-label="n/a"
           type="button"
         >
           {expanded ? __('Show less', 'planet4-blocks') : __('Show more', 'planet4-blocks')}

--- a/assets/src/blocks/Timeline/YearsNavigation.js
+++ b/assets/src/blocks/Timeline/YearsNavigation.js
@@ -183,6 +183,9 @@ export const YearsNavigation = ({years, isEditing, timelineId}) => {
               onClick={() => handleClick(year)}
               data-target={`${timelineId}-${year}`}
               className={`${!isEditing && activeYear === `${timelineId}-${year}` ? 'active': ''}`}
+              data-ga-category="Timeline"
+              data-ga-action="Date"
+              data-ga-label="n/a"
             >
               {displayDate}
             </a>


### PR DESCRIPTION
### Summary

In order to track engagement in GA4/Mixpanel on the new Timeline block, we need to add the standard data attributes. This structure should be the same as most other blocks (ex:Post List), with the values of the clickable elements listed below. 

### Requirements
The data attributes should be:
- data-ga-category="Timeline”
- data-ga-action="Date”, “Image”, “Show More” 
- data-ga-label = “n/a”

<!-- Please provide a brief summary of the change introduced in this Pull Request. -->

---

<!-- Please add a reference link to the ticket, if one exists. -->
Ref: https://greenpeace-planet4.atlassian.net/browse/PLANET-8261

### Testing

<!-- Please add the steps required to test the changes in this Pull Request. -->
1. Create a new page and add the timeline block
2. Publish page and inspect the timeline block
3. Data attributes should be present for each clickable element in the block

[Test Page
](https://www-dev.greenpeace.org/test-pandora/test-page/)