### PR TITLE
PLANET-8235 Add a visually hidden H1 to the homepage

### DIFF
--- a/templates/page.twig
+++ b/templates/page.twig
@@ -2,6 +2,11 @@
 
 {% block content %}
     <main class="page-content container {% if hide_page_title or not header_title %}no-page-title{% endif %}" id="content">
+        {% if fn('is_front_page') %}
+            <h1 class="visually-hidden" tabindex="0">
+                {{ __('%s homepage', 'planet4-master-theme')|format(site.name) }}
+            </h1>
+        {% endif %}
         {% if not post.password_required %}
             {% include 'blocks/header.twig' %}
         {% endif %}


### PR DESCRIPTION
### Summary

Ref: [PLANET-8235](https://greenpeace-planet4.atlassian.net/browse/PLANET-8235)

### Testing

On local, you first need to run `npx wp-env run cli wp timber clear_cache`. Then:
1. Check out the site title in the general settings. You can change it for testing purposes.
2. Go to the homepage and make sure that there is now a hidden H1 with said site title. It should be announced by screen readers when tabbing the page.
3. Go to any other page and verify that the H1 is **not** present there.

Of course you can also check the [mars test instance](https://www-dev.greenpeace.org/test-mars) that is used for UAT.

[PLANET-8235]: https://greenpeace-planet4.atlassian.net/browse/PLANET-8235?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ