### PR TITLE
PLANET-8255: add support for Youtube videos in the Timeline block

### DIFF
--- a/assets/src/blocks/Timeline/TimelineEvent.js
+++ b/assets/src/blocks/Timeline/TimelineEvent.js
@@ -1,4 +1,6 @@
 const {useState} = wp.element;
+const useSelect = wp.data?.useSelect;
+const SandBox = wp.components?.SandBox;
 const {__} = wp.i18n;
 
 /**
@@ -73,11 +75,35 @@ const hasVideo = event => event.media && /\.(mp4|webm)(\?.*)?$/i.test(event.medi
  */
 const hasYoutube = event => event.media && /^(https?:\/\/)?(www\.)?(youtube\.com\/(watch\?v=|embed\/|shorts\/)|youtu\.be\/)/i.test(event.media);
 
-export const TimelineEvent = ({event}) => {
+export const TimelineEvent = ({event, isEditing}) => {
   const [expanded, setExpanded] = useState(false);
   const eventDay = event.day ?? `-${event.day}`;
   const eventMonth = event.month ?? `-${event.month}`;
   const contentId = `timeline-content${eventDay}${eventMonth}`;
+
+  /**
+   * The oEmbed preview HTML for the YouTube video.
+   * This is necessary in the editor, as a simple iframe doesn't work.
+   *
+   * @type {string|null}
+   */
+  const youtubeHtml = isEditing && useSelect ?
+    useSelect(
+      select => {
+        const url = hasYoutube(event) ? event.media : null;
+        if (!url) {return null;}
+
+        const {getEmbedPreview, hasFinishedResolution} = select('core');
+        const preview = getEmbedPreview(url);
+        const hasResolved = hasFinishedResolution('getEmbedPreview', [url]);
+
+        if (!hasResolved || !preview || preview.html === false) {return null;}
+
+        return preview.html;
+      },
+      [event.media, isEditing]
+    ) :
+    null;
 
   return (
     <li className="timeline-block-event">
@@ -105,13 +131,25 @@ export const TimelineEvent = ({event}) => {
         </video>
       )}
       {hasYoutube(event) && (
-        <iframe
-          src={getYoutubeEmbedUrl(event)}
-          title={event.media_caption ?? ''}
-          loading="lazy"
-          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-          allowFullScreen
-        />
+        isEditing ?
+          (youtubeHtml && SandBox && (
+            <SandBox
+              html={youtubeHtml}
+              title={event.media_caption ?? ''}
+              type="embed"
+              allowSameOrigin
+              styles={['body, div, iframe { width: 100%; height: 100%; overflow: hidden; }']}
+            />
+          )) :
+          (
+            <iframe
+              src={getYoutubeEmbedUrl(event)}
+              title={event.media_caption ?? ''}
+              loading="lazy"
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+              allowFullScreen
+            />
+          )
       )}
       <h3 className="timeline-block-event-title">{event.headline}</h3>
       <div className="timeline-description-wrapper">

--- a/assets/src/blocks/Timeline/TimelineEvent.js
+++ b/assets/src/blocks/Timeline/TimelineEvent.js
@@ -40,6 +40,19 @@ const isValidHttpsUrl = value => {
 };
 
 /**
+ * Get the embeddable YouTube URL for an event's media.
+ *
+ * @param {Object} event - The event to be checked.
+ * @return {string|null} - The embeddable URL
+ */
+const getYoutubeEmbedUrl = event => {
+  const match = event.media.match(
+    /(?:youtube\.com\/(?:watch\?v=|embed\/|shorts\/)|youtu\.be\/)([\w-]{11})/i
+  );
+  return match ? `https://www.youtube.com/embed/${match[1]}` : null;
+};
+
+/**
  * Check if an event has an image.
  *
  * @param {Object} event - The event to be checked.
@@ -52,6 +65,13 @@ const hasImage = event => event.media && /\.(jpg|jpeg|png|webp|avif|gif|svg)(\?.
  * @param {Object} event - The event to be checked.
  */
 const hasVideo = event => event.media && /\.(mp4|webm)(\?.*)?$/i.test(event.media);
+
+/**
+ * Check if an event has a YouTube URL.
+ *
+ * @param {Object} event - The event to be checked.
+ */
+const hasYoutube = event => event.media && /^(https?:\/\/)?(www\.)?(youtube\.com\/(watch\?v=|embed\/|shorts\/)|youtu\.be\/)/i.test(event.media);
 
 export const TimelineEvent = ({event}) => {
   const [expanded, setExpanded] = useState(false);
@@ -83,6 +103,15 @@ export const TimelineEvent = ({event}) => {
             onError={e => e.currentTarget.style.display = 'none'}
           />
         </video>
+      )}
+      {hasYoutube(event) && (
+        <iframe
+          src={getYoutubeEmbedUrl(event)}
+          title={event.media_caption ?? ''}
+          loading="lazy"
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+          allowFullScreen
+        />
       )}
       <h3 className="timeline-block-event-title">{event.headline}</h3>
       <div className="timeline-description-wrapper">

--- a/assets/src/blocks/Timeline/TimelineFrontend.js
+++ b/assets/src/blocks/Timeline/TimelineFrontend.js
@@ -193,6 +193,7 @@ export const TimelineFrontend = ({attributes}) => {
                   <TimelineEvent
                     key={`${timeline_id}-event-${event.Day}-${index}`}
                     event={event}
+                    isEditing={isEditing}
                   />
                 ))}
               </ul>

--- a/assets/src/scss/blocks/Timeline/TimelineStyle.scss
+++ b/assets/src/scss/blocks/Timeline/TimelineStyle.scss
@@ -73,13 +73,14 @@
       margin-bottom: $sp-1x;
     }
 
-    img {
+    img, iframe {
       border-radius: 4px;
       width: 100%;
       margin-bottom: $sp-1x;
       object-fit: cover;
       height: 164px;
       cursor: default;
+      display: block;
     }
 
     .timeline-block-event-day {
@@ -207,7 +208,7 @@
       height: fit-content;
       position: relative;
 
-      img {
+      img, iframe {
         height: 212px;
       }
 


### PR DESCRIPTION
### Summary

This PR adds support for YouTube videos in the Timeline block.

---

Ref: https://greenpeace-planet4.atlassian.net/browse/PLANET-8255

### Testing

1. Add a Timeline block to any post or page.
2. In the block, use a spreadsheet that contains a YouTube video as a Media element.
3. Check that the video is embedded correctly in the block editor and on the front.
4. Check that videos are embedded correctly when using short links urls (`youtu.be`).