### PR TITLE
PLANET-7830 Restrict Quote block to use only Paragraph blocks

### DIFF
--- a/assets/src/block-editor/BlockFilters/index.js
+++ b/assets/src/block-editor/BlockFilters/index.js
@@ -71,7 +71,7 @@ const addGravityFormsBlockFilter = () => addFilter('blocks.registerBlockType', '
   return settings;
 });
 
-// Add more details to Quote block description.
+// Add more details to Quote block description and restrict its inner blocks to Paragraphs only.
 const addQuoteBlockExtraDescription = () => addFilter('blocks.registerBlockType', 'planet4-blocks/filters/quote', (settings, name) => {
   if ('core/quote' !== name) {
     return settings;
@@ -79,6 +79,9 @@ const addQuoteBlockExtraDescription = () => addFilter('blocks.registerBlockType'
 
   const {description} = settings;
   settings.description = `${description}. ${__('Try to keep your Quote short and concise, so that it stands out effectively.', 'planet4-master-theme-backend')}`;
+
+  // Only allow Paragraph blocks inside a Quote.
+  settings.allowedBlocks = ['core/paragraph'];
 
   return settings;
 });


### PR DESCRIPTION
### Summary

Currently, it's possible to add pretty much any block inside a Quote block. It would be nice to be able to limit this to only Paragraphs.


---
Ref: https://greenpeace-planet4.atlassian.net/browse/PLANET-7830

### Testing

- On local env, create a new page/post and add a Quote block.
- Verify that only the Paragraph block can be added as an inner block of the Quote block.
