### PR TITLE
PLANET-8259 Fix dynamic listing page special characters

### DIFF
--- a/assets/src/js/Components/PostItem.js
+++ b/assets/src/js/Components/PostItem.js
@@ -1,3 +1,9 @@
+// Decodes HTML entities in a string.
+function decodeHtmlEntities(value) {
+  const doc = new DOMParser().parseFromString(value, 'text/html');
+  return doc.documentElement.textContent;
+}
+
 /**
  * Renders a single post item within the listing page.
  *
@@ -69,7 +75,7 @@ function PostItem({post}) {
         <header>
           <h4 className="query-list-item-headline wp-block-post-title">
             <a href={post.link} target="_self">
-              { post.title.rendered }
+              {decodeHtmlEntities(post.title.rendered)}
             </a>
           </h4>
         </header>


### PR DESCRIPTION
### Summary
Following up from [PLANET-8181](https://greenpeace-planet4.atlassian.net/browse/PLANET-8181), it was reported that special characters are showing up in Post titles in listing pages.

<!-- Please provide a brief summary of the change introduced in this Pull Request. -->

---

<!-- Please add a reference link to the ticket, if one exists. -->
Ref: https://greenpeace-planet4.atlassian.net/browse/PLANET-8259

### Testing

<!-- Please add the steps required to test the changes in this Pull Request. -->
- Special Characters should no longer show up in Post titles on listing pages.
- Also, using page type in the taxonomy section instead of category as per the original implementation

**NB:**
To test this, have the GPI instance running locally, with this branch.


[PLANET-8181]: https://greenpeace-planet4.atlassian.net/browse/PLANET-8181?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ