### PR TITLE
Include shared link styling to timeline content

### DIFF
--- a/assets/src/scss/blocks/Timeline/TimelineStyle.scss
+++ b/assets/src/scss/blocks/Timeline/TimelineStyle.scss
@@ -105,6 +105,8 @@
     a {
       display: block;
       width: fit-content;
+
+      @include shared-link-styles;
     }
 
     a, li {


### PR DESCRIPTION
### Summary

Include in advance shared links styles to <a> through Timeline content to avoid having conflicts when <a> it's not inside <p>

---

<!-- Please add a reference link to the ticket, if one exists. -->
Ref: No ticket needed

### Testing

<!-- Please add the steps required to test the changes in this Pull Request. -->
1. Create a new page with a Timeline block
2. Use this sheet as a reference https://docs.google.com/spreadsheets/d/1jQpl0HbXJ3RIPgTrO5u6VlZfZB3iWZIi/edit?gid=557922313#gid=557922313
3. ALL links should be styled as expected
