### PR TITLE
PLANET-8282: Fix Timeline description styles

### DIFF
--- a/assets/src/blocks/Timeline/TimelineEvent.js
+++ b/assets/src/blocks/Timeline/TimelineEvent.js
@@ -55,7 +55,9 @@ const hasVideo = event => event.media && /\.(mp4|webm)(\?.*)?$/i.test(event.medi
 
 export const TimelineEvent = ({event}) => {
   const [expanded, setExpanded] = useState(false);
-  const contentId = `timeline-content${event.day ?? `-${event.day}`}${event.month ?? `-${event.month}`}`;
+  const eventDay = event.day ?? `-${event.day}`;
+  const eventMonth = event.month ?? `-${event.month}`;
+  const contentId = `timeline-content${eventDay}${eventMonth}`;
 
   return (
     <li className="timeline-block-event">

--- a/assets/src/blocks/Timeline/TimelineEvent.js
+++ b/assets/src/blocks/Timeline/TimelineEvent.js
@@ -55,7 +55,7 @@ const hasVideo = event => event.media && /\.(mp4|webm)(\?.*)?$/i.test(event.medi
 
 export const TimelineEvent = ({event}) => {
   const [expanded, setExpanded] = useState(false);
-  const contentId = `timeline-content-${event.day}-${event.month}`;
+  const contentId = `timeline-content${event.day ?? `-${event.day}`}${event.month ?? `-${event.month}`}`;
 
   return (
     <li className="timeline-block-event">
@@ -84,7 +84,7 @@ export const TimelineEvent = ({event}) => {
       )}
       <h3 className="timeline-block-event-title">{event.headline}</h3>
       <div className="timeline-description-wrapper">
-        <p
+        <div
           id={contentId}
           className={`timeline-block-event-description ${expanded ? 'expanded' : 'clamped'}`}
           dangerouslySetInnerHTML={{__html: event.text}}

--- a/assets/src/scss/blocks/Timeline/TimelineStyle.scss
+++ b/assets/src/scss/blocks/Timeline/TimelineStyle.scss
@@ -98,6 +98,11 @@
     font-size: var(--font-size-m--font-family-tertiary);
     line-height: var(--line-height-m--font-family-tertiary);
     margin-bottom: $sp-1;
+
+    a {
+      display: block;
+      width: fit-content;
+    }
   }
 
   .timeline-block-event-description.clamped {

--- a/assets/src/scss/blocks/Timeline/TimelineStyle.scss
+++ b/assets/src/scss/blocks/Timeline/TimelineStyle.scss
@@ -9,8 +9,8 @@
   .timeline-block-year,
   .timeline-block-event-title {
     font-family: var(--font-family-primary);
-    font-size: var(--font-size-m--font-family-primary);
-    line-height: var(--line-height-m--font-family-tertiary);
+    font-size: var(--font-size-l--font-family-primary);
+    line-height: var(--line-height-l--font-family-primary);
   }
 
   .timeline-block-event-title {
@@ -95,13 +95,20 @@
   }
 
   .timeline-block-event-description {
-    font-size: var(--font-size-m--font-family-tertiary);
-    line-height: var(--line-height-m--font-family-tertiary);
     margin-bottom: $sp-1;
+
+    * {
+      font-size: var(--font-size-m--font-family-tertiary);
+      line-height: var(--line-height-m--font-family-tertiary);
+    }
 
     a {
       display: block;
       width: fit-content;
+    }
+
+    a, li {
+      margin-top: $sp-1x;
     }
   }
 
@@ -384,7 +391,7 @@
         font-family: var(--font-family-tertiary);
         color: var(--grey-600);
         font-weight: 600;
-        font-size: 17px;
+        font-size: var(--font-size-m--font-family-tertiary);
 
         &:hover,
         &.active {


### PR DESCRIPTION


### Summary
The changes are applied to fix the layout and also avoid wrong formatting from sheets.
Currently the user can put everything into the `text` column, and teh block render all its content inside a `<p/>` which is wrong since in these cases we can probably get something like:

```html
<p>
   <p></p>
</p>
```

The idea is to avoid this html structure.

Ref: https://greenpeace-planet4.atlassian.net/browse/PLANET-8282

<!-- Please provide a brief summary of the change introduced in this Pull Request. -->

---

### Testing

<!-- Please add the steps required to test the changes in this Pull Request. -->
1. Use [this sheet](https://docs.google.com/spreadsheets/d/1jQpl0HbXJ3RIPgTrO5u6VlZfZB3iWZIi/edit?usp=sharing&ouid=118195650485480328901&rtpof=true&sd=true) to avoid changing the one used through techvision prod

